### PR TITLE
[wpimath] Remove Rotation2d(units::degree_t) overload

### DIFF
--- a/wpimath/src/main/native/include/frc/geometry/Rotation2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Rotation2d.h
@@ -35,13 +35,6 @@ class WPILIB_DLLEXPORT Rotation2d {
   constexpr Rotation2d(units::radian_t value);  // NOLINT
 
   /**
-   * Constructs a Rotation2d with the given degree value.
-   *
-   * @param value The value of the angle in degrees.
-   */
-  constexpr Rotation2d(units::degree_t value);  // NOLINT
-
-  /**
    * Constructs a Rotation2d with the given x and y (cosine and sine)
    * components. The x and y don't have to be normalized.
    *

--- a/wpimath/src/main/native/include/frc/geometry/Rotation2d.inc
+++ b/wpimath/src/main/native/include/frc/geometry/Rotation2d.inc
@@ -16,9 +16,6 @@ constexpr Rotation2d::Rotation2d(units::radian_t value)
       m_cos(gcem::cos(value.to<double>())),
       m_sin(gcem::sin(value.to<double>())) {}
 
-constexpr Rotation2d::Rotation2d(units::degree_t value)
-    : Rotation2d(units::radian_t{value}) {}
-
 constexpr Rotation2d::Rotation2d(double x, double y) {
   double magnitude = gcem::hypot(x, y);
   if (magnitude > 1e-6) {


### PR DESCRIPTION
The implicit conversion between `units::degree_t` and `units::radian_t` means removing this overload shouldn't really break anything.

Fixes #6312.