### PR TITLE
Removed printf in CANJNI

### DIFF
--- a/hal/src/main/native/cpp/jni/CANJNI.cpp
+++ b/hal/src/main/native/cpp/jni/CANJNI.cpp
@@ -176,7 +176,6 @@ Java_edu_wpi_first_hal_can_CANJNI_readCANStreamSession
       // OOM, just return
       elem = JLocal<jobject>{env, CreateCANStreamMessage(env)};
       if (elem) {
-        std::printf("Allocated and set object\n");
         env->SetObjectArrayElement(messages, i, elem);
       } else {
         return 0;


### PR DESCRIPTION
Removes `std::printf` in Java_edu_wpi_first_hal_can_CANJNI_readCANStreamSession to allow for use without spamming the log.