### PR TITLE
[ci] Use mirror repository for liblzma

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Check XZ-Utils Upstream
         # If this fails, tukaani-project/xz is back online and the liblzma overlay patch should be removed.
-        run:  git ls-remote https://github.com/tukaani-project/xz nonexistant-ref; if ($LastExitCode -eq 0) {$LastExitCode = 1; Write-Output "tuukani-project/xz is reachable. liblzma overlay patch should be removed."} else { $LastExitCode = 0}
+        run:  Invoke-RestMethod -SkipHttpErrorCheck -StatusCodeVariable "sc" -Uri https://api.github.com/repos/tukaani-project/xz > $null; if($sc -eq 200) {$LastExitCode = 1; Write-Output "tuukani-project/xz is reachable. liblzma overlay patch should be removed."} else { $LastExitCode = 0}
 
       - uses: ilammy/msvc-dev-cmd@v1
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -91,7 +91,7 @@ jobs:
           vcpkgGitCommitId: 37c3e63a1306562f7f59c4c3c8892ddd50fdf992 # HEAD on 2024-02-24
 
       - name: configure
-        run: cmake -S . -B build -G "Ninja" -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_BUILD_TYPE=Release -DWITH_JAVA=OFF -DWITH_EXAMPLES=ON -DUSE_SYSTEM_FMTLIB=ON -DUSE_SYSTEM_LIBUV=ON -DUSE_SYSTEM_EIGEN=OFF -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_OVERLAY_PORTS=vcpkg-ports -DVCPKG_INSTALL_OPTIONS=--clean-after-build -DVCPKG_TARGET_TRIPLET=x64-windows-release -DVCPKG_HOST_TRIPLET=x64-windows-release
+        run: cmake -S . -B build -G "Ninja" -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_BUILD_TYPE=Release -DWITH_JAVA=OFF -DWITH_EXAMPLES=ON -DUSE_SYSTEM_FMTLIB=ON -DUSE_SYSTEM_LIBUV=ON -DUSE_SYSTEM_EIGEN=OFF -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_INSTALL_OPTIONS=--clean-after-build -DVCPKG_TARGET_TRIPLET=x64-windows-release -DVCPKG_HOST_TRIPLET=x64-windows-release
         env:
           SCCACHE_GHA_ENABLED: "true"
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -91,7 +91,7 @@ jobs:
           vcpkgGitCommitId: 37c3e63a1306562f7f59c4c3c8892ddd50fdf992 # HEAD on 2024-02-24
 
       - name: configure
-        run: cmake -S . -B build -G "Ninja" -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_BUILD_TYPE=Release -DWITH_JAVA=OFF -DWITH_EXAMPLES=ON -DUSE_SYSTEM_FMTLIB=ON -DUSE_SYSTEM_LIBUV=ON -DUSE_SYSTEM_EIGEN=OFF -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_INSTALL_OPTIONS=--clean-after-build -DVCPKG_TARGET_TRIPLET=x64-windows-release -DVCPKG_HOST_TRIPLET=x64-windows-release
+        run: cmake -S . -B build -G "Ninja" -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_BUILD_TYPE=Release -DWITH_JAVA=OFF -DWITH_EXAMPLES=ON -DUSE_SYSTEM_FMTLIB=ON -DUSE_SYSTEM_LIBUV=ON -DUSE_SYSTEM_EIGEN=OFF -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_OVERLAY_PORTS=vcpkg-ports -DVCPKG_INSTALL_OPTIONS=--clean-after-build -DVCPKG_TARGET_TRIPLET=x64-windows-release -DVCPKG_HOST_TRIPLET=x64-windows-release
         env:
           SCCACHE_GHA_ENABLED: "true"
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -71,6 +71,10 @@ jobs:
     name: "Build - Windows"
     runs-on: windows-2022
     steps:
