### PR TITLE
Remove unusable std::unique_ptr case for SendableChooser

### DIFF
--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.h
@@ -37,9 +37,6 @@ class SendableChooser : public SendableChooserBase {
   static U _unwrap_smart_ptr(const U& value);
 
   template <class U>
-  static U* _unwrap_smart_ptr(const std::unique_ptr<U>& value);
-
-  template <class U>
   static std::weak_ptr<U> _unwrap_smart_ptr(const std::shared_ptr<U>& value);
 
  public:
@@ -71,8 +68,8 @@ class SendableChooser : public SendableChooserBase {
   void SetDefaultOption(std::string_view name, T object);
 
   /**
-   * Returns a copy of the selected option (a raw pointer U* if T =
-   * std::unique_ptr<U> or a std::weak_ptr<U> if T = std::shared_ptr<U>).
+   * Returns a copy of the selected option (a std::weak_ptr<U> if T =
+   * std::shared_ptr<U>).
    *
    * If there is none selected, it will return the default. If there is none
    * selected and no default, then it will return a value-initialized instance.

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.inc
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.inc
@@ -124,13 +124,6 @@ U SendableChooser<T>::_unwrap_smart_ptr(const U& value) {
 template <class T>
   requires std::copy_constructible<T> && std::default_initializable<T>
 template <class U>
-U* SendableChooser<T>::_unwrap_smart_ptr(const std::unique_ptr<U>& value) {
-  return value.get();
-}
-
-template <class T>
-  requires std::copy_constructible<T> && std::default_initializable<T>
-template <class U>
 std::weak_ptr<U> SendableChooser<T>::_unwrap_smart_ptr(
     const std::shared_ptr<U>& value) {
   return value;


### PR DESCRIPTION
The `std::unique_ptr` case was added in #512, but it seems we never tested if `std::unique_ptr` can actually be used for `SendableChooser`, and as #5071 discusses, move-only types (which includes `std::unique_ptr`) aren't valid for `SendableChooser`.