### PR TITLE
[upstream_utils] Suppress deprecation warnings for Eigen's has_denorm

### DIFF
--- a/upstream_utils/eigen_patches/0001-Disable-warnings.patch
+++ b/upstream_utils/eigen_patches/0001-Disable-warnings.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Wed, 18 May 2022 09:14:24 -0700
-Subject: [PATCH 1/2] Disable warnings
+Subject: [PATCH 1/3] Disable warnings
 
 ---
  Eigen/src/Core/util/DisableStupidWarnings.h | 9 +++++++++

--- a/upstream_utils/eigen_patches/0002-Intellisense-fix.patch
+++ b/upstream_utils/eigen_patches/0002-Intellisense-fix.patch
@@ -1,14 +1,14 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Fri, 20 Jan 2023 23:41:56 -0800
-Subject: [PATCH 2/2] Intellisense fix
+Subject: [PATCH 2/3] Intellisense fix
 
 ---
  Eigen/src/Core/util/Macros.h | 10 ++++++++++
  1 file changed, 10 insertions(+)
 
 diff --git a/Eigen/src/Core/util/Macros.h b/Eigen/src/Core/util/Macros.h
-index 5d054e67c4355a549b1351f1ecc5e49a96e91ace..fda6ad91eedacc9958a5a0bc34db33d8b4e57cd6 100644
+index 4d10eecd05db826ea5e6a65115022b19f1112c6a..5c8b3a3b3ea66c7bf5159f50c9ce09f7b90182d4 100644
 --- a/Eigen/src/Core/util/Macros.h
 +++ b/Eigen/src/Core/util/Macros.h
 @@ -60,6 +60,16 @@

