### PR TITLE
`SmartDashboard.setDefault*` documentation

### DIFF
--- a/ntcore/src/main/native/include/networktables/GenericEntry.h
+++ b/ntcore/src/main/native/include/networktables/GenericEntry.h
@@ -387,7 +387,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultBoolean(bool defaultValue) {
     return nt::SetDefaultBoolean(m_pubHandle, defaultValue);
@@ -397,7 +397,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultInteger(int64_t defaultValue) {
     return nt::SetDefaultInteger(m_pubHandle, defaultValue);
@@ -407,7 +407,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultFloat(float defaultValue) {
     return nt::SetDefaultFloat(m_pubHandle, defaultValue);
@@ -417,7 +417,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultDouble(double defaultValue) {
     return nt::SetDefaultDouble(m_pubHandle, defaultValue);
@@ -427,7 +427,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultString(std::string_view defaultValue) {
     return nt::SetDefaultString(m_pubHandle, defaultValue);
@@ -437,7 +437,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultRaw(std::span<const uint8_t> defaultValue) {
     return nt::SetDefaultRaw(m_pubHandle, defaultValue);
@@ -447,7 +447,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultBooleanArray(std::span<const int> defaultValue) {
     return nt::SetDefaultBooleanArray(m_pubHandle, defaultValue);
@@ -457,7 +457,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultIntegerArray(std::span<const int64_t> defaultValue) {
     return nt::SetDefaultIntegerArray(m_pubHandle, defaultValue);
@@ -467,7 +467,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultFloatArray(std::span<const float> defaultValue) {
     return nt::SetDefaultFloatArray(m_pubHandle, defaultValue);
@@ -477,7 +477,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultDoubleArray(std::span<const double> defaultValue) {
     return nt::SetDefaultDoubleArray(m_pubHandle, defaultValue);
@@ -487,7 +487,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultStringArray(std::span<const std::string> defaultValue) {
     return nt::SetDefaultStringArray(m_pubHandle, defaultValue);

--- a/ntcore/src/main/native/include/networktables/GenericEntry.h
+++ b/ntcore/src/main/native/include/networktables/GenericEntry.h
@@ -387,7 +387,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultBoolean(bool defaultValue) {
     return nt::SetDefaultBoolean(m_pubHandle, defaultValue);
@@ -397,7 +397,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultInteger(int64_t defaultValue) {
     return nt::SetDefaultInteger(m_pubHandle, defaultValue);
@@ -407,7 +407,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultFloat(float defaultValue) {
     return nt::SetDefaultFloat(m_pubHandle, defaultValue);
@@ -417,7 +417,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultDouble(double defaultValue) {
     return nt::SetDefaultDouble(m_pubHandle, defaultValue);
@@ -427,7 +427,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultString(std::string_view defaultValue) {
     return nt::SetDefaultString(m_pubHandle, defaultValue);
@@ -437,7 +437,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultRaw(std::span<const uint8_t> defaultValue) {
     return nt::SetDefaultRaw(m_pubHandle, defaultValue);
@@ -447,7 +447,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultBooleanArray(std::span<const int> defaultValue) {
     return nt::SetDefaultBooleanArray(m_pubHandle, defaultValue);
@@ -457,7 +457,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultIntegerArray(std::span<const int64_t> defaultValue) {
     return nt::SetDefaultIntegerArray(m_pubHandle, defaultValue);
@@ -467,7 +467,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultFloatArray(std::span<const float> defaultValue) {
     return nt::SetDefaultFloatArray(m_pubHandle, defaultValue);
@@ -477,7 +477,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultDoubleArray(std::span<const double> defaultValue) {
     return nt::SetDefaultDoubleArray(m_pubHandle, defaultValue);
@@ -487,7 +487,7 @@ class GenericPublisher : public Publisher {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultStringArray(std::span<const std::string> defaultValue) {
     return nt::SetDefaultStringArray(m_pubHandle, defaultValue);

--- a/ntcore/src/main/native/include/networktables/NetworkTable.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTable.h
@@ -365,7 +365,7 @@ class NetworkTable final {
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists
+   * @returns True if the table key did not already exist, otherwise False
    */
   bool SetDefaultNumber(std::string_view key, double defaultValue);
 
@@ -393,7 +393,7 @@ class NetworkTable final {
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists
+   * @returns True if the table key did not already exist, otherwise False
    */
   bool SetDefaultString(std::string_view key, std::string_view defaultValue);
 
@@ -423,7 +423,7 @@ class NetworkTable final {
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists
+   * @returns True if the table key did not already exist, otherwise False
    */
   bool SetDefaultBoolean(std::string_view key, bool defaultValue);
 
@@ -456,7 +456,7 @@ class NetworkTable final {
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @return False if the table key exists
+   * @return True if the table key did not already exist, otherwise False
    */
   bool SetDefaultBooleanArray(std::string_view key,
                               std::span<const int> defaultValue);
@@ -494,7 +494,7 @@ class NetworkTable final {
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists
+   * @returns True if the table key did not already exist, otherwise False
    */
   bool SetDefaultNumberArray(std::string_view key,
                              std::span<const double> defaultValue);
@@ -528,7 +528,7 @@ class NetworkTable final {
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists
+   * @returns True if the table key did not already exist, otherwise False
    */
   bool SetDefaultStringArray(std::string_view key,
                              std::span<const std::string> defaultValue);
@@ -562,7 +562,7 @@ class NetworkTable final {
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @return False if the table key exists
+   * @return True if the table key did not already exist, otherwise False
    */
   bool SetDefaultRaw(std::string_view key,
                      std::span<const uint8_t> defaultValue);
@@ -596,7 +596,7 @@ class NetworkTable final {
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @return False if the table key exists
+   * @return True if the table key did not already exist, otherwise False
    */
   bool SetDefaultValue(std::string_view key, const Value& defaultValue);
 

--- a/ntcore/src/main/native/include/networktables/NetworkTable.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTable.h
@@ -361,11 +361,11 @@ class NetworkTable final {
   bool PutNumber(std::string_view key, double value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set Default Entry Value
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists with a different type
+   * @returns False if the table key exists
    */
   bool SetDefaultNumber(std::string_view key, double defaultValue);
 
@@ -389,11 +389,11 @@ class NetworkTable final {
   bool PutString(std::string_view key, std::string_view value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set Default Entry Value
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists with a different type
+   * @returns False if the table key exists
    */
   bool SetDefaultString(std::string_view key, std::string_view defaultValue);
 
@@ -419,11 +419,11 @@ class NetworkTable final {
   bool PutBoolean(std::string_view key, bool value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set Default Entry Value
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists with a different type
+   * @returns False if the table key exists
    */
   bool SetDefaultBoolean(std::string_view key, bool defaultValue);
 
@@ -452,11 +452,11 @@ class NetworkTable final {
   bool PutBooleanArray(std::string_view key, std::span<const int> value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set Default Entry Value
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @return False if the table key exists with a different type
+   * @return False if the table key exists
    */
   bool SetDefaultBooleanArray(std::string_view key,
                               std::span<const int> defaultValue);
@@ -490,11 +490,11 @@ class NetworkTable final {
   bool PutNumberArray(std::string_view key, std::span<const double> value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set Default Entry Value
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists with a different type
+   * @returns False if the table key exists
    */
   bool SetDefaultNumberArray(std::string_view key,
                              std::span<const double> defaultValue);
@@ -524,11 +524,11 @@ class NetworkTable final {
   bool PutStringArray(std::string_view key, std::span<const std::string> value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set Default Entry Value
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists with a different type
+   * @returns False if the table key exists
    */
   bool SetDefaultStringArray(std::string_view key,
                              std::span<const std::string> defaultValue);
@@ -558,11 +558,11 @@ class NetworkTable final {
   bool PutRaw(std::string_view key, std::span<const uint8_t> value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set Default Entry Value
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @return False if the table key exists with a different type
+   * @return False if the table key exists
    */
   bool SetDefaultRaw(std::string_view key,
                      std::span<const uint8_t> defaultValue);
@@ -592,11 +592,11 @@ class NetworkTable final {
   bool PutValue(std::string_view key, const Value& value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set Default Entry Value.
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @return False if the table key exists with a different type
+   * @return False if the table key exists
    */
   bool SetDefaultValue(std::string_view key, const Value& defaultValue);
 

--- a/ntcore/src/main/native/include/networktables/NetworkTableEntry.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableEntry.h
@@ -260,7 +260,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultValue(const Value& defaultValue) {
     return SetDefaultEntryValue(m_handle, defaultValue);
@@ -270,7 +270,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultBoolean(bool defaultValue) {
     return nt::SetDefaultBoolean(m_handle, defaultValue);
@@ -280,7 +280,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultInteger(int64_t defaultValue) {
     return nt::SetDefaultInteger(m_handle, defaultValue);
@@ -290,7 +290,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultFloat(float defaultValue) {
     return nt::SetDefaultFloat(m_handle, defaultValue);
@@ -300,7 +300,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultDouble(double defaultValue) {
     return nt::SetDefaultDouble(m_handle, defaultValue);
@@ -310,7 +310,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultString(std::string_view defaultValue) {
     return nt::SetDefaultString(m_handle, defaultValue);
@@ -320,7 +320,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultRaw(std::span<const uint8_t> defaultValue) {
     return nt::SetDefaultRaw(m_handle, defaultValue);
@@ -330,7 +330,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultBooleanArray(std::span<const int> defaultValue) {
     return nt::SetDefaultBooleanArray(m_handle, defaultValue);
@@ -340,7 +340,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultIntegerArray(std::span<const int64_t> defaultValue) {
     return nt::SetDefaultIntegerArray(m_handle, defaultValue);
@@ -350,7 +350,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultFloatArray(std::span<const float> defaultValue) {
     return nt::SetDefaultFloatArray(m_handle, defaultValue);
@@ -360,7 +360,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultDoubleArray(std::span<const double> defaultValue) {
     return nt::SetDefaultDoubleArray(m_handle, defaultValue);
@@ -370,7 +370,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists with a different type
+   * @return False if the entry exists
    */
   bool SetDefaultStringArray(std::span<const std::string> defaultValue) {
     return nt::SetDefaultStringArray(m_handle, defaultValue);

--- a/ntcore/src/main/native/include/networktables/NetworkTableEntry.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableEntry.h
@@ -260,7 +260,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultValue(const Value& defaultValue) {
     return SetDefaultEntryValue(m_handle, defaultValue);
@@ -270,7 +270,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultBoolean(bool defaultValue) {
     return nt::SetDefaultBoolean(m_handle, defaultValue);
@@ -280,7 +280,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultInteger(int64_t defaultValue) {
     return nt::SetDefaultInteger(m_handle, defaultValue);
@@ -290,7 +290,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultFloat(float defaultValue) {
     return nt::SetDefaultFloat(m_handle, defaultValue);
@@ -300,7 +300,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultDouble(double defaultValue) {
     return nt::SetDefaultDouble(m_handle, defaultValue);
@@ -310,7 +310,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultString(std::string_view defaultValue) {
     return nt::SetDefaultString(m_handle, defaultValue);
@@ -320,7 +320,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultRaw(std::span<const uint8_t> defaultValue) {
     return nt::SetDefaultRaw(m_handle, defaultValue);
@@ -330,7 +330,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultBooleanArray(std::span<const int> defaultValue) {
     return nt::SetDefaultBooleanArray(m_handle, defaultValue);
@@ -340,7 +340,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultIntegerArray(std::span<const int64_t> defaultValue) {
     return nt::SetDefaultIntegerArray(m_handle, defaultValue);
@@ -350,7 +350,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultFloatArray(std::span<const float> defaultValue) {
     return nt::SetDefaultFloatArray(m_handle, defaultValue);
@@ -360,7 +360,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultDoubleArray(std::span<const double> defaultValue) {
     return nt::SetDefaultDoubleArray(m_handle, defaultValue);
@@ -370,7 +370,7 @@ class NetworkTableEntry final {
    * Sets the entry's value if it does not exist.
    *
    * @param defaultValue the default value to set
-   * @return False if the entry exists
+   * @return True if the entry did not already have a value, otherwise False
    */
   bool SetDefaultStringArray(std::span<const std::string> defaultValue) {
     return nt::SetDefaultStringArray(m_handle, defaultValue);

--- a/ntcore/src/main/native/include/ntcore_c.h
+++ b/ntcore/src/main/native/include/ntcore_c.h
@@ -476,8 +476,8 @@ void NT_GetEntryValueType(NT_Entry entry, unsigned int types,
 /**
  * Set Default Entry Value.
  *
- * Returns copy of current entry value if it exists.
- * Otherwise, sets passed in value, and returns set value.
+ * Returns 0 if name exists.
+ * Otherwise, sets passed in value, and returns 1.
  * Note that one of the type options is "unassigned".
  *
  * @param entry     entry handle

--- a/ntcore/src/main/native/include/ntcore_cpp.h
+++ b/ntcore/src/main/native/include/ntcore_cpp.h
@@ -488,8 +488,8 @@ Value GetEntryValue(NT_Handle subentry);
 /**
  * Set Default Entry Value
  *
- * Returns copy of current entry value if it exists.
- * Otherwise, sets passed in value, and returns set value.
+ * Returns False if name exists.
+ * Otherwise, sets passed in value, and returns True.
  * Note that one of the type options is "unassigned".
  *
  * @param entry     entry handle

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
@@ -122,9 +122,9 @@ class SmartDashboard {
   static bool PutBoolean(std::string_view keyName, bool value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist
    * @param key the key
-   * @param defaultValue the default value to set if key doesn't exist.
+   * @param defaultValue the value to set if key doesn't exist.
    * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultBoolean(std::string_view key, bool defaultValue);
@@ -135,7 +135,7 @@ class SmartDashboard {
    * If the key is not found, returns the default value.
    *
    * @param keyName the key
-   * @param defaultValue the default value to set if key doesn't exist
+   * @param defaultValue the default value to return if key doesn't exist
    * @return the value
    */
   static bool GetBoolean(std::string_view keyName, bool defaultValue);
@@ -153,10 +153,10 @@ class SmartDashboard {
   static bool PutNumber(std::string_view keyName, double value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key          The key.
-   * @param defaultValue The default value to set if key doesn't exist.
+   * @param defaultValue The value to set if key doesn't exist.
    * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultNumber(std::string_view key, double defaultValue);
@@ -167,7 +167,7 @@ class SmartDashboard {
    * If the key is not found, returns the default value.
    *
    * @param keyName the key
-   * @param defaultValue the default value to set if the key doesn't exist
+   * @param defaultValue the default value to return if the key doesn't exist
    * @return the value
    */
   static double GetNumber(std::string_view keyName, double defaultValue);
@@ -185,10 +185,10 @@ class SmartDashboard {
   static bool PutString(std::string_view keyName, std::string_view value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key the key
-   * @param defaultValue the default value to set if key doesn't exist.
+   * @param defaultValue the value to set if key doesn't exist.
    * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultString(std::string_view key,
@@ -200,7 +200,7 @@ class SmartDashboard {
    * If the key is not found, returns the default value.
    *
    * @param keyName the key
-   * @param defaultValue the default value to set if the key doesn't exist
+   * @param defaultValue the default value to return if the key doesn't exist
    * @return the value
    */
   static std::string GetString(std::string_view keyName,
@@ -220,10 +220,10 @@ class SmartDashboard {
   static bool PutBooleanArray(std::string_view key, std::span<const int> value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key the key
-   * @param defaultValue the default value to set if key doesn't exist.
+   * @param defaultValue the value to set if key doesn't exist.
    * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultBooleanArray(std::string_view key,
@@ -261,10 +261,10 @@ class SmartDashboard {
                              std::span<const double> value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key          The key.
-   * @param defaultValue The default value to set if key doesn't exist.
+   * @param defaultValue The value to set if key doesn't exist.
    * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultNumberArray(std::string_view key,
@@ -298,10 +298,10 @@ class SmartDashboard {
                              std::span<const std::string> value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key          The key.
-   * @param defaultValue The default value to set if key doesn't exist.
+   * @param defaultValue The value to set if key doesn't exist.
    * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultStringArray(std::string_view key,
@@ -334,10 +334,10 @@ class SmartDashboard {
   static bool PutRaw(std::string_view key, std::span<const uint8_t> value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key          The key.
-   * @param defaultValue The default value to set if key doesn't exist.
+   * @param defaultValue The value to set if key doesn't exist.
    * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultRaw(std::string_view key,
@@ -374,10 +374,10 @@ class SmartDashboard {
   static bool PutValue(std::string_view keyName, const nt::Value& value);
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key the key
-   * @param defaultValue The default value to set if key doesn't exist.
+   * @param defaultValue The value to set if key doesn't exist.
    * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultValue(std::string_view key,

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
@@ -125,7 +125,7 @@ class SmartDashboard {
    * Gets the current value in the table, setting it if it does not exist.
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists
+   * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultBoolean(std::string_view key, bool defaultValue);
 
@@ -157,7 +157,7 @@ class SmartDashboard {
    *
    * @param key          The key.
    * @param defaultValue The default value to set if key doesn't exist.
-   * @returns False if the table key exists
+   * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultNumber(std::string_view key, double defaultValue);
 
@@ -189,7 +189,7 @@ class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists
+   * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultString(std::string_view key,
                                std::string_view defaultValue);
@@ -224,7 +224,7 @@ class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists
+   * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultBooleanArray(std::string_view key,
                                      std::span<const int> defaultValue);
@@ -265,7 +265,7 @@ class SmartDashboard {
    *
    * @param key          The key.
    * @param defaultValue The default value to set if key doesn't exist.
-   * @returns False if the table key exists
+   * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultNumberArray(std::string_view key,
                                     std::span<const double> defaultValue);
@@ -302,7 +302,7 @@ class SmartDashboard {
    *
    * @param key          The key.
    * @param defaultValue The default value to set if key doesn't exist.
-   * @returns False if the table key exists
+   * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultStringArray(std::string_view key,
                                     std::span<const std::string> defaultValue);
@@ -338,7 +338,7 @@ class SmartDashboard {
    *
    * @param key          The key.
    * @param defaultValue The default value to set if key doesn't exist.
-   * @returns False if the table key exists
+   * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultRaw(std::string_view key,
                             std::span<const uint8_t> defaultValue);
@@ -378,7 +378,7 @@ class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue The default value to set if key doesn't exist.
-   * @returns False if the table key exists
+   * @returns True if the table key did not already exist, otherwise False
    */
   static bool SetDefaultValue(std::string_view key,
                               const nt::Value& defaultValue);

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
@@ -125,7 +125,7 @@ class SmartDashboard {
    * Gets the current value in the table, setting it if it does not exist.
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists with a different type
+   * @returns False if the table key exists
    */
   static bool SetDefaultBoolean(std::string_view key, bool defaultValue);
 
@@ -157,7 +157,7 @@ class SmartDashboard {
    *
    * @param key          The key.
    * @param defaultValue The default value to set if key doesn't exist.
-   * @returns False if the table key exists with a different type
+   * @returns False if the table key exists
    */
   static bool SetDefaultNumber(std::string_view key, double defaultValue);
 
@@ -189,7 +189,7 @@ class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists with a different type
+   * @returns False if the table key exists
    */
   static bool SetDefaultString(std::string_view key,
                                std::string_view defaultValue);
@@ -224,7 +224,7 @@ class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue the default value to set if key doesn't exist.
-   * @returns False if the table key exists with a different type
+   * @returns False if the table key exists
    */
   static bool SetDefaultBooleanArray(std::string_view key,
                                      std::span<const int> defaultValue);
@@ -265,7 +265,7 @@ class SmartDashboard {
    *
    * @param key          The key.
    * @param defaultValue The default value to set if key doesn't exist.
-   * @returns False if the table key exists with a different type
+   * @returns False if the table key exists
    */
   static bool SetDefaultNumberArray(std::string_view key,
                                     std::span<const double> defaultValue);
@@ -302,7 +302,7 @@ class SmartDashboard {
    *
    * @param key          The key.
    * @param defaultValue The default value to set if key doesn't exist.
-   * @returns False if the table key exists with a different type
+   * @returns False if the table key exists
    */
   static bool SetDefaultStringArray(std::string_view key,
                                     std::span<const std::string> defaultValue);
@@ -338,7 +338,7 @@ class SmartDashboard {
    *
    * @param key          The key.
    * @param defaultValue The default value to set if key doesn't exist.
-   * @returns False if the table key exists with a different type
+   * @returns False if the table key exists
    */
   static bool SetDefaultRaw(std::string_view key,
                             std::span<const uint8_t> defaultValue);
@@ -378,7 +378,7 @@ class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue The default value to set if key doesn't exist.
-   * @returns False if the table key exists with a different type
+   * @returns False if the table key exists
    */
   static bool SetDefaultValue(std::string_view key,
                               const nt::Value& defaultValue);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
@@ -200,7 +200,7 @@ public final class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue the value to set if key does not exist
-   * @return True: success; False the key already existed
+   * @return True if the key did not already exist, otherwise False
    */
   public static boolean setDefaultBoolean(String key, boolean defaultValue) {
     return getEntry(key).setDefaultBoolean(defaultValue);
@@ -235,7 +235,7 @@ public final class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue the value to set if key does not exist
-   * @return True: success; False the key already existed
+   * @return True if the key did not already exist, otherwise False
    */
   public static boolean setDefaultNumber(String key, double defaultValue) {
     return getEntry(key).setDefaultDouble(defaultValue);
@@ -270,7 +270,7 @@ public final class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue the value to set if key does not exist
-   * @return True: success; False the key already existed
+   * @return True if the key did not already exist, otherwise False
    */
   public static boolean setDefaultString(String key, String defaultValue) {
     return getEntry(key).setDefaultString(defaultValue);
@@ -316,7 +316,7 @@ public final class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue the value to set if key does not exist
-   * @return True: success; False the key already existed
+   * @return True if the key did not already exist, otherwise False
    */
   public static boolean setDefaultBooleanArray(String key, boolean[] defaultValue) {
     return getEntry(key).setDefaultBooleanArray(defaultValue);
@@ -327,7 +327,7 @@ public final class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue the value to set if key does not exist
-   * @return True: success; False the key already existed
+   * @return True if the key did not already exist, otherwise False
    */
   public static boolean setDefaultBooleanArray(String key, Boolean[] defaultValue) {
     return getEntry(key).setDefaultBooleanArray(defaultValue);
@@ -386,7 +386,7 @@ public final class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue the value to set if key does not exist
-   * @return True: success; False the key already existed
+   * @return True if the key did not already exist, otherwise False
    */
   public static boolean setDefaultNumberArray(String key, double[] defaultValue) {
     return getEntry(key).setDefaultDoubleArray(defaultValue);
@@ -397,7 +397,7 @@ public final class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue the value to set if key does not exist
-   * @return True: success; False the key already existed
+   * @return True if the key did not already exist, otherwise False
    */
   public static boolean setDefaultNumberArray(String key, Double[] defaultValue) {
     return getEntry(key).setDefaultNumberArray(defaultValue);
@@ -445,7 +445,7 @@ public final class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue the value to set if key does not exist
-   * @return True: success; False the key already existed
+   * @return True if the key did not already exist, otherwise False
    */
   public static boolean setDefaultStringArray(String key, String[] defaultValue) {
     return getEntry(key).setDefaultStringArray(defaultValue);
@@ -480,7 +480,7 @@ public final class SmartDashboard {
    *
    * @param key the key
    * @param defaultValue the value to set if key does not exist
-   * @return True: success; False the key already existed
+   * @return True if the key did not already exist, otherwise False
    */
   public static boolean setDefaultRaw(String key, byte[] defaultValue) {
     return getEntry(key).setDefaultRaw(defaultValue);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
@@ -196,11 +196,11 @@ public final class SmartDashboard {
   }
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key the key
-   * @param defaultValue the default value to set if key does not exist.
-   * @return False if the table key exists with a different type
+   * @param defaultValue the value to set if key does not exist
+   * @return True: success; False the key already existed
    */
   public static boolean setDefaultBoolean(String key, boolean defaultValue) {
     return getEntry(key).setDefaultBoolean(defaultValue);
@@ -231,11 +231,11 @@ public final class SmartDashboard {
   }
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key the key
-   * @param defaultValue the default value to set if key does not exist.
-   * @return False if the table key exists with a different type
+   * @param defaultValue the value to set if key does not exist
+   * @return True: success; False the key already existed
    */
   public static boolean setDefaultNumber(String key, double defaultValue) {
     return getEntry(key).setDefaultDouble(defaultValue);
@@ -266,11 +266,11 @@ public final class SmartDashboard {
   }
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key the key
-   * @param defaultValue the default value to set if key does not exist.
-   * @return False if the table key exists with a different type
+   * @param defaultValue the value to set if key does not exist
+   * @return True: success; False the key already existed
    */
   public static boolean setDefaultString(String key, String defaultValue) {
     return getEntry(key).setDefaultString(defaultValue);
@@ -312,22 +312,22 @@ public final class SmartDashboard {
   }
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key the key
-   * @param defaultValue the default value to set if key does not exist.
-   * @return False if the table key exists with a different type
+   * @param defaultValue the value to set if key does not exist
+   * @return True: success; False the key already existed
    */
   public static boolean setDefaultBooleanArray(String key, boolean[] defaultValue) {
     return getEntry(key).setDefaultBooleanArray(defaultValue);
   }
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key the key
-   * @param defaultValue the default value to set if key does not exist.
-   * @return False if the table key exists with a different type
+   * @param defaultValue the value to set if key does not exist
+   * @return True: success; False the key already existed
    */
   public static boolean setDefaultBooleanArray(String key, Boolean[] defaultValue) {
     return getEntry(key).setDefaultBooleanArray(defaultValue);
@@ -382,22 +382,22 @@ public final class SmartDashboard {
   }
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key the key
-   * @param defaultValue the default value to set if key does not exist.
-   * @return False if the table key exists with a different type
+   * @param defaultValue the value to set if key does not exist
+   * @return True: success; False the key already existed
    */
   public static boolean setDefaultNumberArray(String key, double[] defaultValue) {
     return getEntry(key).setDefaultDoubleArray(defaultValue);
   }
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key the key
-   * @param defaultValue the default value to set if key does not exist.
-   * @return False if the table key exists with a different type
+   * @param defaultValue the value to set if key does not exist
+   * @return True: success; False the key already existed
    */
   public static boolean setDefaultNumberArray(String key, Double[] defaultValue) {
     return getEntry(key).setDefaultNumberArray(defaultValue);
@@ -441,11 +441,11 @@ public final class SmartDashboard {
   }
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key the key
-   * @param defaultValue the default value to set if key does not exist.
-   * @return False if the table key exists with a different type
+   * @param defaultValue the value to set if key does not exist
+   * @return True: success; False the key already existed
    */
   public static boolean setDefaultStringArray(String key, String[] defaultValue) {
     return getEntry(key).setDefaultStringArray(defaultValue);
@@ -476,11 +476,11 @@ public final class SmartDashboard {
   }
 
   /**
-   * Gets the current value in the table, setting it if it does not exist.
+   * Set the value in the table if key does not exist.
    *
    * @param key the key
-   * @param defaultValue the default value to set if key does not exist.
-   * @return False if the table key exists with a different type
+   * @param defaultValue the value to set if key does not exist
+   * @return True: success; False the key already existed
    */
   public static boolean setDefaultRaw(String key, byte[] defaultValue) {
     return getEntry(key).setDefaultRaw(defaultValue);


### PR DESCRIPTION
I would like to address #6334, but realized that some discussion about how the behavior should be documented would help before changing all of them. The code diff here contains a proposal that reflects my understanding of the actual behavior. 

Questions: 
1. Would you suggest different wording for documenting the behavior of these methods?
2. Should documentation in `NetworkTableEntry.java`, `NetworkTablesJNI.java`, `ntcore_c.h`, and `ntcore_cpp.h` also be addressed in the same PR, or in a second PR specific to the ntcore component?

More details about `NetworkTableEntry.java`, `NetworkTablesJNI.java`, `ntcore_c.h`, and `ntcore_cpp.h`: 

`SetDefault*` methods in `NetworkTableEntry.java` called by `SmartDashboard.setDefault*` document the return value as `@return False if the entry exists with a different type` whereas the actual behavior is `@return False if the entry exists`. Interestingly, the descriptive documentation here is `Sets the entry's value if it does not exist.` which is correct.

The next level down is `NetworkTablesJNI.java`. Here the documentation is
```
/**
   * Sets default topic value.
   *
   * @param entry Entry handle.
   * @param time Time in microseconds.
   * @param defaultValue Default value.
   * @return True if set succeeded.
   */
```
which is correct but doesn't identify criteria for success.

On the C/C++ side:

`ntcore_c.h` has
```
/**
 * Set Default Entry Value.
 *
 * Returns copy of current entry value if it exists.
 * Otherwise, sets passed in value, and returns set value.
 * Note that one of the type options is "unassigned".
 *
 * @param entry     entry handle
 * @param default_value     value to be set if name does not exist
 * @return 0 on error (value not set), 1 on success
 */
``` 
having both the "Returns a copy of..." error and lack of specificity about success. `ntcore_cpp.h` has essentially the same issues as `ntcore_c.h`.


