### PR TITLE
Fix memory over-allocation in Apriltag examples

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/AprilTagsVision/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/AprilTagsVision/cpp/Robot.cpp
@@ -39,7 +39,8 @@ class Robot : public frc::TimedRobot {
     frc::AprilTagDetector detector;
     // look for tag36h11, correct 1 error bit
     // hamming 1 allocates 781KB, 2 allocates 27.4 MB, 3 allocates 932 MB
-    // max of 1 recommended for RoboRIO 1, while hamming 2 is feasible on the RoboRIO 2
+    // max of 1 recommended for RoboRIO 1, while hamming 2 is feasible on the
+    // RoboRIO 2
     detector.AddFamily("tag36h11", 1);
 
     // Set up Pose Estimator - parameters are for a Microsoft Lifecam HD-3000

--- a/wpilibcExamples/src/main/cpp/examples/AprilTagsVision/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/AprilTagsVision/cpp/Robot.cpp
@@ -37,8 +37,10 @@ class Robot : public frc::TimedRobot {
  private:
   static void VisionThread() {
     frc::AprilTagDetector detector;
-    // look for tag36h11, correct 3 error bits
-    detector.AddFamily("tag36h11", 3);
+    // look for tag36h11, correct 1 error bit
+    // hamming 1 allocates 781KB, 2 allocates 27.4 MB, 3 allocates 932 MB
+    // max of 1 recommended for RoboRIO 1, while hamming 2 is feasible on the RoboRIO 2
+    detector.AddFamily("tag36h11", 1);
 
     // Set up Pose Estimator - parameters are for a Microsoft Lifecam HD-3000
     // (https://www.chiefdelphi.com/t/wpilib-apriltagdetector-sample-code/421411/21)

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/apriltagsvision/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/apriltagsvision/Robot.java
@@ -39,8 +39,10 @@ public class Robot extends TimedRobot {
 
   void apriltagVisionThreadProc() {
     var detector = new AprilTagDetector();
-    // look for tag36h11, correct 3 error bits
-    detector.addFamily("tag36h11", 3);
+    // look for tag36h11, correct 1 error bit (hamming distance 1)
+    // hamming 1 allocates 781KB, 2 allocates 27.4 MB, 3 allocates 932 MB
+    // max of 1 recommended for RoboRIO 1, while hamming 2 is feasible on the RoboRIO 2
+    detector.addFamily("tag36h11", 1);
 
     // Set up Pose Estimator - parameters are for a Microsoft Lifecam HD-3000
     // (https://www.chiefdelphi.com/t/wpilib-apriltagdetector-sample-code/421411/21)


### PR DESCRIPTION
Hamming distance of 3 (used prior on the example) produced unfeasible memory allocations of 932 MB. Reduced to hamming 1 so that both the RoboRIO 1 + 2 will be able to run it comfortably, whereas the RIO 2 might be able to use hamming 2, so a comment was added to specify that.

Fixes #6516.