### PR TITLE
Cache layout loaded from AprilTagFields resource json

### DIFF
--- a/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFieldLayout.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFieldLayout.java
@@ -230,9 +230,9 @@ public class AprilTagFieldLayout {
    * @throws UncheckedIOException If the layout does not exist.
    */
   public static AprilTagFieldLayout loadField(AprilTagFields field) {
-    if (field.m_FieldLayout == null) {
+    if (field.m_fieldLayout == null) {
       try {
-        field.m_FieldLayout = loadFromResource(field.m_resourceFile);
+        field.m_fieldLayout = loadFromResource(field.m_resourceFile);
       } catch (IOException e) {
         throw new UncheckedIOException(
             "Could not load AprilTagFieldLayout from " + field.m_resourceFile, e);
@@ -240,9 +240,9 @@ public class AprilTagFieldLayout {
     }
     // Copy layout because the layout's origin is mutable
     return new AprilTagFieldLayout(
-        field.m_FieldLayout.getTags(),
-        field.m_FieldLayout.getFieldLength(),
-        field.m_FieldLayout.getFieldWidth());
+        field.m_fieldLayout.getTags(),
+        field.m_fieldLayout.getFieldLength(),
+        field.m_fieldLayout.getFieldWidth());
   }
 
   /**

--- a/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFieldLayout.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFieldLayout.java
@@ -230,12 +230,19 @@ public class AprilTagFieldLayout {
    * @throws UncheckedIOException If the layout does not exist.
    */
   public static AprilTagFieldLayout loadField(AprilTagFields field) {
-    try {
-      return loadFromResource(field.m_resourceFile);
-    } catch (IOException e) {
-      throw new UncheckedIOException(
-          "Could not load AprilTagFieldLayout from " + field.m_resourceFile, e);
+    if (field.m_FieldLayout == null) {
+      try {
+        field.m_FieldLayout = loadFromResource(field.m_resourceFile);
+      } catch (IOException e) {
+        throw new UncheckedIOException(
+            "Could not load AprilTagFieldLayout from " + field.m_resourceFile, e);
+      }
     }
+    // Copy layout because the layout's origin is mutable
+    return new AprilTagFieldLayout(
+        field.m_FieldLayout.getTags(),
+        field.m_FieldLayout.getFieldLength(),
+        field.m_FieldLayout.getFieldWidth());
   }
 
   /**

--- a/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFields.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFields.java
@@ -24,7 +24,7 @@ public enum AprilTagFields {
   /** Resource filename. */
   public final String m_resourceFile;
 
-  AprilTagFieldLayout m_FieldLayout = null;
+  AprilTagFieldLayout m_fieldLayout;
 
   AprilTagFields(String resourceFile) {
     m_resourceFile = kBaseResourceDir + resourceFile;

--- a/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFields.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFields.java
@@ -24,6 +24,8 @@ public enum AprilTagFields {
   /** Resource filename. */
   public final String m_resourceFile;
 
+  AprilTagFieldLayout m_FieldLayout = null;
+
   AprilTagFields(String resourceFile) {
     m_resourceFile = kBaseResourceDir + resourceFile;
   }


### PR DESCRIPTION
This will decrease the impact of calling `AprilTagFieldLayout.loadAprilTagLayoutField()` repeatedly (seen a few times on Discord/team github repos).

It will unfortunately still allocate because the origin of the field layout is mutable and could be changed by callers, so a fresh construction is needed.

Not sure the most ergonomic/idiomatic way to do this for c++; Also not sure how necessary it is (in both performance impact and likelihood of userbase to make the same mistake)