### PR TITLE
Fix stringop overflow warnings from GCC 14

### DIFF
--- a/cscore/src/main/native/cpp/c_util.h
+++ b/cscore/src/main/native/cpp/c_util.h
@@ -14,7 +14,7 @@
 namespace cs {
 
 inline char* ConvertToC(std::string_view in) {
-  if (in.size() == std::numeric_limits<size_t>::max()) {
+  if (in.size() == (std::numeric_limits<size_t>::max)()) {
     wpi::report_bad_alloc_error("Allocation failed");
   }
 

--- a/cscore/src/main/native/cpp/c_util.h
+++ b/cscore/src/main/native/cpp/c_util.h
@@ -5,8 +5,8 @@
 #ifndef CSCORE_C_UTIL_H_
 #define CSCORE_C_UTIL_H_
 
-#include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <string_view>
 
 #include <wpi/MemAlloc.h>
@@ -14,6 +14,10 @@
 namespace cs {
 
 inline char* ConvertToC(std::string_view in) {
+  if (in.size() == std::numeric_limits<size_t>::max()) {
+    wpi::report_bad_alloc_error("Allocation failed");
+  }
+
   char* out = static_cast<char*>(wpi::safe_malloc(in.size() + 1));
   std::memmove(out, in.data(), in.size());
   out[in.size()] = '\0';

--- a/ntcore/src/main/native/cpp/Value_internal.h
+++ b/ntcore/src/main/native/cpp/Value_internal.h
@@ -443,7 +443,7 @@ O* ConvertToC(const std::vector<I>& in, size_t* out_len) {
 
 template <typename O, typename I>
 O* ConvertToC(const std::basic_string<I>& in, size_t* out_len) {
-  if (in.size() == std::numeric_limits<size_t>::max()) {
+  if (in.size() == (std::numeric_limits<size_t>::max)()) {
     wpi::report_bad_alloc_error("Allocation failed");
   }
 

--- a/ntcore/src/main/native/cpp/Value_internal.h
+++ b/ntcore/src/main/native/cpp/Value_internal.h
@@ -6,7 +6,7 @@
 
 #include <concepts>
 #include <cstring>
-#include <memory>
+#include <limits>
 #include <span>
 #include <string>
 #include <string_view>
@@ -443,6 +443,10 @@ O* ConvertToC(const std::vector<I>& in, size_t* out_len) {
 
 template <typename O, typename I>
 O* ConvertToC(const std::basic_string<I>& in, size_t* out_len) {
+  if (in.size() == std::numeric_limits<size_t>::max()) {
+    wpi::report_bad_alloc_error("Allocation failed");
+  }
+
   char* out = static_cast<char*>(wpi::safe_malloc(in.size() + 1));
   std::memmove(out, in.data(), in.size());  // NOLINT
   out[in.size()] = '\0';


### PR DESCRIPTION
If ConvertToC(size_t) is passed a string with length std::numeric_limits<size_t>::max(), the wpi::safe_malloc(in.size() + 1) call will overflow to 0, causing wpi::safe_malloc() to return a buffer with length 1. This isn't enough to contain the input string.

We now report failure if a string of that size is provided, because it's impossible to convert to a C-style string.