### PR TITLE
Deprecate AbsoluteEncoder classes, Replace DCE with DutyCyclePotentiometer

### DIFF
--- a/myRobot/src/main/java/frc/robot/MyRobot.java
+++ b/myRobot/src/main/java/frc/robot/MyRobot.java
@@ -4,15 +4,21 @@
 
 package frc.robot;
 
+import edu.wpi.first.wpilibj.DutyCyclePotentiometer;
 import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 public class MyRobot extends TimedRobot {
+  DutyCyclePotentiometer pot;
   /**
    * This function is run when the robot is first started up and should be used for any
    * initialization code.
    */
   @Override
-  public void robotInit() {}
+  public void robotInit() {
+    pot = new DutyCyclePotentiometer(0);
+    pot.setAssumedFrequency(967.77);
+  }
 
   /** This function is run once each time the robot enters autonomous mode. */
   @Override
@@ -36,5 +42,8 @@ public class MyRobot extends TimedRobot {
 
   /** This function is called periodically during all modes. */
   @Override
-  public void robotPeriodic() {}
+  public void robotPeriodic() {
+    SmartDashboard.putNumber("DC", pot.get());
+    SmartDashboard.putNumber("Freq", pot.getFrequency());
+  }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogEncoder.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogEncoder.java
@@ -13,7 +13,13 @@ import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.AnalogTriggerOutput.AnalogTriggerType;
 
-/** Class for supporting continuous analog encoders, such as the US Digital MA3. */
+/**
+ * Class for supporting continuous analog encoders, such as the US Digital MA3.
+ *
+ * @deprecated Use AnalogPotentiometer instead. If rollover support is necessary,
+ * use enableRolloverSupport() on AnalogPotentiometer.
+ */
+@Deprecated(since = "2025", forRemoval = true)
 public class AnalogEncoder implements Sendable, AutoCloseable {
   private final AnalogInput m_analogInput;
   private AnalogTrigger m_analogTrigger;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometer.java
@@ -4,13 +4,20 @@
 
 package edu.wpi.first.wpilibj;
 
+import static edu.wpi.first.util.ErrorMessages.requireNonNullParam;
+import edu.wpi.first.hal.SimDevice;
+import edu.wpi.first.hal.SimDouble;
+import edu.wpi.first.hal.SimDevice.Direction;
 import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.util.sendable.SendableRegistry;
+import edu.wpi.first.wpilibj.AnalogTriggerOutput.AnalogTriggerType;
 
 /**
- * Class for reading analog potentiometers. Analog potentiometers read in an analog voltage that
- * corresponds to a position. The position is in whichever units you choose, by way of the scaling
+ * Class for reading analog potentiometers. Analog potentiometers read in an
+ * analog voltage that
+ * corresponds to a position. The position is in whichever units you choose, by
+ * way of the scaling
  * and offset constants passed to the constructor.
  */
 public class AnalogPotentiometer implements Sendable, AutoCloseable {
@@ -18,20 +25,42 @@ public class AnalogPotentiometer implements Sendable, AutoCloseable {
   private boolean m_initAnalogInput;
   private double m_fullRange;
   private double m_offset;
+  private AnalogTrigger m_rotationTrigger;
+  private Counter m_rotationCounter;
+  private double m_lastPosition;
+
+  private SimDevice m_simDevice;
+  private SimDouble m_simPosition;
+
+  private void init() {
+    m_simDevice = SimDevice.create("AnalogPotentiometer", m_analogInput.getChannel());
+
+    if (m_simDevice != null) {
+      m_simPosition = m_simDevice.createDouble("Position", Direction.kInput, 0.0);
+    }
+  }
 
   /**
    * AnalogPotentiometer constructor.
    *
-   * <p>Use the fullRange and offset values so that the output produces meaningful values. I.E: you
-   * have a 270 degree potentiometer, and you want the output to be degrees with the halfway point
-   * as 0 degrees. The fullRange value is 270.0(degrees) and the offset is -135.0 since the halfway
-   * point after scaling is 135 degrees. This will calculate the result from the fullRange times the
+   * <p>
+   * Use the fullRange and offset values so that the output produces meaningful
+   * values. I.E: you
+   * have a 270 degree potentiometer, and you want the output to be degrees with
+   * the halfway point
+   * as 0 degrees. The fullRange value is 270.0(degrees) and the offset is -135.0
+   * since the halfway
+   * point after scaling is 135 degrees. This will calculate the result from the
+   * fullRange times the
    * fraction of the supply voltage, plus the offset.
    *
-   * @param channel The analog input channel this potentiometer is plugged into. 0-3 are on-board
-   *     and 4-7 are on the MXP port.
-   * @param fullRange The scaling to multiply the fraction by to get a meaningful unit.
-   * @param offset The offset to add to the scaled value for controlling the zero value
+   * @param channel   The analog input channel this potentiometer is plugged into.
+   *                  0-3 are on-board
+   *                  and 4-7 are on the MXP port.
+   * @param fullRange The scaling to multiply the fraction by to get a meaningful
+   *                  unit.
+   * @param offset    The offset to add to the scaled value for controlling the
+   *                  zero value
    */
   @SuppressWarnings("this-escape")
   public AnalogPotentiometer(final int channel, double fullRange, double offset) {
@@ -43,37 +72,51 @@ public class AnalogPotentiometer implements Sendable, AutoCloseable {
   /**
    * AnalogPotentiometer constructor.
    *
-   * <p>Use the fullRange and offset values so that the output produces meaningful values. I.E: you
-   * have a 270 degree potentiometer, and you want the output to be degrees with the halfway point
-   * as 0 degrees. The fullRange value is 270.0(degrees) and the offset is -135.0 since the halfway
-   * point after scaling is 135 degrees. This will calculate the result from the fullRange times the
+   * <p>
+   * Use the fullRange and offset values so that the output produces meaningful
+   * values. I.E: you
+   * have a 270 degree potentiometer, and you want the output to be degrees with
+   * the halfway point
+   * as 0 degrees. The fullRange value is 270.0(degrees) and the offset is -135.0
+   * since the halfway
+   * point after scaling is 135 degrees. This will calculate the result from the
+   * fullRange times the
    * fraction of the supply voltage, plus the offset.
    *
-   * @param input The {@link AnalogInput} this potentiometer is plugged into.
-   * @param fullRange The angular value (in desired units) representing the full 0-5V range of the
-   *     input.
-   * @param offset The angular value (in desired units) representing the angular output at 0V.
+   * @param input     The {@link AnalogInput} this potentiometer is plugged into.
+   * @param fullRange The angular value (in desired units) representing the full
+   *                  0-5V range of the
+   *                  input.
+   * @param offset    The angular value (in desired units) representing the
+   *                  angular output at 0V.
    */
   @SuppressWarnings("this-escape")
   public AnalogPotentiometer(final AnalogInput input, double fullRange, double offset) {
     SendableRegistry.addLW(this, "AnalogPotentiometer", input.getChannel());
-    m_analogInput = input;
+    m_analogInput = requireNonNullParam(input, "input", "AnalogPotentiometer");
     m_initAnalogInput = false;
 
     m_fullRange = fullRange;
     m_offset = offset;
+
+    init();
   }
 
   /**
    * AnalogPotentiometer constructor.
    *
-   * <p>Use the scale value so that the output produces meaningful values. I.E: you have a 270
-   * degree potentiometer, and you want the output to be degrees with the starting point as 0
+   * <p>
+   * Use the scale value so that the output produces meaningful values. I.E: you
+   * have a 270
+   * degree potentiometer, and you want the output to be degrees with the starting
+   * point as 0
    * degrees. The scale value is 270.0(degrees).
    *
-   * @param channel The analog input channel this potentiometer is plugged into. 0-3 are on-board
-   *     and 4-7 are on the MXP port.
-   * @param scale The scaling to multiply the voltage by to get a meaningful unit.
+   * @param channel The analog input channel this potentiometer is plugged into.
+   *                0-3 are on-board
+   *                and 4-7 are on the MXP port.
+   * @param scale   The scaling to multiply the voltage by to get a meaningful
+   *                unit.
    */
   public AnalogPotentiometer(final int channel, double scale) {
     this(channel, scale, 0);
@@ -82,8 +125,11 @@ public class AnalogPotentiometer implements Sendable, AutoCloseable {
   /**
    * AnalogPotentiometer constructor.
    *
-   * <p>Use the fullRange and offset values so that the output produces meaningful values. I.E: you
-   * have a 270 degree potentiometer, and you want the output to be degrees with the starting point
+   * <p>
+   * Use the fullRange and offset values so that the output produces meaningful
+   * values. I.E: you
+   * have a 270 degree potentiometer, and you want the output to be degrees with
+   * the starting point
    * as 0 degrees. The scale value is 270.0(degrees).
    *
    * @param input The {@link AnalogInput} this potentiometer is plugged into.
@@ -96,10 +142,12 @@ public class AnalogPotentiometer implements Sendable, AutoCloseable {
   /**
    * AnalogPotentiometer constructor.
    *
-   * <p>The potentiometer will return a value between 0 and 1.0.
+   * <p>
+   * The potentiometer will return a value between 0 and 1.0.
    *
-   * @param channel The analog input channel this potentiometer is plugged into. 0-3 are on-board
-   *     and 4-7 are on the MXP port.
+   * @param channel The analog input channel this potentiometer is plugged into.
+   *                0-3 are on-board
+   *                and 4-7 are on the MXP port.
    */
   public AnalogPotentiometer(final int channel) {
     this(channel, 1, 0);
@@ -108,12 +156,43 @@ public class AnalogPotentiometer implements Sendable, AutoCloseable {
   /**
    * AnalogPotentiometer constructor.
    *
-   * <p>The potentiometer will return a value between 0 and 1.0.
+   * <p>
+   * The potentiometer will return a value between 0 and 1.0.
    *
    * @param input The {@link AnalogInput} this potentiometer is plugged into.
    */
   public AnalogPotentiometer(final AnalogInput input) {
     this(input, 1, 0);
+  }
+
+  private boolean doubleEquals(double a, double b) {
+    double epsilon = 0.00001d;
+    return Math.abs(a - b) < epsilon;
+  }
+
+  private double getRollovers() {
+    if (m_simPosition != null) {
+      return m_simPosition.get();
+    }
+
+    // As the values are not atomic, keep trying until we get 2 reads of the same
+    // value. If we don't within 10 attempts, warn
+    for (int i = 0; i < 10; i++) {
+      double counter = m_rotationCounter.get();
+      double pos = m_analogInput.getVoltage();
+      double counter2 = m_rotationCounter.get();
+      double pos2 = m_analogInput.getVoltage();
+      if (counter == counter2 && doubleEquals(pos, pos2)) {
+        pos = pos / RobotController.getVoltage5V();
+        double position = (counter + pos) * m_fullRange + m_offset;
+        m_lastPosition = position;
+        return position;
+      }
+    }
+
+    DriverStation.reportWarning(
+        "Failed to read Analog Encoder. Potential Speed Overrun. Returning last value", false);
+    return m_lastPosition;
   }
 
   /**
@@ -122,11 +201,35 @@ public class AnalogPotentiometer implements Sendable, AutoCloseable {
    * @return The current position of the potentiometer.
    */
   public double get() {
-    if (m_analogInput == null) {
-      return m_offset;
+    if (m_simPosition != null) {
+      return m_simPosition.get();
     }
+
+    if (m_rotationCounter != null) {
+      return getRollovers();
+    }
+
     return (m_analogInput.getAverageVoltage() / RobotController.getVoltage5V()) * m_fullRange
         + m_offset;
+  }
+
+  public void enableRolloverSupport() {
+    if (m_rotationCounter != null) {
+      return;
+    }
+    m_rotationTrigger = new AnalogTrigger(m_analogInput);
+    m_rotationCounter = new Counter();
+
+    // Limits need to be 25% from each end
+    m_rotationTrigger.setLimitsVoltage(1.25, 3.75);
+    m_rotationCounter.setUpSource(m_rotationTrigger, AnalogTriggerType.kRisingPulse);
+    m_rotationCounter.setDownSource(m_rotationTrigger, AnalogTriggerType.kFallingPulse);
+  }
+
+  public void resetRollovers() {
+    if (m_rotationCounter != null) {
+      m_rotationCounter.reset();
+    }
   }
 
   @Override
@@ -140,10 +243,17 @@ public class AnalogPotentiometer implements Sendable, AutoCloseable {
   @Override
   public void close() {
     SendableRegistry.remove(this);
+    if (m_rotationCounter != null) {
+      m_rotationCounter.close();
+      m_rotationTrigger.close();
+      m_rotationCounter = null;
+      m_rotationTrigger = null;
+    }
     if (m_initAnalogInput) {
       m_analogInput.close();
       m_analogInput = null;
       m_initAnalogInput = false;
     }
+
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycleEncoder.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycleEncoder.java
@@ -16,7 +16,11 @@ import edu.wpi.first.wpilibj.AnalogTriggerOutput.AnalogTriggerType;
 /**
  * Class for supporting duty cycle/PWM encoders, such as the US Digital MA3 with PWM Output, the
  * CTRE Mag Encoder, the Rev Hex Encoder, and the AM Mag Encoder.
+ *
+ * @deprecated Use DutyCyclePotentiometer instead. Rollover support is not supported for
+ * duty cycle encoders, there is no reliable way to do so.
  */
+@Deprecated(since = "2025", forRemoval = true)
 public class DutyCycleEncoder implements Sendable, AutoCloseable {
   private final DutyCycle m_dutyCycle;
   private boolean m_ownsDutyCycle;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCyclePotentiometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCyclePotentiometer.java
@@ -1,0 +1,330 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj;
+
+import static edu.wpi.first.util.ErrorMessages.requireNonNullParam;
+
+import edu.wpi.first.hal.SimBoolean;
+import edu.wpi.first.hal.SimDevice;
+import edu.wpi.first.hal.SimDevice.Direction;
+import edu.wpi.first.hal.SimDouble;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
+
+/**
+ * Class for reading duty cyle potentiometers. Duty cycle potentiometers read in
+ * an pwm signal that
+ * corresponds to a position. The position is in whichever units you choose, by
+ * way of the scaling
+ * and offset constants passed to the constructor.
+ */
+public class DutyCyclePotentiometer implements Sendable, AutoCloseable {
+    private DutyCycle m_dutyCycle;
+    private DigitalSource m_digitalSource;
+    private boolean m_ownsDutyCycle;
+    private double m_fullRange;
+    private double m_offset;
+    private int m_frequencyThreshold = 100;
+    private double m_periodNanos;
+
+    private SimDevice m_simDevice;
+    private SimDouble m_simPosition;
+    private SimBoolean m_simIsConnected;
+
+    private final void init(double fullRange, double offset) {
+        SendableRegistry.addLW(this, "DutyCyclePotentiometer", m_dutyCycle.getFPGAIndex());
+        m_fullRange = fullRange;
+        m_offset = offset;
+
+        m_simDevice = SimDevice.create("DutyCyclePotentiometer", m_dutyCycle.getFPGAIndex());
+
+        if (m_simDevice != null) {
+            m_simPosition = m_simDevice.createDouble("Position", Direction.kInput, 0.0);
+            m_simIsConnected = m_simDevice.createBoolean("Connected", SimDevice.Direction.kInput, true);
+        }
+    }
+
+    /**
+     * AnalogPotentiometer constructor.
+     *
+     * <p>
+     * Use the fullRange and offset values so that the output produces meaningful
+     * values. I.E: you
+     * have a 270 degree potentiometer, and you want the output to be degrees with
+     * the halfway point
+     * as 0 degrees. The fullRange value is 270.0(degrees) and the offset is -135.0
+     * since the halfway
+     * point after scaling is 135 degrees. This will calculate the result from the
+     * fullRange times the
+     * fraction of the supply voltage, plus the offset.
+     *
+     * @param channel   The analog input channel this potentiometer is plugged into.
+     *                  0-3 are on-board
+     *                  and 4-7 are on the MXP port.
+     * @param fullRange The scaling to multiply the fraction by to get a meaningful
+     *                  unit.
+     * @param offset    The offset to add to the scaled value for controlling the
+     *                  zero value
+     */
+    @SuppressWarnings("this-escape")
+    public DutyCyclePotentiometer(final int channel, double fullRange, double offset) {
+        m_digitalSource = new DigitalInput(channel);
+        m_dutyCycle = new DutyCycle(m_digitalSource);
+        m_ownsDutyCycle = true;
+        init(fullRange, offset);
+        SendableRegistry.addChild(this, m_dutyCycle);
+    }
+
+    /**
+     * AnalogPotentiometer constructor.
+     *
+     * <p>
+     * Use the fullRange and offset values so that the output produces meaningful
+     * values. I.E: you
+     * have a 270 degree potentiometer, and you want the output to be degrees with
+     * the halfway point
+     * as 0 degrees. The fullRange value is 270.0(degrees) and the offset is -135.0
+     * since the halfway
+     * point after scaling is 135 degrees. This will calculate the result from the
+     * fullRange times the
+     * fraction of the supply voltage, plus the offset.
+     *
+     * @param input     The {@link DutyCycle} this potentiometer is plugged into.
+     * @param fullRange The angular value (in desired units) representing the full
+     *                  0-5V range of the
+     *                  input.
+     * @param offset    The angular value (in desired units) representing the
+     *                  angular output at 0V.
+     */
+    @SuppressWarnings("this-escape")
+    public DutyCyclePotentiometer(final DigitalSource input, double fullRange, double offset) {
+        m_dutyCycle = new DutyCycle(requireNonNullParam(input, "input", "DutyCyclePotentiometer"));
+        m_ownsDutyCycle = true;
+        init(fullRange, offset);
+    }
+
+    /**
+     * AnalogPotentiometer constructor.
+     *
+     * <p>
+     * Use the fullRange and offset values so that the output produces meaningful
+     * values. I.E: you
+     * have a 270 degree potentiometer, and you want the output to be degrees with
+     * the halfway point
+     * as 0 degrees. The fullRange value is 270.0(degrees) and the offset is -135.0
+     * since the halfway
+     * point after scaling is 135 degrees. This will calculate the result from the
+     * fullRange times the
+     * fraction of the supply voltage, plus the offset.
+     *
+     * @param input     The {@link DutyCycle} this potentiometer is plugged into.
+     * @param fullRange The angular value (in desired units) representing the full
+     *                  0-5V range of the
+     *                  input.
+     * @param offset    The angular value (in desired units) representing the
+     *                  angular output at 0V.
+     */
+    @SuppressWarnings("this-escape")
+    public DutyCyclePotentiometer(final DutyCycle input, double fullRange, double offset) {
+        m_dutyCycle = requireNonNullParam(input, "input", "DutyCyclePotentiometer");
+        init(fullRange, offset);
+    }
+
+    /**
+     * AnalogPotentiometer constructor.
+     *
+     * <p>
+     * Use the scale value so that the output produces meaningful values. I.E: you
+     * have a 270
+     * degree potentiometer, and you want the output to be degrees with the starting
+     * point as 0
+     * degrees. The scale value is 270.0(degrees).
+     *
+     * @param channel The analog input channel this potentiometer is plugged into.
+     *                0-3 are on-board
+     *                and 4-7 are on the MXP port.
+     * @param scale   The scaling to multiply the voltage by to get a meaningful
+     *                unit.
+     */
+    public DutyCyclePotentiometer(final int channel, double scale) {
+        this(channel, scale, 0);
+    }
+
+    /**
+     * AnalogPotentiometer constructor.
+     *
+     * <p>
+     * Use the fullRange and offset values so that the output produces meaningful
+     * values. I.E: you
+     * have a 270 degree potentiometer, and you want the output to be degrees with
+     * the starting point
+     * as 0 degrees. The scale value is 270.0(degrees).
+     *
+     * @param input The {@link DutyCycle} this potentiometer is plugged into.
+     * @param scale The scaling to multiply the voltage by to get a meaningful unit.
+     */
+    public DutyCyclePotentiometer(final DigitalSource input, double scale) {
+        this(input, scale, 0);
+    }
+
+    /**
+     * AnalogPotentiometer constructor.
+     *
+     * <p>
+     * Use the fullRange and offset values so that the output produces meaningful
+     * values. I.E: you
+     * have a 270 degree potentiometer, and you want the output to be degrees with
+     * the starting point
+     * as 0 degrees. The scale value is 270.0(degrees).
+     *
+     * @param input The {@link DutyCycle} this potentiometer is plugged into.
+     * @param scale The scaling to multiply the voltage by to get a meaningful unit.
+     */
+    public DutyCyclePotentiometer(final DutyCycle input, double scale) {
+        this(input, scale, 0);
+    }
+
+    /**
+     * AnalogPotentiometer constructor.
+     *
+     * <p>
+     * The potentiometer will return a value between 0 and 1.0.
+     *
+     * @param channel The analog input channel this potentiometer is plugged into.
+     *                0-3 are on-board
+     *                and 4-7 are on the MXP port.
+     */
+    public DutyCyclePotentiometer(final int channel) {
+        this(channel, 1, 0);
+    }
+
+    /**
+     * AnalogPotentiometer constructor.
+     *
+     * <p>
+     * The potentiometer will return a value between 0 and 1.0.
+     *
+     * @param input The {@link DutyCycle} this potentiometer is plugged into.
+     */
+    public DutyCyclePotentiometer(final DigitalSource input) {
+        this(input, 1, 0);
+    }
+
+    /**
+     * AnalogPotentiometer constructor.
+     *
+     * <p>
+     * The potentiometer will return a value between 0 and 1.0.
+     *
+     * @param input The {@link DutyCycle} this potentiometer is plugged into.
+     */
+    public DutyCyclePotentiometer(final DutyCycle input) {
+        this(input, 1, 0);
+    }
+
+    /**
+     * Get the current reading of the potentiometer.
+     *
+     * @return The current position of the potentiometer.
+     */
+    public double get() {
+        if (m_simPosition != null) {
+            return m_simPosition.get();
+        }
+        double pos;
+        if (m_periodNanos == 0.0) {
+            pos = m_dutyCycle.getOutput();
+        } else {
+            int highTime = m_dutyCycle.getHighTimeNanoseconds();
+            pos = highTime / m_periodNanos;
+        }
+
+        return pos * m_fullRange + m_offset;
+    }
+
+    /**
+     * Get the frequency in Hz of the duty cycle signal from the encoder.
+     *
+     * @return duty cycle frequency in Hz
+     */
+    public int getFrequency() {
+        return m_dutyCycle.getFrequency();
+    }
+
+    /**
+     * Get if the sensor is connected
+     *
+     * <p>
+     * This uses the duty cycle frequency to determine if the sensor is connected.
+     * By default, a
+     * value of 100 Hz is used as the threshold, and this value can be changed with
+     * {@link
+     * #setConnectedFrequencyThreshold(int)}.
+     *
+     * @return true if the sensor is connected
+     */
+    public boolean isConnected() {
+        if (m_simIsConnected != null) {
+            return m_simIsConnected.get();
+        }
+        return getFrequency() > m_frequencyThreshold;
+    }
+
+    /**
+     * Change the frequency threshold for detecting connection used by
+     * {@link #isConnected()}.
+     *
+     * @param frequency the minimum frequency in Hz.
+     */
+    public void setConnectedFrequencyThreshold(int frequency) {
+        if (frequency < 0) {
+            frequency = 0;
+        }
+
+        m_frequencyThreshold = frequency;
+    }
+
+    /**
+     * Sets the assumed frequency of the connected device.
+     *
+     * <p>
+     * By default, the DutyCycle engine has to compute the frequency of the input
+     * signal. This can result in both delayed readings and jumpy readings. To solve
+     * this, you can pass the expected frequency of the sensor to this function.
+     * This will use that frequency to compute the DutyCycle percentage, rather than
+     * the computed frequency.
+     *
+     * @param frequency
+     */
+    public void setAssumedFrequency(double frequency) {
+        if (frequency == 0.0) {
+            m_periodNanos = 0.0;
+        } else {
+            m_periodNanos = 1000000000 / frequency;
+        }
+    }
+
+    @Override
+    public void initSendable(SendableBuilder builder) {
+        if (m_dutyCycle != null) {
+            builder.setSmartDashboardType("Analog Input");
+            builder.addDoubleProperty("Value", this::get, null);
+        }
+    }
+
+    @Override
+    public void close() {
+        SendableRegistry.remove(this);
+        if (m_ownsDutyCycle) {
+            m_dutyCycle.close();
+            m_dutyCycle = null;
+            m_ownsDutyCycle = false;
+        }
+        if (m_digitalSource != null) {
+            m_digitalSource.close();
+        }
+    }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/AnalogEncoderSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/AnalogEncoderSim.java
@@ -9,6 +9,7 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.AnalogEncoder;
 
 /** Class to control a simulated analog encoder. */
+@Deprecated()
 public class AnalogEncoderSim {
   private final SimDouble m_simPosition;
 
@@ -17,6 +18,7 @@ public class AnalogEncoderSim {
    *
    * @param encoder AnalogEncoder to simulate
    */
+  @SuppressWarnings("removal")
   public AnalogEncoderSim(AnalogEncoder encoder) {
     SimDeviceSim wrappedSimDevice =
         new SimDeviceSim("AnalogEncoder" + "[" + encoder.getChannel() + "]");

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DutyCycleEncoderSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DutyCycleEncoderSim.java
@@ -9,6 +9,7 @@ import edu.wpi.first.hal.SimDouble;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
 
 /** Class to control a simulated duty cycle encoder. */
+@Deprecated()
 public class DutyCycleEncoderSim {
   private final SimDouble m_simPosition;
   private final SimDouble m_simDistancePerRotation;
@@ -20,6 +21,7 @@ public class DutyCycleEncoderSim {
    *
    * @param encoder DutyCycleEncoder to simulate
    */
+  @SuppressWarnings("removal")
   public DutyCycleEncoderSim(DutyCycleEncoder encoder) {
     this(encoder.getSourceChannel());
   }


### PR DESCRIPTION
The existing AnalogEncoder and DutyCycleEncoder classes are massive footguns. They automatically include rollover support, which is often not what people want. Additionally, DutyCycle's rollover support is completely broken and cannot be trusted. It also cannot be easily fixed even at the FPGA level. 

To solve this, deprecate AnalogEncoder and DutyCycleEncoder. For AnalogEncoder, the fix is fairly easy, it's AnalogPotentiometer. It supports all the correct functionality. To AnalogPotentiometer, I have added an enableRollover() function that will enable rollover support if a user does want that.

DutyCycleEncoder has been replaced with DutyCyclePotentiometer (Maybe someone has a better name for this?). This class has no rollover support, and never will. However, it adds functionality for trivially working around the frequency fluctuation issue, which we should document how to use.