### PR TITLE
[wpilibc] Fix SysIdRoutineLog state log entry name typo

### DIFF
--- a/wpilibc/src/main/native/cpp/sysid/SysIdRoutineLog.cpp
+++ b/wpilibc/src/main/native/cpp/sysid/SysIdRoutineLog.cpp
@@ -43,7 +43,7 @@ void SysIdRoutineLog::RecordState(State state) {
   if (!m_stateInitialized) {
     m_state =
         wpi::log::StringLogEntry{frc::DataLogManager::GetLog(),
-                                 fmt::format("sysid-test-state{}", m_logName)};
+                                 fmt::format("sysid-test-state-{}", m_logName)};
     m_stateInitialized = true;
   }
   m_state.Append(StateEnumToString(state));


### PR DESCRIPTION
The [Java version](https://github.com/wpilibsuite/allwpilib/blob/d392570659551868b0a9604e247b7dd612de9f31/wpilibj/src/main/java/edu/wpi/first/wpilibj/sysid/SysIdRoutineLog.java#L223) has a hyphen between `test-state` and the mechanism name.