### PR TITLE
[wpilibj] Call abort() on Rio on caught Java exception

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/HAL.java
+++ b/hal/src/main/java/edu/wpi/first/hal/HAL.java
@@ -75,9 +75,7 @@ public final class HAL extends JNIWrapper {
    */
   public static native void exitMain();
 
-  /**
-   * Terminates the executable (at the native level). Does nothing in simulation.
-   */
+  /** Terminates the executable (at the native level). Does nothing in simulation. */
   public static native void terminate();
 
   private static native void simPeriodicBeforeNative();

--- a/hal/src/main/java/edu/wpi/first/hal/HAL.java
+++ b/hal/src/main/java/edu/wpi/first/hal/HAL.java
@@ -75,6 +75,11 @@ public final class HAL extends JNIWrapper {
    */
   public static native void exitMain();
 
+  /**
+   * Terminates the executable (at the native level). Does nothing in simulation.
+   */
+  public static native void terminate();
+
   private static native void simPeriodicBeforeNative();
 
   private static final List<Runnable> s_simPeriodicBefore = new ArrayList<>();

--- a/hal/src/main/native/cpp/jni/HAL.cpp
+++ b/hal/src/main/native/cpp/jni/HAL.cpp
@@ -88,7 +88,7 @@ Java_edu_wpi_first_hal_HAL_exitMain
  * Method:    terminate
  * Signature: ()Z
  */
-JNIEXPORT jboolean JNICALL
+JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_HAL_terminate
   (JNIEnv*, jclass)
 {

--- a/hal/src/main/native/cpp/jni/HAL.cpp
+++ b/hal/src/main/native/cpp/jni/HAL.cpp
@@ -86,7 +86,7 @@ Java_edu_wpi_first_hal_HAL_exitMain
 /*
  * Class:     edu_wpi_first_hal_HAL
  * Method:    terminate
- * Signature: ()Z
+ * Signature: ()V
  */
 JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_HAL_terminate

--- a/hal/src/main/native/cpp/jni/HAL.cpp
+++ b/hal/src/main/native/cpp/jni/HAL.cpp
@@ -7,6 +7,7 @@
 #include <jni.h>
 
 #include <cassert>
+#include <cstdlib>
 #include <cstring>
 
 #include <fmt/format.h>
@@ -80,6 +81,20 @@ Java_edu_wpi_first_hal_HAL_exitMain
   (JNIEnv*, jclass)
 {
   HAL_ExitMain();
+}
+
+/*
+ * Class:     edu_wpi_first_hal_HAL
+ * Method:    terminate
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_hal_HAL_terminate
+  (JNIEnv*, jclass)
+{
+#ifdef __FRC_ROBORIO__
+  std::abort();
+#endif
 }
 
 /*

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -453,6 +453,11 @@ public abstract class RobotBase implements AutoCloseable {
       runRobot(robotSupplier);
     }
 
+    // On RIO, this will just terminate rather than shutting down cleanly (it's a no-op in sim).
+    // It's not worth the risk of hanging on shutdown when we want the code to restart as quickly
+    // as possible.
+    HAL.terminate();
+
     HAL.shutdown();
 
     System.exit(0);


### PR DESCRIPTION
On Rio, we simply want to restart the robot program as quickly as possible, and don't want to risk a hang somewhere that will keep that from happening.