### PR TITLE
[apriltag] Deprecate AprilTagFields.loadAprilTagLayoutField() and LoadAprilTagLayoutField()

### DIFF
--- a/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFields.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFields.java
@@ -35,7 +35,9 @@ public enum AprilTagFields {
    *
    * @return AprilTagFieldLayout of the field
    * @throws UncheckedIOException If the layout does not exist
+   * @deprecated Use {@link AprilTagFieldLayout#loadField(AprilTagFields)} instead.
    */
+  @Deprecated(forRemoval = true, since = "2025")
   public AprilTagFieldLayout loadAprilTagLayoutField() {
     return AprilTagFieldLayout.loadField(this);
   }

--- a/apriltag/src/main/native/include/frc/apriltag/AprilTagFieldLayout.h
+++ b/apriltag/src/main/native/include/frc/apriltag/AprilTagFieldLayout.h
@@ -166,7 +166,9 @@ void from_json(const wpi::json& json, AprilTagFieldLayout& layout);
  *
  * @param field The predefined field
  * @return AprilTagFieldLayout of the field
+ * @deprecated Use AprilTagFieldLayout::LoadField() instead
  */
+[[deprecated("Use AprilTagFieldLayout::LoadField() instead")]]
 WPILIB_DLLEXPORT AprilTagFieldLayout
 LoadAprilTagLayoutField(AprilTagField field);
 


### PR DESCRIPTION
Replaces #6331 in tandem with #6377 (which is already merged).