### PR TITLE
[hal] Sim HAL_RefreshDSData: Update control word with DS data

### DIFF
--- a/hal/src/main/native/sim/DriverStation.cpp
+++ b/hal/src/main/native/sim/DriverStation.cpp
@@ -334,8 +334,8 @@ HAL_Bool HAL_RefreshDSData(void) {
   JoystickDataCache* prev = currentCache.exchange(nullptr);
   if (prev != nullptr) {
     currentRead = prev;
+    newestControlWord = controlWord;
   }
-  newestControlWord = controlWord;
   return prev != nullptr;
 }
 


### PR DESCRIPTION
Previously, it was possible to be enabled before the joystick cache was synchronized, which resulted in alliance color not being valid in user code AutonomousInit.