### PR TITLE
[cmd] Nonbreakingly rename `Subsystem` to `Resource`

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
@@ -29,7 +29,7 @@ import java.util.function.BooleanSupplier;
  */
 public abstract class Command implements Sendable {
   /** Requirements set. */
-  protected Set<Subsystem> m_requirements = new HashSet<>();
+  protected Set<Resource> m_requirements = new HashSet<>();
 
   /** Default constructor. */
   @SuppressWarnings("this-escape")
@@ -77,7 +77,7 @@ public abstract class Command implements Sendable {
    * @return the set of subsystems that are required
    * @see InterruptionBehavior
    */
-  public Set<Subsystem> getRequirements() {
+  public Set<Resource> getRequirements() {
     return m_requirements;
   }
 
@@ -90,8 +90,8 @@ public abstract class Command implements Sendable {
    *
    * @param requirements the requirements to add
    */
-  public final void addRequirements(Subsystem... requirements) {
-    for (Subsystem requirement : requirements) {
+  public final void addRequirements(Resource... requirements) {
+    for (Resource requirement : requirements) {
       m_requirements.add(requireNonNullParam(requirement, "requirement", "addRequirements"));
     }
   }
@@ -218,7 +218,7 @@ public abstract class Command implements Sendable {
    * @param requirements the required subsystems
    * @return the decorated command
    */
-  public SequentialCommandGroup beforeStarting(Runnable toRun, Subsystem... requirements) {
+  public SequentialCommandGroup beforeStarting(Runnable toRun, Resource... requirements) {
     return beforeStarting(new InstantCommand(toRun, requirements));
   }
 
@@ -251,7 +251,7 @@ public abstract class Command implements Sendable {
    * @param requirements the required subsystems
    * @return the decorated command
    */
-  public SequentialCommandGroup andThen(Runnable toRun, Subsystem... requirements) {
+  public SequentialCommandGroup andThen(Runnable toRun, Resource... requirements) {
     return andThen(new InstantCommand(toRun, requirements));
   }
 
@@ -532,7 +532,7 @@ public abstract class Command implements Sendable {
    * @param requirement the subsystem to inquire about
    * @return whether the subsystem is required
    */
-  public boolean hasRequirement(Subsystem requirement) {
+  public boolean hasRequirement(Resource requirement) {
     return getRequirements().contains(requirement);
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -34,7 +34,7 @@ public final class Commands {
    * @param requirements Subsystems to require
    * @return the command
    */
-  public static Command idle(Subsystem... requirements) {
+  public static Command idle(Resource... requirements) {
     return run(() -> {}, requirements);
   }
 
@@ -48,7 +48,7 @@ public final class Commands {
    * @return the command
    * @see InstantCommand
    */
-  public static Command runOnce(Runnable action, Subsystem... requirements) {
+  public static Command runOnce(Runnable action, Resource... requirements) {
     return new InstantCommand(action, requirements);
   }
 
@@ -60,7 +60,7 @@ public final class Commands {
    * @return the command
    * @see RunCommand
    */
-  public static Command run(Runnable action, Subsystem... requirements) {
+  public static Command run(Runnable action, Resource... requirements) {
     return new RunCommand(action, requirements);
   }
 
@@ -74,7 +74,7 @@ public final class Commands {
    * @return the command
    * @see StartEndCommand
    */
-  public static Command startEnd(Runnable start, Runnable end, Subsystem... requirements) {
+  public static Command startEnd(Runnable start, Runnable end, Resource... requirements) {
     return new StartEndCommand(start, end, requirements);
   }
 
@@ -87,7 +87,7 @@ public final class Commands {
    * @param requirements subsystems the action requires
    * @return the command
    */
-  public static Command runEnd(Runnable run, Runnable end, Subsystem... requirements) {
+  public static Command runEnd(Runnable run, Runnable end, Resource... requirements) {
     requireNonNullParam(end, "end", "Command.runEnd");
     return new FunctionalCommand(
         () -> {}, run, interrupted -> end.run(), () -> false, requirements);
@@ -102,7 +102,7 @@ public final class Commands {
    * @param requirements subsystems the action requires
    * @return the command
    */
-  public static Command startRun(Runnable start, Runnable run, Subsystem... requirements) {
+  public static Command startRun(Runnable start, Runnable run, Resource... requirements) {
     return new FunctionalCommand(start, run, interrupted -> {}, () -> false, requirements);
   }
 
@@ -188,7 +188,7 @@ public final class Commands {
    * @return the command
    * @see DeferredCommand
    */
-  public static Command defer(Supplier<Command> supplier, Set<Subsystem> requirements) {
+  public static Command defer(Supplier<Command> supplier, Set<Resource> requirements) {
     return new DeferredCommand(supplier, requirements);
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
@@ -39,9 +39,9 @@ public class DeferredCommand extends Command {
    *     set.
    */
   @SuppressWarnings("this-escape")
-  public DeferredCommand(Supplier<Command> supplier, Set<Subsystem> requirements) {
+  public DeferredCommand(Supplier<Command> supplier, Set<Resource> requirements) {
     m_supplier = requireNonNullParam(supplier, "supplier", "DeferredCommand");
-    addRequirements(requirements.toArray(new Subsystem[0]));
+    addRequirements(requirements.toArray(new Resource[0]));
   }
 
   @Override

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/FunctionalCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/FunctionalCommand.java
@@ -38,7 +38,7 @@ public class FunctionalCommand extends Command {
       Runnable onExecute,
       Consumer<Boolean> onEnd,
       BooleanSupplier isFinished,
-      Subsystem... requirements) {
+      Resource... requirements) {
     m_onInit = requireNonNullParam(onInit, "onInit", "FunctionalCommand");
     m_onExecute = requireNonNullParam(onExecute, "onExecute", "FunctionalCommand");
     m_onEnd = requireNonNullParam(onEnd, "onEnd", "FunctionalCommand");

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/InstantCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/InstantCommand.java
@@ -18,7 +18,7 @@ public class InstantCommand extends FunctionalCommand {
    * @param toRun the Runnable to run
    * @param requirements the subsystems required by this command
    */
-  public InstantCommand(Runnable toRun, Subsystem... requirements) {
+  public InstantCommand(Runnable toRun, Resource... requirements) {
     super(toRun, () -> {}, interrupted -> {}, () -> true, requirements);
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommand.java
@@ -103,7 +103,7 @@ public class MecanumControllerCommand extends Command {
       PIDController rearRightController,
       Supplier<MecanumDriveWheelSpeeds> currentWheelSpeeds,
       Consumer<MecanumDriveMotorVoltages> outputDriveVoltages,
-      Subsystem... requirements) {
+      Resource... requirements) {
     m_trajectory = requireNonNullParam(trajectory, "trajectory", "MecanumControllerCommand");
     m_pose = requireNonNullParam(pose, "pose", "MecanumControllerCommand");
     m_feedforward = requireNonNullParam(feedforward, "feedforward", "MecanumControllerCommand");
@@ -189,7 +189,7 @@ public class MecanumControllerCommand extends Command {
       PIDController rearRightController,
       Supplier<MecanumDriveWheelSpeeds> currentWheelSpeeds,
       Consumer<MecanumDriveMotorVoltages> outputDriveVoltages,
-      Subsystem... requirements) {
+      Resource... requirements) {
     this(
         trajectory,
         pose,
@@ -241,7 +241,7 @@ public class MecanumControllerCommand extends Command {
       Supplier<Rotation2d> desiredRotation,
       double maxWheelVelocityMetersPerSecond,
       Consumer<MecanumDriveWheelSpeeds> outputWheelSpeeds,
-      Subsystem... requirements) {
+      Resource... requirements) {
     m_trajectory = requireNonNullParam(trajectory, "trajectory", "MecanumControllerCommand");
     m_pose = requireNonNullParam(pose, "pose", "MecanumControllerCommand");
     m_feedforward = new SimpleMotorFeedforward(0, 0, 0);
@@ -307,7 +307,7 @@ public class MecanumControllerCommand extends Command {
       ProfiledPIDController thetaController,
       double maxWheelVelocityMetersPerSecond,
       Consumer<MecanumDriveWheelSpeeds> outputWheelSpeeds,
-      Subsystem... requirements) {
+      Resource... requirements) {
     this(
         trajectory,
         pose,

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/NotifierCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/NotifierCommand.java
@@ -29,7 +29,7 @@ public class NotifierCommand extends Command {
    * @param requirements the subsystems required by this command
    */
   @SuppressWarnings("this-escape")
-  public NotifierCommand(Runnable toRun, double period, Subsystem... requirements) {
+  public NotifierCommand(Runnable toRun, double period, Resource... requirements) {
     m_notifier = new Notifier(toRun);
     m_period = period;
     addRequirements(requirements);

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/PIDCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/PIDCommand.java
@@ -45,7 +45,7 @@ public class PIDCommand extends Command {
       DoubleSupplier measurementSource,
       DoubleSupplier setpointSource,
       DoubleConsumer useOutput,
-      Subsystem... requirements) {
+      Resource... requirements) {
     requireNonNullParam(controller, "controller", "PIDCommand");
     requireNonNullParam(measurementSource, "measurementSource", "PIDCommand");
     requireNonNullParam(setpointSource, "setpointSource", "PIDCommand");
@@ -72,7 +72,7 @@ public class PIDCommand extends Command {
       DoubleSupplier measurementSource,
       double setpoint,
       DoubleConsumer useOutput,
-      Subsystem... requirements) {
+      Resource... requirements) {
     this(controller, measurementSource, () -> setpoint, useOutput, requirements);
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDCommand.java
@@ -48,7 +48,7 @@ public class ProfiledPIDCommand extends Command {
       DoubleSupplier measurementSource,
       Supplier<State> goalSource,
       BiConsumer<Double, State> useOutput,
-      Subsystem... requirements) {
+      Resource... requirements) {
     requireNonNullParam(controller, "controller", "ProfiledPIDCommand");
     requireNonNullParam(measurementSource, "measurementSource", "ProfiledPIDCommand");
     requireNonNullParam(goalSource, "goalSource", "ProfiledPIDCommand");
@@ -76,7 +76,7 @@ public class ProfiledPIDCommand extends Command {
       DoubleSupplier measurementSource,
       DoubleSupplier goalSource,
       BiConsumer<Double, State> useOutput,
-      Subsystem... requirements) {
+      Resource... requirements) {
     requireNonNullParam(controller, "controller", "SynchronousPIDCommand");
     requireNonNullParam(measurementSource, "measurementSource", "SynchronousPIDCommand");
     requireNonNullParam(goalSource, "goalSource", "SynchronousPIDCommand");
@@ -104,7 +104,7 @@ public class ProfiledPIDCommand extends Command {
       DoubleSupplier measurementSource,
       State goal,
       BiConsumer<Double, State> useOutput,
-      Subsystem... requirements) {
+      Resource... requirements) {
     this(controller, measurementSource, () -> goal, useOutput, requirements);
   }
 
@@ -123,7 +123,7 @@ public class ProfiledPIDCommand extends Command {
       DoubleSupplier measurementSource,
       double goal,
       BiConsumer<Double, State> useOutput,
-      Subsystem... requirements) {
+      Resource... requirements) {
     this(controller, measurementSource, () -> goal, useOutput, requirements);
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RamseteCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RamseteCommand.java
@@ -83,7 +83,7 @@ public class RamseteCommand extends Command {
       PIDController leftController,
       PIDController rightController,
       BiConsumer<Double, Double> outputVolts,
-      Subsystem... requirements) {
+      Resource... requirements) {
     m_trajectory = requireNonNullParam(trajectory, "trajectory", "RamseteCommand");
     m_pose = requireNonNullParam(pose, "pose", "RamseteCommand");
     m_follower = requireNonNullParam(controller, "controller", "RamseteCommand");
@@ -121,7 +121,7 @@ public class RamseteCommand extends Command {
       RamseteController follower,
       DifferentialDriveKinematics kinematics,
       BiConsumer<Double, Double> outputMetersPerSecond,
-      Subsystem... requirements) {
+      Resource... requirements) {
     m_trajectory = requireNonNullParam(trajectory, "trajectory", "RamseteCommand");
     m_pose = requireNonNullParam(pose, "pose", "RamseteCommand");
     m_follower = requireNonNullParam(follower, "follower", "RamseteCommand");

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Resource.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Resource.java
@@ -25,58 +25,12 @@ import java.util.function.Supplier;
  */
 public interface Resource {
   /**
-   * This method is called periodically by the {@link CommandScheduler}. Useful for updating
-   * resource-specific state that you don't want to offload to a {@link Command}. Teams should try
-   * to be consistent within their own codebases about which responsibilities will be handled by
-   * Commands, and which will be handled here.
-   */
-  default void periodic() {}
-
-  /**
-   * This method is called periodically by the {@link CommandScheduler}. Useful for updating
-   * resource-specific state that needs to be maintained for simulations, such as for updating
-   * {@link edu.wpi.first.wpilibj.simulation} classes and setting simulated sensor readings.
-   */
-  default void simulationPeriodic() {}
-
-  /**
    * Gets the name of this resource for telemetry.
    *
    * @return resource name
    */
   default String getName() {
     return this.getClass().getSimpleName();
-  }
-
-  /**
-   * Sets the default {@link Command} of the resource. The default command will be automatically
-   * scheduled when no other commands are scheduled that require the resource. Default commands
-   * should generally not end on their own, i.e. their {@link Command#isFinished()} method should
-   * always return false. Will automatically register this resource with the {@link
-   * CommandScheduler}.
-   *
-   * @param defaultCommand the default command to associate with this resource
-   */
-  default void setDefaultCommand(Command defaultCommand) {
-    CommandScheduler.getInstance().setDefaultCommand(this, defaultCommand);
-  }
-
-  /**
-   * Removes the default command for the resource. This will not cancel the default command if it
-   * is currently running.
-   */
-  default void removeDefaultCommand() {
-    CommandScheduler.getInstance().removeDefaultCommand(this);
-  }
-
-  /**
-   * Gets the default command for this resource. Returns null if no default command is currently
-   * associated with the resource.
-   *
-   * @return the default command associated with this resource
-   */
-  default Command getDefaultCommand() {
-    return CommandScheduler.getInstance().getDefaultCommand(this);
   }
 
   /**
@@ -87,14 +41,6 @@ public interface Resource {
    */
   default Command getCurrentCommand() {
     return CommandScheduler.getInstance().requiring(this);
-  }
-
-  /**
-   * Registers this resource with the {@link CommandScheduler}, allowing its {@link
-   * Resource#periodic()} method to be called when the scheduler runs.
-   */
-  default void register() {
-    CommandScheduler.getInstance().registerResources(this);
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Resource.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Resource.java
@@ -1,0 +1,171 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj2.command;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * `Resource` is the <a href="https://en.wikipedia.org/wiki/Lock_(computer_science)">locking</a> 
+ * implementation for the Command-based concurrency model, encapsulating program state that should 
+ * only be controlled by one {@link Command} at a time.  If multiple commands requiring the same
+ * resource are scheduled at the same time, the {@link CommandScheduler} will resolve the resource
+ * contention by interrupting (or refusing to schedule) all but one of the commands.
+ * 
+ * <p>Typically, protected state represents hardware resources (like motors) for which control
+ * disputes would present an operational hazard.  But, it may also be appropriate to
+ * protect software resources, like vision pipelines, whose outputs might become invalid if
+ * their configurations are changed inappropriately during a task.
+ * 
+ * <p>Classes containing protected state should implement this interface.  Commands that require
+ * said state should be written using the Command factories (e.g. {@link Resource#run(Runnable)}
+ * defined on this interface, which automatically declare the resource requirement.
+ */
+public interface Resource {
+  /**
+   * This method is called periodically by the {@link CommandScheduler}. Useful for updating
+   * resource-specific state that you don't want to offload to a {@link Command}. Teams should try
+   * to be consistent within their own codebases about which responsibilities will be handled by
+   * Commands, and which will be handled here.
+   */
+  default void periodic() {}
+
+  /**
+   * This method is called periodically by the {@link CommandScheduler}. Useful for updating
+   * resource-specific state that needs to be maintained for simulations, such as for updating
+   * {@link edu.wpi.first.wpilibj.simulation} classes and setting simulated sensor readings.
+   */
+  default void simulationPeriodic() {}
+
+  /**
+   * Gets the name of this resource for telemetry.
+   *
+   * @return resource name
+   */
+  default String getName() {
+    return this.getClass().getSimpleName();
+  }
+
+  /**
+   * Sets the default {@link Command} of the resource. The default command will be automatically
+   * scheduled when no other commands are scheduled that require the resource. Default commands
+   * should generally not end on their own, i.e. their {@link Command#isFinished()} method should
+   * always return false. Will automatically register this resource with the {@link
+   * CommandScheduler}.
+   *
+   * @param defaultCommand the default command to associate with this resource
+   */
+  default void setDefaultCommand(Command defaultCommand) {
+    CommandScheduler.getInstance().setDefaultCommand(this, defaultCommand);
+  }
+
+  /**
+   * Removes the default command for the resource. This will not cancel the default command if it
+   * is currently running.
+   */
+  default void removeDefaultCommand() {
+    CommandScheduler.getInstance().removeDefaultCommand(this);
+  }
+
+  /**
+   * Gets the default command for this resource. Returns null if no default command is currently
+   * associated with the resource.
+   *
+   * @return the default command associated with this resource
+   */
+  default Command getDefaultCommand() {
+    return CommandScheduler.getInstance().getDefaultCommand(this);
+  }
+
+  /**
+   * Returns the command currently running on this resource. Returns null if no command is
+   * currently scheduled that requires this resource.
+   *
+   * @return the scheduled command currently requiring this resource
+   */
+  default Command getCurrentCommand() {
+    return CommandScheduler.getInstance().requiring(this);
+  }
+
+  /**
+   * Registers this resource with the {@link CommandScheduler}, allowing its {@link
+   * Resource#periodic()} method to be called when the scheduler runs.
+   */
+  default void register() {
+    CommandScheduler.getInstance().registerResources(this);
+  }
+
+  /**
+   * Constructs a command that runs an action once and finishes. Requires this resource.
+   *
+   * @param action the action to run
+   * @return the command
+   * @see InstantCommand
+   */
+  default Command runOnce(Runnable action) {
+    return Commands.runOnce(action, this);
+  }
+
+  /**
+   * Constructs a command that runs an action every iteration until interrupted. Requires this
+   * resource.
+   *
+   * @param action the action to run
+   * @return the command
+   * @see RunCommand
+   */
+  default Command run(Runnable action) {
+    return Commands.run(action, this);
+  }
+
+  /**
+   * Constructs a command that runs an action once and another action when the command is
+   * interrupted. Requires this resource.
+   *
+   * @param start the action to run on start
+   * @param end the action to run on interrupt
+   * @return the command
+   * @see StartEndCommand
+   */
+  default Command startEnd(Runnable start, Runnable end) {
+    return Commands.startEnd(start, end, this);
+  }
+
+  /**
+   * Constructs a command that runs an action every iteration until interrupted, and then runs a
+   * second action. Requires this resource.
+   *
+   * @param run the action to run every iteration
+   * @param end the action to run on interrupt
+   * @return the command
+   */
+  default Command runEnd(Runnable run, Runnable end) {
+    return Commands.runEnd(run, end, this);
+  }
+
+  /**
+   * Constructs a command that runs an action once and then runs another action every iteration
+   * until interrupted. Requires this resource.
+   *
+   * @param start the action to run on start
+   * @param run the action to run every iteration
+   * @return the command
+   */
+  default Command startRun(Runnable start, Runnable run) {
+    return Commands.startRun(start, run, this);
+  }
+
+  /**
+   * Constructs a {@link DeferredCommand} with the provided supplier. This resource is added as a
+   * requirement.
+   *
+   * @param supplier the command supplier.
+   * @return the command.
+   * @see DeferredCommand
+   */
+  default Command defer(Supplier<Command> supplier) {
+    return Commands.defer(supplier, Set.of(this));
+  }
+}

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RunCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RunCommand.java
@@ -21,7 +21,7 @@ public class RunCommand extends FunctionalCommand {
    * @param toRun the Runnable to run
    * @param requirements the subsystems to require
    */
-  public RunCommand(Runnable toRun, Subsystem... requirements) {
+  public RunCommand(Runnable toRun, Resource... requirements) {
     super(() -> {}, toRun, interrupted -> {}, () -> false, requirements);
   }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/StartEndCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/StartEndCommand.java
@@ -25,7 +25,7 @@ public class StartEndCommand extends FunctionalCommand {
    * @param onEnd the Runnable to run on command end
    * @param requirements the subsystems required by this command
    */
-  public StartEndCommand(Runnable onInit, Runnable onEnd, Subsystem... requirements) {
+  public StartEndCommand(Runnable onInit, Runnable onEnd, Resource... requirements) {
     super(
         onInit,
         () -> {},

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
@@ -1,14 +1,11 @@
-// Copyright (c) FIRST and other WPILib contributors.
-// Open Source Software; you can modify and/or share it under the terms of
-// the WPILib BSD license file in the root directory of this project.
-
 package edu.wpi.first.wpilibj2.command;
 
-import java.util.Set;
-import java.util.function.Supplier;
-
 /**
- * A robot subsystem. Subsystems are the basic unit of robot organization in the Command-based
+ * NOTE: The `Subsystem` interface has been renamed to {@link Resource}; this interface remains as
+ * an alias for backwards-compatibility.  The new name better represents the in-code purpose of
+ * the interface.
+ *
+ * <p>A robot subsystem. Subsystems are the basic unit of robot organization in the Command-based
  * framework; they encapsulate low-level hardware objects (motor controllers, sensors, etc.) and
  * provide methods through which they can be used by {@link Command}s. Subsystems are used by the
  * {@link CommandScheduler}'s resource management system to ensure multiple robot actions are not
@@ -24,149 +21,5 @@ import java.util.function.Supplier;
  *
  * <p>This class is provided by the NewCommands VendorDep
  */
-public interface Subsystem {
-  /**
-   * This method is called periodically by the {@link CommandScheduler}. Useful for updating
-   * subsystem-specific state that you don't want to offload to a {@link Command}. Teams should try
-   * to be consistent within their own codebases about which responsibilities will be handled by
-   * Commands, and which will be handled here.
-   */
-  default void periodic() {}
-
-  /**
-   * This method is called periodically by the {@link CommandScheduler}. Useful for updating
-   * subsystem-specific state that needs to be maintained for simulations, such as for updating
-   * {@link edu.wpi.first.wpilibj.simulation} classes and setting simulated sensor readings.
-   */
-  default void simulationPeriodic() {}
-
-  /**
-   * Gets the subsystem name of this Subsystem.
-   *
-   * @return Subsystem name
-   */
-  default String getName() {
-    return this.getClass().getSimpleName();
-  }
-
-  /**
-   * Sets the default {@link Command} of the subsystem. The default command will be automatically
-   * scheduled when no other commands are scheduled that require the subsystem. Default commands
-   * should generally not end on their own, i.e. their {@link Command#isFinished()} method should
-   * always return false. Will automatically register this subsystem with the {@link
-   * CommandScheduler}.
-   *
-   * @param defaultCommand the default command to associate with this subsystem
-   */
-  default void setDefaultCommand(Command defaultCommand) {
-    CommandScheduler.getInstance().setDefaultCommand(this, defaultCommand);
-  }
-
-  /**
-   * Removes the default command for the subsystem. This will not cancel the default command if it
-   * is currently running.
-   */
-  default void removeDefaultCommand() {
-    CommandScheduler.getInstance().removeDefaultCommand(this);
-  }
-
-  /**
-   * Gets the default command for this subsystem. Returns null if no default command is currently
-   * associated with the subsystem.
-   *
-   * @return the default command associated with this subsystem
-   */
-  default Command getDefaultCommand() {
-    return CommandScheduler.getInstance().getDefaultCommand(this);
-  }
-
-  /**
-   * Returns the command currently running on this subsystem. Returns null if no command is
-   * currently scheduled that requires this subsystem.
-   *
-   * @return the scheduled command currently requiring this subsystem
-   */
-  default Command getCurrentCommand() {
-    return CommandScheduler.getInstance().requiring(this);
-  }
-
-  /**
-   * Registers this subsystem with the {@link CommandScheduler}, allowing its {@link
-   * Subsystem#periodic()} method to be called when the scheduler runs.
-   */
-  default void register() {
-    CommandScheduler.getInstance().registerSubsystem(this);
-  }
-
-  /**
-   * Constructs a command that runs an action once and finishes. Requires this subsystem.
-   *
-   * @param action the action to run
-   * @return the command
-   * @see InstantCommand
-   */
-  default Command runOnce(Runnable action) {
-    return Commands.runOnce(action, this);
-  }
-
-  /**
-   * Constructs a command that runs an action every iteration until interrupted. Requires this
-   * subsystem.
-   *
-   * @param action the action to run
-   * @return the command
-   * @see RunCommand
-   */
-  default Command run(Runnable action) {
-    return Commands.run(action, this);
-  }
-
-  /**
-   * Constructs a command that runs an action once and another action when the command is
-   * interrupted. Requires this subsystem.
-   *
-   * @param start the action to run on start
-   * @param end the action to run on interrupt
-   * @return the command
-   * @see StartEndCommand
-   */
-  default Command startEnd(Runnable start, Runnable end) {
-    return Commands.startEnd(start, end, this);
-  }
-
-  /**
-   * Constructs a command that runs an action every iteration until interrupted, and then runs a
-   * second action. Requires this subsystem.
-   *
-   * @param run the action to run every iteration
-   * @param end the action to run on interrupt
-   * @return the command
-   */
-  default Command runEnd(Runnable run, Runnable end) {
-    return Commands.runEnd(run, end, this);
-  }
-
-  /**
-   * Constructs a command that runs an action once and then runs another action every iteration
-   * until interrupted. Requires this subsystem.
-   *
-   * @param start the action to run on start
-   * @param run the action to run every iteration
-   * @return the command
-   */
-  default Command startRun(Runnable start, Runnable run) {
-    return Commands.startRun(start, run, this);
-  }
-
-  /**
-   * Constructs a {@link DeferredCommand} with the provided supplier. This subsystem is added as a
-   * requirement.
-   *
-   * @param supplier the command supplier.
-   * @return the command.
-   * @see DeferredCommand
-   */
-  default Command defer(Supplier<Command> supplier) {
-    return Commands.defer(supplier, Set.of(this));
-  }
+public interface Subsystem extends Resource {
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
@@ -1,16 +1,12 @@
 package edu.wpi.first.wpilibj2.command;
 
 /**
- * NOTE: The `Subsystem` interface has been renamed to {@link Resource}; this interface remains as
- * an alias for backwards-compatibility.  The new name better represents the in-code purpose of
- * the interface.
- *
  * <p>A robot subsystem. Subsystems are the basic unit of robot organization in the Command-based
  * framework; they encapsulate low-level hardware objects (motor controllers, sensors, etc.) and
  * provide methods through which they can be used by {@link Command}s. Subsystems are used by the
- * {@link CommandScheduler}'s resource management system to ensure multiple robot actions are not
+ * {@link CommandScheduler}'s subsystem management system to ensure multiple robot actions are not
  * "fighting" over the same hardware; Commands that use a subsystem should include that subsystem in
- * their {@link Command#getRequirements()} method, and resources used within a subsystem should
+ * their {@link Command#getRequirements()} method, and subsystems used within a subsystem should
  * generally remain encapsulated and not be shared by other parts of the robot.
  *
  * <p>Subsystems must be registered with the scheduler with the {@link
@@ -22,4 +18,65 @@ package edu.wpi.first.wpilibj2.command;
  * <p>This class is provided by the NewCommands VendorDep
  */
 public interface Subsystem extends Resource {
+    /**
+     * Gets the name of this subsystem for telemetry.
+     *
+     * @return resource name
+     */
+    default String getName() {
+        return this.getClass().getSimpleName();
+    }
+
+    /**
+     * This method is called periodically by the {@link CommandScheduler}. Useful for updating
+     * subsystem-specific state that you don't want to offload to a {@link Command}. Teams should try
+     * to be consistent within their own codebases about which responsibilities will be handled by
+     * Commands, and which will be handled here.
+     */
+    default void periodic() {}
+
+    /**
+     * This method is called periodically by the {@link CommandScheduler}. Useful for updating
+     * subsystem-specific state that needs to be maintained for simulations, such as for updating
+     * {@link edu.wpi.first.wpilibj.simulation} classes and setting simulated sensor readings.
+     */
+    default void simulationPeriodic() {}
+    /**
+     * Sets the default {@link Command} of the subsystem. The default command will be automatically
+     * scheduled when no other commands are scheduled that require the subsystem. Default commands
+     * should generally not end on their own, i.e. their {@link Command#isFinished()} method should
+     * always return false. Will automatically register this subsystem with the {@link
+     * CommandScheduler}.
+     *
+     * @param defaultCommand the default command to associate with this subsystem
+     */
+    default void setDefaultCommand(Command defaultCommand) {
+        CommandScheduler.getInstance().setDefaultCommand(this, defaultCommand);
+    }
+
+    /**
+     * Removes the default command for the subsystem. This will not cancel the default command if it
+     * is currently running.
+     */
+    default void removeDefaultCommand() {
+        CommandScheduler.getInstance().removeDefaultCommand(this);
+    }
+
+    /**
+     * Gets the default command for this subsystem. Returns null if no default command is currently
+     * associated with the subsystem.
+     *
+     * @return the default command associated with this subsystem
+     */
+    default Command getDefaultCommand() {
+        return CommandScheduler.getInstance().getDefaultCommand(this);
+    }
+
+    /**
+     * Registers this subsystem with the {@link CommandScheduler}, allowing its {@link
+     * Subsystem#periodic()} method to be called when the scheduler runs.
+     */
+    default void register() {
+        CommandScheduler.getInstance().registerSubsystem(this);
+    }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SubsystemBase.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SubsystemBase.java
@@ -14,14 +14,14 @@ import edu.wpi.first.util.sendable.SendableRegistry;
  *
  * <p>This class is provided by the NewCommands VendorDep
  */
-public abstract class SubsystemBase implements Subsystem, Sendable {
+public abstract class SubsystemBase implements Resource, Sendable {
   /** Constructor. Telemetry/log name defaults to the classname. */
   @SuppressWarnings("this-escape")
   public SubsystemBase() {
     String name = this.getClass().getSimpleName();
     name = name.substring(name.lastIndexOf('.') + 1);
     SendableRegistry.addLW(this, name, name);
-    CommandScheduler.getInstance().registerSubsystem(this);
+    CommandScheduler.getInstance().registerResources(this);
   }
 
   /**
@@ -32,7 +32,7 @@ public abstract class SubsystemBase implements Subsystem, Sendable {
   @SuppressWarnings("this-escape")
   public SubsystemBase(String name) {
     SendableRegistry.addLW(this, name, name);
-    CommandScheduler.getInstance().registerSubsystem(this);
+    CommandScheduler.getInstance().registerResources(this);
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SubsystemBase.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SubsystemBase.java
@@ -14,14 +14,14 @@ import edu.wpi.first.util.sendable.SendableRegistry;
  *
  * <p>This class is provided by the NewCommands VendorDep
  */
-public abstract class SubsystemBase implements Resource, Sendable {
+public abstract class SubsystemBase implements Subsystem, Sendable {
   /** Constructor. Telemetry/log name defaults to the classname. */
   @SuppressWarnings("this-escape")
   public SubsystemBase() {
     String name = this.getClass().getSimpleName();
     name = name.substring(name.lastIndexOf('.') + 1);
     SendableRegistry.addLW(this, name, name);
-    CommandScheduler.getInstance().registerResources(this);
+    CommandScheduler.getInstance().registerSubsystem(this);
   }
 
   /**
@@ -32,7 +32,7 @@ public abstract class SubsystemBase implements Resource, Sendable {
   @SuppressWarnings("this-escape")
   public SubsystemBase(String name) {
     SendableRegistry.addLW(this, name, name);
-    CommandScheduler.getInstance().registerResources(this);
+    CommandScheduler.getInstance().registerSubsystem(this);
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommand.java
@@ -70,7 +70,7 @@ public class SwerveControllerCommand extends Command {
       ProfiledPIDController thetaController,
       Supplier<Rotation2d> desiredRotation,
       Consumer<SwerveModuleState[]> outputModuleStates,
-      Subsystem... requirements) {
+      Resource... requirements) {
     this(
         trajectory,
         pose,
@@ -115,7 +115,7 @@ public class SwerveControllerCommand extends Command {
       PIDController yController,
       ProfiledPIDController thetaController,
       Consumer<SwerveModuleState[]> outputModuleStates,
-      Subsystem... requirements) {
+      Resource... requirements) {
     this(
         trajectory,
         pose,
@@ -156,7 +156,7 @@ public class SwerveControllerCommand extends Command {
       SwerveDriveKinematics kinematics,
       HolonomicDriveController controller,
       Consumer<SwerveModuleState[]> outputModuleStates,
-      Subsystem... requirements) {
+      Resource... requirements) {
     this(
         trajectory,
         pose,
@@ -194,7 +194,7 @@ public class SwerveControllerCommand extends Command {
       HolonomicDriveController controller,
       Supplier<Rotation2d> desiredRotation,
       Consumer<SwerveModuleState[]> outputModuleStates,
-      Subsystem... requirements) {
+      Resource... requirements) {
     m_trajectory = requireNonNullParam(trajectory, "trajectory", "SwerveControllerCommand");
     m_pose = requireNonNullParam(pose, "pose", "SwerveControllerCommand");
     m_kinematics = requireNonNullParam(kinematics, "kinematics", "SwerveControllerCommand");

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/TrapezoidProfileCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/TrapezoidProfileCommand.java
@@ -40,7 +40,7 @@ public class TrapezoidProfileCommand extends Command {
       Consumer<State> output,
       Supplier<State> goal,
       Supplier<State> currentState,
-      Subsystem... requirements) {
+      Resource... requirements) {
     m_profile = requireNonNullParam(profile, "profile", "TrapezoidProfileCommand");
     m_output = requireNonNullParam(output, "output", "TrapezoidProfileCommand");
     m_goal = goal;

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/WrapperCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/WrapperCommand.java
@@ -82,7 +82,7 @@ public abstract class WrapperCommand extends Command {
    * @return the set of subsystems that are required
    */
   @Override
-  public Set<Subsystem> getRequirements() {
+  public Set<Resource> getRequirements() {
     return m_command.getRequirements();
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/sysid/SysIdRoutine.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/sysid/SysIdRoutine.java
@@ -19,7 +19,6 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.sysid.SysIdRoutineLog;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Resource;
-
 import java.util.Map;
 import java.util.function.Consumer;
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/sysid/SysIdRoutine.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/sysid/SysIdRoutine.java
@@ -18,7 +18,8 @@ import edu.wpi.first.units.Voltage;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.sysid.SysIdRoutineLog;
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Subsystem;
+import edu.wpi.first.wpilibj2.command.Resource;
+
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -141,7 +142,7 @@ public class SysIdRoutine extends SysIdRoutineLog {
     public final Consumer<SysIdRoutineLog> m_log;
 
     /** The subsystem containing the motor(s) that is (or are) being characterized. */
-    public final Subsystem m_subsystem;
+    public final Resource m_resource;
 
     /** The name of the mechanism being tested. */
     public final String m_name;
@@ -156,7 +157,7 @@ public class SysIdRoutine extends SysIdRoutineLog {
      *     call one or more of the chainable logging handles (e.g. `voltage`) on the returned
      *     `MotorLog`. Multiple motors can be logged in a single callback by calling `motor`
      *     multiple times.
-     * @param subsystem The subsystem containing the motor(s) that is (or are) being characterized.
+     * @param resource The subsystem containing the motor(s) that is (or are) being characterized.
      *     Will be declared as a requirement for the returned test commands.
      * @param name The name of the mechanism being tested. Will be appended to the log entry title
      *     for the routine's test state, e.g. "sysid-test-state-mechanism". Defaults to the name of
@@ -165,12 +166,12 @@ public class SysIdRoutine extends SysIdRoutineLog {
     public Mechanism(
         Consumer<Measure<Voltage>> drive,
         Consumer<SysIdRoutineLog> log,
-        Subsystem subsystem,
+        Resource resource,
         String name) {
       m_drive = drive;
       m_log = log != null ? log : l -> {};
-      m_subsystem = subsystem;
-      m_name = name != null ? name : subsystem.getName();
+      m_resource = resource;
+      m_name = name != null ? name : resource.getName();
     }
 
     /**
@@ -184,14 +185,14 @@ public class SysIdRoutine extends SysIdRoutineLog {
      *     call one or more of the chainable logging handles (e.g. `voltage`) on the returned
      *     `MotorLog`. Multiple motors can be logged in a single callback by calling `motor`
      *     multiple times.
-     * @param subsystem The subsystem containing the motor(s) that is (or are) being characterized.
+     * @param resource The subsystem containing the motor(s) that is (or are) being characterized.
      *     Will be declared as a requirement for the returned test commands. The subsystem's `name`
      *     will be appended to the log entry title for the routine's test state, e.g.
      *     "sysid-test-state-subsystem".
      */
     public Mechanism(
-        Consumer<Measure<Voltage>> drive, Consumer<SysIdRoutineLog> log, Subsystem subsystem) {
-      this(drive, log, subsystem, null);
+        Consumer<Measure<Voltage>> drive, Consumer<SysIdRoutineLog> log, Resource resource) {
+      this(drive, log, resource, null);
     }
   }
 
@@ -225,10 +226,10 @@ public class SysIdRoutine extends SysIdRoutineLog {
 
     Timer timer = new Timer();
     return m_mechanism
-        .m_subsystem
+        .m_resource
         .runOnce(timer::restart)
         .andThen(
-            m_mechanism.m_subsystem.run(
+            m_mechanism.m_resource.run(
                 () -> {
                   m_mechanism.m_drive.accept(
                       m_outputVolts.mut_replace(
@@ -266,11 +267,11 @@ public class SysIdRoutine extends SysIdRoutineLog {
             .get(direction);
 
     return m_mechanism
-        .m_subsystem
+        .m_resource
         .runOnce(
             () -> m_outputVolts.mut_replace(m_config.m_stepVoltage.in(Volts) * outputSign, Volts))
         .andThen(
-            m_mechanism.m_subsystem.run(
+            m_mechanism.m_resource.run(
                 () -> {
                   m_mechanism.m_drive.accept(m_outputVolts);
                   m_mechanism.m_log.accept(this);

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandRequirementsTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandRequirementsTest.java
@@ -15,7 +15,7 @@ class CommandRequirementsTest extends CommandTestBase {
   @Test
   void requirementInterruptTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      Subsystem requirement = new SubsystemBase() {};
+      Resource requirement = new SubsystemBase() {};
 
       MockCommandHolder interruptedHolder = new MockCommandHolder(true, requirement);
       Command interrupted = interruptedHolder.getMock();
@@ -42,7 +42,7 @@ class CommandRequirementsTest extends CommandTestBase {
   @Test
   void requirementUninterruptibleTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      Subsystem requirement = new SubsystemBase() {};
+      Resource requirement = new SubsystemBase() {};
 
       Command notInterrupted =
           new RunCommand(() -> {}, requirement)
@@ -61,7 +61,7 @@ class CommandRequirementsTest extends CommandTestBase {
   @Test
   void defaultCommandRequirementErrorTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      Subsystem system = new SubsystemBase() {};
+      Resource system = new SubsystemBase() {};
 
       Command missingRequirement = new WaitUntilCommand(() -> false);
 

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandTestBase.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandTestBase.java
@@ -45,7 +45,7 @@ public class CommandTestBase {
   public static class MockCommandHolder {
     private final Command m_mockCommand = mock(Command.class);
 
-    public MockCommandHolder(boolean runWhenDisabled, Subsystem... requirements) {
+    public MockCommandHolder(boolean runWhenDisabled, Resource... requirements) {
       when(m_mockCommand.getRequirements()).thenReturn(Set.of(requirements));
       when(m_mockCommand.isFinished()).thenReturn(false);
       when(m_mockCommand.runsWhenDisabled()).thenReturn(runWhenDisabled);

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/ConditionalCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/ConditionalCommandTest.java
@@ -46,9 +46,9 @@ class ConditionalCommandTest extends CommandTestBase {
 
   @Test
   void conditionalCommandRequirementTest() {
-    Subsystem system1 = new SubsystemBase() {};
-    Subsystem system2 = new SubsystemBase() {};
-    Subsystem system3 = new SubsystemBase() {};
+    Resource system1 = new SubsystemBase() {};
+    Resource system2 = new SubsystemBase() {};
+    Resource system3 = new SubsystemBase() {};
 
     try (CommandScheduler scheduler = new CommandScheduler()) {
       MockCommandHolder command1Holder = new MockCommandHolder(true, system1, system2);

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/DefaultCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/DefaultCommandTest.java
@@ -14,7 +14,7 @@ class DefaultCommandTest extends CommandTestBase {
   @Test
   void defaultCommandScheduleTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      Subsystem hasDefaultCommand = new SubsystemBase() {};
+      Resource hasDefaultCommand = new SubsystemBase() {};
 
       MockCommandHolder defaultHolder = new MockCommandHolder(true, hasDefaultCommand);
       Command defaultCommand = defaultHolder.getMock();
@@ -29,7 +29,7 @@ class DefaultCommandTest extends CommandTestBase {
   @Test
   void defaultCommandInterruptResumeTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      Subsystem hasDefaultCommand = new SubsystemBase() {};
+      Resource hasDefaultCommand = new SubsystemBase() {};
 
       MockCommandHolder defaultHolder = new MockCommandHolder(true, hasDefaultCommand);
       Command defaultCommand = defaultHolder.getMock();
@@ -54,7 +54,7 @@ class DefaultCommandTest extends CommandTestBase {
   @Test
   void defaultCommandDisableResumeTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      Subsystem hasDefaultCommand = new SubsystemBase() {};
+      Resource hasDefaultCommand = new SubsystemBase() {};
 
       MockCommandHolder defaultHolder = new MockCommandHolder(false, hasDefaultCommand);
       Command defaultCommand = defaultHolder.getMock();

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/DeferredCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/DeferredCommandTest.java
@@ -65,10 +65,10 @@ class DeferredCommandTest extends CommandTestBase {
 
   @Test
   void deferredRequirementsTest() {
-    Subsystem subsystem = new Subsystem() {};
-    DeferredCommand command = new DeferredCommand(Commands::none, Set.of(subsystem));
+    Resource resource = new Resource() {};
+    DeferredCommand command = new DeferredCommand(Commands::none, Set.of(resource));
 
-    assertTrue(command.getRequirements().contains(subsystem));
+    assertTrue(command.getRequirements().contains(resource));
   }
 
   @Test

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommandTest.java
@@ -93,7 +93,7 @@ class MecanumControllerCommandTest {
   @Test
   @ResourceLock("timing")
   void testReachesReference() {
-    final var subsystem = new Subsystem() {};
+    final var subsystem = new Resource() {};
 
     final var waypoints = new ArrayList<Pose2d>();
     waypoints.add(Pose2d.kZero);

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/ParallelCommandGroupTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/ParallelCommandGroupTest.java
@@ -89,10 +89,10 @@ class ParallelCommandGroupTest extends MultiCompositionTestBase<ParallelCommandG
 
   @Test
   void parallelGroupRequirementTest() {
-    Subsystem system1 = new SubsystemBase() {};
-    Subsystem system2 = new SubsystemBase() {};
-    Subsystem system3 = new SubsystemBase() {};
-    Subsystem system4 = new SubsystemBase() {};
+    Resource system1 = new SubsystemBase() {};
+    Resource system2 = new SubsystemBase() {};
+    Resource system3 = new SubsystemBase() {};
+    Resource system4 = new SubsystemBase() {};
 
     try (CommandScheduler scheduler = new CommandScheduler()) {
       MockCommandHolder command1Holder = new MockCommandHolder(true, system1, system2);
@@ -114,9 +114,9 @@ class ParallelCommandGroupTest extends MultiCompositionTestBase<ParallelCommandG
 
   @Test
   void parallelGroupRequirementErrorTest() {
-    Subsystem system1 = new SubsystemBase() {};
-    Subsystem system2 = new SubsystemBase() {};
-    Subsystem system3 = new SubsystemBase() {};
+    Resource system1 = new SubsystemBase() {};
+    Resource system2 = new SubsystemBase() {};
+    Resource system3 = new SubsystemBase() {};
 
     MockCommandHolder command1Holder = new MockCommandHolder(true, system1, system2);
     Command command1 = command1Holder.getMock();

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/ParallelDeadlineGroupTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/ParallelDeadlineGroupTest.java
@@ -87,10 +87,10 @@ class ParallelDeadlineGroupTest extends MultiCompositionTestBase<ParallelDeadlin
 
   @Test
   void parallelDeadlineRequirementTest() {
-    Subsystem system1 = new SubsystemBase() {};
-    Subsystem system2 = new SubsystemBase() {};
-    Subsystem system3 = new SubsystemBase() {};
-    Subsystem system4 = new SubsystemBase() {};
+    Resource system1 = new SubsystemBase() {};
+    Resource system2 = new SubsystemBase() {};
+    Resource system3 = new SubsystemBase() {};
+    Resource system4 = new SubsystemBase() {};
 
     try (CommandScheduler scheduler = new CommandScheduler()) {
       MockCommandHolder command1Holder = new MockCommandHolder(true, system1, system2);
@@ -112,9 +112,9 @@ class ParallelDeadlineGroupTest extends MultiCompositionTestBase<ParallelDeadlin
 
   @Test
   void parallelDeadlineRequirementErrorTest() {
-    Subsystem system1 = new SubsystemBase() {};
-    Subsystem system2 = new SubsystemBase() {};
-    Subsystem system3 = new SubsystemBase() {};
+    Resource system1 = new SubsystemBase() {};
+    Resource system2 = new SubsystemBase() {};
+    Resource system3 = new SubsystemBase() {};
 
     MockCommandHolder command1Holder = new MockCommandHolder(true, system1, system2);
     Command command1 = command1Holder.getMock();

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/ParallelRaceGroupTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/ParallelRaceGroupTest.java
@@ -91,10 +91,10 @@ class ParallelRaceGroupTest extends MultiCompositionTestBase<ParallelRaceGroup> 
 
   @Test
   void parallelRaceRequirementTest() {
-    Subsystem system1 = new SubsystemBase() {};
-    Subsystem system2 = new SubsystemBase() {};
-    Subsystem system3 = new SubsystemBase() {};
-    Subsystem system4 = new SubsystemBase() {};
+    Resource system1 = new SubsystemBase() {};
+    Resource system2 = new SubsystemBase() {};
+    Resource system3 = new SubsystemBase() {};
+    Resource system4 = new SubsystemBase() {};
 
     try (CommandScheduler scheduler = new CommandScheduler()) {
       MockCommandHolder command1Holder = new MockCommandHolder(true, system1, system2);
@@ -116,9 +116,9 @@ class ParallelRaceGroupTest extends MultiCompositionTestBase<ParallelRaceGroup> 
 
   @Test
   void parallelRaceRequirementErrorTest() {
-    Subsystem system1 = new SubsystemBase() {};
-    Subsystem system2 = new SubsystemBase() {};
-    Subsystem system3 = new SubsystemBase() {};
+    Resource system1 = new SubsystemBase() {};
+    Resource system2 = new SubsystemBase() {};
+    Resource system3 = new SubsystemBase() {};
 
     MockCommandHolder command1Holder = new MockCommandHolder(true, system1, system2);
     Command command1 = command1Holder.getMock();
@@ -130,8 +130,8 @@ class ParallelRaceGroupTest extends MultiCompositionTestBase<ParallelRaceGroup> 
 
   @Test
   void parallelRaceOnlyCallsEndOnceTest() {
-    Subsystem system1 = new SubsystemBase() {};
-    Subsystem system2 = new SubsystemBase() {};
+    Resource system1 = new SubsystemBase() {};
+    Resource system2 = new SubsystemBase() {};
 
     MockCommandHolder command1Holder = new MockCommandHolder(true, system1);
     Command command1 = command1Holder.getMock();

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SchedulerTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SchedulerTest.java
@@ -71,9 +71,9 @@ class SchedulerTest extends CommandTestBase {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicInteger counter = new AtomicInteger();
 
-      Subsystem subsystem = new Subsystem() {};
-      Command command = subsystem.run(() -> {});
-      Command interruptor = subsystem.runOnce(() -> {});
+      Resource resource = new Resource() {};
+      Command command = resource.run(() -> {});
+      Command interruptor = resource.runOnce(() -> {});
 
       scheduler.onCommandInterrupt(
           (interrupted, cause) -> {
@@ -94,9 +94,9 @@ class SchedulerTest extends CommandTestBase {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicInteger counter = new AtomicInteger();
 
-      Subsystem subsystem = new Subsystem() {};
-      Command command = subsystem.run(() -> {});
-      Command interruptor = subsystem.runOnce(() -> {});
+      Resource resource = new Resource() {};
+      Command command = resource.run(() -> {});
+      Command interruptor = resource.runOnce(() -> {});
       // This command will schedule interruptor in execute() inside the run loop
       Command interruptorScheduler = Commands.runOnce(() -> scheduler.schedule(interruptor));
 
@@ -120,7 +120,7 @@ class SchedulerTest extends CommandTestBase {
   void registerSubsystemTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicInteger counter = new AtomicInteger(0);
-      Subsystem system =
+      Resource system =
           new SubsystemBase() {
             @Override
             public void periodic() {
@@ -128,7 +128,7 @@ class SchedulerTest extends CommandTestBase {
             }
           };
 
-      assertDoesNotThrow(() -> scheduler.registerSubsystem(system));
+      assertDoesNotThrow(() -> scheduler.registerResources(system));
 
       scheduler.run();
       assertEquals(1, counter.get());
@@ -139,14 +139,14 @@ class SchedulerTest extends CommandTestBase {
   void unregisterSubsystemTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicInteger counter = new AtomicInteger(0);
-      Subsystem system =
+      Resource system =
           new SubsystemBase() {
             @Override
             public void periodic() {
               counter.incrementAndGet();
             }
           };
-      scheduler.registerSubsystem(system);
+      scheduler.registerResources(system);
       assertDoesNotThrow(() -> scheduler.unregisterSubsystem(system));
 
       scheduler.run();

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SchedulerTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SchedulerTest.java
@@ -120,7 +120,7 @@ class SchedulerTest extends CommandTestBase {
   void registerSubsystemTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicInteger counter = new AtomicInteger(0);
-      Resource system =
+      Subsystem system =
           new SubsystemBase() {
             @Override
             public void periodic() {
@@ -128,7 +128,7 @@ class SchedulerTest extends CommandTestBase {
             }
           };
 
-      assertDoesNotThrow(() -> scheduler.registerResources(system));
+      assertDoesNotThrow(() -> scheduler.registerSubsystem(system));
 
       scheduler.run();
       assertEquals(1, counter.get());
@@ -139,14 +139,14 @@ class SchedulerTest extends CommandTestBase {
   void unregisterSubsystemTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicInteger counter = new AtomicInteger(0);
-      Resource system =
+      SubsystemBase system =
           new SubsystemBase() {
             @Override
             public void periodic() {
               counter.incrementAndGet();
             }
           };
-      scheduler.registerResources(system);
+      scheduler.registerSubsystem(system);
       assertDoesNotThrow(() -> scheduler.unregisterSubsystem(system));
 
       scheduler.run();

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SchedulingRecursionTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SchedulingRecursionTest.java
@@ -26,7 +26,7 @@ class SchedulingRecursionTest extends CommandTestBase {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicBoolean hasOtherRun = new AtomicBoolean();
       AtomicInteger counter = new AtomicInteger();
-      Subsystem requirement = new SubsystemBase() {};
+      Resource requirement = new SubsystemBase() {};
       Command selfCancels =
           new Command() {
             {
@@ -70,7 +70,7 @@ class SchedulingRecursionTest extends CommandTestBase {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicBoolean hasOtherRun = new AtomicBoolean();
       AtomicInteger counter = new AtomicInteger();
-      Subsystem requirement = new Subsystem() {};
+      Resource requirement = new Resource() {};
       Command selfCancels =
           new Command() {
             {
@@ -110,7 +110,7 @@ class SchedulingRecursionTest extends CommandTestBase {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicBoolean hasOtherRun = new AtomicBoolean();
       AtomicInteger counter = new AtomicInteger();
-      Subsystem requirement = new SubsystemBase() {};
+      Resource requirement = new SubsystemBase() {};
       Command selfCancels =
           new Command() {
             {
@@ -328,7 +328,7 @@ class SchedulingRecursionTest extends CommandTestBase {
   void scheduleFromEndCancel() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicInteger counter = new AtomicInteger();
-      Subsystem requirement = new SubsystemBase() {};
+      Resource requirement = new SubsystemBase() {};
       InstantCommand other = new InstantCommand(() -> {}, requirement);
       FunctionalCommand selfCancels =
           new FunctionalCommand(
@@ -353,7 +353,7 @@ class SchedulingRecursionTest extends CommandTestBase {
   void scheduleFromEndInterrupt() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicInteger counter = new AtomicInteger();
-      Subsystem requirement = new SubsystemBase() {};
+      Resource requirement = new SubsystemBase() {};
       InstantCommand other = new InstantCommand(() -> {}, requirement);
       FunctionalCommand selfCancels =
           new FunctionalCommand(
@@ -379,7 +379,7 @@ class SchedulingRecursionTest extends CommandTestBase {
   void scheduleFromEndInterruptAction() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicInteger counter = new AtomicInteger();
-      Subsystem requirement = new Subsystem() {};
+      Resource requirement = new Resource() {};
       InstantCommand other = new InstantCommand(() -> {}, requirement);
       InstantCommand selfCancels = new InstantCommand(() -> {}, requirement);
       scheduler.onCommandInterrupt(
@@ -401,7 +401,7 @@ class SchedulingRecursionTest extends CommandTestBase {
   void scheduleInitializeFromDefaultCommand(InterruptionBehavior interruptionBehavior) {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicInteger counter = new AtomicInteger();
-      Subsystem requirement = new SubsystemBase() {};
+      Resource requirement = new SubsystemBase() {};
       Command other =
           new InstantCommand(() -> {}, requirement).withInterruptBehavior(interruptionBehavior);
       FunctionalCommand defaultCommand =
@@ -430,7 +430,7 @@ class SchedulingRecursionTest extends CommandTestBase {
   void cancelDefaultCommandFromEnd() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicInteger counter = new AtomicInteger();
-      Subsystem requirement = new Subsystem() {};
+      Resource requirement = new Resource() {};
       Command defaultCommand =
           new FunctionalCommand(
               () -> {},

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SelectCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SelectCommandTest.java
@@ -75,10 +75,10 @@ class SelectCommandTest extends MultiCompositionTestBase<SelectCommand<Integer>>
 
   @Test
   void selectCommandRequirementTest() {
-    Subsystem system1 = new SubsystemBase() {};
-    Subsystem system2 = new SubsystemBase() {};
-    Subsystem system3 = new SubsystemBase() {};
-    Subsystem system4 = new SubsystemBase() {};
+    Resource system1 = new SubsystemBase() {};
+    Resource system2 = new SubsystemBase() {};
+    Resource system3 = new SubsystemBase() {};
+    Resource system4 = new SubsystemBase() {};
 
     try (CommandScheduler scheduler = new CommandScheduler()) {
       MockCommandHolder command1Holder = new MockCommandHolder(true, system1, system2);

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SequentialCommandGroupTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SequentialCommandGroupTest.java
@@ -99,10 +99,10 @@ class SequentialCommandGroupTest extends MultiCompositionTestBase<SequentialComm
 
   @Test
   void sequentialGroupRequirementTest() {
-    Subsystem system1 = new SubsystemBase() {};
-    Subsystem system2 = new SubsystemBase() {};
-    Subsystem system3 = new SubsystemBase() {};
-    Subsystem system4 = new SubsystemBase() {};
+    Resource system1 = new SubsystemBase() {};
+    Resource system2 = new SubsystemBase() {};
+    Resource system3 = new SubsystemBase() {};
+    Resource system4 = new SubsystemBase() {};
 
     try (CommandScheduler scheduler = new CommandScheduler()) {
       MockCommandHolder command1Holder = new MockCommandHolder(true, system1, system2);

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommandTest.java
@@ -92,7 +92,7 @@ class SwerveControllerCommandTest {
   @Test
   @ResourceLock("timing")
   void testReachesReference() {
-    final var subsystem = new Subsystem() {};
+    final var subsystem = new Resource() {};
 
     final var waypoints = new ArrayList<Pose2d>();
     waypoints.add(Pose2d.kZero);

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/sysid/SysIdRoutineTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/sysid/SysIdRoutineTest.java
@@ -19,13 +19,13 @@ import edu.wpi.first.units.Voltage;
 import edu.wpi.first.wpilibj.simulation.SimHooks;
 import edu.wpi.first.wpilibj.sysid.SysIdRoutineLog;
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Subsystem;
+import edu.wpi.first.wpilibj2.command.Resource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class SysIdRoutineTest {
-  interface Mechanism extends Subsystem {
+  interface Mechanism extends Resource {
     void recordState(SysIdRoutineLog.State state);
 
     void drive(Measure<Voltage> voltage);
@@ -57,7 +57,7 @@ class SysIdRoutineTest {
     m_sysidRoutine =
         new SysIdRoutine(
             new SysIdRoutine.Config(null, null, null, m_mechanism::recordState),
-            new SysIdRoutine.Mechanism(m_mechanism::drive, m_mechanism::log, new Subsystem() {}));
+            new SysIdRoutine.Mechanism(m_mechanism::drive, m_mechanism::log, new Resource() {}));
     m_quasistaticForward = m_sysidRoutine.quasistatic(SysIdRoutine.Direction.kForward);
     m_quasistaticReverse = m_sysidRoutine.quasistatic(SysIdRoutine.Direction.kReverse);
     m_dynamicForward = m_sysidRoutine.dynamic(SysIdRoutine.Direction.kForward);


### PR DESCRIPTION
Per recent discussion, this should be a strict improvement for readability and correctness-of-use.  No deprecations to avoid freaking anyone out.