### PR TITLE
Fix macOS apps not always being an application

### DIFF
--- a/datalogtool/publish.gradle
+++ b/datalogtool/publish.gradle
@@ -29,51 +29,8 @@ model {
                         def applicationPath = binary.executable.file
                         def icon = file("$project.projectDir/src/main/native/mac/datalogtool.icns")
 
-                        // Create the macOS bundle.
-                        def bundleTask = project.tasks.create("bundleDataLogToolOsxApp" + binary.targetPlatform.architecture.name, Copy) {
-                            description("Creates a macOS application bundle for DataLogTool")
-                            from(file("$project.projectDir/Info.plist"))
-                            into(file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/DataLogTool.app/Contents"))
-                            into("MacOS") {
-                                with copySpec {
-                                    from binary.executable.file
-                                }
-                            }
-                            into("Resources") {
-                                with copySpec {
-                                    from icon
-                                }
-                            }
-
-                            inputs.property "HasDeveloperId", project.hasProperty("developerID")
-
-                            doLast {
-                                if (project.hasProperty("developerID")) {
-                                    // Get path to binary.
-                                    exec {
-                                        workingDir rootDir
-                                        def args = [
-                                            "sh",
-                                            "-c",
-                                            "codesign --force --strict --deep " +
-                                            "--timestamp --options=runtime " +
-                                            "--verbose -s ${project.findProperty("developerID")} " +
-                                            "$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/DataLogTool.app/"
-                                        ]
-                                        commandLine args
-                                    }
-                                }
-                            }
-                        }
-
-                        // Reset the application path if we are creating a bundle.
-                        if (binary.targetPlatform.operatingSystem.isMacOsX()) {
-                            applicationPath = file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name")
-                            project.build.dependsOn bundleTask
-                        }
-
                         // Create the ZIP.
-                        def task = project.tasks.create("copyDataLogToolExecutable" + binary.targetPlatform.architecture.name, Zip) {
+                        def task = project.tasks.create("copyDataLogToolExecutable" + binary.targetPlatform.operatingSystem.name + binary.targetPlatform.architecture.name, Zip) {
                             description("Copies the DataLogTool executable to the outputs directory.")
                             destinationDirectory = outputsFolder
 
@@ -85,13 +42,63 @@ model {
                                 into '/'
                             }
 
-                            from(applicationPath)
+                            if (binary.targetPlatform.operatingSystem.isWindows()) {
+                                def exePath = binary.executable.file.absolutePath
+                                exePath = exePath.substring(0, exePath.length() - 4)
+                                def pdbPath = new File(exePath + '.pdb')
+                                from(pdbPath)
+                            }
+
                             into(nativeUtils.getPlatformPath(binary))
                         }
 
                         if (binary.targetPlatform.operatingSystem.isMacOsX()) {
+                            // Create the macOS bundle.
+                            def bundleTask = project.tasks.create("bundleDataLogToolOsxApp" + binary.targetPlatform.architecture.name, Copy) {
+                                description("Creates a macOS application bundle for DataLogTool")
+                                from(file("$project.projectDir/Info.plist"))
+                                into(file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/DataLogTool.app/Contents"))
+                                into("MacOS") {
+                                    with copySpec {
+                                        from binary.executable.file
+                                    }
+                                }
+                                into("Resources") {
+                                    with copySpec {
+                                        from icon
+                                    }
+                                }
+
+                                inputs.property "HasDeveloperId", project.hasProperty("developerID")
+
+                                doLast {
+                                    if (project.hasProperty("developerID")) {
+                                        // Get path to binary.
+                                        exec {
+                                            workingDir rootDir
+                                            def args = [
+                                                "sh",
+                                                "-c",
+                                                "codesign --force --strict --deep " +
+                                                "--timestamp --options=runtime " +
+                                                "--verbose -s ${project.findProperty("developerID")} " +
+                                                "$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/DataLogTool.app/"
+                                            ]
+                                            commandLine args
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Reset the application path if we are creating a bundle.
+                            applicationPath = file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name")
+                            task.from(applicationPath)
+                            project.build.dependsOn bundleTask
+
                             bundleTask.dependsOn binary.tasks.link
                             task.dependsOn(bundleTask)
+                        } else {
+                            task.from(applicationPath)
                         }
 
                         task.dependsOn binary.tasks.link

--- a/glass/publish.gradle
+++ b/glass/publish.gradle
@@ -97,8 +97,6 @@ model {
                                 into '/'
                             }
 
-                            from(applicationPath)
-
                             if (binary.targetPlatform.operatingSystem.isWindows()) {
                                 def exePath = binary.executable.file.absolutePath
                                 exePath = exePath.substring(0, exePath.length() - 4)
@@ -149,10 +147,13 @@ model {
 
                             // Reset the application path if we are creating a bundle.
                             applicationPath = file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name")
+                            task.from(applicationPath)
                             project.build.dependsOn bundleTask
 
                             bundleTask.dependsOn binary.tasks.link
                             task.dependsOn(bundleTask)
+                        } else {
+                            task.from(applicationPath)
                         }
 
                         task.dependsOn binary.tasks.link

--- a/outlineviewer/publish.gradle
+++ b/outlineviewer/publish.gradle
@@ -29,51 +29,8 @@ model {
                         def applicationPath = binary.executable.file
                         def icon = file("$project.projectDir/src/main/native/mac/ov.icns")
 
-                        // Create the macOS bundle.
-                        def bundleTask = project.tasks.create("bundleOutlineViewerOsxApp" + binary.targetPlatform.architecture.name, Copy) {
-                            description("Creates a macOS application bundle for OutlineViewer")
-                            from(file("$project.projectDir/Info.plist"))
-                            into(file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/OutlineViewer.app/Contents"))
-                            into("MacOS") {
-                                with copySpec {
-                                    from binary.executable.file
-                                }
-                            }
-                            into("Resources") {
-                                with copySpec {
-                                    from icon
-                                }
-                            }
-
-                            inputs.property "HasDeveloperId", project.hasProperty("developerID")
-
-                            doLast {
-                                if (project.hasProperty("developerID")) {
-                                    // Get path to binary.
-                                    exec {
-                                        workingDir rootDir
-                                        def args = [
-                                            "sh",
-                                            "-c",
-                                            "codesign --force --strict --deep " +
-                                            "--timestamp --options=runtime " +
-                                            "--verbose -s ${project.findProperty("developerID")} " +
-                                            "$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/OutlineViewer.app/"
-                                        ]
-                                        commandLine args
-                                    }
-                                }
-                            }
-                        }
-
-                        // Reset the application path if we are creating a bundle.
-                        if (binary.targetPlatform.operatingSystem.isMacOsX()) {
-                            applicationPath = file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name")
-                            project.build.dependsOn bundleTask
-                        }
-
                         // Create the ZIP.
-                        def task = project.tasks.create("copyOutlineViewerExecutable" + binary.targetPlatform.architecture.name, Zip) {
+                        def task = project.tasks.create("copyOutlineViewerExecutable" + binary.targetPlatform.operatingSystem.name + binary.targetPlatform.architecture.name, Zip) {
                             description("Copies the OutlineViewer executable to the outputs directory.")
                             destinationDirectory = outputsFolder
 
@@ -84,8 +41,6 @@ model {
                             from(licenseFile) {
                                 into '/'
                             }
-
-                            from(applicationPath)
 
                             if (binary.targetPlatform.operatingSystem.isWindows()) {
                                 def exePath = binary.executable.file.absolutePath
@@ -98,8 +53,52 @@ model {
                         }
 
                         if (binary.targetPlatform.operatingSystem.isMacOsX()) {
+                            // Create the macOS bundle.
+                            def bundleTask = project.tasks.create("bundleOutlineViewerOsxApp" + binary.targetPlatform.architecture.name, Copy) {
+                                description("Creates a macOS application bundle for OutlineViewer")
+                                from(file("$project.projectDir/Info.plist"))
+                                into(file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/OutlineViewer.app/Contents"))
+                                into("MacOS") {
+                                    with copySpec {
+                                        from binary.executable.file
+                                    }
+                                }
+                                into("Resources") {
+                                    with copySpec {
+                                        from icon
+                                    }
+                                }
+
+                                inputs.property "HasDeveloperId", project.hasProperty("developerID")
+
+                                doLast {
+                                    if (project.hasProperty("developerID")) {
+                                        // Get path to binary.
+                                        exec {
+                                            workingDir rootDir
+                                            def args = [
+                                                "sh",
+                                                "-c",
+                                                "codesign --force --strict --deep " +
+                                                "--timestamp --options=runtime " +
+                                                "--verbose -s ${project.findProperty("developerID")} " +
+                                                "$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/OutlineViewer.app/"
+                                            ]
+                                            commandLine args
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Reset the application path if we are creating a bundle.
+                            applicationPath = file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name")
+                            task.from(applicationPath)
+                            project.build.dependsOn bundleTask
+
                             bundleTask.dependsOn binary.tasks.link
                             task.dependsOn(bundleTask)
+                        } else {
+                            task.from(applicationPath)
                         }
 
                         task.dependsOn binary.tasks.link

--- a/roborioteamnumbersetter/publish.gradle
+++ b/roborioteamnumbersetter/publish.gradle
@@ -42,8 +42,6 @@ model {
                                 into '/'
                             }
 
-                            from(applicationPath)
-
                             if (binary.targetPlatform.operatingSystem.isWindows()) {
                                 def exePath = binary.executable.file.absolutePath
                                 exePath = exePath.substring(0, exePath.length() - 4)
@@ -94,10 +92,13 @@ model {
 
                             // Reset the application path if we are creating a bundle.
                             applicationPath = file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name")
+                            task.from(applicationPath)
                             project.build.dependsOn bundleTask
 
                             bundleTask.dependsOn binary.tasks.link
                             task.dependsOn(bundleTask)
+                        } else {
+                            task.from(applicationPath)
                         }
 
                         task.dependsOn binary.tasks.link


### PR DESCRIPTION
Closes #6204

#5586 was grabbing the incorrect executable on macOS. Also for some reason I only applied that to Glass and RTNS, when it should have been applied to all tools. Fix Glass and RTNS, and update the other tools to fix the issue that PR was originally supposed to fix.
