### PR TITLE
Don't write a 0 length led string to the FPGA

### DIFF
--- a/hal/src/main/native/athena/AddressableLED.cpp
+++ b/hal/src/main/native/athena/AddressableLED.cpp
@@ -198,6 +198,10 @@ void HAL_WriteAddressableLEDData(HAL_AddressableLEDHandle handle,
     return;
   }
 
+  if (length == 0) {
+    return;
+  }
+
   std::memcpy(led->ledBuffer, data, length * sizeof(HAL_AddressableLEDData));
 
   asm("dmb");


### PR DESCRIPTION
Due to something weird in the FPGA, calling strobeLoad() with a string length of 0 causes both CPUs to spin at 100%, basically shutting down everything else on the robot.

If a 0 length string happens to be passed, just bail out early.

Closes #6257