### PR TITLE
[wpilibc] SysIdRoutineLog: Initialize m_stateInitialized

### DIFF
--- a/wpilibc/src/main/native/include/frc/sysid/SysIdRoutineLog.h
+++ b/wpilibc/src/main/native/include/frc/sysid/SysIdRoutineLog.h
@@ -194,7 +194,7 @@ class SysIdRoutineLog {
  private:
   LogEntries m_logEntries;
   std::string m_logName;
-  bool m_stateInitialized;
+  bool m_stateInitialized = false;
   wpi::log::StringLogEntry m_state;
 };
 }  // namespace frc::sysid


### PR DESCRIPTION
Fixes the m_stateInitialized not being initialized which causes non deterministic behavior as to if the `sysid-test-state-` will appear in the log.