### PR TITLE
[ntcore] Use last received time instead of last ping response

### DIFF
--- a/ntcore/src/main/native/cpp/NetworkClient.cpp
+++ b/ntcore/src/main/native/cpp/NetworkClient.cpp
@@ -403,7 +403,6 @@ void NetworkClient::WsConnected(wpi::WebSocket& ws, uv::Tcp& tcp,
 
   m_wire =
       std::make_shared<net::WebSocketConnection>(ws, connInfo.protocol_version);
-  m_wire->Start();
   m_clientImpl = std::make_unique<net::ClientImpl>(
       m_loop.Now().count(), m_inst, *m_wire, m_logger, m_timeSyncUpdated,
       [this](uint32_t repeatMs) {

--- a/ntcore/src/main/native/cpp/NetworkServer.cpp
+++ b/ntcore/src/main/native/cpp/NetworkServer.cpp
@@ -281,7 +281,6 @@ void NetworkServer::ServerConnection4::ProcessWsUpgrade() {
     INFO("CONNECTED NT4 client '{}' (from {})", dedupName, m_connInfo);
     m_info.remote_id = dedupName;
     m_server.AddConnection(this, m_info);
-    m_wire->Start();
     m_websocket->closed.connect([this](uint16_t, std::string_view reason) {
       auto realReason = m_wire->GetDisconnectReason();
       INFO("DISCONNECTED NT4 client '{}' (from {}): {}", m_info.remote_id,

--- a/ntcore/src/main/native/cpp/net/NetworkPing.cpp
+++ b/ntcore/src/main/native/cpp/net/NetworkPing.cpp
@@ -12,14 +12,15 @@ bool NetworkPing::Send(uint64_t curTimeMs) {
   if (curTimeMs < m_nextPingTimeMs) {
     return true;
   }
-  // if we didn't receive a timely response to our last ping, disconnect
-  uint64_t lastPing = m_wire.GetLastPingResponse();
+  // if we haven't received data in a while, disconnect
+  // (we should at least be getting PONG responses)
+  uint64_t lastData = m_wire.GetLastReceivedTime();
   // DEBUG4("WS ping: lastPing={} curTime={} pongTimeMs={}\n", lastPing,
   //        curTimeMs, m_pongTimeMs);
-  if (lastPing == 0) {
-    lastPing = m_pongTimeMs;
+  if (lastData == 0) {
+    lastData = m_pongTimeMs;
   }
-  if (m_pongTimeMs != 0 && curTimeMs > (lastPing + kPingTimeoutMs)) {
+  if (m_pongTimeMs != 0 && curTimeMs > (lastData + kPingTimeoutMs)) {
     m_wire.Disconnect("connection timed out");
     return false;
   }

--- a/ntcore/src/main/native/cpp/net/WebSocketConnection.cpp
+++ b/ntcore/src/main/native/cpp/net/WebSocketConnection.cpp
@@ -113,18 +113,6 @@ WebSocketConnection::~WebSocketConnection() {
   }
 }
 
-void WebSocketConnection::Start() {
-  m_ws.pong.connect([selfweak = weak_from_this()](auto data) {
-    if (data.size() != 8) {
-      return;
-    }
-    if (auto self = selfweak.lock()) {
-      self->m_lastPingResponse =
-          wpi::support::endian::read64<wpi::support::native>(data.data());
-    }
-  });
-}
-
 void WebSocketConnection::SendPing(uint64_t time) {
   auto buf = AllocBuf();
   buf.len = 8;

--- a/ntcore/src/main/native/cpp/net/WebSocketConnection.h
+++ b/ntcore/src/main/native/cpp/net/WebSocketConnection.h
@@ -26,8 +26,6 @@ class WebSocketConnection final
   WebSocketConnection(const WebSocketConnection&) = delete;
   WebSocketConnection& operator=(const WebSocketConnection&) = delete;
 
-  void Start();
-
   unsigned int GetVersion() const final { return m_version; }
 
   void SendPing(uint64_t time) final;
@@ -51,7 +49,9 @@ class WebSocketConnection final
 
   uint64_t GetLastFlushTime() const final { return m_lastFlushTime; }
 
-  uint64_t GetLastPingResponse() const final { return m_lastPingResponse; }
+  uint64_t GetLastReceivedTime() const final {
+    return m_ws.GetLastReceivedTime();
+  }
 
   void Disconnect(std::string_view reason) final;
 
@@ -92,7 +92,6 @@ class WebSocketConnection final
   State m_state = kEmpty;
   std::string m_reason;
   uint64_t m_lastFlushTime = 0;
-  uint64_t m_lastPingResponse = 0;
   unsigned int m_version;
 };
 

--- a/ntcore/src/main/native/cpp/net/WireConnection.h
+++ b/ntcore/src/main/native/cpp/net/WireConnection.h
@@ -51,8 +51,8 @@ class WireConnection {
 
   virtual uint64_t GetLastFlushTime() const = 0;  // in microseconds
 
-  // Gets the timestamp of the last ping we got a reply to
-  virtual uint64_t GetLastPingResponse() const = 0;  // in microseconds
+  // Gets the timestamp of the last incoming data
+  virtual uint64_t GetLastReceivedTime() const = 0;  // in microseconds
 
   virtual void Disconnect(std::string_view reason) = 0;
 };

--- a/ntcore/src/test/native/cpp/net/MockWireConnection.h
+++ b/ntcore/src/test/native/cpp/net/MockWireConnection.h
@@ -63,7 +63,7 @@ class MockWireConnection : public WireConnection {
   MOCK_METHOD(int, Flush, (), (override));
 
   MOCK_METHOD(uint64_t, GetLastFlushTime, (), (const, override));
-  MOCK_METHOD(uint64_t, GetLastPingResponse, (), (const, override));
+  MOCK_METHOD(uint64_t, GetLastReceivedTime, (), (const, override));
 
   MOCK_METHOD(void, Disconnect, (std::string_view reason), (override));
 };

--- a/ntcore/src/test/native/cpp/net/ServerImplTest.cpp
+++ b/ntcore/src/test/native/cpp/net/ServerImplTest.cpp
@@ -181,7 +181,7 @@ TEST_F(ServerImplTest, PublishLocal) {
     // EXPECT_CALL(wire, Flush()).WillOnce(Return(0));     // AddClient()
     EXPECT_CALL(setPeriodic, Call(100));  // ClientSubscribe()
     // EXPECT_CALL(wire, Flush()).WillOnce(Return(0));     // ClientSubscribe()
-    EXPECT_CALL(wire, GetLastPingResponse()).WillOnce(Return(0));
+    EXPECT_CALL(wire, GetLastReceivedTime()).WillOnce(Return(0));
     EXPECT_CALL(wire, SendPing(100));
     EXPECT_CALL(wire, Ready()).WillOnce(Return(true));  // SendControl()
     EXPECT_CALL(
@@ -258,7 +258,7 @@ TEST_F(ServerImplTest, ClientSubTopicOnlyThenValue) {
     // EXPECT_CALL(wire, Flush()).WillOnce(Return(0));     // AddClient()
     EXPECT_CALL(setPeriodic, Call(100));  // ClientSubscribe()
     // EXPECT_CALL(wire, Flush()).WillOnce(Return(0));     // ClientSubscribe()
-    EXPECT_CALL(wire, GetLastPingResponse()).WillOnce(Return(0));
+    EXPECT_CALL(wire, GetLastReceivedTime()).WillOnce(Return(0));
     EXPECT_CALL(wire, SendPing(100));
     EXPECT_CALL(wire, Ready()).WillOnce(Return(true));  // SendValues()
     EXPECT_CALL(

--- a/wpinet/src/main/native/cpp/WebSocket.cpp
+++ b/wpinet/src/main/native/cpp/WebSocket.cpp
@@ -418,6 +418,8 @@ static inline void Unmask(std::span<uint8_t> data,
 }
 
 void WebSocket::HandleIncoming(uv::Buffer& buf, size_t size) {
+  m_lastReceivedTime = m_stream.GetLoopRef().Now().count();
+
   // ignore incoming data if we're failed or closed
   if (m_state == FAILED || m_state == CLOSED) {
     return;

--- a/wpinet/src/main/native/include/wpinet/WebSocket.h
+++ b/wpinet/src/main/native/include/wpinet/WebSocket.h
@@ -458,6 +458,12 @@ class WebSocket : public std::enable_shared_from_this<WebSocket> {
   void Shutdown();
 
   /**
+   * Gets the last time data was received on the stream.
+   * @return Timestamp
+   */
+  uint64_t GetLastReceivedTime() const { return m_lastReceivedTime; }
+
+  /**
    * Open event.  Emitted when the connection is open and ready to communicate.
    * The parameter is the selected subprotocol.
    */
@@ -521,6 +527,7 @@ class WebSocket : public std::enable_shared_from_this<WebSocket> {
   State m_state = CONNECTING;
 
   // incoming message buffers/state
+  uint64_t m_lastReceivedTime = 0;
   SmallVector<uint8_t, 14> m_header;
   size_t m_headerSize = 0;
   SmallVector<uint8_t, 1024> m_payload;


### PR DESCRIPTION
This relaxes the timeout constraint for long message transmissions.