### PR TITLE
[cmd] TrapezoidProfileCommand: Use period instead of elapsed time in new TrapezoidProfile.calculate API

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/TrapezoidProfileCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/TrapezoidProfileCommand.java
@@ -54,6 +54,16 @@ public class TrapezoidProfileCommand extends Command {
     addRequirements(requirements);
   }
 
+    /**
+   * Creates a new TrapezoidProfileCommand that will execute the given {@link TrapezoidProfile}.
+   * Output will be piped to the provided consumer function.
+   *
+   * @param profile The motion profile to execute.
+   * @param output The consumer for the profile output.
+   * @param goal The supplier for the desired state
+   * @param currentState The current state
+   * @param requirements The subsystems required by this command.
+   */
   public TrapezoidProfileCommand(
       TrapezoidProfile profile,
       Consumer<State> output,

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/TrapezoidProfileCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/TrapezoidProfileCommand.java
@@ -23,7 +23,8 @@ public class TrapezoidProfileCommand extends Command {
   private final Supplier<State> m_goal;
   private final Supplier<State> m_currentState;
   private final boolean m_newAPI; // TODO: Remove
-  private final Timer m_timer = new Timer();
+  private final Timer m_timer = new Timer(); // TODO: Remove
+  private final double m_period;
 
   /**
    * Creates a new TrapezoidProfileCommand that will execute the given {@link TrapezoidProfile}.
@@ -33,6 +34,7 @@ public class TrapezoidProfileCommand extends Command {
    * @param output The consumer for the profile output.
    * @param goal The supplier for the desired state
    * @param currentState The current state
+   * @param period The period of the command scheduler loop, in seconds.
    * @param requirements The subsystems required by this command.
    */
   @SuppressWarnings("this-escape")
@@ -41,13 +43,24 @@ public class TrapezoidProfileCommand extends Command {
       Consumer<State> output,
       Supplier<State> goal,
       Supplier<State> currentState,
+      double period,
       Subsystem... requirements) {
     m_profile = requireNonNullParam(profile, "profile", "TrapezoidProfileCommand");
     m_output = requireNonNullParam(output, "output", "TrapezoidProfileCommand");
     m_goal = goal;
     m_currentState = currentState;
     m_newAPI = true;
+    m_period = period;
     addRequirements(requirements);
+  }
+
+  public TrapezoidProfileCommand(
+      TrapezoidProfile profile,
+      Consumer<State> output,
+      Supplier<State> goal,
+      Supplier<State> currentState,
+      Subsystem... requirements) {
+    this(profile, output, goal, currentState, 0.02, requirements);
   }
 
   /**
@@ -69,6 +82,7 @@ public class TrapezoidProfileCommand extends Command {
     m_newAPI = false;
     m_goal = null;
     m_currentState = null;
+    m_period = 0.02;
     addRequirements(requirements);
   }
 
@@ -81,7 +95,7 @@ public class TrapezoidProfileCommand extends Command {
   @SuppressWarnings("removal")
   public void execute() {
     if (m_newAPI) {
-      m_output.accept(m_profile.calculate(m_timer.get(), m_currentState.get(), m_goal.get()));
+      m_output.accept(m_profile.calculate(m_period, m_currentState.get(), m_goal.get()));
     } else {
       m_output.accept(m_profile.calculate(m_timer.get()));
     }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/TrapezoidProfileCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/TrapezoidProfileCommand.h
@@ -40,6 +40,32 @@ class TrapezoidProfileCommand
    * @param output       The consumer for the profile output.
    * @param goal The supplier for the desired state
    * @param currentState The current state
+   * @param period       The period of the command scheduler loop, in seconds.
+   * @param requirements The list of requirements.
+   */
+  TrapezoidProfileCommand(frc::TrapezoidProfile<Distance> profile,
+                          std::function<void(State)> output,
+                          std::function<State()> goal,
+                          std::function<State()> currentState,
+                          double period,
+                          Requirements requirements = {})
+      : m_profile(profile),
+        m_output(output),
+        m_goal(goal),
+        m_currentState(currentState),
+        m_period(period) {
+    this->AddRequirements(requirements);
+    m_newAPI = true;
+  }
+
+  /**
+   * Creates a new TrapezoidProfileCommand that will execute the given
+   * TrapezoidalProfile. Output will be piped to the provided consumer function.
+   *
+   * @param profile      The motion profile to execute.
+   * @param output       The consumer for the profile output.
+   * @param goal The supplier for the desired state
+   * @param currentState The current state
    * @param requirements The list of requirements.
    */
   TrapezoidProfileCommand(frc::TrapezoidProfile<Distance> profile,
@@ -50,7 +76,8 @@ class TrapezoidProfileCommand
       : m_profile(profile),
         m_output(output),
         m_goal(goal),
-        m_currentState(currentState) {
+        m_currentState(currentState),
+        m_period(0.02) {
     this->AddRequirements(requirements);
     m_newAPI = true;
   }
@@ -79,7 +106,11 @@ class TrapezoidProfileCommand
   void Initialize() override { m_timer.Restart(); }
 
   void Execute() override {
-    m_output(m_profile.Calculate(m_timer.Get(), m_currentState(), m_goal()));
+    if (m_newAPI) {
+      m_output(m_profile.Calculate(m_period, m_currentState(), m_goal())); 
+    } else {
+      m_output(m_profile.Calculate(m_timer.Get()));
+    }
   }
 
   void End(bool interrupted) override { m_timer.Stop(); }
@@ -94,7 +125,8 @@ class TrapezoidProfileCommand
   std::function<State()> m_goal;
   std::function<State()> m_currentState;
   bool m_newAPI;  // TODO: Remove
-  frc::Timer m_timer;
+  frc::Timer m_timer; // TODO: Remove
+  double m_period;
 };
 
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/TrapezoidProfileCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/TrapezoidProfileCommand.h
@@ -13,6 +13,8 @@
 #include "frc2/command/CommandHelper.h"
 #include "frc2/command/Requirements.h"
 
+#include <units/time.h>
+
 namespace frc2 {
 /**
  * A command that runs a TrapezoidProfile.  Useful for smoothly controlling

--- a/wpilibNewCommands/src/main/native/include/frc2/command/TrapezoidProfileCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/TrapezoidProfileCommand.h
@@ -8,12 +8,11 @@
 
 #include <frc/Timer.h>
 #include <frc/trajectory/TrapezoidProfile.h>
+#include <units/time.h>
 
 #include "frc2/command/Command.h"
 #include "frc2/command/CommandHelper.h"
 #include "frc2/command/Requirements.h"
-
-#include <units/time.h>
 
 namespace frc2 {
 /**
@@ -108,7 +107,7 @@ class TrapezoidProfileCommand
 
   void Execute() override {
     if (m_newAPI) {
-      m_output(m_profile.Calculate(m_period, m_currentState(), m_goal())); 
+      m_output(m_profile.Calculate(m_period, m_currentState(), m_goal()));
     } else {
       m_output(m_profile.Calculate(m_timer.Get()));
     }
@@ -125,8 +124,8 @@ class TrapezoidProfileCommand
   std::function<void(State)> m_output;
   std::function<State()> m_goal;
   std::function<State()> m_currentState;
-  bool m_newAPI;  // TODO: Remove
-  frc::Timer m_timer; // TODO: Remove
+  bool m_newAPI;       // TODO: Remove
+  frc::Timer m_timer;  // TODO: Remove
   units::second_t m_period = 20_ms;
 };
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/TrapezoidProfileCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/TrapezoidProfileCommand.h
@@ -47,7 +47,7 @@ class TrapezoidProfileCommand
                           std::function<void(State)> output,
                           std::function<State()> goal,
                           std::function<State()> currentState,
-                          double period,
+                          units::second_t period,
                           Requirements requirements = {})
       : m_profile(profile),
         m_output(output),
@@ -76,8 +76,7 @@ class TrapezoidProfileCommand
       : m_profile(profile),
         m_output(output),
         m_goal(goal),
-        m_currentState(currentState),
-        m_period(0.02) {
+        m_currentState(currentState) {
     this->AddRequirements(requirements);
     m_newAPI = true;
   }
@@ -126,7 +125,7 @@ class TrapezoidProfileCommand
   std::function<State()> m_currentState;
   bool m_newAPI;  // TODO: Remove
   frc::Timer m_timer; // TODO: Remove
-  double m_period;
+  units::second_t m_period = 20_ms;
 };
 
 }  // namespace frc2


### PR DESCRIPTION
DevilBotz 2876 experienced odd instabilities with the TrapezoidProfileCommand.  Sometimes, the position returned by the calculate would go in the opposite direction.  This was reproduced in simulation, so not a hardware issue.  Digging into the code, we found that the new call to calculate is using the wrong parameter for "time" when calling `TrapezoidProfile.calculate(double t, State current, State goal)`.  It was providing the elapsed time from the _initial_ state but since the _current_ state is being used, the period should be used, instead.  Bug introduced in #5457

My test case was with changing position as follows:
1. 0 --> 90
2. 90 --> 0
3. 0 --> 45
4. 45 --> 90  _this caused the trapezoid profile to slam down to zero before going to 90_