### PR TITLE
[cmd] Fix double composition error truncation issue

### DIFF
--- a/myRobot/src/main/java/frc/robot/MyRobot.java
+++ b/myRobot/src/main/java/frc/robot/MyRobot.java
@@ -5,6 +5,8 @@
 package frc.robot;
 
 import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj2.command.PrintCommand;
+
 
 public class MyRobot extends TimedRobot {
   /**
@@ -12,7 +14,11 @@ public class MyRobot extends TimedRobot {
    * initialization code.
    */
   @Override
-  public void robotInit() {}
+  public void robotInit() {
+    var c = new PrintCommand("Hello");
+    c.andThen(new PrintCommand("World!"));
+    c.andThen(new PrintCommand("Failure!"));
+  }
 
   /** This function is run once each time the robot enters autonomous mode. */
   @Override

--- a/myRobot/src/main/java/frc/robot/MyRobot.java
+++ b/myRobot/src/main/java/frc/robot/MyRobot.java
@@ -5,8 +5,6 @@
 package frc.robot;
 
 import edu.wpi.first.wpilibj.TimedRobot;
-import edu.wpi.first.wpilibj2.command.PrintCommand;
-
 
 public class MyRobot extends TimedRobot {
   /**
@@ -14,11 +12,7 @@ public class MyRobot extends TimedRobot {
    * initialization code.
    */
   @Override
-  public void robotInit() {
-    var c = new PrintCommand("Hello");
-    c.andThen(new PrintCommand("World!"));
-    c.andThen(new PrintCommand("Failure!"));
-  }
+  public void robotInit() {}
 
   /** This function is run once each time the robot enters autonomous mode. */
   @Override

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -20,6 +20,8 @@ import edu.wpi.first.wpilibj.Watchdog;
 import edu.wpi.first.wpilibj.event.EventLoop;
 import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj2.command.Command.InterruptionBehavior;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -635,10 +637,14 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
     for (var command : commands) {
       var exception = m_composedCommands.getOrDefault(command, null);
       if (exception != null) {
-        throw new IllegalArgumentException(
+        var buffer = new StringWriter();
+        var writer = new PrintWriter(buffer);
+        writer.println(
             "Commands that have been composed may not be added to another composition or scheduled "
-                + "individually!",
-            exception);
+                + "individually!");
+        writer.println(exception.getMessage());
+        exception.printStackTrace(writer);
+        throw new IllegalArgumentException(buffer.toString());
       }
     }
   }


### PR DESCRIPTION
Fixes #6437

This is the resulting error message:
```
Error at frc.robot.MyRobot.robotInit(MyRobot.java:20): Unhandled exception: java.lang.IllegalArgumentException: Commands that have been composed may not be added to another composition or scheduled individually!
java.lang.Exception: Originally composed at:
        at edu.wpi.first.wpilibj2.command.Command.andThen(Command.java:252)
        at frc.robot.MyRobot.robotInit(MyRobot.java:19)
        at edu.wpi.first.wpilibj.TimedRobot.startCompetition(TimedRobot.java:107)
        at edu.wpi.first.wpilibj.RobotBase.runRobot(RobotBase.java:365)
        at edu.wpi.first.wpilibj.RobotBase.lambda$startRobot$0(RobotBase.java:433)
        at java.base/java.lang.Thread.run(Thread.java:833)

        at edu.wpi.first.wpilibj2.command.Command.andThen(Command.java:252)
        at frc.robot.MyRobot.robotInit(MyRobot.java:20)
        at edu.wpi.first.wpilibj.TimedRobot.startCompetition(TimedRobot.java:107)
        at edu.wpi.first.wpilibj.RobotBase.runRobot(RobotBase.java:365)
        at edu.wpi.first.wpilibj.RobotBase.lambda$startRobot$0(RobotBase.java:433)
        at java.base/java.lang.Thread.run(Thread.java:833)
```
(code that caused that stacktrace):
```java
  public void robotInit() {
    var c = new PrintCommand("Hello");
    c.andThen(new PrintCommand("World!")); # line 19
    c.andThen(new PrintCommand("Failure!")); # line 20
  }
```

Thoughts?