### PR TITLE
[wpilib] Deprecate MotorController

### DIFF
--- a/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
@@ -82,7 +82,9 @@ class DifferentialDrive : public RobotDriveBase,
    *
    * @param leftMotor Left motor.
    * @param rightMotor Right motor.
+   * @deprecated Use DifferentialDrive constructor with function arguments.
    */
+  [[deprecated("Use DifferentialDrive constructor with function arguments")]]
   DifferentialDrive(MotorController& leftMotor, MotorController& rightMotor);
 
   WPI_UNIGNORE_DEPRECATED

--- a/wpilibc/src/main/native/include/frc/drive/MecanumDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/MecanumDrive.h
@@ -86,7 +86,9 @@ class MecanumDrive : public RobotDriveBase,
    * @param rearLeftMotor Rear-left motor.
    * @param frontRightMotor Front-right motor.
    * @param rearRightMotor Rear-right motor.
+   * @deprecated Use MecanumDrive constructor with function arguments.
    */
+  [[deprecated("Use MecanumDrive constructor with function arguments")]]
   MecanumDrive(MotorController& frontLeftMotor, MotorController& rearLeftMotor,
                MotorController& frontRightMotor,
                MotorController& rearRightMotor);

--- a/wpilibc/src/main/native/include/frc/motorcontrol/MotorController.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/MotorController.h
@@ -11,7 +11,7 @@ namespace frc {
 /**
  * Interface for motor controlling devices.
  */
-class MotorController {
+class [[deprecated("Use the derived class instead")]] MotorController {
  public:
   virtual ~MotorController() = default;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -101,7 +101,9 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    *
    * @param leftMotor Left motor.
    * @param rightMotor Right motor.
+   * @deprecated Use DifferentialDrive constructor with function arguments.
    */
+  @Deprecated(forRemoval = true, since = "2025")
   @SuppressWarnings({"removal", "this-escape"})
   public DifferentialDrive(MotorController leftMotor, MotorController rightMotor) {
     this((double output) -> leftMotor.set(output), (double output) -> rightMotor.set(output));

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
@@ -117,7 +117,9 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
    * @param rearLeftMotor The motor on the rear-left corner.
    * @param frontRightMotor The motor on the front-right corner.
    * @param rearRightMotor The motor on the rear-right corner.
+   * @deprecated Use MecanumDrive constructor with function arguments.
    */
+  @Deprecated(forRemoval = true, since = "2025")
   @SuppressWarnings({"removal", "this-escape"})
   public MecanumDrive(
       MotorController frontLeftMotor,

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/MotorController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/MotorController.java
@@ -6,7 +6,12 @@ package edu.wpi.first.wpilibj.motorcontrol;
 
 import edu.wpi.first.wpilibj.RobotController;
 
-/** Interface for motor controlling devices. */
+/**
+ * Interface for motor controlling devices.
+ *
+ * @deprecated Use the derived class instead.
+ */
+@Deprecated(forRemoval = true, since = "2025")
 public interface MotorController {
   /**
    * Common interface for setting the speed of a motor controller.


### PR DESCRIPTION
The drive classes no longer need this interface, and it rigidly couples us to motor controller vendors who only update and do a major release of their vendordep once per year.

We were originally going to do this in #6053, but we wanted to gather feedback on the alternate approach during a season first (as far as I know, we received none).