### PR TITLE
[wpinet] WebSocket: Improve disconnect reason reporting

### DIFF
--- a/wpinet/src/main/native/cpp/WebSocket.cpp
+++ b/wpinet/src/main/native/cpp/WebSocket.cpp
@@ -638,7 +638,7 @@ void WebSocket::HandleIncoming(uv::Buffer& buf, size_t size) {
             if (m_state != CLOSING) {
               SendClose(code, reason);
             }
-            SetClosed(code, reason);
+            SetClosed(code, fmt::format("remote close: {}", reason));
             // If we're the server, shutdown the connection.
             if (m_server) {
               Shutdown();
@@ -675,7 +675,8 @@ void WebSocket::HandleIncoming(uv::Buffer& buf, size_t size) {
             pong(m_controlPayload);
             break;
           default:
-            return Fail(1002, "invalid message opcode");
+            return Fail(1002, fmt::format("invalid message opcode {}",
+                                          static_cast<unsigned int>(opcode)));
         }
 
         // Prepare for next message

--- a/wpinet/src/test/native/cpp/WebSocketServerTest.cpp
+++ b/wpinet/src/test/native/cpp/WebSocketServerTest.cpp
@@ -167,7 +167,7 @@ TEST_F(WebSocketServerTest, CloseReason) {
     ws->closed.connect([&](uint16_t code, std::string_view reason) {
       ++gotClosed;
       ASSERT_EQ(code, 1000);
-      ASSERT_EQ(reason, "hangup");
+      ASSERT_EQ(reason, "remote close: hangup");
     });
   };
   // need to respond with close for server to finish shutdown
@@ -237,7 +237,7 @@ TEST_F(WebSocketServerTest, ReceiveCloseReason) {
     ws->closed.connect([&](uint16_t code, std::string_view reason) {
       ++gotClosed;
       ASSERT_EQ(code, 1000);
-      ASSERT_EQ(reason, "hangup");
+      ASSERT_EQ(reason, "remote close: hangup");
     });
   };
   const uint8_t contents[] = {0x03u, 0xe8u, 'h', 'a', 'n', 'g', 'u', 'p'};


### PR DESCRIPTION
Add "remote close:" to messages coming from the remote end. Previously it was impossible to tell if the error was on the local side or communicated by the remote side.