### PR TITLE
[build] Bump macOS deployment target to 13

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -61,7 +61,7 @@ jobs:
 
   build-host:
     env:
-      MACOSX_DEPLOYMENT_TARGET: 12
+      MACOSX_DEPLOYMENT_TARGET: 13
     strategy:
       fail-fast: false
       matrix:

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,5 +9,5 @@ repositories {
     }
 }
 dependencies {
-    implementation "edu.wpi.first:native-utils:2024.5.2"
+    implementation "edu.wpi.first:native-utils:2024.7.1"
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,5 +9,5 @@ repositories {
     }
 }
 dependencies {
-    implementation "edu.wpi.first:native-utils:2024.7.1"
+    implementation "edu.wpi.first:native-utils:2024.7.2"
 }


### PR DESCRIPTION
macOS 12 is EOL in mid-October of 2024 based on when macOS 11 was dropped last year.

Depends on wpilibsuite/native-utils#197.