### PR TITLE
[wpimath] Add lastValue() method to filters

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
@@ -314,6 +314,15 @@ public class LinearFilter {
   }
 
   /**
+   * Returns the last value calculated by the LinearFilter.
+   *
+   * @return The last value.
+   */
+  public double lastValue() {
+    return m_outputs.getFirst();
+  }
+
+  /**
    * Factorial of n.
    *
    * @param n Argument of which to take factorial.

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/MedianFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/MedianFilter.java
@@ -72,6 +72,15 @@ public class MedianFilter {
     }
   }
 
+  /**
+   * Returns the last value calculated by the MedianFilter.
+   *
+   * @return The last value.
+   */
+  public double lastValue() {
+    return m_valueBuffer.getFirst();
+  }
+
   /** Resets the filter, clearing the window of all elements. */
   public void reset() {
     m_orderedValues.clear();

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
@@ -65,6 +65,15 @@ public class SlewRateLimiter {
   }
 
   /**
+   * Returns the value last calculated by the SlewRateLimiter.
+   *
+   * @return The last value.
+   */
+  public double lastValue() {
+    return m_prevVal;
+  }
+
+  /**
    * Resets the slew rate limiter to the specified value; ignores the rate limit when doing so.
    *
    * @param value The value to reset to.

--- a/wpimath/src/main/native/cpp/controller/RamseteController.cpp
+++ b/wpimath/src/main/native/cpp/controller/RamseteController.cpp
@@ -4,8 +4,6 @@
 
 #include "frc/controller/RamseteController.h"
 
-#include <cmath>
-
 #include "units/angle.h"
 #include "units/math.h"
 

--- a/wpimath/src/main/native/include/frc/filter/LinearFilter.h
+++ b/wpimath/src/main/native/include/frc/filter/LinearFilter.h
@@ -371,6 +371,13 @@ class LinearFilter {
     return retVal;
   }
 
+  /**
+   * Returns the last value calculated by the LinearFilter.
+   *
+   * @return The last value.
+   */
+  T LastValue() const { return m_outputs.front(); }
+
  private:
   wpi::circular_buffer<T> m_inputs;
   wpi::circular_buffer<T> m_outputs;

--- a/wpimath/src/main/native/include/frc/filter/MedianFilter.h
+++ b/wpimath/src/main/native/include/frc/filter/MedianFilter.h
@@ -62,6 +62,13 @@ class MedianFilter {
   }
 
   /**
+   * Returns the last value calculated by the MedianFilter.
+   *
+   * @return The last value.
+   */
+  T LastValue() const { return m_valueBuffer.front(); }
+
+  /**
    * Resets the filter, clearing the window of all elements.
    */
   void Reset() {

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -76,6 +76,13 @@ class SlewRateLimiter {
   }
 
   /**
+   * Returns the value last calculated by the SlewRateLimiter.
+   *
+   * @return The last value.
+   */
+  Unit_t LastValue() const { return m_prevVal; }
+
+  /**
    * Resets the slew rate limiter to the specified value; ignores the rate limit
    * when doing so.
    *


### PR DESCRIPTION
Adds the getValue method to return the current value of a SlewRateLimiter without recalculating the value.