### PR TITLE
Add typed C GetEntryValue and ReadQueueValue functions

### DIFF
--- a/ntcore/src/main/native/cpp/LocalStorage.h
+++ b/ntcore/src/main/native/cpp/LocalStorage.h
@@ -254,13 +254,13 @@ class LocalStorage final : public net::ILocalStorage {
       wpi::SmallVectorImpl<typename TypeInfo<T>::SmallElem>& buf,
       typename TypeInfo<T>::View defaultValue);
 
-  std::vector<Value> ReadQueueValue(NT_Handle subentry) {
+  std::vector<Value> ReadQueueValue(NT_Handle subentry, unsigned int types) {
     std::scoped_lock lock{m_mutex};
     auto subscriber = m_impl.GetSubEntry(subentry);
     if (!subscriber) {
       return {};
     }
-    return subscriber->pollStorage.ReadValue();
+    return subscriber->pollStorage.ReadValue(types);
   }
 
   template <ValidType T>

--- a/ntcore/src/main/native/cpp/ValueCircularBuffer.cpp
+++ b/ntcore/src/main/native/cpp/ValueCircularBuffer.cpp
@@ -6,10 +6,13 @@
 
 using namespace nt;
 
-std::vector<Value> ValueCircularBuffer::ReadValue() {
+std::vector<Value> ValueCircularBuffer::ReadValue(unsigned int types) {
   std::vector<Value> rv;
   rv.reserve(m_storage.size());
   for (auto&& val : m_storage) {
+    if (types != 0 && (types & val.type()) == 0) {
+      continue;
+    }
     rv.emplace_back(std::move(val));
   }
   m_storage.reset();

--- a/ntcore/src/main/native/cpp/ValueCircularBuffer.h
+++ b/ntcore/src/main/native/cpp/ValueCircularBuffer.h
@@ -24,7 +24,7 @@ class ValueCircularBuffer {
     m_storage.emplace_back(std::forward<Args...>(args...));
   }
 
-  std::vector<Value> ReadValue();
+  std::vector<Value> ReadValue(unsigned int types);
   template <ValidType T>
   std::vector<Timestamped<typename TypeInfo<T>::Value>> Read();
 

--- a/ntcore/src/main/native/cpp/ntcore_c.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_c.cpp
@@ -175,9 +175,16 @@ uint64_t NT_GetEntryLastChange(NT_Entry entry) {
 }
 
 void NT_GetEntryValue(NT_Entry entry, struct NT_Value* value) {
+  NT_GetEntryValueType(entry, 0, value);
+}
+
+void NT_GetEntryValueType(NT_Entry entry, unsigned int types, struct NT_Value* value) {
   NT_InitValue(value);
   auto v = nt::GetEntryValue(entry);
   if (!v) {
+    return;
+  }
+  if (types != 0 && (types & v.type()) == 0) {
     return;
   }
   ConvertToC(v, value);
@@ -202,6 +209,10 @@ unsigned int NT_GetEntryFlags(NT_Entry entry) {
 
 struct NT_Value* NT_ReadQueueValue(NT_Handle subentry, size_t* count) {
   return ConvertToC<NT_Value>(nt::ReadQueueValue(subentry), count);
+}
+
+struct NT_Value* NT_ReadQueueValueType(NT_Handle subentry, unsigned int types, size_t* count) {
+  return ConvertToC<NT_Value>(nt::ReadQueueValue(subentry, types), count);
 }
 
 NT_Topic* NT_GetTopics(NT_Inst inst, const char* prefix, size_t prefix_len,

--- a/ntcore/src/main/native/cpp/ntcore_c.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_c.cpp
@@ -178,7 +178,8 @@ void NT_GetEntryValue(NT_Entry entry, struct NT_Value* value) {
   NT_GetEntryValueType(entry, 0, value);
 }
 
-void NT_GetEntryValueType(NT_Entry entry, unsigned int types, struct NT_Value* value) {
+void NT_GetEntryValueType(NT_Entry entry, unsigned int types,
+                          struct NT_Value* value) {
   NT_InitValue(value);
   auto v = nt::GetEntryValue(entry);
   if (!v) {
@@ -211,7 +212,8 @@ struct NT_Value* NT_ReadQueueValue(NT_Handle subentry, size_t* count) {
   return ConvertToC<NT_Value>(nt::ReadQueueValue(subentry), count);
 }
 
-struct NT_Value* NT_ReadQueueValueType(NT_Handle subentry, unsigned int types, size_t* count) {
+struct NT_Value* NT_ReadQueueValueType(NT_Handle subentry, unsigned int types,
+                                       size_t* count) {
   return ConvertToC<NT_Value>(nt::ReadQueueValue(subentry, types), count);
 }
 

--- a/ntcore/src/main/native/cpp/ntcore_cpp.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_cpp.cpp
@@ -144,8 +144,12 @@ unsigned int GetEntryFlags(NT_Entry entry) {
 }
 
 std::vector<Value> ReadQueueValue(NT_Handle subentry) {
+  return ReadQueueValue(subentry, 0);
+}
+
+std::vector<Value> ReadQueueValue(NT_Handle subentry, unsigned int types) {
   if (auto ii = InstanceImpl::GetHandle(subentry)) {
-    return ii->localStorage.ReadQueueValue(subentry);
+    return ii->localStorage.ReadQueueValue(subentry, types);
   } else {
     return {};
   }

--- a/ntcore/src/main/native/include/ntcore_c.h
+++ b/ntcore/src/main/native/include/ntcore_c.h
@@ -479,7 +479,8 @@ void NT_GetEntryValue(NT_Entry entry, struct NT_Value* value);
  * needed (the utility function NT_DisposeValue() is useful for this
  * purpose).
  */
-void NT_GetEntryValueType(NT_Entry entry, unsigned int types, struct NT_Value* value);
+void NT_GetEntryValueType(NT_Entry entry, unsigned int types,
+                          struct NT_Value* value);
 
 /**
  * Set Default Entry Value.
@@ -547,7 +548,8 @@ struct NT_Value* NT_ReadQueueValue(NT_Handle subentry, size_t* count);
  * @param count        count of items in returned array (output)
  * @return entry value array; returns NULL and count=0 if no new values
  */
-struct NT_Value* NT_ReadQueueValueType(NT_Handle subentry, unsigned int types, size_t* count);
+struct NT_Value* NT_ReadQueueValueType(NT_Handle subentry, unsigned int types,
+                                       size_t* count);
 
 /** @} */
 

--- a/ntcore/src/main/native/include/ntcore_c.h
+++ b/ntcore/src/main/native/include/ntcore_c.h
@@ -465,6 +465,23 @@ uint64_t NT_GetEntryLastChange(NT_Entry entry);
 void NT_GetEntryValue(NT_Entry entry, struct NT_Value* value);
 
 /**
+ * Get Entry Value.
+ *
+ * Returns copy of current entry value.
+ * Note that one of the type options is "unassigned".
+ *
+ * @param entry     entry handle
+ * @param types     bitmask of NT_Type values; 0 is treated specially
+ *                  as a "don't care"
+ * @param value     storage for returned entry value
+ *
+ * It is the caller's responsibility to free value once it's no longer
+ * needed (the utility function NT_DisposeValue() is useful for this
+ * purpose).
+ */
+void NT_GetEntryValueType(NT_Entry entry, unsigned int types, struct NT_Value* value);
+
+/**
  * Set Default Entry Value.
  *
  * Returns copy of current entry value if it exists.
@@ -517,6 +534,20 @@ unsigned int NT_GetEntryFlags(NT_Entry entry);
  * @return entry value array; returns NULL and count=0 if no new values
  */
 struct NT_Value* NT_ReadQueueValue(NT_Handle subentry, size_t* count);
+
+/**
+ * Read Entry Queue.
+ *
+ * Returns new entry values since last call. The returned array must be freed
+ * using NT_DisposeValueArray().
+ *
+ * @param subentry     subscriber or entry handle
+ * @param types        bitmask of NT_Type values; 0 is treated specially
+ *                     as a "don't care"
+ * @param count        count of items in returned array (output)
+ * @return entry value array; returns NULL and count=0 if no new values
+ */
+struct NT_Value* NT_ReadQueueValueType(NT_Handle subentry, unsigned int types, size_t* count);
 
 /** @} */
 

--- a/ntcore/src/main/native/include/ntcore_cpp.h
+++ b/ntcore/src/main/native/include/ntcore_cpp.h
@@ -528,6 +528,18 @@ unsigned int GetEntryFlags(NT_Entry entry);
  */
 std::vector<Value> ReadQueueValue(NT_Handle subentry);
 
+/**
+ * Read Entry Queue.
+ *
+ * Returns new entry values since last call.
+ *
+ * @param subentry     subscriber or entry handle
+ * @param types        bitmask of NT_Type values; 0 is treated specially
+ *                     as a "don't care"
+ * @return entry value array
+ */
+std::vector<Value> ReadQueueValue(NT_Handle subentry, unsigned int types);
+
 /** @} */
 
 /**


### PR DESCRIPTION
From the C API, using the raw entry API's can be easier. However, there are times when doing a small amount of type filtering in the native layer can remove a lot of copies and extra allocations in higher layers. Adds type filtering versions of NT_GetEntryValue and NT_ReadQueueValue functions to accommodate this.