### PR TITLE
[wpimath] Fix incorrect docs for Rotation3d default constructor

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Rotation3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Rotation3d.java
@@ -30,7 +30,7 @@ public class Rotation3d
     implements Interpolatable<Rotation3d>, ProtobufSerializable, StructSerializable {
   private final Quaternion m_q;
 
-  /** Constructs a Rotation3d with a default angle of 0 degrees. */
+  /** Constructs a Rotation3d representing no rotation. */
   public Rotation3d() {
     m_q = new Quaternion();
   }

--- a/wpimath/src/main/native/include/frc/geometry/Rotation3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Rotation3d.h
@@ -20,7 +20,7 @@ namespace frc {
 class WPILIB_DLLEXPORT Rotation3d {
  public:
   /**
-   * Constructs a Rotation3d with a default angle of 0 degrees.
+   * Constructs a Rotation3d representing no rotation.
    */
   Rotation3d() = default;
 


### PR DESCRIPTION
A Rotation3d is not defined by one angle.