### PR TITLE
Expose tracer.printEpoch with string consumer in watchdog and commandScheduler.

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -530,6 +530,10 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
     m_disabled = false;
   }
 
+  public void printWatchdogEpochs(Consumer<String> output) {
+    m_watchdog.printEpochs(output);
+  }
+
   /**
    * Adds an action to perform on the initialization of any command by the scheduler.
    *

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -428,6 +428,10 @@ void CommandScheduler::Enable() {
   m_impl->disabled = false;
 }
 
+void CommandScheduler::PrintWatchdogEpochs(wpi::raw_ostream& os) {
+  m_watchdog.PrintEpochs(os);
+}
+
 void CommandScheduler::OnCommandInitialize(Action action) {
   m_impl->initActions.emplace_back(std::move(action));
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -334,6 +334,13 @@ class CommandScheduler final : public wpi::Sendable,
   void Enable();
 
   /**
+   * Prints list of epochs added so far and their times to a stream.
+   *
+   * @param os output stream
+   */
+  void PrintWatchdogEpochs(wpi::raw_ostream& os);
+
+  /**
    * Adds an action to perform on the initialization of any command by the
    * scheduler.
    *

--- a/wpilibc/src/main/native/cpp/Watchdog.cpp
+++ b/wpilibc/src/main/native/cpp/Watchdog.cpp
@@ -200,6 +200,10 @@ void Watchdog::PrintEpochs() {
   m_tracer.PrintEpochs();
 }
 
+void Watchdog::PrintEpochs(wpi::raw_ostream& os) {
+  m_tracer.PrintEpochs(os);
+}
+
 void Watchdog::Reset() {
   Enable();
 }

--- a/wpilibc/src/main/native/include/frc/Watchdog.h
+++ b/wpilibc/src/main/native/include/frc/Watchdog.h
@@ -84,6 +84,13 @@ class Watchdog {
   void PrintEpochs();
 
   /**
+   * Prints list of epochs added so far and their times to a stream.
+   *
+   * @param os output stream
+   */
+  void PrintEpochs(wpi::raw_ostream& os);
+
+  /**
    * Resets the watchdog timer.
    *
    * This also enables the timer if it was previously disabled.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -8,6 +8,7 @@ import edu.wpi.first.hal.NotifierJNI;
 import java.io.Closeable;
 import java.util.PriorityQueue;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 /**
  * A class that's a wrapper around a watchdog timer.
@@ -157,6 +158,10 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
    */
   public void printEpochs() {
     m_tracer.printEpochs();
+  }
+
+  public void printEpochs(Consumer<String> output) {
+    m_tracer.printEpochs(output);
   }
 
   /**


### PR DESCRIPTION
If wanted, I can change wpi::raw_ostream to something else, _like std::function<>_.

Also did not expose to InteractiveRobotBase but can if wanted to just by exposing the watchdog's printEpoch function.


#6582 and #6581 only expose printing, this PR is made to expose the consumer instead. 