### PR TITLE
[examples] Move triggers to subsystem fields

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/RapidReactCommandBot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/RapidReactCommandBot.cpp
@@ -12,7 +12,7 @@
 
 void RapidReactCommandBot::ConfigureBindings() {
   // Automatically run the storage motor whenever the ball storage is not full,
-  // and turn it off whenever it fills. Uses subsystem-hosted trigger to 
+  // and turn it off whenever it fills. Uses subsystem-hosted trigger to
   // improve readability and make inter-subsystem communication easier.
   m_storage.HasCargo.WhileFalse(m_storage.RunCommand());
 

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/RapidReactCommandBot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/RapidReactCommandBot.cpp
@@ -12,16 +12,13 @@
 
 void RapidReactCommandBot::ConfigureBindings() {
   // Automatically run the storage motor whenever the ball storage is not full,
-  // and turn it off whenever it fills.
-  frc2::Trigger([this] {
-    return m_storage.IsFull();
-  }).WhileFalse(m_storage.RunCommand());
+  // and turn it off whenever it fills. Uses subsystem-hosted trigger to 
+  // improve readability and make inter-subsystem communication easier.
+  m_storage.m_isFull.WhileFalse(m_storage.RunCommand());
 
   // Automatically disable and retract the intake whenever the ball storage is
   // full.
-  frc2::Trigger([this] {
-    return m_storage.IsFull();
-  }).OnTrue(m_intake.RetractCommand());
+  m_storage.m_isFull.OnTrue(m_intake.RetractCommand());
 
   // Control the drive with split-stick arcade controls
   m_drive.SetDefaultCommand(m_drive.ArcadeDriveCommand(

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/RapidReactCommandBot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/RapidReactCommandBot.cpp
@@ -14,11 +14,11 @@ void RapidReactCommandBot::ConfigureBindings() {
   // Automatically run the storage motor whenever the ball storage is not full,
   // and turn it off whenever it fills. Uses subsystem-hosted trigger to 
   // improve readability and make inter-subsystem communication easier.
-  m_storage.m_isFull.WhileFalse(m_storage.RunCommand());
+  m_storage.HasCargo.WhileFalse(m_storage.RunCommand());
 
   // Automatically disable and retract the intake whenever the ball storage is
   // full.
-  m_storage.m_isFull.OnTrue(m_intake.RetractCommand());
+  m_storage.HasCargo.OnTrue(m_intake.RetractCommand());
 
   // Control the drive with split-stick arcade controls
   m_drive.SetDefaultCommand(m_drive.ArcadeDriveCommand(

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Storage.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Storage.cpp
@@ -12,7 +12,3 @@ Storage::Storage() {
 frc2::CommandPtr Storage::RunCommand() {
   return Run([this] { m_motor.Set(1.0); }).WithName("Run");
 }
-
-bool Storage::IsFull() const {
-  return m_ballSensor.Get();
-}

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Storage.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Storage.h
@@ -23,9 +23,7 @@ class Storage : frc2::SubsystemBase {
   bool IsFull() const;
 
   /** Exposes the IsFull trigger. */
-  frc2::Trigger HasCargo{[this] {
-    return IsFull();
-  }};
+  frc2::Trigger HasCargo{[this] { return IsFull(); }};
 
  private:
   frc::PWMSparkMax m_motor{StorageConstants::kMotorPort};

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Storage.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Storage.h
@@ -19,11 +19,9 @@ class Storage : frc2::SubsystemBase {
   [[nodiscard]]
   frc2::CommandPtr RunCommand();
 
-  /** Whether the ball storage is full. */
-  bool IsFull() const;
 
-  /** Exposes the IsFull trigger. */
-  frc2::Trigger HasCargo{[this] { return IsFull(); }};
+  /** Whether the ball storage is full. */
+  frc2::Trigger HasCargo{[this] { return m_ballSensor.Get(); }};
 
  private:
   frc::PWMSparkMax m_motor{StorageConstants::kMotorPort};

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Storage.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Storage.h
@@ -8,6 +8,7 @@
 #include <frc/motorcontrol/PWMSparkMax.h>
 #include <frc2/command/CommandPtr.h>
 #include <frc2/command/SubsystemBase.h>
+#include <frc2/command/button/Trigger.h>
 
 #include "Constants.h"
 
@@ -20,6 +21,11 @@ class Storage : frc2::SubsystemBase {
 
   /** Whether the ball storage is full. */
   bool IsFull() const;
+
+  /** Exposes the IsFull trigger. */
+  frc2::Trigger m_isFull{[this] {
+    return IsFull();
+  }};
 
  private:
   frc::PWMSparkMax m_motor{StorageConstants::kMotorPort};

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Storage.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Storage.h
@@ -19,7 +19,6 @@ class Storage : frc2::SubsystemBase {
   [[nodiscard]]
   frc2::CommandPtr RunCommand();
 
-
   /** Whether the ball storage is full. */
   frc2::Trigger HasCargo{[this] { return m_ballSensor.Get(); }};
 

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Storage.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Storage.h
@@ -23,7 +23,7 @@ class Storage : frc2::SubsystemBase {
   bool IsFull() const;
 
   /** Exposes the IsFull trigger. */
-  frc2::Trigger m_isFull{[this] {
+  frc2::Trigger HasCargo{[this] {
     return IsFull();
   }};
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/RapidReactCommandBot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/RapidReactCommandBot.java
@@ -48,10 +48,10 @@ public class RapidReactCommandBot {
     // Automatically run the storage motor whenever the ball storage is not full,
     // and turn it off whenever it fills. Uses subsystem-hosted trigger to 
     // improve readability and make inter-subsystem communication easier.
-    m_storage.m_isFull.whileFalse(m_storage.runCommand());
+    m_storage.hasCargo.whileFalse(m_storage.runCommand());
 
     // Automatically disable and retract the intake whenever the ball storage is full.
-    m_storage.m_isFull.onTrue(m_intake.retractCommand());
+    m_storage.hasCargo.onTrue(m_intake.retractCommand());
 
     // Control the drive with split-stick arcade controls
     m_drive.setDefaultCommand(

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/RapidReactCommandBot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/RapidReactCommandBot.java
@@ -46,11 +46,12 @@ public class RapidReactCommandBot {
    */
   public void configureBindings() {
     // Automatically run the storage motor whenever the ball storage is not full,
-    // and turn it off whenever it fills.
-    new Trigger(m_storage::isFull).whileFalse(m_storage.runCommand());
+    // and turn it off whenever it fills. Uses subsystem-hosted trigger to 
+    // improve readability and make inter-subsystem communication easier.
+    m_storage.m_isFull.whileFalse(m_storage.runCommand());
 
     // Automatically disable and retract the intake whenever the ball storage is full.
-    new Trigger(m_storage::isFull).onTrue(m_intake.retractCommand());
+    m_storage.m_isFull.onTrue(m_intake.retractCommand());
 
     // Control the drive with split-stick arcade controls
     m_drive.setDefaultCommand(

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/RapidReactCommandBot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/RapidReactCommandBot.java
@@ -46,7 +46,7 @@ public class RapidReactCommandBot {
    */
   public void configureBindings() {
     // Automatically run the storage motor whenever the ball storage is not full,
-    // and turn it off whenever it fills. Uses subsystem-hosted trigger to 
+    // and turn it off whenever it fills. Uses subsystem-hosted trigger to
     // improve readability and make inter-subsystem communication easier.
     m_storage.hasCargo.whileFalse(m_storage.runCommand());
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Storage.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Storage.java
@@ -14,7 +14,7 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 public class Storage extends SubsystemBase {
   private final PWMSparkMax m_motor = new PWMSparkMax(StorageConstants.kMotorPort);
   private final DigitalInput m_ballSensor = new DigitalInput(StorageConstants.kBallSensorPort);
-  
+
   // Expose trigger from subsystem to improve readability and ease
   // inter-subsystem communications
   @SuppressWarnings("checkstyle:MemberName")

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Storage.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Storage.java
@@ -16,7 +16,7 @@ public class Storage extends SubsystemBase {
   private final DigitalInput m_ballSensor = new DigitalInput(StorageConstants.kBallSensorPort);
   // Expose trigger from subsystem to improve readability and ease 
   // inter-subsystem communications
-  public final Trigger m_isFull = new Trigger(this::isFull);
+  public final Trigger hasCargo = new Trigger(this::isFull);
 
   /** Create a new Storage subsystem. */
   public Storage() {

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Storage.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Storage.java
@@ -16,6 +16,7 @@ public class Storage extends SubsystemBase {
   private final DigitalInput m_ballSensor = new DigitalInput(StorageConstants.kBallSensorPort);
   // Expose trigger from subsystem to improve readability and ease
   // inter-subsystem communications
+  @SuppressWarnings("checkstyle:MemberName")
   public final Trigger hasCargo = new Trigger(this::isFull);
 
   /** Create a new Storage subsystem. */

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Storage.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Storage.java
@@ -14,6 +14,7 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 public class Storage extends SubsystemBase {
   private final PWMSparkMax m_motor = new PWMSparkMax(StorageConstants.kMotorPort);
   private final DigitalInput m_ballSensor = new DigitalInput(StorageConstants.kBallSensorPort);
+  
   // Expose trigger from subsystem to improve readability and ease
   // inter-subsystem communications
   @SuppressWarnings("checkstyle:MemberName")

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Storage.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Storage.java
@@ -14,7 +14,7 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 public class Storage extends SubsystemBase {
   private final PWMSparkMax m_motor = new PWMSparkMax(StorageConstants.kMotorPort);
   private final DigitalInput m_ballSensor = new DigitalInput(StorageConstants.kBallSensorPort);
-  // Expose trigger from subsystem to improve readability and ease 
+  // Expose trigger from subsystem to improve readability and ease
   // inter-subsystem communications
   public final Trigger hasCargo = new Trigger(this::isFull);
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Storage.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Storage.java
@@ -17,18 +17,14 @@ public class Storage extends SubsystemBase {
 
   // Expose trigger from subsystem to improve readability and ease
   // inter-subsystem communications
+  /** Whether the ball storage is full. */
   @SuppressWarnings("checkstyle:MemberName")
-  public final Trigger hasCargo = new Trigger(this::isFull);
+  public final Trigger hasCargo = new Trigger(m_ballSensor::get);
 
   /** Create a new Storage subsystem. */
   public Storage() {
     // Set default command to turn off the storage motor and then idle
     setDefaultCommand(runOnce(m_motor::disable).andThen(run(() -> {})).withName("Idle"));
-  }
-
-  /** Whether the ball storage is full. */
-  public boolean isFull() {
-    return m_ballSensor.get();
   }
 
   /** Returns a command that runs the storage motor indefinitely. */

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Storage.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Storage.java
@@ -4,16 +4,19 @@
 
 package edu.wpi.first.wpilibj.examples.rapidreactcommandbot.subsystems;
 
-import static edu.wpi.first.wpilibj.examples.rapidreactcommandbot.Constants.StorageConstants;
-
 import edu.wpi.first.wpilibj.DigitalInput;
+import edu.wpi.first.wpilibj.examples.rapidreactcommandbot.Constants.StorageConstants;
 import edu.wpi.first.wpilibj.motorcontrol.PWMSparkMax;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 
 public class Storage extends SubsystemBase {
   private final PWMSparkMax m_motor = new PWMSparkMax(StorageConstants.kMotorPort);
   private final DigitalInput m_ballSensor = new DigitalInput(StorageConstants.kBallSensorPort);
+  // Expose trigger from subsystem to improve readability and ease 
+  // inter-subsystem communications
+  public final Trigger m_isFull = new Trigger(this::isFull);
 
   /** Create a new Storage subsystem. */
   public Storage() {


### PR DESCRIPTION
This eases inter-subsystem communication by making it easier to hook command and triggers together regardless of location and also makes code much cleaner and more readable.