### PR TITLE
[commands] Cache button and POV triggers

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandGenericHID.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandGenericHID.java
@@ -7,6 +7,8 @@ package edu.wpi.first.wpilibj2.command.button;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.event.EventLoop;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A version of {@link GenericHID} with {@link Trigger} factories for command-based.
@@ -15,6 +17,8 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
  */
 public class CommandGenericHID {
   private final GenericHID m_hid;
+  private final Map<EventLoop, Map<Integer, Trigger>> m_buttonCache = new HashMap<>();
+  private final Map<EventLoop, Map<Integer, Trigger>> m_povCache = new HashMap<>();
 
   /**
    * Construct an instance of a device.
@@ -54,7 +58,9 @@ public class CommandGenericHID {
    * @return an event instance representing the button's digital signal attached to the given loop.
    */
   public Trigger button(int button, EventLoop loop) {
-    return new Trigger(loop, () -> m_hid.getRawButton(button));
+    var cache = m_buttonCache.computeIfAbsent(loop, k -> new HashMap<>());
+    return cache.computeIfAbsent(button, k ->
+        new Trigger(loop, () -> m_hid.getRawButton(k)));
   }
 
   /**
@@ -85,7 +91,10 @@ public class CommandGenericHID {
    * @return a Trigger instance based around this angle of a POV on the HID.
    */
   public Trigger pov(int pov, int angle, EventLoop loop) {
-    return new Trigger(loop, () -> m_hid.getPOV(pov) == angle);
+    var cache = m_povCache.computeIfAbsent(loop, k -> new HashMap<>());
+    // angle can be -1, so use 3600 instead of 360
+    return cache.computeIfAbsent(pov * 3600 + angle, k ->
+        new Trigger(loop, () -> m_hid.getPOV(pov) == angle));
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandGenericHID.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandGenericHID.java
@@ -59,8 +59,7 @@ public class CommandGenericHID {
    */
   public Trigger button(int button, EventLoop loop) {
     var cache = m_buttonCache.computeIfAbsent(loop, k -> new HashMap<>());
-    return cache.computeIfAbsent(button, k ->
-        new Trigger(loop, () -> m_hid.getRawButton(k)));
+    return cache.computeIfAbsent(button, k -> new Trigger(loop, () -> m_hid.getRawButton(k)));
   }
 
   /**
@@ -93,8 +92,8 @@ public class CommandGenericHID {
   public Trigger pov(int pov, int angle, EventLoop loop) {
     var cache = m_povCache.computeIfAbsent(loop, k -> new HashMap<>());
     // angle can be -1, so use 3600 instead of 360
-    return cache.computeIfAbsent(pov * 3600 + angle, k ->
-        new Trigger(loop, () -> m_hid.getPOV(pov) == angle));
+    return cache.computeIfAbsent(
+        pov * 3600 + angle, k -> new Trigger(loop, () -> m_hid.getPOV(pov) == angle));
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandJoystick.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandJoystick.java
@@ -55,7 +55,7 @@ public class CommandJoystick extends CommandGenericHID {
    *     given loop.
    */
   public Trigger trigger(EventLoop loop) {
-    return m_hid.trigger(loop).castTo(Trigger::new);
+    return button(Joystick.ButtonType.kTrigger.value, loop);
   }
 
   /**
@@ -77,7 +77,7 @@ public class CommandJoystick extends CommandGenericHID {
    *     loop.
    */
   public Trigger top(EventLoop loop) {
-    return m_hid.top(loop).castTo(Trigger::new);
+    return button(Joystick.ButtonType.kTop.value, loop);
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandPS4Controller.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandPS4Controller.java
@@ -55,7 +55,7 @@ public class CommandPS4Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger L2(EventLoop loop) {
-    return m_hid.L2(loop).castTo(Trigger::new);
+    return button(PS4Controller.Button.kL2.value, loop);
   }
 
   /**
@@ -76,7 +76,7 @@ public class CommandPS4Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger R2(EventLoop loop) {
-    return m_hid.R2(loop).castTo(Trigger::new);
+    return button(PS4Controller.Button.kR2.value, loop);
   }
 
   /**
@@ -97,7 +97,7 @@ public class CommandPS4Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger L1(EventLoop loop) {
-    return m_hid.L1(loop).castTo(Trigger::new);
+    return button(PS4Controller.Button.kL1.value, loop);
   }
 
   /**
@@ -118,7 +118,7 @@ public class CommandPS4Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger R1(EventLoop loop) {
-    return m_hid.R1(loop).castTo(Trigger::new);
+    return button(PS4Controller.Button.kR1.value, loop);
   }
 
   /**
@@ -139,7 +139,7 @@ public class CommandPS4Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger L3(EventLoop loop) {
-    return m_hid.L3(loop).castTo(Trigger::new);
+    return button(PS4Controller.Button.kL3.value, loop);
   }
 
   /**
@@ -160,7 +160,7 @@ public class CommandPS4Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger R3(EventLoop loop) {
-    return m_hid.R3(loop).castTo(Trigger::new);
+    return button(PS4Controller.Button.kR3.value, loop);
   }
 
   /**
@@ -181,7 +181,7 @@ public class CommandPS4Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger square(EventLoop loop) {
-    return m_hid.square(loop).castTo(Trigger::new);
+    return button(PS4Controller.Button.kSquare.value, loop);
   }
 
   /**
@@ -202,7 +202,7 @@ public class CommandPS4Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger cross(EventLoop loop) {
-    return m_hid.cross(loop).castTo(Trigger::new);
+    return button(PS4Controller.Button.kCross.value, loop);
   }
 
   /**
@@ -223,7 +223,7 @@ public class CommandPS4Controller extends CommandGenericHID {
    *     given loop.
    */
   public Trigger triangle(EventLoop loop) {
-    return m_hid.triangle(loop).castTo(Trigger::new);
+    return button(PS4Controller.Button.kTriangle.value, loop);
   }
 
   /**
@@ -244,7 +244,7 @@ public class CommandPS4Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger circle(EventLoop loop) {
-    return m_hid.circle(loop).castTo(Trigger::new);
+    return button(PS4Controller.Button.kCircle.value, loop);
   }
 
   /**
@@ -265,7 +265,7 @@ public class CommandPS4Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger share(EventLoop loop) {
-    return m_hid.share(loop).castTo(Trigger::new);
+    return button(PS4Controller.Button.kShare.value, loop);
   }
 
   /**
@@ -286,7 +286,7 @@ public class CommandPS4Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger PS(EventLoop loop) {
-    return m_hid.PS(loop).castTo(Trigger::new);
+    return button(PS4Controller.Button.kPS.value, loop);
   }
 
   /**
@@ -307,7 +307,7 @@ public class CommandPS4Controller extends CommandGenericHID {
    *     given loop.
    */
   public Trigger options(EventLoop loop) {
-    return m_hid.options(loop).castTo(Trigger::new);
+    return button(PS4Controller.Button.kOptions.value, loop);
   }
 
   /**
@@ -328,7 +328,7 @@ public class CommandPS4Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger touchpad(EventLoop loop) {
-    return m_hid.touchpad(loop).castTo(Trigger::new);
+    return button(PS4Controller.Button.kTouchpad.value, loop);
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandPS5Controller.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandPS5Controller.java
@@ -55,7 +55,7 @@ public class CommandPS5Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger L2(EventLoop loop) {
-    return m_hid.L2(loop).castTo(Trigger::new);
+    return button(PS5Controller.Button.kL2.value, loop);
   }
 
   /**
@@ -76,7 +76,7 @@ public class CommandPS5Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger R2(EventLoop loop) {
-    return m_hid.R2(loop).castTo(Trigger::new);
+    return button(PS5Controller.Button.kR2.value, loop);
   }
 
   /**
@@ -97,7 +97,7 @@ public class CommandPS5Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger L1(EventLoop loop) {
-    return m_hid.L1(loop).castTo(Trigger::new);
+    return button(PS5Controller.Button.kL1.value, loop);
   }
 
   /**
@@ -118,7 +118,7 @@ public class CommandPS5Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger R1(EventLoop loop) {
-    return m_hid.R1(loop).castTo(Trigger::new);
+    return button(PS5Controller.Button.kR1.value, loop);
   }
 
   /**
@@ -139,7 +139,7 @@ public class CommandPS5Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger L3(EventLoop loop) {
-    return m_hid.L3(loop).castTo(Trigger::new);
+    return button(PS5Controller.Button.kL3.value, loop);
   }
 
   /**
@@ -160,7 +160,7 @@ public class CommandPS5Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger R3(EventLoop loop) {
-    return m_hid.R3(loop).castTo(Trigger::new);
+    return button(PS5Controller.Button.kR3.value, loop);
   }
 
   /**
@@ -181,7 +181,7 @@ public class CommandPS5Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger square(EventLoop loop) {
-    return m_hid.square(loop).castTo(Trigger::new);
+    return button(PS5Controller.Button.kSquare.value, loop);
   }
 
   /**
@@ -202,7 +202,7 @@ public class CommandPS5Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger cross(EventLoop loop) {
-    return m_hid.cross(loop).castTo(Trigger::new);
+    return button(PS5Controller.Button.kCross.value, loop);
   }
 
   /**
@@ -223,7 +223,7 @@ public class CommandPS5Controller extends CommandGenericHID {
    *     given loop.
    */
   public Trigger triangle(EventLoop loop) {
-    return m_hid.triangle(loop).castTo(Trigger::new);
+    return button(PS5Controller.Button.kTriangle.value, loop);
   }
 
   /**
@@ -244,7 +244,7 @@ public class CommandPS5Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger circle(EventLoop loop) {
-    return m_hid.circle(loop).castTo(Trigger::new);
+    return button(PS5Controller.Button.kCircle.value, loop);
   }
 
   /**
@@ -265,7 +265,7 @@ public class CommandPS5Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger create(EventLoop loop) {
-    return m_hid.create(loop).castTo(Trigger::new);
+    return button(PS5Controller.Button.kCreate.value, loop);
   }
 
   /**
@@ -286,7 +286,7 @@ public class CommandPS5Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger PS(EventLoop loop) {
-    return m_hid.PS(loop).castTo(Trigger::new);
+    return button(PS5Controller.Button.kPS.value, loop);
   }
 
   /**
@@ -307,7 +307,7 @@ public class CommandPS5Controller extends CommandGenericHID {
    *     given loop.
    */
   public Trigger options(EventLoop loop) {
-    return m_hid.options(loop).castTo(Trigger::new);
+    return button(PS5Controller.Button.kOptions.value, loop);
   }
 
   /**
@@ -328,7 +328,7 @@ public class CommandPS5Controller extends CommandGenericHID {
    *     loop.
    */
   public Trigger touchpad(EventLoop loop) {
-    return m_hid.touchpad(loop).castTo(Trigger::new);
+    return button(PS5Controller.Button.kTouchpad.value, loop);
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandStadiaController.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandStadiaController.java
@@ -56,7 +56,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     loop.
    */
   public Trigger leftBumper(EventLoop loop) {
-    return m_hid.leftBumper(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kLeftBumper.value, loop);
   }
 
   /**
@@ -78,7 +78,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     loop.
    */
   public Trigger rightBumper(EventLoop loop) {
-    return m_hid.rightBumper(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kRightBumper.value, loop);
   }
 
   /**
@@ -100,7 +100,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     given loop.
    */
   public Trigger leftStick(EventLoop loop) {
-    return m_hid.leftStick(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kLeftStick.value, loop);
   }
 
   /**
@@ -122,7 +122,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     given loop.
    */
   public Trigger rightStick(EventLoop loop) {
-    return m_hid.rightStick(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kRightStick.value, loop);
   }
 
   /**
@@ -144,7 +144,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     the given loop.
    */
   public Trigger rightTrigger(EventLoop loop) {
-    return m_hid.rightTrigger(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kRightTrigger.value, loop);
   }
 
   /**
@@ -166,7 +166,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     given loop.
    */
   public Trigger leftTrigger(EventLoop loop) {
-    return m_hid.leftTrigger(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kLeftTrigger.value, loop);
   }
 
   /**
@@ -188,7 +188,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     loop.
    */
   public Trigger a(EventLoop loop) {
-    return m_hid.a(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kA.value, loop);
   }
 
   /**
@@ -210,7 +210,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     loop.
    */
   public Trigger b(EventLoop loop) {
-    return m_hid.b(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kB.value, loop);
   }
 
   /**
@@ -232,7 +232,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     loop.
    */
   public Trigger x(EventLoop loop) {
-    return m_hid.x(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kX.value, loop);
   }
 
   /**
@@ -254,7 +254,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     loop.
    */
   public Trigger y(EventLoop loop) {
-    return m_hid.y(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kY.value, loop);
   }
 
   /**
@@ -276,7 +276,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     given loop.
    */
   public Trigger ellipses(EventLoop loop) {
-    return m_hid.ellipses(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kEllipses.value, loop);
   }
 
   /**
@@ -298,7 +298,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     loop.
    */
   public Trigger stadia(EventLoop loop) {
-    return m_hid.stadia(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kStadia.value, loop);
   }
 
   /**
@@ -320,7 +320,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     loop.
    */
   public Trigger google(EventLoop loop) {
-    return m_hid.google(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kGoogle.value, loop);
   }
 
   /**
@@ -342,7 +342,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     loop.
    */
   public Trigger frame(EventLoop loop) {
-    return m_hid.frame(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kFrame.value, loop);
   }
 
   /**
@@ -364,7 +364,7 @@ public class CommandStadiaController extends CommandGenericHID {
    *     given loop.
    */
   public Trigger hamburger(EventLoop loop) {
-    return m_hid.hamburger(loop).castTo(Trigger::new);
+    return button(StadiaController.Button.kHamburger.value, loop);
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandXboxController.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandXboxController.java
@@ -56,7 +56,7 @@ public class CommandXboxController extends CommandGenericHID {
    *     loop.
    */
   public Trigger leftBumper(EventLoop loop) {
-    return m_hid.leftBumper(loop).castTo(Trigger::new);
+    return button(XboxController.Button.kLeftBumper.value, loop);
   }
 
   /**
@@ -78,7 +78,7 @@ public class CommandXboxController extends CommandGenericHID {
    *     loop.
    */
   public Trigger rightBumper(EventLoop loop) {
-    return m_hid.rightBumper(loop).castTo(Trigger::new);
+    return button(XboxController.Button.kRightBumper.value, loop);
   }
 
   /**
@@ -100,7 +100,7 @@ public class CommandXboxController extends CommandGenericHID {
    *     given loop.
    */
   public Trigger leftStick(EventLoop loop) {
-    return m_hid.leftStick(loop).castTo(Trigger::new);
+    return button(XboxController.Button.kLeftStick.value, loop);
   }
 
   /**
@@ -122,7 +122,7 @@ public class CommandXboxController extends CommandGenericHID {
    *     given loop.
    */
   public Trigger rightStick(EventLoop loop) {
-    return m_hid.rightStick(loop).castTo(Trigger::new);
+    return button(XboxController.Button.kRightStick.value, loop);
   }
 
   /**
@@ -144,7 +144,7 @@ public class CommandXboxController extends CommandGenericHID {
    *     loop.
    */
   public Trigger a(EventLoop loop) {
-    return m_hid.a(loop).castTo(Trigger::new);
+    return button(XboxController.Button.kA.value, loop);
   }
 
   /**
@@ -166,7 +166,7 @@ public class CommandXboxController extends CommandGenericHID {
    *     loop.
    */
   public Trigger b(EventLoop loop) {
-    return m_hid.b(loop).castTo(Trigger::new);
+    return button(XboxController.Button.kB.value, loop);
   }
 
   /**
@@ -188,7 +188,7 @@ public class CommandXboxController extends CommandGenericHID {
    *     loop.
    */
   public Trigger x(EventLoop loop) {
-    return m_hid.x(loop).castTo(Trigger::new);
+    return button(XboxController.Button.kX.value, loop);
   }
 
   /**
@@ -210,7 +210,7 @@ public class CommandXboxController extends CommandGenericHID {
    *     loop.
    */
   public Trigger y(EventLoop loop) {
-    return m_hid.y(loop).castTo(Trigger::new);
+    return button(XboxController.Button.kY.value, loop);
   }
 
   /**
@@ -232,7 +232,7 @@ public class CommandXboxController extends CommandGenericHID {
    *     loop.
    */
   public Trigger start(EventLoop loop) {
-    return m_hid.start(loop).castTo(Trigger::new);
+    return button(XboxController.Button.kStart.value, loop);
   }
 
   /**
@@ -254,7 +254,7 @@ public class CommandXboxController extends CommandGenericHID {
    *     loop.
    */
   public Trigger back(EventLoop loop) {
-    return m_hid.back(loop).castTo(Trigger::new);
+    return button(XboxController.Button.kBack.value, loop);
   }
 
   /**


### PR DESCRIPTION
This is a common footgun for teams.  Caching is a low-risk way to prevent this problem.

Points to discuss:
- Do we need to do this for C++?
- Should we implement a cache for the EventLoop-taking functions in the non-command joysticks?
- Should we cache axisGreaterThan/axisLessThan?  This primarily affects XBoxController triggers which "look" like buttons but are actually implemented with this.

Fixes #5903.