### PR TITLE
[hal] HAL_RefreshDSData: Zero out control word on DS disconnected, Use cache in sim

### DIFF
--- a/hal/src/main/native/athena/FRCDriverStation.cpp
+++ b/hal/src/main/native/athena/FRCDriverStation.cpp
@@ -539,15 +539,24 @@ HAL_Bool HAL_RefreshDSData(void) {
     }
     // If newest state shows we have a DS attached, just use the
     // control word out of the cache, As it will be the one in sync
-    // with the data. Otherwise use the state that shows disconnected.
-    if (controlWord.dsAttached) {
-      newestControlWord = currentRead->controlWord;
-    } else {
-      // Zero out the control word. When the DS has never been connected
-      // this returns garbage. And there is no way we can detect that.
-      std::memset(&controlWord, 0, sizeof(controlWord));
-      newestControlWord = controlWord;
+    // with the data. If no data has been updated, at this point,
+    // and a DS wasn't attached previously, this will still return
+    // a zeroed out control word, with is the correct state for
+    // no new data.
+    if (!dsAttached) {
+      // If the DS is not attached, we need to zero out the control word.
+      // This is because HAL_RefreshDSData is called asynchronously from
+      // the DS data. The dsAttached variable comes directly from netcomm
+      // and could be updated before the caches are. If that happens,
+      // we would end up returning the previous cached control word,
+      // which is out of sync with the current control word and could
+      // break invariants such as which alliance station is in used.
+      // Also, when the DS has never been connected the rest of the fields
+      // in control word are garbage, so we also need to zero out in that
+      // case too
+      std::memset(&currentRead->controlWord, 0, sizeof(currentRead->controlWord));
     }
+    newestControlWord = currentRead->controlWord;
   }
 
   uint32_t mask = tcpMask.exchange(0);

