### PR TITLE
JDK 17 updates

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 13
+          java-version: 17
       - name: Set environment variables (Development)
         run: |
           echo "BRANCH=development" >> $GITHUB_ENV

--- a/README-CMAKE.md
+++ b/README-CMAKE.md
@@ -35,7 +35,7 @@ The protobuf library and compiler are needed for protobuf generation.
 
 OpenCV needs to be findable by CMake. On systems like the Jetson, this is installed by default. Otherwise, you will need to build OpenCV from source and install it.
 
-If you want JNI and Java, you will need a JDK of at least version 11 installed. In addition, you need a `JAVA_HOME` environment variable set properly and set to the JDK directory.
+If you want JNI and Java, you will need a JDK of at least version 17 installed. In addition, you need a `JAVA_HOME` environment variable set properly and set to the JDK directory.
 
 If you are building with unit tests or simulation modules, you will also need an Internet connection for the initial setup process, as CMake will clone google-test and imgui from GitHub.
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Using Gradle makes building WPILib very straightforward. It only has a few depen
 
 ## Requirements
 
-- [JDK 11](https://adoptium.net/temurin/releases/?version=11)
+- [JDK 17](https://adoptium.net/temurin/releases/?version=17)
     - Note that the JRE is insufficient; the full JDK is required
-    - On Ubuntu, run `sudo apt install openjdk-11-jdk`
-    - On Windows, install the JDK 11 .msi from the link above
-    - On macOS, install the JDK 11 .pkg from the link above
+    - On Ubuntu, run `sudo apt install openjdk-17-jdk`
+    - On Windows, install the JDK 17 .msi from the link above
+    - On macOS, install the JDK 17 .pkg from the link above
 - C++ compiler
     - On Linux, install GCC 11 or greater
     - On Windows, install [Visual Studio Community 2022](https://visualstudio.microsoft.com/vs/community/) and select the C++ programming language during installation (Gradle can't use the build tools for Visual Studio)

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -255,23 +255,7 @@ task generateJavaDocs(type: Javadoc) {
         // The second argument '-quiet' is a hack. The one parameter
         // addStringOption() doesn't work, so we add '-quiet', which is added
         // anyway by gradle. See https://github.com/gradle/gradle/issues/2354.
-        //
-        // See JDK-8200363 (https://bugs.openjdk.java.net/browse/JDK-8200363)
-        // for information about the nonstandard -Xwerror option. JDK 15+ has
-        // -Werror.
-        options.addStringOption('Xwerror', '-quiet')
-    }
-
-    if (JavaVersion.current().isJava11Compatible()) {
-        if (!JavaVersion.current().isJava12Compatible()) {
-            options.addBooleanOption('-no-module-directories', true)
-        }
-        doLast {
-            // This is a work-around for https://bugs.openjdk.java.net/browse/JDK-8211194. Can be removed once that issue is fixed on JDK's side
-            // Since JDK 11, package-list is missing from javadoc output files and superseded by element-list file, but a lot of external tools still need it
-            // Here we generate this file manually
-            new File(destinationDir, 'package-list').text = new File(destinationDir, 'element-list').text
-        }
+        options.addStringOption('Werror', '-quiet')
     }
 }
 


### PR DESCRIPTION
Build javadocs with JDK 17 and remove JDK 11 workarounds 
Switch jdk distribution to temurin
Update readme to say to install JDK 17