### PR TITLE
Fix SysIdRoutine Naming

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/sysid/SysIdRoutine.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/sysid/SysIdRoutine.java
@@ -53,7 +53,7 @@ public class SysIdRoutine extends SysIdRoutineLog {
    * @param mechanism Hardware interface for the SysId routine.
    */
   public SysIdRoutine(Config config, Mechanism mechanism) {
-    super(mechanism.m_subsystem.getName());
+    super(mechanism.m_name);
     m_config = config;
     m_mechanism = mechanism;
     m_recordState = config.m_recordState != null ? config.m_recordState : this::recordState;

--- a/wpilibNewCommands/src/main/native/include/frc2/command/sysid/SysIdRoutine.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/sysid/SysIdRoutine.h
@@ -179,7 +179,7 @@ class SysIdRoutine : public frc::sysid::SysIdRoutineLog {
    * @param mechanism Hardware interface for the SysId routine.
    */
   SysIdRoutine(Config config, Mechanism mechanism)
-      : SysIdRoutineLog(mechanism.m_subsystem->GetName()),
+      : SysIdRoutineLog(mechanism.m_name),
         m_config(config),
         m_mechanism(mechanism),
         m_recordState(config.m_recordState ? config.m_recordState


### PR DESCRIPTION
Previously, this used `mechanism.m_subsystem.getName()`, instead of `mechanism.m_name`, meaning differently named SysId routines from the same subsystem would clobber each other when logged.