### PR TITLE
[glass] Add math expression input for NetworkTables numerical values

### DIFF
--- a/glass/src/lib/native/cpp/support/ExpressionParser.cpp
+++ b/glass/src/lib/native/cpp/support/ExpressionParser.cpp
@@ -1,0 +1,314 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "glass/support/ExpressionParser.h"
+
+#include <cctype>
+#include <cmath>
+#include <stack>
+#include <string>
+
+#include <imgui.h>
+
+namespace glass {
+namespace expression {
+
+ParseResult ParseResult::CreateSuccess(double value) {
+  ParseResult result;
+  result.kind = ParseResult::Success;
+  result.successVal = value;
+  return result;
+}
+
+ParseResult ParseResult::CreateError(const char* errorMessage) {
+  ParseResult result;
+  result.kind = ParseResult::Error;
+  result.errorMessage = errorMessage;
+  return result;
+}
+
+enum class TokenType {
+  Number,
+  Add,
+  Subtract,
+  Multiply,
+  Divide,
+  Exponent,
+  OpenParen,
+  CloseParen,
+
+  End,    // Hit end of input
+  Error,  // Invalid character found
+};
+
+struct Token {
+  TokenType type;
+  const char* str;
+  int strLen;
+
+  explicit Token(TokenType type) : type(type), str(nullptr), strLen(0) {}
+
+  Token(TokenType type, const char* str, int strLen)
+      : type(type), str(str), strLen(strLen) {}
+};
+
+class Lexer {
+ public:
+  explicit Lexer(const char* input)
+      : input(input), startIdx(0), currentIdx(0) {}
+
+  Token NextToken() {
+    // Skip leading whitespace
+    startIdx = currentIdx;
+    while (std::isspace(input[startIdx]))
+      startIdx++;
+    if (input[startIdx] == 0)
+      return Token(TokenType::End);
+    currentIdx = startIdx;
+
+    char c = input[currentIdx];
+    currentIdx++;
+    switch (c) {
+      case '+':
+        return Token(TokenType::Add);
+      case '-':
+        return Token(TokenType::Subtract);
+      case '*':
+        return Token(TokenType::Multiply);
+      case '/':
+        return Token(TokenType::Divide);
+      case '^':
+        return Token(TokenType::Exponent);
+      case '(':
+        return Token(TokenType::OpenParen);
+      case ')':
+        return Token(TokenType::CloseParen);
+      default:
+        currentIdx--;
+        if (std::isdigit(c) || c == '.')
+          return nextNumber();
+        return Token(TokenType::Error);
+    }
+  }
+
+  // Makes NextToken() return the same token as previously
+  void Repeat() { currentIdx = startIdx; }
+
+ private:
+  const char* input;
+  int startIdx, currentIdx;
+
+  Token nextNumber() {
+    // Read whole part
+    bool hasDigitsBeforeDecimal = false;
+    while (std::isdigit(input[currentIdx])) {
+      currentIdx++;
+      hasDigitsBeforeDecimal = true;
+    }
+
+    // Read decimal part if it exists
+    if (input[currentIdx] == '.') {
+      currentIdx++;
+      if (!hasDigitsBeforeDecimal && !std::isdigit(input[currentIdx]))
+        return Token(TokenType::Error);
+
+      while (std::isdigit(input[currentIdx]))
+        currentIdx++;
+    }
+
+    return Token(TokenType::Number, input + startIdx, currentIdx - startIdx);
+  }
+};
+
+enum class Operator { Add, Subtract, Multiply, Divide, Exponent, Negate, None };
+
+Operator GetOperator(TokenType type) {
+  switch (type) {
+    case TokenType::Add:
+      return Operator::Add;
+    case TokenType::Subtract:
+      return Operator::Subtract;
+    case TokenType::Multiply:
+      return Operator::Multiply;
+    case TokenType::Divide:
+      return Operator::Divide;
+    case TokenType::Exponent:
+      return Operator::Exponent;
+    default:
+      return Operator::None;
+  }
+}
+
+int OperatorPrecedence(Operator op) {
+  switch (op) {
+    case Operator::Add:
+    case Operator::Subtract:
+      return 1;
+    case Operator::Multiply:
+    case Operator::Divide:
+      return 2;
+    case Operator::Exponent:
+      return 3;
+    case Operator::Negate:
+      return 4;
+    case Operator::None:
+      return 0;
+  }
+  return 0;
+}
+
+bool IsOperatorRightAssociative(Operator op) {
+  return op == Operator::Exponent || op == Operator::Negate;
+}
+
+void ApplyOperator(std::stack<double>& valStack, Operator op) {
+  double right = valStack.top();
+  valStack.pop();
+  double left = valStack.top();
+  valStack.pop();
+
+  double val = 0;
+  switch (op) {
+    case Operator::Add:
+      val = left + right;
+      break;
+    case Operator::Subtract:
+      val = left - right;
+      break;
+    case Operator::Multiply:
+      val = left * right;
+      break;
+    case Operator::Divide:
+      val = left / right;
+      break;
+    case Operator::Exponent:
+      val = std::pow(left, right);
+      break;
+    case Operator::Negate:
+      val = -right;
+      break;
+    case Operator::None:
+      break;
+  }
+
+  valStack.push(val);
+}
+
+ParseResult ParseExpr(Lexer& lexer, bool insideParen) {
+  std::stack<Operator> operStack;
+  std::stack<double> valStack;
+
+  bool prevWasOp = true;
+  TokenType prevType = TokenType::Add;
+
+  while (true) {
+    Token token = lexer.NextToken();
+
+    bool wasOp = false;
+    switch (token.type) {
+      case TokenType::End:
+        goto end;
+      case TokenType::Number:
+        // This happens if there's multiple decimal places in the number
+        if (prevType == TokenType::Number)
+          return ParseResult::CreateError("Invalid number");
+
+        // Implicit multiplication. Ex: 2(4 + 5)
+        if (!prevWasOp)
+          operStack.push(Operator::Multiply);
+        valStack.push(std::atof(std::string(token.str, token.strLen).c_str()));
+        break;
+
+      case TokenType::OpenParen: {
+        // Implicit multiplication
+        if (!prevWasOp)
+          operStack.push(Operator::Multiply);
+
+        ParseResult result = ParseExpr(lexer, true);
+        if (result.kind == ParseResult::Error)
+          return result;
+        valStack.push(result.successVal);
+
+        TokenType nextType = lexer.NextToken().type;
+        if (nextType != TokenType::CloseParen) {
+          if (nextType == TokenType::End)
+            goto end;  // Act as if closed at end of expression
+          return ParseResult::CreateError("Expected )");
+        }
+        break;
+      }
+
+      case TokenType::CloseParen:
+        if (insideParen) {
+          lexer.Repeat();
+          goto end;
+        }
+        // Act as if there was open paren at start of expression
+        break;
+
+      case TokenType::Error:
+        return ParseResult::CreateError("Unexpected character");
+
+      default:
+        Operator op = GetOperator(token.type);
+        if (op == Operator::None) {
+          lexer.Repeat();
+          goto end;
+        }
+        if (op == Operator::Subtract && prevWasOp) {
+          op = Operator::Negate;
+          // Dummy left-hand side for negation
+          valStack.push(0.0);
+        }
+        wasOp = true;
+
+        while (!operStack.empty()) {
+          Operator prevOp = operStack.top();
+
+          bool rightAssoc = IsOperatorRightAssociative(op);
+          int precedence = OperatorPrecedence(op);
+          int prevPrecedence = OperatorPrecedence(prevOp);
+
+          if ((!rightAssoc && precedence == prevPrecedence) ||
+              precedence < prevPrecedence) {
+            operStack.pop();
+            if (valStack.size() < 2) {
+              return ParseResult::CreateError("Missing operand");
+            }
+            ApplyOperator(valStack, prevOp);
+          } else {
+            break;
+          }
+        }
+        operStack.push(op);
+        break;
+    }
+    prevType = token.type;
+    prevWasOp = wasOp;
+  }
+
+// Reached the end of the expression
+end:
+  while (!operStack.empty()) {
+    if (valStack.size() < 2) {
+      return ParseResult::CreateError("Missing operand");
+    }
+    ApplyOperator(valStack, operStack.top());
+    operStack.pop();
+  }
+  if (valStack.empty()) {
+    return ParseResult::CreateError("No value");
+  }
+
+  return ParseResult::CreateSuccess(valStack.top());
+}
+
+// expr is null-terminated string, as ImGui::inputText() uses
+ParseResult TryParseExpr(const char* expr) {
+  Lexer lexer(expr);
+  return ParseExpr(lexer, false);
+}
+
+}  // namespace expression
+}  // namespace glass

