### PR TITLE
Add command.repeatdly(int count) to both java and c++

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
@@ -370,6 +370,28 @@ public abstract class Command implements Sendable {
   }
 
   /**
+   * Decorates this command to run repeatedly, restarting until the command runs for the given times
+   * amount. The decorated command can still be canceled.
+   *
+   * <p>This is just syntactic sugar for {@code this.finallyDo(() ->
+   * counter[0]++).repeatedly().until(() -> counter[0] >= times)} which just means: runs the
+   * command, then increments the counter, repeatedly until the counter saturates.
+   *
+   * <p>Note: This decorator works by adding this command to a composition. The command the
+   * decorator was called on cannot be scheduled independently or be added to a different
+   * composition (namely, decorators), unless it is manually cleared from the list of composed
+   * commands with {@link CommandScheduler#removeComposedCommand(Command)}. The command composition
+   * returned from this method can be further decorated without issue.
+   *
+   * @param times
+   * @return the decorated command
+   */
+  public ParallelRaceGroup repeatedly(int times) {
+    int[] counter = {0};
+    return this.finallyDo(() -> counter[0]++).repeatedly().until(() -> counter[0] >= times);
+  }
+
+  /**
    * Decorates this command to run "by proxy" by wrapping it in a {@link ProxyCommand}. Use this for
    * "forking off" from command compositions when the user does not wish to extend the command's
    * requirements to the entire command composition. ProxyCommand has unique implications and

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -530,6 +530,10 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
     m_disabled = false;
   }
 
+  public void printWatchdogEpochs(Consumer<String> output) {
+    m_watchdog.printEpochs(output);
+  }
+
   /**
    * Adds an action to perform on the initialization of any command by the scheduler.
    *

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
@@ -108,6 +108,10 @@ CommandPtr Command::Repeatedly() && {
   return std::move(*this).ToPtr().Repeatedly();
 }
 
+CommandPtr Command::Repeatedly(int times) && {
+  return std::move(*this).ToPtr().Repeatedly(times);
+}
+
 CommandPtr Command::AsProxy() && {
   return std::move(*this).ToPtr().AsProxy();
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
@@ -51,9 +51,10 @@ CommandPtr CommandPtr::Repeatedly(int times) && {
   AssertValid();
   std::shared_ptr<int> countPtr = std::make_shared<int>(0);
   return std::move(*this)
-      .FinallyDo([countPtr = countPtr] { (*countPtr)++;})
+      .FinallyDo([countPtr = countPtr] { (*countPtr)++; printf("command finished\n");})
       .Repeatedly()
       .Until([countPtr = countPtr, times = times] {
+        printf("checking if command should run again... current count: %d, should be: %d, finished:%s\n", *countPtr, times, (*countPtr) >= times ? "true" : "false");
         return ((*countPtr) >= times);
       });
 

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
@@ -47,6 +47,18 @@ CommandPtr CommandPtr::Repeatedly() && {
   return std::move(*this);
 }
 
+CommandPtr CommandPtr::Repeatedly(int times) && {
+  AssertValid();
+  std::shared_ptr<int> countPtr = std::make_shared<int>(0);
+  return std::move(*this)
+      .FinallyDo([countPtr = countPtr] { (*countPtr)++;})
+      .Repeatedly()
+      .Until([countPtr = countPtr, times = times] {
+        return ((*countPtr) >= times);
+      });
+
+}
+
 CommandPtr CommandPtr::AsProxy() && {
   AssertValid();
   m_ptr = std::make_unique<ProxyCommand>(std::move(m_ptr));

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -428,6 +428,10 @@ void CommandScheduler::Enable() {
   m_impl->disabled = false;
 }
 
+void CommandScheduler::PrintWatchdogEpochs(wpi::raw_ostream& os) {
+  m_watchdog.PrintEpochs(os);
+}
+
 void CommandScheduler::OnCommandInitialize(Action action) {
   m_impl->initActions.emplace_back(std::move(action));
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -209,14 +209,18 @@ void CommandScheduler::Run() {
     m_watchdog.AddEpoch(command->GetName() + ".Execute()");
 
     if (command->IsFinished()) {
+      printf("Command %s is finished\n", command->GetName().c_str());
       m_impl->endingCommands.insert(command);
+      printf("Ending command %s\n", command->GetName().c_str());
       command->End(false);
+      printf("Command %s has ended\n", command->GetName().c_str());
       for (auto&& action : m_impl->finishActions) {
         action(*command);
       }
       m_impl->endingCommands.erase(command);
 
       m_impl->scheduledCommands.erase(command);
+      printf("Erasing command %s from scheduledCommands\n", command->GetName().c_str());
       for (auto&& requirement : command->GetRequirements()) {
         m_impl->requirements.erase(requirement);
       }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -249,6 +249,16 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
   CommandPtr Repeatedly() &&;
 
   /**
+   * Decorates this command to run repeatedly until the given count is reached
+   * or is interrupted. The decorated command can still be canceled.
+   *
+   * @param times the number/count of times to run the command
+   * @return the decorated command
+   */
+  [[nodiscard]]
+  CommandPtr Repeatedly(int times) &&;
+
+  /**
    * Decorates this command to run "by proxy" by wrapping it in a ProxyCommand.
    * Use this for "forking off" from command compositions when the user does not
    * wish to extend the command's requirements to the entire command

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
@@ -50,6 +50,16 @@ class CommandPtr final {
   CommandPtr Repeatedly() &&;
 
   /**
+   * Decorates this command to run repeatedly until the given count is reached
+   * or is interrupted. The decorated command can still be canceled.
+   *
+   * @param times the number of times to run the command
+   * @return the decorated command
+   */
+  [[nodiscard]]
+  CommandPtr Repeatedly(int times) &&;
+
+  /**
    * Decorates this command to run "by proxy" by wrapping it in a ProxyCommand.
    * Use this for "forking off" from command compositions when the user does not
    * wish to extend the command's requirements to the entire command

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -334,6 +334,13 @@ class CommandScheduler final : public wpi::Sendable,
   void Enable();
 
   /**
+   * Prints list of epochs added so far and their times to a stream.
+   *
+   * @param os output stream
+   */
+  void PrintWatchdogEpochs(wpi::raw_ostream& os);
+
+  /**
    * Adds an action to perform on the initialization of any command by the
    * scheduler.
    *

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
@@ -225,7 +225,10 @@ class CommandDecoratorTest extends CommandTestBase {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicInteger counter = new AtomicInteger(0);
 
-      Command command = new InstantCommand(counter::incrementAndGet);
+      Command command = new InstantCommand(() -> {
+        counter.incrementAndGet();
+        System.out.println("Counter at: " + counter.get());
+      });
 
       Command group = command.repeatedly(3);
 

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
@@ -201,6 +201,45 @@ class CommandDecoratorTest extends CommandTestBase {
   }
 
   @Test
+  void repeatedlyTest() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicInteger counter = new AtomicInteger(0);
+
+      Command command = new InstantCommand(counter::incrementAndGet);
+
+      Command group = command.repeatedly();
+      
+      scheduler.schedule(group);
+      for (int i = 1; i <= 50; i++) {
+          scheduler.run();
+          assertEquals(i, counter.get());
+      }
+
+      // Should still be scheduled
+      assertTrue(scheduler.isScheduled(group));
+    }
+  }
+
+  @Test
+  void repeatForTest() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicInteger counter = new AtomicInteger(0);
+
+      Command command = new InstantCommand(counter::incrementAndGet);
+
+      Command group = command.repeatedly(3);
+
+      scheduler.schedule(group);
+      for (int i = 0; scheduler.isScheduled(group); i++) { // If this causes an infinite loop, repeatedly is cooked
+        scheduler.run();
+        assertEquals(i + 1, counter.get());
+      }
+      assertEquals(3, counter.get());
+    }
+
+  }
+
+  @Test
   void unlessTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicBoolean unlessCondition = new AtomicBoolean(true);

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
@@ -118,6 +118,39 @@ TEST_F(CommandDecoratorTest, AndThen) {
   EXPECT_TRUE(finished);
 }
 
+TEST_F(CommandDecoratorTest, Repeatedly) {
+  CommandScheduler scheduler = GetScheduler();
+
+  int counter = 0;
+
+  auto command = InstantCommand([&counter] { counter++; }, {}).Repeatedly();
+
+  scheduler.Schedule(command);
+
+  for (int i = 1; i <= 50; i++) {
+    scheduler.Run();
+    EXPECT_EQ(i, counter);
+  }
+
+  EXPECT_TRUE(scheduler.IsScheduled(command));
+}
+
+TEST_F(CommandDecoratorTest, RepeatFor) {
+  CommandScheduler scheduler = GetScheduler();
+
+  int counter = 0;
+
+  auto command = InstantCommand([&counter] { counter++;}, {}).Repeatedly(3);
+
+  scheduler.Schedule(command);
+  for (int i = 0; scheduler.IsScheduled(command); i++) {
+    scheduler.Run();
+    EXPECT_EQ(i + 1, counter);
+  }
+
+  EXPECT_EQ(3, counter);
+}
+
 TEST_F(CommandDecoratorTest, Unless) {
   CommandScheduler scheduler = GetScheduler();
 

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
@@ -140,12 +140,13 @@ TEST_F(CommandDecoratorTest, RepeatFor) {
 
   int counter = 0;
 
-  auto command = InstantCommand([&counter] { counter++;}, {}).Repeatedly(3);
+  auto command = InstantCommand([&counter] { counter++; printf("Incrementing counter to: %d\n", counter);}, {}).Repeatedly(3);
 
   scheduler.Schedule(command);
   for (int i = 0; scheduler.IsScheduled(command); i++) {
     scheduler.Run();
     EXPECT_EQ(i + 1, counter);
+    printf("counter: %d\n", counter);
   }
 
   EXPECT_EQ(3, counter);

--- a/wpilibc/src/main/native/cpp/Watchdog.cpp
+++ b/wpilibc/src/main/native/cpp/Watchdog.cpp
@@ -200,6 +200,10 @@ void Watchdog::PrintEpochs() {
   m_tracer.PrintEpochs();
 }
 
+void Watchdog::PrintEpochs(wpi::raw_ostream& os) {
+  m_tracer.PrintEpochs(os);
+}
+
 void Watchdog::Reset() {
   Enable();
 }

--- a/wpilibc/src/main/native/include/frc/Watchdog.h
+++ b/wpilibc/src/main/native/include/frc/Watchdog.h
@@ -84,6 +84,13 @@ class Watchdog {
   void PrintEpochs();
 
   /**
+   * Prints list of epochs added so far and their times to a stream.
+   *
+   * @param os output stream
+   */
+  void PrintEpochs(wpi::raw_ostream& os);
+
+  /**
    * Resets the watchdog timer.
    *
    * This also enables the timer if it was previously disabled.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -8,6 +8,7 @@ import edu.wpi.first.hal.NotifierJNI;
 import java.io.Closeable;
 import java.util.PriorityQueue;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 /**
  * A class that's a wrapper around a watchdog timer.
@@ -157,6 +158,10 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
    */
   public void printEpochs() {
     m_tracer.printEpochs();
+  }
+
+  public void printEpochs(Consumer<String> output) {
+    m_tracer.printEpochs(output);
   }
 
   /**


### PR DESCRIPTION
Currently, the unit tests fail and there are a lot of print statements for whoever might be checking into this.

The problem is. The exact same function calls create different results between C++ and Java. I may just be the idiot but it seems to require further look into

The debug's are in a different commits making it a lot easier to revert them if needed.