--- a/upstream_utils/eigen_patches/0003-Suppress-C-23-deprecation-warnings-for-std-has_denor.patch
+++ b/upstream_utils/eigen_patches/0003-Suppress-C-23-deprecation-warnings-for-std-has_denor.patch
@@ -1,0 +1,87 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tyler Veness <calcmogul@gmail.com>
+Date: Mon, 13 May 2024 12:46:15 -0700
+Subject: [PATCH 3/3] Suppress C++23 deprecation warnings for std::has_denorm
+ and std::has_denorm_loss
+
+---
+ Eigen/src/Core/arch/Default/BFloat16.h | 14 ++++++++++++++
+ Eigen/src/Core/arch/Default/Half.h     | 14 ++++++++++++++
+ 2 files changed, 28 insertions(+)
+
+diff --git a/Eigen/src/Core/arch/Default/BFloat16.h b/Eigen/src/Core/arch/Default/BFloat16.h
+index f31c6cee6e97e8f1ad6fa4341fec2c1e65dec705..c6fa034b04896e7666e8de53e0e011f9551d5d78 100644
+--- a/Eigen/src/Core/arch/Default/BFloat16.h
++++ b/Eigen/src/Core/arch/Default/BFloat16.h
+@@ -139,8 +139,15 @@ struct numeric_limits_bfloat16_impl {
+   static EIGEN_CONSTEXPR const bool has_infinity = true;
+   static EIGEN_CONSTEXPR const bool has_quiet_NaN = true;
+   static EIGEN_CONSTEXPR const bool has_signaling_NaN = true;
++#if __cplusplus >= 202302L
++  EIGEN_DIAGNOSTICS(push)
++  EIGEN_DISABLE_DEPRECATION_WARNING
++#endif
+   static EIGEN_CONSTEXPR const std::float_denorm_style has_denorm = std::denorm_present;
+   static EIGEN_CONSTEXPR const bool has_denorm_loss = false;
++#if __cplusplus >= 202302L
++  EIGEN_DIAGNOSTICS(pop)
++#endif
+   static EIGEN_CONSTEXPR const std::float_round_style round_style = std::numeric_limits<float>::round_style;
+   static EIGEN_CONSTEXPR const bool is_iec559 = true;
+   // The C++ standard defines this as "true if the set of values representable
+@@ -187,10 +194,17 @@ template <typename T>
+ EIGEN_CONSTEXPR const bool numeric_limits_bfloat16_impl<T>::has_quiet_NaN;
+ template <typename T>
+ EIGEN_CONSTEXPR const bool numeric_limits_bfloat16_impl<T>::has_signaling_NaN;
++#if __cplusplus >= 202302L
++EIGEN_DIAGNOSTICS(push)
++EIGEN_DISABLE_DEPRECATION_WARNING
++#endif
+ template <typename T>
+ EIGEN_CONSTEXPR const std::float_denorm_style numeric_limits_bfloat16_impl<T>::has_denorm;
+ template <typename T>
+ EIGEN_CONSTEXPR const bool numeric_limits_bfloat16_impl<T>::has_denorm_loss;
++#if __cplusplus >= 202302L
++EIGEN_DIAGNOSTICS(pop)
++#endif
+ template <typename T>
+ EIGEN_CONSTEXPR const std::float_round_style numeric_limits_bfloat16_impl<T>::round_style;
+ template <typename T>
+diff --git a/Eigen/src/Core/arch/Default/Half.h b/Eigen/src/Core/arch/Default/Half.h
+index 9c195c12a17fcb791c96a0ce6cf873f455c4f8be..506feca058bb7940663d9cda8b2fe902060fdc8f 100644
+--- a/Eigen/src/Core/arch/Default/Half.h
++++ b/Eigen/src/Core/arch/Default/Half.h
+@@ -208,8 +208,15 @@ struct numeric_limits_half_impl {
+   static EIGEN_CONSTEXPR const bool has_infinity = true;
+   static EIGEN_CONSTEXPR const bool has_quiet_NaN = true;
+   static EIGEN_CONSTEXPR const bool has_signaling_NaN = true;
++#if __cplusplus >= 202302L
++  EIGEN_DIAGNOSTICS(push)
++  EIGEN_DISABLE_DEPRECATION_WARNING
++#endif
+   static EIGEN_CONSTEXPR const std::float_denorm_style has_denorm = std::denorm_present;
+   static EIGEN_CONSTEXPR const bool has_denorm_loss = false;
++#if __cplusplus >= 202302L
++  EIGEN_DIAGNOSTICS(pop)
++#endif
+   static EIGEN_CONSTEXPR const std::float_round_style round_style = std::round_to_nearest;
+   static EIGEN_CONSTEXPR const bool is_iec559 = true;
+   // The C++ standard defines this as "true if the set of values representable
+@@ -256,10 +263,17 @@ template <typename T>
+ EIGEN_CONSTEXPR const bool numeric_limits_half_impl<T>::has_quiet_NaN;
+ template <typename T>
+ EIGEN_CONSTEXPR const bool numeric_limits_half_impl<T>::has_signaling_NaN;
++#if __cplusplus >= 202302L
++EIGEN_DIAGNOSTICS(push)
++EIGEN_DISABLE_DEPRECATION_WARNING
++#endif
+ template <typename T>
+ EIGEN_CONSTEXPR const std::float_denorm_style numeric_limits_half_impl<T>::has_denorm;
+ template <typename T>
+ EIGEN_CONSTEXPR const bool numeric_limits_half_impl<T>::has_denorm_loss;
++#if __cplusplus >= 202302L
++EIGEN_DIAGNOSTICS(pop)
++#endif
+ template <typename T>
+ EIGEN_CONSTEXPR const std::float_round_style numeric_limits_half_impl<T>::round_style;
+ template <typename T>

--- a/upstream_utils/update_eigen.py
+++ b/upstream_utils/update_eigen.py
@@ -109,6 +109,7 @@ def main():
     for f in [
         "0001-Disable-warnings.patch",
         "0002-Intellisense-fix.patch",
+        "0003-Suppress-C-23-deprecation-warnings-for-std-has_denor.patch",
     ]:
         git_am(os.path.join(wpilib_root, "upstream_utils/eigen_patches", f))
 

--- a/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/arch/Default/BFloat16.h
+++ b/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/arch/Default/BFloat16.h
@@ -139,8 +139,15 @@ struct numeric_limits_bfloat16_impl {
   static EIGEN_CONSTEXPR const bool has_infinity = true;
   static EIGEN_CONSTEXPR const bool has_quiet_NaN = true;
   static EIGEN_CONSTEXPR const bool has_signaling_NaN = true;
+#if __cplusplus >= 202302L
+  EIGEN_DIAGNOSTICS(push)
+  EIGEN_DISABLE_DEPRECATION_WARNING
+#endif
   static EIGEN_CONSTEXPR const std::float_denorm_style has_denorm = std::denorm_present;
   static EIGEN_CONSTEXPR const bool has_denorm_loss = false;
+#if __cplusplus >= 202302L
+  EIGEN_DIAGNOSTICS(pop)
+#endif
   static EIGEN_CONSTEXPR const std::float_round_style round_style = std::numeric_limits<float>::round_style;
   static EIGEN_CONSTEXPR const bool is_iec559 = true;
   // The C++ standard defines this as "true if the set of values representable
@@ -187,10 +194,17 @@ template <typename T>
 EIGEN_CONSTEXPR const bool numeric_limits_bfloat16_impl<T>::has_quiet_NaN;
 template <typename T>
 EIGEN_CONSTEXPR const bool numeric_limits_bfloat16_impl<T>::has_signaling_NaN;
+#if __cplusplus >= 202302L
+EIGEN_DIAGNOSTICS(push)
+EIGEN_DISABLE_DEPRECATION_WARNING
+#endif
 template <typename T>
 EIGEN_CONSTEXPR const std::float_denorm_style numeric_limits_bfloat16_impl<T>::has_denorm;
 template <typename T>
 EIGEN_CONSTEXPR const bool numeric_limits_bfloat16_impl<T>::has_denorm_loss;
+#if __cplusplus >= 202302L
+EIGEN_DIAGNOSTICS(pop)
+#endif
 template <typename T>
 EIGEN_CONSTEXPR const std::float_round_style numeric_limits_bfloat16_impl<T>::round_style;
 template <typename T>

--- a/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/arch/Default/Half.h
+++ b/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/arch/Default/Half.h
@@ -208,8 +208,15 @@ struct numeric_limits_half_impl {
   static EIGEN_CONSTEXPR const bool has_infinity = true;
   static EIGEN_CONSTEXPR const bool has_quiet_NaN = true;
   static EIGEN_CONSTEXPR const bool has_signaling_NaN = true;
+#if __cplusplus >= 202302L
+  EIGEN_DIAGNOSTICS(push)
+  EIGEN_DISABLE_DEPRECATION_WARNING
+#endif
   static EIGEN_CONSTEXPR const std::float_denorm_style has_denorm = std::denorm_present;
   static EIGEN_CONSTEXPR const bool has_denorm_loss = false;
+#if __cplusplus >= 202302L
+  EIGEN_DIAGNOSTICS(pop)
+#endif
   static EIGEN_CONSTEXPR const std::float_round_style round_style = std::round_to_nearest;
   static EIGEN_CONSTEXPR const bool is_iec559 = true;
   // The C++ standard defines this as "true if the set of values representable
@@ -256,10 +263,17 @@ template <typename T>
 EIGEN_CONSTEXPR const bool numeric_limits_half_impl<T>::has_quiet_NaN;
 template <typename T>
 EIGEN_CONSTEXPR const bool numeric_limits_half_impl<T>::has_signaling_NaN;
+#if __cplusplus >= 202302L
+EIGEN_DIAGNOSTICS(push)
+EIGEN_DISABLE_DEPRECATION_WARNING
+#endif
 template <typename T>
 EIGEN_CONSTEXPR const std::float_denorm_style numeric_limits_half_impl<T>::has_denorm;
 template <typename T>
 EIGEN_CONSTEXPR const bool numeric_limits_half_impl<T>::has_denorm_loss;
+#if __cplusplus >= 202302L
+EIGEN_DIAGNOSTICS(pop)
+#endif
 template <typename T>
 EIGEN_CONSTEXPR const std::float_round_style numeric_limits_half_impl<T>::round_style;
 template <typename T>


### PR DESCRIPTION
std::has_denorm and std::has_denorm_loss were deprecated in C++23. This avoids deprecation warnings with Clang 18 set to C++23.