### PR TITLE
[wpimath] Add PIDController::GetTotalError and ProfiledPIDController::GetTotalError

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -365,6 +365,15 @@ public class PIDController implements Sendable, AutoCloseable {
   }
 
   /**
+   * Returns the total accumulated error.
+   *
+   * @return The total error.
+   */
+  public double getTotalError() {
+    return m_totalError;
+  }
+
+  /**
    * Returns the next output of the PID controller.
    *
    * @param measurement The current measurement of the process variable.

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/ProfiledPIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/ProfiledPIDController.java
@@ -334,6 +334,15 @@ public class ProfiledPIDController implements Sendable {
   }
 
   /**
+   * Returns the total accumulated error.
+   *
+   * @return The total accumulated error.
+   */
+  public double getTotalError() {
+    return m_controller.getTotalError();
+  }
+
+  /**
    * Returns the next output of the PID controller.
    *
    * @param measurement The current measurement of the process variable.

--- a/wpimath/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpimath/src/main/native/cpp/controller/PIDController.cpp
@@ -170,6 +170,10 @@ double PIDController::GetVelocityError() const {
   return m_velocityError;
 }
 
+double PIDController::GetTotalError() const {
+  return m_totalError;
+}
+
 double PIDController::Calculate(double measurement) {
   m_measurement = measurement;
   m_prevError = m_positionError;

--- a/wpimath/src/main/native/include/frc/controller/PIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/PIDController.h
@@ -210,6 +210,11 @@ class WPILIB_DLLEXPORT PIDController
   double GetVelocityError() const;
 
   /**
+   * Returns the total accumulated error.
+   */
+  double GetTotalError() const;
+
+  /**
    * Returns the next output of the PID controller.
    *
    * @param measurement The current measurement of the process variable.

--- a/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -300,6 +300,13 @@ class ProfiledPIDController
   }
 
   /**
+   * Returns the total accumulated error.
+   */
+  Distance_t GetTotalError() const {
+    return Distance_t{m_controller.GetTotalError()};
+  }
+
+  /**
    * Returns the next output of the PID controller.
    *
    * @param measurement The current measurement of the process variable.


### PR DESCRIPTION
Adds the ability to retrieve the accumulated error from both PIDController and ProfiledPIDController to allow for the user to monitor the outputs of each individual term.