### PR TITLE
[cmd] Improve Java and C++ decorator consistency

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelCommandGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelCommandGroup.java
@@ -5,7 +5,7 @@
 package edu.wpi.first.wpilibj2.command;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -19,7 +19,7 @@ import java.util.Map;
  */
 public class ParallelCommandGroup extends Command {
   // maps commands in this composition to whether they are still running
-  private final Map<Command, Boolean> m_commands = new HashMap<>();
+  private final Map<Command, Boolean> m_commands = new LinkedHashMap<>();
   private boolean m_runWhenDisabled = true;
   private InterruptionBehavior m_interruptBehavior = InterruptionBehavior.kCancelIncoming;
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelDeadlineGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelDeadlineGroup.java
@@ -6,7 +6,7 @@ package edu.wpi.first.wpilibj2.command;
 
 import edu.wpi.first.util.sendable.SendableBuilder;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -22,7 +22,7 @@ import java.util.Map;
  */
 public class ParallelDeadlineGroup extends Command {
   // maps commands in this composition to whether they are still running
-  private final Map<Command, Boolean> m_commands = new HashMap<>();
+  private final Map<Command, Boolean> m_commands = new LinkedHashMap<>();
   private boolean m_runWhenDisabled = true;
   private boolean m_finished = true;
   private Command m_deadline;
@@ -39,8 +39,8 @@ public class ParallelDeadlineGroup extends Command {
    * @throws IllegalArgumentException if the deadline command is also in the otherCommands argument
    */
   public ParallelDeadlineGroup(Command deadline, Command... otherCommands) {
-    addCommands(otherCommands);
     setDeadline(deadline);
+    addCommands(otherCommands);
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelRaceGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelRaceGroup.java
@@ -5,7 +5,7 @@
 package edu.wpi.first.wpilibj2.command;
 
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -19,7 +19,7 @@ import java.util.Set;
  * <p>This class is provided by the NewCommands VendorDep
  */
 public class ParallelRaceGroup extends Command {
-  private final Set<Command> m_commands = new HashSet<>();
+  private final Set<Command> m_commands = new LinkedHashSet<>();
   private boolean m_runWhenDisabled = true;
   private boolean m_finished = true;
   private InterruptionBehavior m_interruptBehavior = InterruptionBehavior.kCancelIncoming;

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
@@ -99,9 +99,17 @@ CommandPtr Command::BeforeStarting(std::function<void()> toRun,
                                                  requirements);
 }
 
+CommandPtr Command::BeforeStarting(CommandPtr&& before) && {
+  return std::move(*this).ToPtr().BeforeStarting(std::move(before));
+}
+
 CommandPtr Command::AndThen(std::function<void()> toRun,
                             Requirements requirements) && {
   return std::move(*this).ToPtr().AndThen(std::move(toRun), requirements);
+}
+
+CommandPtr Command::AndThen(CommandPtr&& next) && {
+  return std::move(*this).ToPtr().AndThen(std::move(next));
 }
 
 CommandPtr Command::Repeatedly() && {
@@ -118,6 +126,18 @@ CommandPtr Command::Unless(std::function<bool()> condition) && {
 
 CommandPtr Command::OnlyIf(std::function<bool()> condition) && {
   return std::move(*this).ToPtr().OnlyIf(std::move(condition));
+}
+
+CommandPtr Command::DeadlineFor(CommandPtr&& parallel) && {
+  return std::move(*this).ToPtr().DeadlineFor(std::move(parallel));
+}
+
+CommandPtr Command::AlongWith(CommandPtr&& parallel) && {
+  return std::move(*this).ToPtr().AlongWith(std::move(parallel));
+}
+
+CommandPtr Command::RaceWith(CommandPtr&& parallel) && {
+  return std::move(*this).ToPtr().RaceWith(std::move(parallel));
 }
 
 CommandPtr Command::FinallyDo(std::function<void(bool)> end) && {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
@@ -132,8 +132,8 @@ CommandPtr CommandPtr::BeforeStarting(CommandPtr&& before) && {
 CommandPtr CommandPtr::WithTimeout(units::second_t duration) && {
   AssertValid();
   std::vector<std::unique_ptr<Command>> temp;
-  temp.emplace_back(std::make_unique<WaitCommand>(duration));
   temp.emplace_back(std::move(m_ptr));
+  temp.emplace_back(std::make_unique<WaitCommand>(duration));
   m_ptr = std::make_unique<ParallelRaceGroup>(std::move(temp));
   return std::move(*this);
 }
@@ -141,8 +141,8 @@ CommandPtr CommandPtr::WithTimeout(units::second_t duration) && {
 CommandPtr CommandPtr::Until(std::function<bool()> condition) && {
   AssertValid();
   std::vector<std::unique_ptr<Command>> temp;
-  temp.emplace_back(std::make_unique<WaitUntilCommand>(std::move(condition)));
   temp.emplace_back(std::move(m_ptr));
+  temp.emplace_back(std::make_unique<WaitUntilCommand>(std::move(condition)));
   m_ptr = std::make_unique<ParallelRaceGroup>(std::move(temp));
   return std::move(*this);
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -229,6 +229,16 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
                             Requirements requirements = {}) &&;
 
   /**
+   * Decorates this command with another command to run before this command
+   * starts.
+   *
+   * @param before the command to run before this one
+   * @return the decorated command
+   */
+  [[nodiscard]]
+  CommandPtr BeforeStarting(CommandPtr&& before) &&;
+
+  /**
    * Decorates this command with a runnable to run after the command finishes.
    *
    * @param toRun the Runnable to run
@@ -238,6 +248,17 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
   [[nodiscard]]
   CommandPtr AndThen(std::function<void()> toRun,
                      Requirements requirements = {}) &&;
+
+  /**
+   * Decorates this command with a set of commands to run after it in sequence.
+   * Often more convenient/less-verbose than constructing a
+   * SequentialCommandGroup explicitly.
+   *
+   * @param next the commands to run next
+   * @return the decorated command
+   */
+  [[nodiscard]]
+  CommandPtr AndThen(CommandPtr&& next) &&;
 
   /**
    * Decorates this command to run repeatedly, restarting it when it ends, until
@@ -287,6 +308,40 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    */
   [[nodiscard]]
   CommandPtr OnlyIf(std::function<bool()> condition) &&;
+
+  /**
+   * Decorates this command with a set of commands to run parallel to it, ending
+   * when the calling command ends and interrupting all the others. Often more
+   * convenient/less-verbose than constructing a new {@link
+   * ParallelDeadlineGroup} explicitly.
+   *
+   * @param parallel the commands to run in parallel. Note the parallel commands
+   * will be interupted when the deadline command ends
+   * @return the decorated command
+   */
+  [[nodiscard]]
+  CommandPtr DeadlineFor(CommandPtr&& parallel) &&;
+  /**
+   * Decorates this command with a set of commands to run parallel to it, ending
+   * when the last command ends. Often more convenient/less-verbose than
+   * constructing a new {@link ParallelCommandGroup} explicitly.
+   *
+   * @param parallel the commands to run in parallel
+   * @return the decorated command
+   */
+  [[nodiscard]]
+  CommandPtr AlongWith(CommandPtr&& parallel) &&;
+
+  /**
+   * Decorates this command with a set of commands to run parallel to it, ending
+   * when the first command ends. Often more convenient/less-verbose than
+   * constructing a new {@link ParallelRaceGroup} explicitly.
+   *
+   * @param parallel the commands to run in parallel
+   * @return the decorated command
+   */
+  [[nodiscard]]
+  CommandPtr RaceWith(CommandPtr&& parallel) &&;
 
   /**
    * Decorates this command to run or stop when disabled.

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.wpilibj2.command;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -22,17 +23,14 @@ class CommandDecoratorTest extends CommandTestBase {
     HAL.initialize(500, 0);
     SimHooks.pauseTiming();
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      Command command1 = new WaitCommand(10);
-
-      Command timeout = command1.withTimeout(2);
+      Command timeout = new RunCommand(() -> {}).withTimeout(0.1);
 
       scheduler.schedule(timeout);
       scheduler.run();
 
-      assertFalse(scheduler.isScheduled(command1));
       assertTrue(scheduler.isScheduled(timeout));
 
-      SimHooks.stepTiming(3);
+      SimHooks.stepTiming(0.15);
       scheduler.run();
 
       assertFalse(scheduler.isScheduled(timeout));
@@ -44,32 +42,98 @@ class CommandDecoratorTest extends CommandTestBase {
   @Test
   void untilTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      AtomicBoolean condition = new AtomicBoolean();
+      AtomicBoolean finish = new AtomicBoolean();
 
-      Command command = new WaitCommand(10).until(condition::get);
+      Command command = new RunCommand(() -> {}).until(finish::get);
 
       scheduler.schedule(command);
       scheduler.run();
+
       assertTrue(scheduler.isScheduled(command));
-      condition.set(true);
+
+      finish.set(true);
       scheduler.run();
+
       assertFalse(scheduler.isScheduled(command));
+    }
+  }
+
+  @Test
+  void untilOrderTest() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicBoolean firstHasRun = new AtomicBoolean(false);
+      AtomicBoolean firstWasPolled = new AtomicBoolean(false);
+
+      Command first =
+          new FunctionalCommand(
+              () -> {},
+              () -> firstHasRun.set(true),
+              interrupted -> {},
+              () -> {
+                firstWasPolled.set(true);
+                return true;
+              });
+      Command command =
+          first.until(
+              () -> {
+                assertAll(
+                    () -> assertTrue(firstHasRun.get()), () -> assertTrue(firstWasPolled.get()));
+                return true;
+              });
+
+      scheduler.schedule(command);
+      scheduler.run();
+
+      assertAll(() -> assertTrue(firstHasRun.get()), () -> assertTrue(firstWasPolled.get()));
     }
   }
 
   @Test
   void onlyWhileTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      AtomicBoolean condition = new AtomicBoolean(true);
+      AtomicBoolean run = new AtomicBoolean(true);
 
-      Command command = new WaitCommand(10).onlyWhile(condition::get);
+      Command command = new RunCommand(() -> {}).onlyWhile(run::get);
 
       scheduler.schedule(command);
       scheduler.run();
+
       assertTrue(scheduler.isScheduled(command));
-      condition.set(false);
+
+      run.set(false);
       scheduler.run();
+
       assertFalse(scheduler.isScheduled(command));
+    }
+  }
+
+  @Test
+  void onlyWhileOrderTest() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicBoolean firstHasRun = new AtomicBoolean(false);
+      AtomicBoolean firstWasPolled = new AtomicBoolean(false);
+
+      Command first =
+          new FunctionalCommand(
+              () -> {},
+              () -> firstHasRun.set(true),
+              interrupted -> {},
+              () -> {
+                firstWasPolled.set(true);
+                return true;
+              });
+      Command command =
+          first.onlyWhile(
+              () -> {
+                assertAll(
+                    () -> assertTrue(firstHasRun.get()), () -> assertTrue(firstWasPolled.get()));
+                return false;
+              });
+
+      scheduler.schedule(command);
+      scheduler.run();
+
+      assertAll(() -> assertTrue(firstHasRun.get()), () -> assertTrue(firstWasPolled.get()));
     }
   }
 
@@ -90,61 +154,75 @@ class CommandDecoratorTest extends CommandTestBase {
   @Test
   void beforeStartingTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      AtomicBoolean condition = new AtomicBoolean();
-      condition.set(false);
+      AtomicBoolean finished = new AtomicBoolean();
+      finished.set(false);
 
-      Command command = new InstantCommand();
+      Command command = new InstantCommand().beforeStarting(() -> finished.set(true));
 
-      scheduler.schedule(command.beforeStarting(() -> condition.set(true)));
+      scheduler.schedule(command);
 
-      assertTrue(condition.get());
+      assertTrue(finished.get());
+
+      scheduler.run();
+
+      assertTrue(scheduler.isScheduled(command));
+
+      scheduler.run();
+
+      assertFalse(scheduler.isScheduled(command));
     }
   }
 
   @Test
   void andThenLambdaTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      AtomicBoolean condition = new AtomicBoolean();
-      condition.set(false);
+      AtomicBoolean finished = new AtomicBoolean(false);
 
-      Command command = new InstantCommand();
+      Command command = new InstantCommand().andThen(() -> finished.set(true));
 
-      scheduler.schedule(command.andThen(() -> condition.set(true)));
+      scheduler.schedule(command);
 
-      assertFalse(condition.get());
+      assertFalse(finished.get());
 
       scheduler.run();
 
-      assertTrue(condition.get());
+      assertTrue(finished.get());
+
+      scheduler.run();
+
+      assertFalse(scheduler.isScheduled(command));
     }
   }
 
   @Test
   void andThenTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      AtomicBoolean condition = new AtomicBoolean();
-      condition.set(false);
+      AtomicBoolean condition = new AtomicBoolean(false);
 
       Command command1 = new InstantCommand();
       Command command2 = new InstantCommand(() -> condition.set(true));
+      Command group = command1.andThen(command2);
 
-      scheduler.schedule(command1.andThen(command2));
+      scheduler.schedule(group);
 
       assertFalse(condition.get());
 
       scheduler.run();
 
       assertTrue(condition.get());
+
+      scheduler.run();
+
+      assertFalse(scheduler.isScheduled(group));
     }
   }
 
   @Test
-  void deadlineWithTest() {
+  void deadlineForTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      AtomicBoolean condition = new AtomicBoolean();
-      condition.set(false);
+      AtomicBoolean finish = new AtomicBoolean(false);
 
-      Command dictator = new WaitUntilCommand(condition::get);
+      Command dictator = new WaitUntilCommand(finish::get);
       Command endsBefore = new InstantCommand();
       Command endsAfter = new WaitUntilCommand(() -> false);
 
@@ -155,7 +233,7 @@ class CommandDecoratorTest extends CommandTestBase {
 
       assertTrue(scheduler.isScheduled(group));
 
-      condition.set(true);
+      finish.set(true);
       scheduler.run();
 
       assertFalse(scheduler.isScheduled(group));
@@ -163,12 +241,42 @@ class CommandDecoratorTest extends CommandTestBase {
   }
 
   @Test
+  void deadlineForOrderTest() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicBoolean dictatorHasRun = new AtomicBoolean(false);
+      AtomicBoolean dictatorWasPolled = new AtomicBoolean(false);
+
+      Command dictator =
+          new FunctionalCommand(
+              () -> {},
+              () -> dictatorHasRun.set(true),
+              interrupted -> {},
+              () -> {
+                dictatorWasPolled.set(true);
+                return true;
+              });
+      Command other =
+          new RunCommand(
+              () ->
+                  assertAll(
+                      () -> assertTrue(dictatorHasRun.get()),
+                      () -> assertTrue(dictatorWasPolled.get())));
+
+      Command group = dictator.deadlineFor(other);
+
+      scheduler.schedule(group);
+      scheduler.run();
+
+      assertAll(() -> assertTrue(dictatorHasRun.get()), () -> assertTrue(dictatorWasPolled.get()));
+    }
+  }
+
+  @Test
   void alongWithTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      AtomicBoolean condition = new AtomicBoolean();
-      condition.set(false);
+      AtomicBoolean finish = new AtomicBoolean(false);
 
-      Command command1 = new WaitUntilCommand(condition::get);
+      Command command1 = new WaitUntilCommand(finish::get);
       Command command2 = new InstantCommand();
 
       Command group = command1.alongWith(command2);
@@ -178,10 +286,40 @@ class CommandDecoratorTest extends CommandTestBase {
 
       assertTrue(scheduler.isScheduled(group));
 
-      condition.set(true);
+      finish.set(true);
       scheduler.run();
 
       assertFalse(scheduler.isScheduled(group));
+    }
+  }
+
+  @Test
+  void alongWithOrderTest() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicBoolean firstHasRun = new AtomicBoolean(false);
+      AtomicBoolean firstWasPolled = new AtomicBoolean(false);
+
+      Command command1 =
+          new FunctionalCommand(
+              () -> {},
+              () -> firstHasRun.set(true),
+              interrupted -> {},
+              () -> {
+                firstWasPolled.set(true);
+                return true;
+              });
+      Command command2 =
+          new RunCommand(
+              () ->
+                  assertAll(
+                      () -> assertTrue(firstHasRun.get()), () -> assertTrue(firstWasPolled.get())));
+
+      Command group = command1.alongWith(command2);
+
+      scheduler.schedule(group);
+      scheduler.run();
+
+      assertAll(() -> assertTrue(firstHasRun.get()), () -> assertTrue(firstWasPolled.get()));
     }
   }
 
@@ -201,42 +339,71 @@ class CommandDecoratorTest extends CommandTestBase {
   }
 
   @Test
+  void raceWithOrderTest() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicBoolean firstHasRun = new AtomicBoolean(false);
+      AtomicBoolean firstWasPolled = new AtomicBoolean(false);
+
+      Command command1 =
+          new FunctionalCommand(
+              () -> {},
+              () -> firstHasRun.set(true),
+              interrupted -> {},
+              () -> {
+                firstWasPolled.set(true);
+                return true;
+              });
+      Command command2 =
+          new RunCommand(
+              () -> {
+                assertTrue(firstHasRun.get());
+                assertTrue(firstWasPolled.get());
+              });
+
+      Command group = command1.raceWith(command2);
+
+      scheduler.schedule(group);
+      scheduler.run();
+
+      assertAll(() -> assertTrue(firstHasRun.get()), () -> assertTrue(firstWasPolled.get()));
+    }
+  }
+
+  @Test
   void unlessTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicBoolean hasRun = new AtomicBoolean(false);
       AtomicBoolean unlessCondition = new AtomicBoolean(true);
-      AtomicBoolean hasRunCondition = new AtomicBoolean(false);
 
-      Command command =
-          new InstantCommand(() -> hasRunCondition.set(true)).unless(unlessCondition::get);
+      Command command = new InstantCommand(() -> hasRun.set(true)).unless(unlessCondition::get);
 
       scheduler.schedule(command);
       scheduler.run();
-      assertFalse(hasRunCondition.get());
+      assertFalse(hasRun.get());
 
       unlessCondition.set(false);
       scheduler.schedule(command);
       scheduler.run();
-      assertTrue(hasRunCondition.get());
+      assertTrue(hasRun.get());
     }
   }
 
   @Test
   void onlyIfTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicBoolean hasRun = new AtomicBoolean(false);
       AtomicBoolean onlyIfCondition = new AtomicBoolean(false);
-      AtomicBoolean hasRunCondition = new AtomicBoolean(false);
 
-      Command command =
-          new InstantCommand(() -> hasRunCondition.set(true)).onlyIf(onlyIfCondition::get);
+      Command command = new InstantCommand(() -> hasRun.set(true)).onlyIf(onlyIfCondition::get);
 
       scheduler.schedule(command);
       scheduler.run();
-      assertFalse(hasRunCondition.get());
+      assertFalse(hasRun.get());
 
       onlyIfCondition.set(true);
       scheduler.schedule(command);
       scheduler.run();
-      assertTrue(hasRunCondition.get());
+      assertTrue(hasRun.get());
     }
   }
 

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
@@ -8,6 +8,7 @@
 #include "frc2/command/FunctionalCommand.h"
 #include "frc2/command/InstantCommand.h"
 #include "frc2/command/RunCommand.h"
+#include "frc2/command/WaitUntilCommand.h"
 
 using namespace frc2;
 class CommandDecoratorTest : public CommandTestBase {};
@@ -20,13 +21,14 @@ TEST_F(CommandDecoratorTest, WithTimeout) {
   auto command = RunCommand([] {}, {}).WithTimeout(100_ms);
 
   scheduler.Schedule(command);
-
   scheduler.Run();
+
   EXPECT_TRUE(scheduler.IsScheduled(command));
 
   frc::sim::StepTiming(150_ms);
 
   scheduler.Run();
+
   EXPECT_FALSE(scheduler.IsScheduled(command));
 
   frc::sim::ResumeTiming();
@@ -35,19 +37,44 @@ TEST_F(CommandDecoratorTest, WithTimeout) {
 TEST_F(CommandDecoratorTest, Until) {
   CommandScheduler scheduler = GetScheduler();
 
-  bool finished = false;
+  bool finish = false;
 
-  auto command = RunCommand([] {}, {}).Until([&finished] { return finished; });
+  auto command = RunCommand([] {}, {}).Until([&finish] { return finish; });
 
   scheduler.Schedule(command);
-
   scheduler.Run();
+
   EXPECT_TRUE(scheduler.IsScheduled(command));
 
-  finished = true;
-
+  finish = true;
   scheduler.Run();
+
   EXPECT_FALSE(scheduler.IsScheduled(command));
+}
+
+TEST_F(CommandDecoratorTest, UntilOrder) {
+  CommandScheduler scheduler = GetScheduler();
+
+  bool firstHasRun = false;
+  bool firstWasPolled = false;
+
+  auto first = FunctionalCommand([] {}, [&firstHasRun] { firstHasRun = true; },
+                                 [](bool interrupted) {},
+                                 [&firstWasPolled] {
+                                   firstWasPolled = true;
+                                   return true;
+                                 });
+  auto command = std::move(first).Until([&firstHasRun, &firstWasPolled] {
+    EXPECT_TRUE(firstHasRun);
+    EXPECT_TRUE(firstWasPolled);
+    return true;
+  });
+
+  scheduler.Schedule(command);
+  scheduler.Run();
+
+  EXPECT_TRUE(firstHasRun);
+  EXPECT_TRUE(firstWasPolled);
 }
 
 TEST_F(CommandDecoratorTest, OnlyWhile) {
@@ -58,14 +85,39 @@ TEST_F(CommandDecoratorTest, OnlyWhile) {
   auto command = RunCommand([] {}, {}).OnlyWhile([&run] { return run; });
 
   scheduler.Schedule(command);
-
   scheduler.Run();
+
   EXPECT_TRUE(scheduler.IsScheduled(command));
 
   run = false;
-
   scheduler.Run();
+
   EXPECT_FALSE(scheduler.IsScheduled(command));
+}
+
+TEST_F(CommandDecoratorTest, OnlyWhileOrder) {
+  CommandScheduler scheduler = GetScheduler();
+
+  bool firstHasRun = false;
+  bool firstWasPolled = false;
+
+  auto first = FunctionalCommand([] {}, [&firstHasRun] { firstHasRun = true; },
+                                 [](bool interrupted) {},
+                                 [&firstWasPolled] {
+                                   firstWasPolled = true;
+                                   return true;
+                                 });
+  auto command = std::move(first).Until([&firstHasRun, &firstWasPolled] {
+    EXPECT_TRUE(firstHasRun);
+    EXPECT_TRUE(firstWasPolled);
+    return false;
+  });
+
+  scheduler.Schedule(command);
+  scheduler.Run();
+
+  EXPECT_TRUE(firstHasRun);
+  EXPECT_TRUE(firstWasPolled);
 }
 
 TEST_F(CommandDecoratorTest, IgnoringDisable) {
@@ -94,12 +146,15 @@ TEST_F(CommandDecoratorTest, BeforeStarting) {
   EXPECT_TRUE(finished);
 
   scheduler.Run();
+
+  EXPECT_TRUE(scheduler.IsScheduled(command));
+
   scheduler.Run();
 
   EXPECT_FALSE(scheduler.IsScheduled(command));
 }
 
-TEST_F(CommandDecoratorTest, AndThen) {
+TEST_F(CommandDecoratorTest, AndThenLambda) {
   CommandScheduler scheduler = GetScheduler();
 
   bool finished = false;
@@ -112,28 +167,185 @@ TEST_F(CommandDecoratorTest, AndThen) {
   EXPECT_FALSE(finished);
 
   scheduler.Run();
+
+  EXPECT_TRUE(finished);
+
   scheduler.Run();
 
   EXPECT_FALSE(scheduler.IsScheduled(command));
+}
+
+TEST_F(CommandDecoratorTest, AndThen) {
+  CommandScheduler scheduler = GetScheduler();
+
+  bool finished = false;
+
+  auto command1 = InstantCommand();
+  auto command2 = InstantCommand([&finished] { finished = true; });
+  auto group = std::move(command1).AndThen(std::move(command2).ToPtr());
+
+  scheduler.Schedule(group);
+
+  EXPECT_FALSE(finished);
+
+  scheduler.Run();
+
   EXPECT_TRUE(finished);
+
+  scheduler.Run();
+
+  EXPECT_FALSE(scheduler.IsScheduled(group));
+}
+
+TEST_F(CommandDecoratorTest, DeadlineFor) {
+  CommandScheduler scheduler = GetScheduler();
+
+  bool finish = false;
+
+  auto dictator = WaitUntilCommand([&finish] { return finish; });
+  auto endsAfter = WaitUntilCommand([] { return false; });
+
+  auto group = std::move(dictator).DeadlineFor(std::move(endsAfter).ToPtr());
+
+  scheduler.Schedule(group);
+  scheduler.Run();
+
+  EXPECT_TRUE(scheduler.IsScheduled(group));
+
+  finish = true;
+  scheduler.Run();
+
+  EXPECT_FALSE(scheduler.IsScheduled(group));
+}
+
+TEST_F(CommandDecoratorTest, DeadlineForOrder) {
+  CommandScheduler scheduler = GetScheduler();
+
+  bool dictatorHasRun = false;
+  bool dictatorWasPolled = false;
+
+  auto dictator =
+      FunctionalCommand([] {}, [&dictatorHasRun] { dictatorHasRun = true; },
+                        [](bool interrupted) {},
+                        [&dictatorWasPolled] {
+                          dictatorWasPolled = true;
+                          return true;
+                        });
+  auto other = RunCommand([&dictatorHasRun, &dictatorWasPolled] {
+    EXPECT_TRUE(dictatorHasRun);
+    EXPECT_TRUE(dictatorWasPolled);
+  });
+
+  auto group = std::move(dictator).DeadlineFor(std::move(other).ToPtr());
+
+  scheduler.Schedule(group);
+  scheduler.Run();
+
+  EXPECT_TRUE(dictatorHasRun);
+  EXPECT_TRUE(dictatorWasPolled);
+}
+
+TEST_F(CommandDecoratorTest, AlongWith) {
+  CommandScheduler scheduler = GetScheduler();
+
+  bool finish = false;
+
+  auto command1 = WaitUntilCommand([&finish] { return finish; });
+  auto command2 = InstantCommand();
+
+  auto group = std::move(command1).AlongWith(std::move(command2).ToPtr());
+
+  scheduler.Schedule(group);
+  scheduler.Run();
+
+  EXPECT_TRUE(scheduler.IsScheduled(group));
+
+  finish = true;
+  scheduler.Run();
+
+  EXPECT_FALSE(scheduler.IsScheduled(group));
+}
+
+TEST_F(CommandDecoratorTest, AlongWithOrder) {
+  CommandScheduler scheduler = GetScheduler();
+
+  bool firstHasRun = false;
+  bool firstWasPolled = false;
+
+  auto command1 = FunctionalCommand(
+      [] {}, [&firstHasRun] { firstHasRun = true; }, [](bool interrupted) {},
+      [&firstWasPolled] {
+        firstWasPolled = true;
+        return true;
+      });
+  auto command2 = RunCommand([&firstHasRun, &firstWasPolled] {
+    EXPECT_TRUE(firstHasRun);
+    EXPECT_TRUE(firstWasPolled);
+  });
+
+  auto group = std::move(command1).AlongWith(std::move(command2).ToPtr());
+
+  scheduler.Schedule(group);
+  scheduler.Run();
+
+  EXPECT_TRUE(firstHasRun);
+  EXPECT_TRUE(firstWasPolled);
+}
+
+TEST_F(CommandDecoratorTest, RaceWith) {
+  CommandScheduler scheduler = GetScheduler();
+
+  auto command1 = WaitUntilCommand([] { return false; });
+  auto command2 = InstantCommand();
+
+  auto group = std::move(command1).RaceWith(std::move(command2).ToPtr());
+
+  scheduler.Schedule(group);
+  scheduler.Run();
+
+  EXPECT_FALSE(scheduler.IsScheduled(group));
+}
+
+TEST_F(CommandDecoratorTest, RaceWithOrder) {
+  CommandScheduler scheduler = GetScheduler();
+
+  bool firstHasRun = false;
+  bool firstWasPolled = false;
+
+  auto command1 = FunctionalCommand(
+      [] {}, [&firstHasRun] { firstHasRun = true; }, [](bool interrupted) {},
+      [&firstWasPolled] {
+        firstWasPolled = true;
+        return true;
+      });
+  auto command2 = RunCommand([&firstHasRun, &firstWasPolled] {
+    EXPECT_TRUE(firstHasRun);
+    EXPECT_TRUE(firstWasPolled);
+  });
+
+  auto group = std::move(command1).RaceWith(std::move(command2).ToPtr());
+
+  scheduler.Schedule(group);
+  scheduler.Run();
+
+  EXPECT_TRUE(firstHasRun);
+  EXPECT_TRUE(firstWasPolled);
 }
 
 TEST_F(CommandDecoratorTest, Unless) {
   CommandScheduler scheduler = GetScheduler();
 
   bool hasRun = false;
-  bool unlessBool = true;
+  bool unlessCondition = true;
 
-  auto command =
-      InstantCommand([&hasRun] { hasRun = true; }, {}).Unless([&unlessBool] {
-        return unlessBool;
-      });
+  auto command = InstantCommand([&hasRun] { hasRun = true; }, {})
+                     .Unless([&unlessCondition] { return unlessCondition; });
 
   scheduler.Schedule(command);
   scheduler.Run();
   EXPECT_FALSE(hasRun);
 
-  unlessBool = false;
+  unlessCondition = false;
   scheduler.Schedule(command);
   scheduler.Run();
   EXPECT_TRUE(hasRun);
@@ -143,18 +355,16 @@ TEST_F(CommandDecoratorTest, OnlyIf) {
   CommandScheduler scheduler = GetScheduler();
 
   bool hasRun = false;
-  bool onlyIfBool = false;
+  bool onlyIfCondition = false;
 
-  auto command =
-      InstantCommand([&hasRun] { hasRun = true; }, {}).OnlyIf([&onlyIfBool] {
-        return onlyIfBool;
-      });
+  auto command = InstantCommand([&hasRun] { hasRun = true; }, {})
+                     .OnlyIf([&onlyIfCondition] { return onlyIfCondition; });
 
   scheduler.Schedule(command);
   scheduler.Run();
   EXPECT_FALSE(hasRun);
 
-  onlyIfBool = true;
+  onlyIfCondition = true;
   scheduler.Schedule(command);
   scheduler.Run();
   EXPECT_TRUE(hasRun);


### PR DESCRIPTION
Notes:
* `CommandPtr` didn't already have `AndThen`, `DeadlineFor`, `AlongWith`, and `RaceWith` decorators that take multiple commands, so I didn't add equivalents of those to `Command`. (I did add the single command argument versions, though) This unfortunately affected the `DeadlineFor` test, so if people want me to add those as well in this PR then I'm fine with doing that. (Or if they want to do it themselves in a separate PR, that's cool too)
* Defines consistent execution order of `Until`, `OnlyWhile`, `DeadlineFor`, `AlongWith`, `RaceWith`, where the textual order of arguments matches the order of processing. (The decorated command is processed first (`execute()` run and `isFinished()` checked, optionally running `end()`), then the arguments to the decorator)