### PR TITLE
Modify C++ `LinearFilter::Reset(span<double>, span<double>)` to take `span<T>`

### DIFF
--- a/wpimath/src/main/native/include/frc/filter/LinearFilter.h
+++ b/wpimath/src/main/native/include/frc/filter/LinearFilter.h
@@ -321,8 +321,7 @@ class LinearFilter {
    * @throws std::runtime_error if size of inputBuffer or outputBuffer does not
    *   match the size of ffGains and fbGains provided in the constructor.
    */
-  void Reset(std::span<const T> inputBuffer,
-             std::span<const T> outputBuffer) {
+  void Reset(std::span<const T> inputBuffer, std::span<const T> outputBuffer) {
     // Clear buffers
     Reset();
 

--- a/wpimath/src/main/native/include/frc/filter/LinearFilter.h
+++ b/wpimath/src/main/native/include/frc/filter/LinearFilter.h
@@ -321,8 +321,8 @@ class LinearFilter {
    * @throws std::runtime_error if size of inputBuffer or outputBuffer does not
    *   match the size of ffGains and fbGains provided in the constructor.
    */
-  void Reset(std::span<const double> inputBuffer,
-             std::span<const double> outputBuffer) {
+  void Reset(std::span<const T> inputBuffer,
+             std::span<const T> outputBuffer) {
     // Clear buffers
     Reset();
 


### PR DESCRIPTION
Previously, the two-parameter `LinearFilter::Reset` overload took `span<double>` parameters. However, m_inputs and m_outputs store T, so for any T that does not have an implicit constructor from double (such as the units library), the two-parameter Reset function is not usable.

The two possible solutions are to add an explicit T() in the push_back calls, or fix the overload to take `span<T>`. This PR does the latter.