### PR TITLE
[Sim] Enable ConfigDockingWithShift in SimGui

### DIFF
--- a/simulation/halsim_gui/src/main/native/cpp/main.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/main.cpp
@@ -48,7 +48,7 @@ __declspec(dllexport)
 
   gui::CreateContext();
   glass::CreateContext();
-
+  gui::AddInit([] { ImGui::GetIO().ConfigDockingWithShift = true; });
   glass::SetStorageName("simgui");
 
   HAL_RegisterExtension(HALSIMGUI_EXT_ADDGUIINIT,


### PR DESCRIPTION
Docking is enabled when not holding shift, unlike in glass where it is not.
Closes: #6428 