### PR TITLE
Use 64 bit timestamp in DMA

### DIFF
--- a/hal/src/main/native/athena/DMA.cpp
+++ b/hal/src/main/native/athena/DMA.cpp
@@ -737,10 +737,10 @@ enum HAL_DMAReadStatus HAL_ReadDMADirect(void* dmaPointer,
                      &remainingBytes, status);
 
   if ((remainingBytes % dma->captureStore.captureSize) != 0) {
-    fmt::println(
+    fmt::print(
         "Remaining bytes {} is not a multiple of capture size {}. This is "
         "likely a "
-        "bug in WPILib. Please report this issue with a copy of your code.",
+        "bug in WPILib. Please report this issue with a copy of your code.\n",
         remainingBytes, dma->captureStore.captureSize);
   }
 

--- a/hal/src/main/native/athena/DMA.cpp
+++ b/hal/src/main/native/athena/DMA.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <memory>
 #include <type_traits>
+#include <fmt/format.h>
 
 #include "AnalogInternal.h"
 #include "ConstantsInternal.h"
@@ -676,7 +677,7 @@ void HAL_StartDMA(HAL_DMAHandle handle, int32_t queueDepth, int32_t* status) {
     SET_SIZE(Enable_DutyCycle_Low);
     SET_SIZE(Enable_DutyCycle_High);
 #undef SET_SIZE
-    dma->captureStore.captureSize = accum_size + 1;
+    dma->captureStore.captureSize = accum_size + 2;
   }
 
   uint32_t byteDepth = queueDepth * dma->captureStore.captureSize;
@@ -734,12 +735,22 @@ enum HAL_DMAReadStatus HAL_ReadDMADirect(void* dmaPointer,
                      static_cast<uint32_t>(timeoutSeconds * 1000),
                      &remainingBytes, status);
 
+  if ((remainingBytes % dma->captureStore.captureSize) != 0) {
+    fmt::println(
+        "Remaining bytes {} is not a multiple of capture size {}. This is "
+        "likely a "
+        "bug in WPILib. Please report this issue with a copy of your code.",
+        remainingBytes, dma->captureStore.captureSize);
+  }
+
   *remainingOut = remainingBytes / dma->captureStore.captureSize;
 
   if (*status == 0) {
-    uint32_t lower_sample =
+    uint64_t upper_sample =
         dmaSample->readBuffer[dma->captureStore.captureSize - 1];
-    dmaSample->timeStamp = HAL_ExpandFPGATime(lower_sample, status);
+    uint64_t lower_sample =
+        dmaSample->readBuffer[dma->captureStore.captureSize - 2];
+    dmaSample->timeStamp = (upper_sample << 32) + lower_sample;
     if (*status != 0) {
       return HAL_DMA_ERROR;
     }

--- a/hal/src/main/native/athena/DMA.cpp
+++ b/hal/src/main/native/athena/DMA.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <memory>
 #include <type_traits>
+
 #include <fmt/format.h>
 
 #include "AnalogInternal.h"


### PR DESCRIPTION
Closes #6276 

Timestamps in DMA are now 64 bits. This means the buffer being read was 1 too small to hold all the data, which caused the DMA buffer to get out of sync with the actual data.

Fix the bug, and also put in a print if this state is ever detected again to report to wpilib. This should never happen if our code is correct.