### PR TITLE
Force cpp files to be lf line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
-*.cpp text
+*.cpp text eol=lf
 *.gradle text eol=lf
-*.h text
-*.inc text
+*.h text eol=lf
+*.inc text eol=lf
 *.java text eol=lf
 *.json text eol=lf
 *.md text eol=lf


### PR DESCRIPTION
Just marking a file as text will cause git to override the local core.autocrlf setting, and assume you want it to be `true`, which isn't what you want.