### PR TITLE
[ntcore] Fix memory leak due to missing deallocations before reference clearing

### DIFF
--- a/ntcore/src/main/native/cpp/net/WebSocketConnection.cpp
+++ b/ntcore/src/main/native/cpp/net/WebSocketConnection.cpp
@@ -226,11 +226,6 @@ int WebSocketConnection::Flush() {
   m_ws_frames.clear();
   if (m_err) {
     m_frames.clear();
-    for(auto& _buf : m_bufs) {
-      if(_buf.len == 0) {
-        _buf.Deallocate();
-      }
-    }
     m_bufs.clear();
     return m_err.code();
   }
@@ -238,14 +233,11 @@ int WebSocketConnection::Flush() {
   int count = 0;
   for (auto&& frame :
        wpi::take_back(std::span{m_frames}, unsentFrames.size())) {
+    ReleaseBufs(
+        std::span{m_bufs}.subspan(frame.start, frame.end - frame.start));
     count += frame.count;
   }
   m_frames.clear();
-  for(auto& _buf : m_bufs) {
-    if(_buf.len == 0) {
-      _buf.Deallocate();
-    }
-  }
   m_bufs.clear();
   return count;
 }

--- a/ntcore/src/main/native/cpp/net/WebSocketConnection.cpp
+++ b/ntcore/src/main/native/cpp/net/WebSocketConnection.cpp
@@ -227,7 +227,9 @@ int WebSocketConnection::Flush() {
   if (m_err) {
     m_frames.clear();
     for(auto& _buf : m_bufs) {
-      if(_buf.len == 0) _buf.Deallocate();
+      if(_buf.len == 0) {
+        _buf.Deallocate();
+      }
     }
     m_bufs.clear();
     return m_err.code();
@@ -240,7 +242,9 @@ int WebSocketConnection::Flush() {
   }
   m_frames.clear();
   for(auto& _buf : m_bufs) {
-    if(_buf.len == 0) _buf.Deallocate();
+    if(_buf.len == 0) {
+      _buf.Deallocate();
+    }
   }
   m_bufs.clear();
   return count;

--- a/ntcore/src/main/native/cpp/net/WebSocketConnection.cpp
+++ b/ntcore/src/main/native/cpp/net/WebSocketConnection.cpp
@@ -226,6 +226,9 @@ int WebSocketConnection::Flush() {
   m_ws_frames.clear();
   if (m_err) {
     m_frames.clear();
+    for(auto& _buf : m_bufs) {
+      if(_buf.len == 0) _buf.Deallocate();
+    }
     m_bufs.clear();
     return m_err.code();
   }
@@ -236,6 +239,9 @@ int WebSocketConnection::Flush() {
     count += frame.count;
   }
   m_frames.clear();
+  for(auto& _buf : m_bufs) {
+    if(_buf.len == 0) _buf.Deallocate();
+  }
   m_bufs.clear();
   return count;
 }


### PR DESCRIPTION
## UPDATE: Please see [this comment](https://github.com/wpilibsuite/allwpilib/pull/6439#issuecomment-1998168552).
I stumbled upon a memory leak having to do with calls to `nt::net::WebSocketConnection::AllocBuf()` within `nt::net::WebSocketConnection::write_impl()` (only seems to happen as a result of sending large binary buffers over NT). I'm not sure if this is the correct solution but it seemed to fix the issue, so feel free to make or suggest changes as necessary.

For reference, here is a screenshot of the memory allocation trace - there is pretty obviously something wrong:
![Screenshot (15)](https://github.com/wpilibsuite/allwpilib/assets/60528506/ccc5e420-01da-4e25-ab1b-e75662b2b4a6)
