### PR TITLE
[wpimath] Remove duplicate calls to norm() in Quaternion::Log()

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Quaternion.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Quaternion.java
@@ -285,11 +285,12 @@ public class Quaternion implements ProtobufSerializable, StructSerializable {
    * @return The logarithm of this quaternion.
    */
   public Quaternion log() {
-    var scalar = Math.log(norm());
+    var norm = norm();
+    var scalar = Math.log(norm);
 
     var v_norm = Math.sqrt(getX() * getX() + getY() * getY() + getZ() * getZ());
 
-    var s_norm = getW() / norm();
+    var s_norm = getW() / norm;
 
     if (Math.abs(s_norm + 1) < 1e-9) {
       return new Quaternion(scalar, -Math.PI, 0, 0);

--- a/wpimath/src/main/native/cpp/geometry/Quaternion.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Quaternion.cpp
@@ -136,11 +136,12 @@ Quaternion Quaternion::Log(const Quaternion& other) const {
 }
 
 Quaternion Quaternion::Log() const {
-  double scalar = std::log(Norm());
+  double norm = Norm();
+  double scalar = std::log(norm);
 
   double v_norm = m_v.norm();
 
-  double s_norm = W() / Norm();
+  double s_norm = W() / norm;
 
   if (std::abs(s_norm + 1) < 1e-9) {
     return Quaternion{scalar, -std::numbers::pi, 0, 0};


### PR DESCRIPTION
Norm() doesn't look to be super cheap, and log seems to be called a decent amount. Easy optimization.