### PR TITLE
Run Doc lint with JDK 21

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -108,6 +108,6 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
       - name: Build with Gradle
         run: ./gradlew docs:zipDocs -PbuildServer -PdocWarningsAsErrors ${{ env.EXTRA_GRADLE_ARGS }}


### PR DESCRIPTION
No changes are necessary now, but may help make sure new contributions won't cause issues when we're ready to switch to JDK 21