### PR TITLE
DataLog: Fix behavior when low on space

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DataLogManager.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DataLogManager.java
@@ -269,7 +269,7 @@ public final class DataLogManager {
     // based on free disk space, scan for "old" FRC_*.wpilog files and remove
     {
       File logDir = new File(m_logDir);
-      long freeSpace = logDir.getFreeSpace();
+      long freeSpace = logDir.getUsableSpace();
       if (freeSpace < kFreeSpaceThreshold) {
         // Delete oldest FRC_*.wpilog files (ignore FRC_TBD_*.wpilog as we just created one)
         File[] files =
@@ -304,7 +304,7 @@ public final class DataLogManager {
                 + freeSpace / 1000000
                 + " MB of free space remaining! Logs will get deleted below "
                 + kFreeSpaceThreshold / 1000000
-                + " MB of free space."
+                + " MB of free space. "
                 + "Consider deleting logs off the storage device.",
             false);
       }

--- a/wpiutil/src/main/native/cpp/DataLog.cpp
+++ b/wpiutil/src/main/native/cpp/DataLog.cpp
@@ -462,6 +462,9 @@ void DataLog::WriterThreadMain(std::string_view dir) {
       lock.unlock();
       StartLogFile(state);
       lock.lock();
+      if (m_state == kStopped) {
+        continue;
+      }
       if (state.f != fs::kInvalidFile) {
         // Emit start and schema data records
         for (auto&& entryInfo : m_entries) {


### PR DESCRIPTION
Uses `getUsableSpace` in Java, matching how C++ determines available space (C++ calls it `available`, but they mean the same thing.) This fixes a bug where logs wouldn't get deleted due to incorrect available space detection.

The DataLog thread now checks if the state was marked as stopped after a call to StartLogFile.

And a typo was fixed.