### PR TITLE
[commands] Deprecate proxy supplier constructor

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -186,8 +186,14 @@ public final class Commands {
    *
    * @param supplier the command supplier
    * @return the command
+   * @deprecated The ProxyCommand supplier constructor has been deprecated in favor of directly
+   *     proxying a {@link DeferredCommand}, see ProxyCommand documentaion for more details. As a
+   *     replacement, consider using `defer(supplier).asProxy()`.
+
    * @see ProxyCommand
    */
+  @Deprecated(since = "2024", forRemoval = true)
+  //@SuppressWarnings("removal")
   public static Command deferredProxy(Supplier<Command> supplier) {
     return new ProxyCommand(supplier);
   }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -189,11 +189,10 @@ public final class Commands {
    * @deprecated The ProxyCommand supplier constructor has been deprecated in favor of directly
    *     proxying a {@link DeferredCommand}, see ProxyCommand documentaion for more details. As a
    *     replacement, consider using `defer(supplier).asProxy()`.
-
    * @see ProxyCommand
    */
   @Deprecated(since = "2024", forRemoval = true)
-  //@SuppressWarnings("removal")
+  @SuppressWarnings("removal")
   public static Command deferredProxy(Supplier<Command> supplier) {
     return new ProxyCommand(supplier);
   }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -191,7 +191,7 @@ public final class Commands {
    *     replacement, consider using `defer(supplier).asProxy()`.
    * @see ProxyCommand
    */
-  @Deprecated(since = "2024", forRemoval = true)
+  @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings("removal")
   public static Command deferredProxy(Supplier<Command> supplier) {
     return new ProxyCommand(supplier);

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProxyCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProxyCommand.java
@@ -31,8 +31,14 @@ public class ProxyCommand extends Command {
    * only initialization time command construction is needed, use {@link DeferredCommand} instead.
    *
    * @param supplier the command supplier
+    * @deprecated This constructor's similarity to {@link DeferredCommand} is confusing and opens
+    *     potential footguns for users who do not fully understand the semantics and implications of
+    *     proxying, but who simply want runtime construction. Users who do know what they are doing
+    *     and need a supplier-constructed proxied command should instead proxy a DeferredCommand
+    *     using the <code>asProxy</code> decorator.
    * @see DeferredCommand
    */
+  @Deprecated(since = "2024", forRemoval = true)
   public ProxyCommand(Supplier<Command> supplier) {
     m_supplier = requireNonNullParam(supplier, "supplier", "ProxyCommand");
   }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProxyCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProxyCommand.java
@@ -31,11 +31,11 @@ public class ProxyCommand extends Command {
    * only initialization time command construction is needed, use {@link DeferredCommand} instead.
    *
    * @param supplier the command supplier
-    * @deprecated This constructor's similarity to {@link DeferredCommand} is confusing and opens
-    *     potential footguns for users who do not fully understand the semantics and implications of
-    *     proxying, but who simply want runtime construction. Users who do know what they are doing
-    *     and need a supplier-constructed proxied command should instead proxy a DeferredCommand
-    *     using the <code>asProxy</code> decorator.
+   * @deprecated This constructor's similarity to {@link DeferredCommand} is confusing and opens
+   *     potential footguns for users who do not fully understand the semantics and implications of
+   *     proxying, but who simply want runtime construction. Users who do know what they are doing
+   *     and need a supplier-constructed proxied command should instead proxy a DeferredCommand
+   *     using the <code>asProxy</code> decorator.
    * @see DeferredCommand
    */
   @Deprecated(since = "2024", forRemoval = true)

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProxyCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProxyCommand.java
@@ -51,7 +51,7 @@ public class ProxyCommand extends Command {
    */
   @SuppressWarnings("this-escape")
   public ProxyCommand(Command command) {
-    this(() -> command);
+    m_supplier = () -> requireNonNullParam(command, "command", "ProxyCommand");
     setName("Proxy(" + command.getName() + ")");
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProxyCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProxyCommand.java
@@ -38,7 +38,7 @@ public class ProxyCommand extends Command {
    *     using the <code>asProxy</code> decorator.
    * @see DeferredCommand
    */
-  @Deprecated(since = "2024", forRemoval = true)
+  @Deprecated(since = "2025", forRemoval = true)
   public ProxyCommand(Supplier<Command> supplier) {
     m_supplier = requireNonNullParam(supplier, "supplier", "ProxyCommand");
   }
@@ -51,8 +51,9 @@ public class ProxyCommand extends Command {
    */
   @SuppressWarnings("this-escape")
   public ProxyCommand(Command command) {
-    m_supplier = () -> requireNonNullParam(command, "command", "ProxyCommand");
-    setName("Proxy(" + command.getName() + ")");
+    Command nullCheckedCommand = requireNonNullParam(command, "command", "ProxyCommand");
+    m_supplier = () -> nullCheckedCommand;
+    setName("Proxy(" + nullCheckedCommand.getName() + ")");
   }
 
   @Override

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
@@ -4,6 +4,8 @@
 
 #include "frc2/command/Commands.h"
 
+#include "wpi/deprecated.h"
+
 #include "frc2/command/ConditionalCommand.h"
 #include "frc2/command/DeferredCommand.h"
 #include "frc2/command/FunctionalCommand.h"
@@ -60,6 +62,7 @@ CommandPtr cmd::Print(std::string_view msg) {
   return PrintCommand(msg).ToPtr();
 }
 
+WPI_IGNORE_DEPRECATED
 CommandPtr cmd::DeferredProxy(wpi::unique_function<Command*()> supplier) {
   return ProxyCommand(std::move(supplier)).ToPtr();
 }
@@ -67,6 +70,7 @@ CommandPtr cmd::DeferredProxy(wpi::unique_function<Command*()> supplier) {
 CommandPtr cmd::DeferredProxy(wpi::unique_function<CommandPtr()> supplier) {
   return ProxyCommand(std::move(supplier)).ToPtr();
 }
+WPI_UNIGNORE_DEPRECATED
 
 CommandPtr cmd::Wait(units::second_t duration) {
   return WaitCommand(duration).ToPtr();

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
@@ -4,7 +4,7 @@
 
 #include "frc2/command/Commands.h"
 
-#include "wpi/deprecated.h"
+#include <wpi/deprecated.h>
 
 #include "frc2/command/ConditionalCommand.h"
 #include "frc2/command/DeferredCommand.h"

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/ProxyCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/ProxyCommand.cpp
@@ -20,12 +20,13 @@ ProxyCommand::ProxyCommand(wpi::unique_function<CommandPtr()> supplier)
         holder = supplier();
         return holder->get();
       }) {}
+WPI_UNIGNORE_DEPRECATED
 
 ProxyCommand::ProxyCommand(Command* command)
-    : ProxyCommand([command] { return command; }) {
+    : m_supplier([command] { return command; }) {
   SetName(fmt::format("Proxy({})", command->GetName()));
 }
-WPI_UNIGNORE_DEPRECATED
+
 ProxyCommand::ProxyCommand(std::unique_ptr<Command> command) {
   SetName(fmt::format("Proxy({})", command->GetName()));
   m_supplier = [command = std::move(command)] { return command.get(); };

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/ProxyCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/ProxyCommand.cpp
@@ -20,13 +20,12 @@ ProxyCommand::ProxyCommand(wpi::unique_function<CommandPtr()> supplier)
         holder = supplier();
         return holder->get();
       }) {}
-WPI_UNIGNORE_DEPRECATED
 
 ProxyCommand::ProxyCommand(Command* command)
     : ProxyCommand([command] { return command; }) {
   SetName(fmt::format("Proxy({})", command->GetName()));
 }
-
+WPI_UNIGNORE_DEPRECATED
 ProxyCommand::ProxyCommand(std::unique_ptr<Command> command) {
   SetName(fmt::format("Proxy({})", command->GetName()));
   m_supplier = [command = std::move(command)] { return command.get(); };

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/ProxyCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/ProxyCommand.cpp
@@ -5,8 +5,8 @@
 #include "frc2/command/ProxyCommand.h"
 
 #include <fmt/core.h>
+#include <wpi/deprecated.h>
 #include <wpi/sendable/SendableBuilder.h>
-#include "wpi/deprecated.h"
 
 using namespace frc2;
 

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/ProxyCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/ProxyCommand.cpp
@@ -6,9 +6,11 @@
 
 #include <fmt/core.h>
 #include <wpi/sendable/SendableBuilder.h>
+#include "wpi/deprecated.h"
 
 using namespace frc2;
 
+WPI_IGNORE_DEPRECATED
 ProxyCommand::ProxyCommand(wpi::unique_function<Command*()> supplier)
     : m_supplier(std::move(supplier)) {}
 
@@ -18,6 +20,7 @@ ProxyCommand::ProxyCommand(wpi::unique_function<CommandPtr()> supplier)
         holder = supplier();
         return holder->get();
       }) {}
+WPI_UNIGNORE_DEPRECATED
 
 ProxyCommand::ProxyCommand(Command* command)
     : ProxyCommand([command] { return command; }) {

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
@@ -12,10 +12,11 @@
 #include <utility>
 #include <vector>
 
+#include <wpi/deprecated.h>
+
 #include "frc2/command/CommandPtr.h"
 #include "frc2/command/Requirements.h"
 #include "frc2/command/SelectCommand.h"
-#include "wpi/deprecated.h"
 
 namespace frc2 {
 class Subsystem;
@@ -161,11 +162,11 @@ CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier,
  *
  * @param supplier the command supplier
  */
- WPI_IGNORE_DEPRECATED
+WPI_IGNORE_DEPRECATED
 [[nodiscard]] [[deprecated(
-    "The ProxyCommand supplier constructor has been deprecated. Use Defer(supplier).AsProxy() instead.")]]
+    "The ProxyCommand supplier constructor has been deprecated. Use "
+    "Defer(supplier).AsProxy() instead.")]]
 CommandPtr DeferredProxy(wpi::unique_function<Command*()> supplier);
-
 
 /**
  * Constructs a command that schedules the command returned from the supplier
@@ -175,8 +176,8 @@ CommandPtr DeferredProxy(wpi::unique_function<Command*()> supplier);
  * @param supplier the command supplier
  */
 [[nodiscard]] [[deprecated(
-  "The ProxyCommand supplier constructor has been deprecated. Use Defer(supplier).AsProxy() instead."
-)]]
+    "The ProxyCommand supplier constructor has been deprecated. Use "
+    "Defer(supplier).AsProxy() instead.")]]
 CommandPtr DeferredProxy(wpi::unique_function<CommandPtr()> supplier);
 WPI_UNIGNORE_DEPRECATED
 // Command Groups

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
@@ -15,6 +15,7 @@
 #include "frc2/command/CommandPtr.h"
 #include "frc2/command/Requirements.h"
 #include "frc2/command/SelectCommand.h"
+#include "wpi/deprecated.h"
 
 namespace frc2 {
 class Subsystem;
@@ -155,12 +156,16 @@ CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier,
 /**
  * Constructs a command that schedules the command returned from the supplier
  * when initialized, and ends when it is no longer scheduled. The supplier is
- * called when the command is initialized.
+ * called when the command is initialized. As a replacement, consider using
+ * `Defer(supplier).AsProxy()`.
  *
  * @param supplier the command supplier
  */
-[[nodiscard]]
+ WPI_IGNORE_DEPRECATED
+[[nodiscard]] [[deprecated(
+    "The ProxyCommand supplier constructor has been deprecated. Use Defer(supplier).AsProxy() instead.")]]
 CommandPtr DeferredProxy(wpi::unique_function<Command*()> supplier);
+
 
 /**
  * Constructs a command that schedules the command returned from the supplier
@@ -169,9 +174,11 @@ CommandPtr DeferredProxy(wpi::unique_function<Command*()> supplier);
  *
  * @param supplier the command supplier
  */
-[[nodiscard]]
+[[nodiscard]] [[deprecated(
+  "The ProxyCommand supplier constructor has been deprecated. Use Defer(supplier).AsProxy() instead."
+)]]
 CommandPtr DeferredProxy(wpi::unique_function<CommandPtr()> supplier);
-
+WPI_UNIGNORE_DEPRECATED
 // Command Groups
 
 namespace impl {

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ProxyCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ProxyCommand.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include <wpi/FunctionExtras.h>
+#include "wpi/deprecated.h"
 
 #include "frc2/command/Command.h"
 #include "frc2/command/CommandHelper.h"
@@ -44,7 +45,8 @@ class ProxyCommand : public CommandHelper<Command, ProxyCommand> {
    *     using the <code>AsProxy</code> decorator.
    * @see DeferredCommand
    */
-  explicit ProxyCommand(wpi::unique_function<Command*()> supplier);
+  WPI_IGNORE_DEPRECATED
+  [[deprecated("Proxy a DeferredCommand instead")]]explicit ProxyCommand(wpi::unique_function<Command*()> supplier);
 
   /**
    * Creates a new ProxyCommand that schedules the supplied command when
@@ -63,7 +65,8 @@ class ProxyCommand : public CommandHelper<Command, ProxyCommand> {
    *     using the <code>AsProxy</code> decorator.
    * @see DeferredCommand
    */
-  explicit ProxyCommand(wpi::unique_function<CommandPtr()> supplier);
+  [[deprecated("Proxy a DeferredCommand instead")]] explicit ProxyCommand(wpi::unique_function<CommandPtr()> supplier);
+WPI_UNIGNORE_DEPRECATED
 
   /**
    * Creates a new ProxyCommand that schedules the given command when

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ProxyCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ProxyCommand.h
@@ -7,7 +7,7 @@
 #include <memory>
 
 #include <wpi/FunctionExtras.h>
-#include "wpi/deprecated.h"
+#include <wpi/deprecated.h>
 
 #include "frc2/command/Command.h"
 #include "frc2/command/CommandHelper.h"
@@ -46,7 +46,8 @@ class ProxyCommand : public CommandHelper<Command, ProxyCommand> {
    * @see DeferredCommand
    */
   WPI_IGNORE_DEPRECATED
-  [[deprecated("Proxy a DeferredCommand instead")]]explicit ProxyCommand(wpi::unique_function<Command*()> supplier);
+  [[deprecated("Proxy a DeferredCommand instead")]]
+  explicit ProxyCommand(wpi::unique_function<Command*()> supplier);
 
   /**
    * Creates a new ProxyCommand that schedules the supplied command when
@@ -65,8 +66,9 @@ class ProxyCommand : public CommandHelper<Command, ProxyCommand> {
    *     using the <code>AsProxy</code> decorator.
    * @see DeferredCommand
    */
-  [[deprecated("Proxy a DeferredCommand instead")]] explicit ProxyCommand(wpi::unique_function<CommandPtr()> supplier);
-WPI_UNIGNORE_DEPRECATED
+  [[deprecated("Proxy a DeferredCommand instead")]]
+  explicit ProxyCommand(wpi::unique_function<CommandPtr()> supplier);
+  WPI_UNIGNORE_DEPRECATED
 
   /**
    * Creates a new ProxyCommand that schedules the given command when

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ProxyCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ProxyCommand.h
@@ -36,6 +36,12 @@ class ProxyCommand : public CommandHelper<Command, ProxyCommand> {
    * DeferredCommand} instead.
    *
    * @param supplier the command supplier
+   * @deprecated This constructor's similarity to {@link DeferredCommand} is
+   * confusing and opens potential footguns for users who do not fully
+   * understand the semantics and implications of proxying, but who simply want
+   * runtime construction. Users who do know what they are doing and need a
+   * supplier-constructed proxied command should instead proxy a DeferredCommand
+   *     using the <code>AsProxy</code> decorator.
    * @see DeferredCommand
    */
   explicit ProxyCommand(wpi::unique_function<Command*()> supplier);
@@ -49,6 +55,12 @@ class ProxyCommand : public CommandHelper<Command, ProxyCommand> {
    * DeferredCommand} instead.
    *
    * @param supplier the command supplier
+   * @deprecated This constructor's similarity to {@link DeferredCommand} is
+   * confusing and opens potential footguns for users who do not fully
+   * understand the semantics and implications of proxying, but who simply want
+   * runtime construction. Users who do know what they are doing and need a
+   * supplier-constructed proxied command should instead proxy a DeferredCommand
+   *     using the <code>AsProxy</code> decorator.
    * @see DeferredCommand
    */
   explicit ProxyCommand(wpi::unique_function<CommandPtr()> supplier);


### PR DESCRIPTION
Deprecates the `ProxyCommand` supplier constructor in favor of deferring a `ProxyCommand` as discussed in #6324 