+      - name: Check XZ-Utils Upstream
+        # If this fails, tukaani-project/xz is back online and the liblzma overlay patch should be removed.
+        run:  git ls-remote https://github.com/tukaani-project/xz nonexistant-ref; if ($LastExitCode -eq 0) {$LastExitCode = 1; Write-Output "tuukani-project/xz is reachable. liblzma overlay patch should be removed."} else { $LastExitCode = 0}
+
       - uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install CMake

--- a/.styleguide
+++ b/.styleguide
@@ -13,6 +13,7 @@ modifiableFileExclude {
   cmake/toolchains/
   \.patch$
   gradlew
+  vcpkg-ports/
 }
 
 generatedFileExclude {

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,5 @@
+{
+  "overlay-ports": [
+    "vcpkg-ports"
+  ]
+}

--- a/vcpkg-ports/liblzma/add_support_ios.patch
+++ b/vcpkg-ports/liblzma/add_support_ios.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 52439b3..0b5e371 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -574,6 +574,7 @@ if(HAVE_GETOPT_LONG)
+ 
+     install(TARGETS xzdec
+             RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++            BUNDLE  DESTINATION "${CMAKE_INSTALL_BINDIR}"
+                     COMPONENT xzdec)
+ 
+     if(UNIX)
+@@ -701,6 +702,7 @@ if(NOT MSVC AND HAVE_GETOPT_LONG)
+ 
+     install(TARGETS xz
+             RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++            BUNDLE  DESTINATION "${CMAKE_INSTALL_BINDIR}"
+                     COMPONENT xz)
+ 
+     if(UNIX)

--- a/vcpkg-ports/liblzma/build-tools.patch
+++ b/vcpkg-ports/liblzma/build-tools.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 03b8301..820d08e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -584,6 +584,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/liblzma-config.cmake"
+         COMPONENT liblzma_Development)
+ 
+ 
++if(BUILD_TOOLS)
+ #############################################################################
+ # getopt_long
+ #############################################################################
+@@ -793,6 +794,7 @@ if(NOT MSVC AND HAVE_GETOPT_LONG)
+         endforeach()
+     endif()
+ endif()
++endif()
+ 
+ 
+ #############################################################################