--- a/hal/src/main/native/athena/FRCDriverStation.cpp
+++ b/hal/src/main/native/athena/FRCDriverStation.cpp
@@ -543,7 +543,7 @@ HAL_Bool HAL_RefreshDSData(void) {
     // and a DS wasn't attached previously, this will still return
     // a zeroed out control word, with is the correct state for
     // no new data.
-    if (!dsAttached) {
+    if (!controlWord.dsAttached) {
       // If the DS is not attached, we need to zero out the control word.
       // This is because HAL_RefreshDSData is called asynchronously from
       // the DS data. The dsAttached variable comes directly from netcomm
@@ -554,7 +554,8 @@ HAL_Bool HAL_RefreshDSData(void) {
       // Also, when the DS has never been connected the rest of the fields
       // in control word are garbage, so we also need to zero out in that
       // case too
-      std::memset(&currentRead->controlWord, 0, sizeof(currentRead->controlWord));
+      std::memset(&currentRead->controlWord, 0,
+                  sizeof(currentRead->controlWord));
     }
     newestControlWord = currentRead->controlWord;
   }

--- a/hal/src/main/native/sim/DriverStation.cpp
+++ b/hal/src/main/native/sim/DriverStation.cpp
@@ -341,14 +341,24 @@ HAL_Bool HAL_RefreshDSData(void) {
   }
   // If newest state shows we have a DS attached, just use the
   // control word out of the cache, As it will be the one in sync
-  // with the data. Otherwise use the state that shows disconnected.
-  if (dsAttached) {
-    newestControlWord = currentRead->controlWord;
-  } else {
-    // Zero out the control word. When the DS has never been connected
-    // this returns garbage. And there is no way we can detect that.
-    std::memset(&newestControlWord, 0, sizeof(newestControlWord));
+  // with the data. If no data has been updated, at this point,
+  // and a DS wasn't attached previously, this will still return
+  // a zeroed out control word, with is the correct state for
+  // no new data.
+  if (!dsAttached) {
+    // If the DS is not attached, we need to zero out the control word.
+    // This is because HAL_RefreshDSData is called asynchronously from
+    // the DS data. The dsAttached variable comes directly from netcomm
+    // and could be updated before the caches are. If that happens,
+    // we would end up returning the previous cached control word,
+    // which is out of sync with the current control word and could
+    // break invariants such as which alliance station is in used.
+    // Also, when the DS has never been connected the rest of the fields
+    // in control word are garbage, so we also need to zero out in that
+    // case too
+    std::memset(&currentRead->controlWord, 0, sizeof(currentRead->controlWord));
   }
+  newestControlWord = currentRead->controlWord;
   return prev != nullptr;
 }
 

--- a/hal/src/main/native/sim/DriverStation.cpp
+++ b/hal/src/main/native/sim/DriverStation.cpp
@@ -382,6 +382,7 @@ void NewDriverStationData() {
   if (gShutdown) {
     return;
   }
+  SimDriverStationData->dsAttached = true;
   cacheToUpdate->Update();
 
   JoystickDataCache* given = cacheToUpdate;
@@ -395,7 +396,6 @@ void NewDriverStationData() {
   }
   lastGiven = given;
 
-  SimDriverStationData->dsAttached = true;
   driverStation->newDataEvents.Wakeup();
   SimDriverStationData->CallNewDataCallbacks();
 }

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/RobotModeTriggersTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/RobotModeTriggersTest.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj2.command.button;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.simulation.DriverStationSim;
 import edu.wpi.first.wpilibj2.command.CommandTestBase;
 import org.junit.jupiter.api.Test;
@@ -18,7 +17,7 @@ class RobotModeTriggersTest extends CommandTestBase {
     DriverStationSim.setAutonomous(true);
     DriverStationSim.setTest(false);
     DriverStationSim.setEnabled(true);
-    DriverStation.refreshData();
+    DriverStationSim.notifyNewData();
     Trigger auto = RobotModeTriggers.autonomous();
     assertTrue(auto.getAsBoolean());
   }
@@ -29,7 +28,7 @@ class RobotModeTriggersTest extends CommandTestBase {
     DriverStationSim.setAutonomous(false);
     DriverStationSim.setTest(false);
     DriverStationSim.setEnabled(true);
-    DriverStation.refreshData();
+    DriverStationSim.notifyNewData();
     Trigger teleop = RobotModeTriggers.teleop();
     assertTrue(teleop.getAsBoolean());
   }
@@ -40,7 +39,7 @@ class RobotModeTriggersTest extends CommandTestBase {
     DriverStationSim.setAutonomous(false);
     DriverStationSim.setTest(true);
     DriverStationSim.setEnabled(true);
-    DriverStation.refreshData();
+    DriverStationSim.notifyNewData();
     Trigger test = RobotModeTriggers.test();
     assertTrue(test.getAsBoolean());
   }
@@ -51,7 +50,7 @@ class RobotModeTriggersTest extends CommandTestBase {
     DriverStationSim.setAutonomous(false);
     DriverStationSim.setTest(false);
     DriverStationSim.setEnabled(false);
-    DriverStation.refreshData();
+    DriverStationSim.notifyNewData();
     Trigger disabled = RobotModeTriggers.disabled();
     assertTrue(disabled.getAsBoolean());
   }

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/button/RobotModeTriggersTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/button/RobotModeTriggersTest.cpp
@@ -18,7 +18,7 @@ TEST(RobotModeTriggersTest, Autonomous) {
   DriverStationSim::SetAutonomous(true);
   DriverStationSim::SetTest(false);
   DriverStationSim::SetEnabled(true);
-  frc::DriverStation::RefreshData();
+  DriverStationSim::NotifyNewData();
   Trigger autonomous = RobotModeTriggers::Autonomous();
   EXPECT_TRUE(autonomous.Get());
 }
@@ -28,7 +28,7 @@ TEST(RobotModeTriggersTest, Teleop) {
   DriverStationSim::SetAutonomous(false);
   DriverStationSim::SetTest(false);
   DriverStationSim::SetEnabled(true);
-  frc::DriverStation::RefreshData();
+  DriverStationSim::NotifyNewData();
   Trigger teleop = RobotModeTriggers::Teleop();
   EXPECT_TRUE(teleop.Get());
 }
@@ -38,7 +38,7 @@ TEST(RobotModeTriggersTest, Disabled) {
   DriverStationSim::SetAutonomous(false);
   DriverStationSim::SetTest(false);
   DriverStationSim::SetEnabled(false);
-  frc::DriverStation::RefreshData();
+  DriverStationSim::NotifyNewData();
   Trigger disabled = RobotModeTriggers::Disabled();
   EXPECT_TRUE(disabled.Get());
 }
@@ -48,7 +48,7 @@ TEST(RobotModeTriggersTest, TestMode) {
   DriverStationSim::SetAutonomous(false);
   DriverStationSim::SetTest(true);
   DriverStationSim::SetEnabled(true);
-  frc::DriverStation::RefreshData();
+  DriverStationSim::NotifyNewData();
   Trigger test = RobotModeTriggers::Test();
   EXPECT_TRUE(test.Get());
 }


### PR DESCRIPTION
Replaces #6379 

We need to have the control word match the control data that is part of the whole DS data structure. However, we need to handle the case where the DS disconnects, which will cause a timeout. We already had the logic to do this on the roboRIO, copy that logic here.