--- a/glass/src/lib/native/cpp/support/ExpressionParser.cpp
+++ b/glass/src/lib/native/cpp/support/ExpressionParser.cpp
@@ -99,8 +99,9 @@ class Lexer {
     // Read decimal part if it exists
     if (input[currentIdx] == '.') {
       // Integers can't have fractional part
-      if (isInteger)
+      if (isInteger) {
         return Token(TokenType::Error, &input[currentIdx], 1);
+      }
 
       currentIdx++;
       // Report a single '.' with no digits as an error

--- a/glass/src/lib/native/cpp/support/ExtraGuiWidgets.cpp
+++ b/glass/src/lib/native/cpp/support/ExtraGuiWidgets.cpp
@@ -11,7 +11,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-// #include <unordered_map>
 
 #include <wpi/DenseMap.h>
 
@@ -231,7 +230,6 @@ struct InputExprState {
   char inputBuffer[kBufferSize];
 };
 
-// static std::unordered_map<int, InputExprState> exprStates;
 static wpi::DenseMap<int, InputExprState> exprStates;
 // Shared string buffer for inactive inputs
 static char previewBuffer[kBufferSize];

--- a/glass/src/lib/native/cpp/support/ExtraGuiWidgets.cpp
+++ b/glass/src/lib/native/cpp/support/ExtraGuiWidgets.cpp
@@ -10,6 +10,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <unordered_map>
 
 #include "glass/DataSource.h"
@@ -222,16 +223,15 @@ bool HamburgerButton(const ImGuiID id, const ImVec2 position) {
   return pressed;
 }
 
+static const int kBufferSize = 256;
+
 struct InputExprState {
-  char* inputBuffer = nullptr;
+  char inputBuffer[kBufferSize];
   bool wasActive = false;
 };
 
-static const int kBufferSize = 256;
-
 static std::unordered_map<int, InputExprState> exprStates;
-static char* previewBuffer =
-    reinterpret_cast<char*>(std::malloc(kBufferSize * sizeof(char)));
+// static char previewBuffer[kBufferSize];
 
 template <typename V>
 bool InputExpr(const char* label, V* v, const char* format,
@@ -240,10 +240,10 @@ bool InputExpr(const char* label, V* v, const char* format,
   InputExprState& state = exprStates[id];
 
   char* inputBuffer;
+  inputBuffer = state.inputBuffer;
   if (state.wasActive) {
-    inputBuffer = state.inputBuffer;
   } else {
-    inputBuffer = previewBuffer;
+    // inputBuffer = previewBuffer;
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -260,12 +260,13 @@ bool InputExpr(const char* label, V* v, const char* format,
   bool active = ImGui::IsItemActive();
 
   if (active || changed) {
-    if (!state.inputBuffer) {
-      // Move the preview buffer into state, and make a new buffer for previews
-      state.inputBuffer = previewBuffer;
-      previewBuffer =
-          reinterpret_cast<char*>(std::malloc(kBufferSize * sizeof(char)));
-    }
+    // if (!state.inputBuffer) {
+      // Move the preview buffer into state
+      
+      // state.inputBuffer = previewBuffer;
+      // previewBuffer =
+      //     reinterpret_cast<char*>(std::malloc(kBufferSize * sizeof(char)));
+    // }
 
     // Attempt to parse current value
     auto result = glass::expression::TryParseExpr<V>(state.inputBuffer);

--- a/glass/src/lib/native/cpp/support/ExtraGuiWidgets.cpp
+++ b/glass/src/lib/native/cpp/support/ExtraGuiWidgets.cpp
@@ -11,7 +11,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-//#include <unordered_map>
+// #include <unordered_map>
 
 #include <wpi/DenseMap.h>
 
@@ -231,7 +231,7 @@ struct InputExprState {
   char inputBuffer[kBufferSize];
 };
 
-//static std::unordered_map<int, InputExprState> exprStates;
+// static std::unordered_map<int, InputExprState> exprStates;
 static wpi::DenseMap<int, InputExprState> exprStates;
 // Shared string buffer for inactive inputs
 static char previewBuffer[kBufferSize];
@@ -271,11 +271,11 @@ bool InputExpr(const char* label, V* v, const char* format,
 
     // Attempt to parse current value
     auto result = glass::expression::TryParseExpr<V>(state.inputBuffer);
-    if (result.kind == glass::expression::ParseResultKind::Success) {
-      *v = result.successVal;
+    if (result) {
+      *v = result.value();
     } else if (active) {
       ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "%s",
-                         result.errorMessage);
+                         result.error().c_str());
     }
   }
 

--- a/glass/src/lib/native/cpp/support/ExtraGuiWidgets.cpp
+++ b/glass/src/lib/native/cpp/support/ExtraGuiWidgets.cpp
@@ -11,7 +11,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <unordered_map>
+//#include <unordered_map>
+
+#include <wpi/DenseMap.h>
 
 #include "glass/DataSource.h"
 #include "glass/support/ExpressionParser.h"
@@ -229,7 +231,8 @@ struct InputExprState {
   char inputBuffer[kBufferSize];
 };
 
-static std::unordered_map<int, InputExprState> exprStates;
+//static std::unordered_map<int, InputExprState> exprStates;
+static wpi::DenseMap<int, InputExprState> exprStates;
 // Shared string buffer for inactive inputs
 static char previewBuffer[kBufferSize];
 
@@ -239,7 +242,7 @@ bool InputExpr(const char* label, V* v, const char* format,
   int id = ImGui::GetID(label);
 
   char* inputBuffer;
-  bool hasState = exprStates.find(id) != exprStates.end();
+  bool hasState = exprStates.contains(id);
   if (hasState) {
     InputExprState& state = exprStates[id];
     inputBuffer = state.inputBuffer;

--- a/glass/src/lib/native/cpp/support/ExtraGuiWidgets.cpp
+++ b/glass/src/lib/native/cpp/support/ExtraGuiWidgets.cpp
@@ -227,14 +227,15 @@ struct InputExprState {
   bool wasActive = false;
 };
 
-bool InputDoubleExpr(const char* label, double* v, const char* format,
-                     ImGuiInputTextFlags flags) {
-  static const int kBufferSize = 256;
+static const int kBufferSize = 256;
 
-  static std::unordered_map<int, InputExprState> exprStates;
-  static char* previewBuffer =
-      reinterpret_cast<char*>(std::malloc(kBufferSize * sizeof(char)));
+static std::unordered_map<int, InputExprState> exprStates;
+static char* previewBuffer =
+    reinterpret_cast<char*>(std::malloc(kBufferSize * sizeof(char)));
 
+template <typename V>
+bool InputExpr(const char* label, V* v, const char* format,
+               ImGuiInputTextFlags flags) {
   int id = ImGui::GetID(label);
   InputExprState& state = exprStates[id];
 
@@ -267,9 +268,8 @@ bool InputDoubleExpr(const char* label, double* v, const char* format,
     }
 
     // Attempt to parse current value
-    glass::expression::ParseResult result =
-        glass::expression::TryParseExpr(state.inputBuffer);
-    if (result.kind == glass::expression::ParseResult::Success) {
+    auto result = glass::expression::TryParseExpr<V>(state.inputBuffer);
+    if (result.kind == glass::expression::ParseResultKind::Success) {
       *v = result.successVal;
     } else if (active) {
       ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "%s",
@@ -280,5 +280,10 @@ bool InputDoubleExpr(const char* label, double* v, const char* format,
 
   return changed;
 }
+
+template bool InputExpr(const char*, int64_t*, const char*,
+                        ImGuiInputTextFlags);
+template bool InputExpr(const char*, float*, const char*, ImGuiInputTextFlags);
+template bool InputExpr(const char*, double*, const char*, ImGuiInputTextFlags);
 
 }  // namespace glass

--- a/glass/src/lib/native/include/glass/support/ExpressionParser.h
+++ b/glass/src/lib/native/include/glass/support/ExpressionParser.h
@@ -6,32 +6,17 @@
 
 #include <stdint.h>
 
+#include <string>
+
+#include <wpi/expected>
+
 namespace glass::expression {
 
-enum class ParseResultKind {
-  Success,
-  Error,
-};
-
 template <typename V>
-struct ParseResult {
-  static ParseResult<V> CreateSuccess(V value);
-  static ParseResult<V> CreateError(const char* errorMessage);
+wpi::expected<V, std::string> TryParseExpr(const char* expr);
 
-  // If kind is Success, expression value is in successVal
-  // If kind is Error, error message is in errorMessage
-  ParseResultKind kind;
-  union {
-    V successVal;
-    const char* errorMessage;
-  };
-};
-
-template <typename V>
-ParseResult<V> TryParseExpr(const char* expr);
-
-extern template ParseResult<double> TryParseExpr(const char*);
-extern template ParseResult<float> TryParseExpr(const char*);
-extern template ParseResult<int64_t> TryParseExpr(const char*);
+extern template wpi::expected<double, std::string> TryParseExpr(const char*);
+extern template wpi::expected<float, std::string> TryParseExpr(const char*);
+extern template wpi::expected<int64_t, std::string> TryParseExpr(const char*);
 
 }  // namespace glass::expression

--- a/glass/src/lib/native/include/glass/support/ExpressionParser.h
+++ b/glass/src/lib/native/include/glass/support/ExpressionParser.h
@@ -4,24 +4,36 @@
 
 #pragma once
 
+#include <stdint.h>
+
 namespace glass {
 namespace expression {
 
-struct ParseResult {
-  static ParseResult CreateSuccess(double value);
-  static ParseResult CreateError(const char* errorMessage);
+enum class ParseResultKind {
+  Success,
+  Error,
+};
 
-  enum { Success, Error } kind;
+template <typename V>
+struct ParseResult {
+  static ParseResult<V> CreateSuccess(V value);
+  static ParseResult<V> CreateError(const char* errorMessage);
 
   // If kind is Success, expression value is in successVal
   // If kind is Error, error message is in errorMessage
+  ParseResultKind kind;
   union {
-    double successVal;
+    V successVal;
     const char* errorMessage;
   };
 };
 
-ParseResult TryParseExpr(const char* expr);
+template <typename V>
+ParseResult<V> TryParseExpr(const char* expr);
+
+extern template ParseResult<double> TryParseExpr(const char*);
+extern template ParseResult<float> TryParseExpr(const char*);
+extern template ParseResult<int64_t> TryParseExpr(const char*);
 
 }  // namespace expression
 }  // namespace glass

--- a/glass/src/lib/native/include/glass/support/ExpressionParser.h
+++ b/glass/src/lib/native/include/glass/support/ExpressionParser.h
@@ -6,8 +6,7 @@
 
 #include <stdint.h>
 
-namespace glass {
-namespace expression {
+namespace glass::expression {
 
 enum class ParseResultKind {
   Success,
@@ -35,5 +34,4 @@ extern template ParseResult<double> TryParseExpr(const char*);
 extern template ParseResult<float> TryParseExpr(const char*);
 extern template ParseResult<int64_t> TryParseExpr(const char*);
 
-}  // namespace expression
-}  // namespace glass
+}  // namespace glass::expression

--- a/glass/src/lib/native/include/glass/support/ExpressionParser.h
+++ b/glass/src/lib/native/include/glass/support/ExpressionParser.h
@@ -1,0 +1,27 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+namespace glass {
+namespace expression {
+
+struct ParseResult {
+  static ParseResult CreateSuccess(double value);
+  static ParseResult CreateError(const char* errorMessage);
+
+  enum { Success, Error } kind;
+
+  // If kind is Success, expression value is in successVal
+  // If kind is Error, error message is in errorMessage
+  union {
+    double successVal;
+    const char* errorMessage;
+  };
+};
+
+ParseResult TryParseExpr(const char* expr);
+
+}  // namespace expression
+}  // namespace glass

--- a/glass/src/lib/native/include/glass/support/ExtraGuiWidgets.h
+++ b/glass/src/lib/native/include/glass/support/ExtraGuiWidgets.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include <imgui.h>
 
@@ -99,10 +101,20 @@ bool HeaderDeleteButton(const char* label);
  */
 bool HamburgerButton(const ImGuiID id, const ImVec2 position);
 
+template <typename V>
+bool InputExpr(const char* label, V* v, const char* format,
+               ImGuiInputTextFlags flags = 0);
+extern template bool InputExpr(const char*, int64_t*, const char*,
+                               ImGuiInputTextFlags);
+extern template bool InputExpr(const char*, float*, const char*,
+                               ImGuiInputTextFlags);
+extern template bool InputExpr(const char*, double*, const char*,
+                               ImGuiInputTextFlags);
+
 /**
  * Edit a double value with expression input. Similar to ImGui::InputDouble()
  */
-bool InputDoubleExpr(const char* label, double* v, const char* format = NULL,
-                     ImGuiInputTextFlags flags = 0);
+// bool InputDoubleExpr(const char* label, double* v, const char* format = NULL,
+//                      ImGuiInputTextFlags flags = 0);
 
 }  // namespace glass

--- a/glass/src/lib/native/include/glass/support/ExtraGuiWidgets.h
+++ b/glass/src/lib/native/include/glass/support/ExtraGuiWidgets.h
@@ -99,4 +99,10 @@ bool HeaderDeleteButton(const char* label);
  */
 bool HamburgerButton(const ImGuiID id, const ImVec2 position);
 
+/**
+ * Edit a double value with expression input. Similar to ImGui::InputDouble()
+ */
+bool InputDoubleExpr(const char* label, double* v, const char* format = NULL,
+                     ImGuiInputTextFlags flags = 0);
+
 }  // namespace glass

--- a/glass/src/lib/native/include/glass/support/ExtraGuiWidgets.h
+++ b/glass/src/lib/native/include/glass/support/ExtraGuiWidgets.h
@@ -101,6 +101,9 @@ bool HeaderDeleteButton(const char* label);
  */
 bool HamburgerButton(const ImGuiID id, const ImVec2 position);
 
+/**
+ * Edit a value with expression input. Similar to ImGui::InputScalar()
+ */
 template <typename V>
 bool InputExpr(const char* label, V* v, const char* format,
                ImGuiInputTextFlags flags = 0);
@@ -110,11 +113,5 @@ extern template bool InputExpr(const char*, float*, const char*,
                                ImGuiInputTextFlags);
 extern template bool InputExpr(const char*, double*, const char*,
                                ImGuiInputTextFlags);
-
-/**
- * Edit a double value with expression input. Similar to ImGui::InputDouble()
- */
-// bool InputDoubleExpr(const char* label, double* v, const char* format = NULL,
-//                      ImGuiInputTextFlags flags = 0);
 
 }  // namespace glass

--- a/glass/src/libnt/native/cpp/NetworkTables.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTables.cpp
@@ -33,6 +33,8 @@
 #include "glass/Context.h"
 #include "glass/DataSource.h"
 #include "glass/Storage.h"
+#include "glass/support/ExpressionParser.h"
+#include "glass/support/ExtraGuiWidgets.h"
 
 using namespace glass;
 using namespace mpack;
@@ -1411,9 +1413,8 @@ static void EmitEntryValueEditable(NetworkTablesModel* model,
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #endif
-      if (ImGui::InputDouble(typeStr, &v, 0, 0,
-                             fmt::format("%.{}f", precision).c_str(),
-                             ImGuiInputTextFlags_EnterReturnsTrue)) {
+      if (InputDoubleExpr(typeStr, &v, fmt::format("%.{}f", precision).c_str(),
+                          ImGuiInputTextFlags_EnterReturnsTrue)) {
         if (entry.publisher == 0) {
           entry.publisher = nt::Publish(entry.info.topic, NT_DOUBLE, "double");
         }

--- a/glass/src/libnt/native/cpp/NetworkTables.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTables.cpp
@@ -33,7 +33,6 @@
 #include "glass/Context.h"
 #include "glass/DataSource.h"
 #include "glass/Storage.h"
-#include "glass/support/ExpressionParser.h"
 #include "glass/support/ExtraGuiWidgets.h"
 
 using namespace glass;

--- a/glass/src/libnt/native/cpp/NetworkTables.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTables.cpp
@@ -1385,8 +1385,8 @@ static void EmitEntryValueEditable(NetworkTablesModel* model,
     }
     case NT_INTEGER: {
       int64_t v = val.GetInteger();
-      if (ImGui::InputScalar(typeStr, ImGuiDataType_S64, &v, nullptr, nullptr,
-                             nullptr, ImGuiInputTextFlags_EnterReturnsTrue)) {
+      if (InputExpr<int64_t>(typeStr, &v, "%d",
+                             ImGuiInputTextFlags_EnterReturnsTrue)) {
         if (entry.publisher == 0) {
           entry.publisher = nt::Publish(entry.info.topic, NT_INTEGER, "int");
         }
@@ -1396,8 +1396,8 @@ static void EmitEntryValueEditable(NetworkTablesModel* model,
     }
     case NT_FLOAT: {
       float v = val.GetFloat();
-      if (ImGui::InputFloat(typeStr, &v, 0, 0, "%.6f",
-                            ImGuiInputTextFlags_EnterReturnsTrue)) {
+      if (InputExpr<float>(typeStr, &v, "%.6f",
+                           ImGuiInputTextFlags_EnterReturnsTrue)) {
         if (entry.publisher == 0) {
           entry.publisher = nt::Publish(entry.info.topic, NT_FLOAT, "float");
         }
@@ -1413,8 +1413,9 @@ static void EmitEntryValueEditable(NetworkTablesModel* model,
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #endif
-      if (InputDoubleExpr(typeStr, &v, fmt::format("%.{}f", precision).c_str(),
-                          ImGuiInputTextFlags_EnterReturnsTrue)) {
+      if (InputExpr<double>(typeStr, &v,
+                            fmt::format("%.{}f", precision).c_str(),
+                            ImGuiInputTextFlags_EnterReturnsTrue)) {
         if (entry.publisher == 0) {
           entry.publisher = nt::Publish(entry.info.topic, NT_DOUBLE, "double");
         }


### PR DESCRIPTION
This is for easier adjustment of NetworkTables values when tuning values. For example, you can increase an angle by 5 degrees easily by adding `+5` to the value instead of doing the addition yourself. We implemented a similar feature in our custom dashboard program, which we found very convenient during the build season.