--- a/vcpkg-ports/liblzma/fix_config_include.patch
+++ b/vcpkg-ports/liblzma/fix_config_include.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 34c6aca00..7b3708ab2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -413,6 +413,7 @@ if(WIN32)
+     if(BUILD_SHARED_LIBS)
+         # Add the Windows resource file for liblzma.dll.
+         target_sources(liblzma PRIVATE src/liblzma/liblzma_w32res.rc)
++        target_include_directories(liblzma PRIVATE windows/vs2019)
+ 
+         set_target_properties(liblzma PROPERTIES
+             LINK_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/common/common_w32res.rc"

--- a/vcpkg-ports/liblzma/portfile.cmake
+++ b/vcpkg-ports/liblzma/portfile.cmake
@@ -1,0 +1,86 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bminor/xz
+    REF "v${VERSION}"
+    SHA512 c28461123562564e030f3f733f078bc4c840e87598d9f4b718d4bca639120d8133f969c45d7bdc62f33f081d789ec0f14a1791fb7da18515682bfe3c0c7362e0
+    HEAD_REF master
+    PATCHES
+        fix_config_include.patch
+        win_output_name.patch # Fix output name on Windows. Autotool build does not generate lib prefixed libraries on windows. 
+        add_support_ios.patch # add install bundle info for support ios 
+        build-tools.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools BUILD_TOOLS
+)
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "wasm32")
+    set(WASM_OPTIONS -DCMAKE_C_BYTE_ORDER=LITTLE_ENDIAN -DCMAKE_CXX_BYTE_ORDER=LITTLE_ENDIAN)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        ${WASM_OPTIONS}
+        -DBUILD_TESTING=OFF
+        -DCREATE_XZ_SYMLINKS=OFF
+        -DCREATE_LZMA_SYMLINKS=OFF
+        -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=   # using flags from (vcpkg) toolchain
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_MSVC_DEBUG_INFORMATION_FORMAT
+        CREATE_XZ_SYMLINKS
+        CREATE_LZMA_SYMLINKS
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+set(exec_prefix "\${prefix}")
+set(libdir "\${prefix}/lib")
+set(includedir "\${prefix}/include")
+set(PACKAGE_URL https://tukaani.org/xz/)
+set(PACKAGE_VERSION 5.4.3)
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    set(PTHREAD_CFLAGS -pthread)
+endif()
+set(prefix "${CURRENT_INSTALLED_DIR}")
+configure_file("${SOURCE_PATH}/src/liblzma/liblzma.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/liblzma.pc" @ONLY)
+if (NOT VCPKG_BUILD_TYPE)
+  set(prefix "${CURRENT_INSTALLED_DIR}/debug")
+  configure_file("${SOURCE_PATH}/src/liblzma/liblzma.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/liblzma.pc" @ONLY)
+endif()
+vcpkg_fixup_pkgconfig()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/liblzma)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/lzma.h" "defined(LZMA_API_STATIC)" "1")
+else()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/lzma.h" "defined(LZMA_API_STATIC)" "0")
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/man"
+)
+
+set(TOOLS xz xzdec)
+foreach(_tool IN LISTS TOOLS)
+    if(NOT EXISTS "${CURRENT_PACKAGES_DIR}/bin/${_tool}${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+        list(REMOVE_ITEM TOOLS ${_tool})
+    endif()
+endforeach()
+if(TOOLS)
+    vcpkg_copy_tools(TOOL_NAMES ${TOOLS} AUTO_CLEAN)
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/vcpkg-ports/liblzma/usage
+++ b/vcpkg-ports/liblzma/usage
@@ -1,0 +1,9 @@
+liblzma is compatible with built-in CMake targets:
+
+    find_package(LibLZMA REQUIRED)
+    target_link_libraries(main PRIVATE LibLZMA::LibLZMA)
+
+liblzma provides CMake targets:
+
+    find_package(liblzma CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE liblzma::liblzma)

--- a/vcpkg-ports/liblzma/vcpkg-cmake-wrapper.cmake
+++ b/vcpkg-ports/liblzma/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,64 @@
+cmake_policy(PUSH)
+cmake_policy(SET CMP0012 NEW)
+cmake_policy(SET CMP0057 NEW)
+set(z_vcpkg_liblzma_fixup_needed 0)
+if(NOT "CONFIG" IN_LIST ARGS AND NOT "NO_MODULE" IN_LIST ARGS AND NOT CMAKE_DISABLE_FIND_PACKAGE_LibLZMA)
+    get_filename_component(z_vcpkg_liblzma_prefix "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
+    get_filename_component(z_vcpkg_liblzma_prefix "${z_vcpkg_liblzma_prefix}" DIRECTORY)
+    find_path(LIBLZMA_INCLUDE_DIR NAMES lzma.h PATHS "${z_vcpkg_liblzma_prefix}/include" NO_DEFAULT_PATH)
+    # liblzma doesn't use a debug postfix, but FindLibLZMA.cmake expects it 
+    find_library(LIBLZMA_LIBRARY_RELEASE NAMES lzma PATHS "${z_vcpkg_liblzma_prefix}/lib" NO_DEFAULT_PATH)
+    find_library(LIBLZMA_LIBRARY_DEBUG NAMES lzma PATHS "${z_vcpkg_liblzma_prefix}/debug/lib" NO_DEFAULT_PATH)
+    unset(z_vcpkg_liblzma_prefix)
+    if(CMAKE_VERSION VERSION_LESS 3.16)
+        # Older versions of FindLibLZMA.cmake need a single lib in LIBLZMA_LIBRARY.
+        set(z_vcpkg_liblzma_fixup_needed 1)
+        set(LIBLZMA_LIBRARY "${LIBLZMA_LIBRARY_RELEASE}" CACHE INTERNAL "")
+    elseif(NOT TARGET LibLZMA::LibLZMA)
+        set(z_vcpkg_liblzma_fixup_needed 1)
+    endif()
+    # Known values, and required. Skip expensive tests.
+    set(LIBLZMA_HAS_AUTO_DECODER 1 CACHE INTERNAL "")
+    set(LIBLZMA_HAS_EASY_ENCODER 1 CACHE INTERNAL "")
+    set(LIBLZMA_HAS_LZMA_PRESET 1 CACHE INTERNAL "")
+endif()
+
+_find_package(${ARGS})
+
+if(z_vcpkg_liblzma_fixup_needed)
+    include(SelectLibraryConfigurations)
+    select_library_configurations(LIBLZMA)
+    if(NOT TARGET LibLZMA::LibLZMA)
+        # Backfill LibLZMA::LibLZMA to versions of cmake before 3.14
+        add_library(LibLZMA::LibLZMA UNKNOWN IMPORTED)
+        if(DEFINED LIBLZMA_INCLUDE_DIRS)
+            set_target_properties(LibLZMA::LibLZMA PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${LIBLZMA_INCLUDE_DIRS}")
+        endif()
+        set_property(TARGET LibLZMA::LibLZMA APPEND PROPERTY
+            IMPORTED_CONFIGURATIONS RELEASE)
+        set_target_properties(LibLZMA::LibLZMA PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "C"
+            IMPORTED_LOCATION_RELEASE "${LIBLZMA_LIBRARY_RELEASE}")
+        if(EXISTS "${LIBLZMA_LIBRARY}")
+            set_target_properties(LibLZMA::LibLZMA PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                IMPORTED_LOCATION "${LIBLZMA_LIBRARY}")
+        endif()
+    endif()
+    if(LIBLZMA_LIBRARY_DEBUG)
+        # Backfill debug variant to versions of cmake before 3.16
+        set_property(TARGET LibLZMA::LibLZMA APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+        set_target_properties(LibLZMA::LibLZMA PROPERTIES IMPORTED_LOCATION_DEBUG "${LIBLZMA_LIBRARY_DEBUG}")
+    endif()
+endif()
+if(LIBLZMA_LIBRARIES AND NOT "Threads::Threads" IN_LIST LIBLZMA_LIBRARIES)
+    set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+    find_package(Threads)
+    list(APPEND LIBLZMA_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+    if(TARGET LibLZMA::LibLZMA)
+        set_property(TARGET LibLZMA::LibLZMA APPEND PROPERTY INTERFACE_LINK_LIBRARIES Threads::Threads)
+    endif()
+endif()
+unset(z_vcpkg_liblzma_fixup_needed)
+cmake_policy(POP)

--- a/vcpkg-ports/liblzma/vcpkg.json
+++ b/vcpkg-ports/liblzma/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "liblzma",
+  "version": "5.4.4",
+  "description": "Compression library with an API similar to that of zlib.",
+  "homepage": "https://tukaani.org/xz/",
+  "license": null,
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tools": {
+      "description": "Build tools",
+      "supports": "!windows, mingw"
+    }
+  }
+}

--- a/vcpkg-ports/liblzma/win_output_name.patch
+++ b/vcpkg-ports/liblzma/win_output_name.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0c6d4b7..62a824a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -868,8 +868,11 @@ set_target_properties(liblzma PROPERTIES
+ 
+     # It's liblzma.so or liblzma.dll, not libliblzma.so or lzma.dll.
+     # Avoid the name lzma.dll because it would conflict with LZMA SDK.
+-    PREFIX ""
++    OUTPUT_NAME lzma
+ )
++if(WIN32 AND NOT MINGW)
++    set_target_properties(liblzma PROPERTIES RUNTIME_OUTPUT_NAME liblzma)
++endif()
+ 
+ # Create liblzma-config-version.cmake.
+ #


### PR DESCRIPTION
uses https://github.com/bminor/xz to work around suspended repository

We should revert this once vcpkg updates to point to an accessible repo