### PR TITLE
[commands] Add a method to get registered subsystems

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -736,4 +736,13 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
           }
         });
   }
+
+  /**
+   * Returns a readonly Map of the Subsystems registered with the Scheduler.
+   *
+   * @return NavigableMap of the registered Subsystems and their active commands.
+   */
+  public Map<Subsystem, Command> getRegisteredSubsystems() {
+    return Collections.unmodifiableMap(m_subsystems);
+  }
 }


### PR DESCRIPTION
Still needs C++, most likely to be done with
https://en.cppreference.com/w/cpp/ranges/keys_view depending on compatibility with `llvm::DenseMap` and C++ 20 support.

Resolves https://github.com/wpilibsuite/allwpilib/issues/6475