### PR TITLE
[ci] Use JDK 17 on docs publish CI

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 13
+          java-version: 17
       - name: Set environment variables (Development)
         run: |
           echo "BRANCH=development" >> $GITHUB_ENV


### PR DESCRIPTION
Previously used jdk13 because of doclint errors in 17 which have since been resolved.