### PR TITLE
Don't constantly retry log creation when low on space

### DIFF
--- a/wpiutil/src/main/native/cpp/DataLog.cpp
+++ b/wpiutil/src/main/native/cpp/DataLog.cpp
@@ -354,6 +354,7 @@ void DataLog::StartLogFile(WriterThreadState& state) {
     WPI_ERROR(m_msglog,
               "Insufficient free space ({} available), no log being saved",
               FormatBytesSize(state.freeSpace));
+    m_state = kStopped;
   } else {
     // try preferred filename, or randomize it a few times, before giving up
     for (int i = 0; i < 5; ++i) {


### PR DESCRIPTION
When low on space, a log file won't be created. This is detected as a "deletion", and the DataLog thread will continously try to create a log, fail to do so because of low space, detect it as a "deletion", and do so in a loop.

If there's not enough space, the DataLog will be marked as stopped, preventing this infinite loop. Calls to start() will hit this code path and mark it as stopped again.