### PR TITLE
Add method to programmatically tell HAL extensions to load

### DIFF
--- a/hal/src/main/native/include/hal/Extensions.h
+++ b/hal/src/main/native/include/hal/Extensions.h
@@ -91,6 +91,13 @@ void HAL_SetShowExtensionsNotFoundMessages(HAL_Bool showMessage);
  */
 void HAL_OnShutdown(void* param, void (*func)(void*));
 
+/**
+ * Adds an extension to be loaded when HAL_LoadExtensions is called
+ * internally. Libraries will be loaded in addition to HALSIM_EXTENSIONS,
+ * without checking for duplicates.
+ */
+void HAL_AddExplicitExtension(const char* extensionPath);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif


### PR DESCRIPTION
Languages that can easily insert inject items from the build into the output binary can fairly easily tell the HAL what extensions they want to load. This can likely be cleaner than using environment variables, as running code might have more information. I can imagine python might use this to load extensions easier. I could also see switching Java to use this too potentially. Especially with the changes coming next year to not require LD_LIBRARY_PATH anymore.