### PR TITLE
[wpilib] Make Java TimedRobot constructor public

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/TimedRobot.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/TimedRobot.java
@@ -77,7 +77,7 @@ public class TimedRobot extends IterativeRobotBase {
   private final PriorityQueue<Callback> m_callbacks = new PriorityQueue<>();
 
   /** Constructor for TimedRobot. */
-  protected TimedRobot() {
+  public TimedRobot() {
     this(kDefaultPeriod);
   }
 
@@ -86,7 +86,7 @@ public class TimedRobot extends IterativeRobotBase {
    *
    * @param period Period in seconds.
    */
-  protected TimedRobot(double period) {
+  public TimedRobot(double period) {
     super(period);
     m_startTime = Timer.getFPGATimestamp();
     addPeriodic(this::loopFunc, period);


### PR DESCRIPTION
It was changed from public to private in #781, which doesn't match TimesliceRobot or C++ TimedRobot.