### PR TITLE
Trigger: pass m_loop to new Trigger in composition functions

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
@@ -237,7 +237,7 @@ public class Trigger implements BooleanSupplier {
    * @return A trigger which is active when both component triggers are active.
    */
   public Trigger and(BooleanSupplier trigger) {
-    return new Trigger(() -> m_condition.getAsBoolean() && trigger.getAsBoolean());
+    return new Trigger(m_loop, () -> m_condition.getAsBoolean() && trigger.getAsBoolean());
   }
 
   /**
@@ -247,7 +247,7 @@ public class Trigger implements BooleanSupplier {
    * @return A trigger which is active when either component trigger is active.
    */
   public Trigger or(BooleanSupplier trigger) {
-    return new Trigger(() -> m_condition.getAsBoolean() || trigger.getAsBoolean());
+    return new Trigger(m_loop, () -> m_condition.getAsBoolean() || trigger.getAsBoolean());
   }
 
   /**
@@ -257,7 +257,7 @@ public class Trigger implements BooleanSupplier {
    * @return the negated trigger
    */
   public Trigger negate() {
-    return new Trigger(() -> !m_condition.getAsBoolean());
+    return new Trigger(m_loop, () -> !m_condition.getAsBoolean());
   }
 
   /**
@@ -281,6 +281,7 @@ public class Trigger implements BooleanSupplier {
    */
   public Trigger debounce(double seconds, Debouncer.DebounceType type) {
     return new Trigger(
+        m_loop,
         new BooleanSupplier() {
           final Debouncer m_debouncer = new Debouncer(seconds, type);
 


### PR DESCRIPTION
This fixes a bug if you're passing a custom EventLoop to Trigger where composing the trigger will use the default event loop instead of the one passed. C++'s Trigger and BooleanEvent already do this, this is solely a deficiency in the Java Trigger implementation AFAICT.