### PR TITLE
Error out of hal initialize if SetupRioNow fails

### DIFF
--- a/wpiutil/src/main/native/include/wpi/timestamp.h
+++ b/wpiutil/src/main/native/include/wpi/timestamp.h
@@ -74,10 +74,10 @@ void SetupNowDefaultOnRio();
  */
 #ifdef __FRC_ROBORIO__
 template <typename T>
-void SetupNowRio(void* chipObjectLibrary, std::unique_ptr<T> hmbObject);
+bool SetupNowRio(void* chipObjectLibrary, std::unique_ptr<T> hmbObject);
 #else
 template <typename T>
-inline void SetupNowRio(void*, std::unique_ptr<T>) {}
+inline bool SetupNowRio(void*, std::unique_ptr<T>) { return true; }
 #endif
 
 /**
@@ -85,7 +85,7 @@ inline void SetupNowRio(void*, std::unique_ptr<T>) {}
  * No effect on non-Rio platforms. This take an FPGA session that has
  * already been initialized, and is used from LabVIEW.
  */
-void SetupNowRio(uint32_t session);
+bool SetupNowRio(uint32_t session);
 
 /**
  * De-initialize the on-Rio Now() implementation. No effect on non-Rio

--- a/wpiutil/src/main/native/include/wpi/timestamp.h
+++ b/wpiutil/src/main/native/include/wpi/timestamp.h
@@ -77,7 +77,9 @@ template <typename T>
 bool SetupNowRio(void* chipObjectLibrary, std::unique_ptr<T> hmbObject);
 #else
 template <typename T>
-inline bool SetupNowRio(void*, std::unique_ptr<T>) { return true; }
+inline bool SetupNowRio(void*, std::unique_ptr<T>) {
+  return true;
+}
 #endif
 
 /**


### PR DESCRIPTION
This might help root cause of the spam error message on wpi::now() failing.