### PR TITLE
Add CAN message schema to wpilib-ws.yaml and add 2 CANMotor props

### DIFF
--- a/simulation/halsim_ws_core/doc/hardware_ws_api.md
+++ b/simulation/halsim_ws_core/doc/hardware_ws_api.md
@@ -261,12 +261,14 @@ C++/Java implementation note: these are created as SimDevice nodes where the dev
 
 Only one of ``"supplyCurrent"`` or ``"motorCurrent"`` should be sent by the hardware; the other value should be set to zero.  If ``"busVoltage"`` is not simulated it should also be set to zero.
 
-| Data Key             | Type             | Description                                      |
-| -------------------- | ---------------- | ------------------------------------------------ |
-| ``"<percentOutput"`` | Integer or Float | Percent output (-1 to 1 range)                   |
-| ``">supplyCurrent"`` | Float            | The supply current in amps as simulated/measured |
-| ``">motorCurrent"``  | Float            | The motor current in amps as simulated/measured  |
-| ``">busVoltage"``    | Float            | The bus voltage as simulated/measured            |
+| Data Key             | Type             | Description                                                                         |
+| -------------------- | ---------------- | ----------------------------------------------------------------------------------- |
+| ``"<percentOutput"`` | Integer or Float | Percent output (-1 to 1 range)                                                      |
+| ``"<brakeMode"``     | Boolean          | Whether to brake (true) or coast (false) when `\|percentOutput\| < neutralDeadband` |
+| `"<neutralDeadband"` | Float            | `\|percentOutput\|` below which `brakeMode` matters (0 to 1)                        |
+| ``">supplyCurrent"`` | Float            | The supply current in amps as simulated/measured                                    |
+| ``">motorCurrent"``  | Float            | The motor current in amps as simulated/measured                                     |
+| ``">busVoltage"``    | Float            | The bus voltage as simulated/measured                                               |
 
 #### CANEncoder
 

--- a/simulation/halsim_ws_core/doc/wpilib-ws.yaml
+++ b/simulation/halsim_ws_core/doc/wpilib-ws.yaml
@@ -52,6 +52,7 @@ components:
             - $ref: "#/components/schemas/relayData"
             - $ref: "#/components/schemas/solenoidData"
             - $ref: "#/components/schemas/roborioData"
+            - $ref: "#/components/schemas/simdeviceData"
 
   schemas:
     accelData:
@@ -514,3 +515,167 @@ components:
             ">3v3_faults":
               type: integer
               description: "Number of faults on 3.3V rail"
+
+    canmotorData:
+      type: object
+      required:
+      - type
+      - device
+      properties:
+        type:
+          type: string
+          description: "Dummy type used for SimDevice type with device=CANMotor:*"
+          const: CANMotor
+        device:
+          type: string
+          description: "Should have the form CANMotor:ControllerClassName[id]"
+        data:
+          type: object
+          description: "CANMotor Data"
+          properties:
+            <init:
+              type: boolean
+              description: "If CANMotor is initialized in the robot program"
+            "<percentOutput":
+              type: number
+              description: "Percent Output"
+              minimum: -1.0
+              maximum: 1.0
+            ">supplyCurrent":
+              type: number
+              description: "Supply current in Amps"
+              minimum: 0.0
+            ">motorCurrent":
+              type: number
+              description: "Motor current in Amps"
+              minimum: 0.0
+            ">busVoltage":
+              type: number
+              description: "Bus voltage in Volts"
+              minimum: 0.0
+            "<neutralDeadband":
+              type: number
+              description: "Neutral Deadband"
+              minimum: 0
+              maximum: 1.0
+            "<brakeMode":
+              type: boolean
+              description: "Is in brake mode"
+
+    canencoderData:
+      type: object
+      required:
+      - type
+      - device
+      properties:
+        type:
+          type: string
+          description: "Dummy type used for SimDevice type with device=CANEncoder:*"
+          const: CANEncoder
+        device:
+          type: string
+          description: "Should have the form CANEncoder:ControllerClassName[id]"
+        data:
+          type: object
+          description: "CANEncoder Data"
+          properties:
+            <init:
+              type: boolean
+              description: "If CANMotor is initialized in the robot program"
+            ">position":
+              type: number
+              description: "Position in rotations"
+            ">velocity":
+              type: number
+              description: "Velocity in rotations per second"
+
+    simdeviceData:
+      type: object
+      required:
+      - type
+      - device
+      oneOf:
+      - properties:
+          type:
+            type: string
+            const: SimDevice
+          device:
+            type: string
+            format: "[^:]+"
+          data:
+            type: object
+            additionalProperties:
+              type: string
+      - properties:
+          type:
+            type: string
+            const: SimDevice
+          device:
+            type: string
+            format: "DutyCycle:.+"
+          data:
+            $ref: "#/components/schemas/dutycycleData/properties/data"
+      - properties:
+          type:
+            type: string
+            const: SimDevice
+          device:
+            type: string
+            format: "CANMotor:.+"
+          data:
+            $ref: "#/components/schemas/canmotorData/properties/data"
+      - properties:
+          type:
+            type: string
+            const: SimDevice
+          device:
+            type: string
+            format: "CANEncoder:.+"
+          data:
+            $ref: "#/components/schemas/canencoderData/properties/data"
+      - properties:
+          type:
+            type: string
+            const: SimDevice
+          device:
+            type: string
+            format: "CANGyro:.+"
+          data:
+            $ref: "#/components/schemas/gyroData/properties/data"
+      - properties:
+          type:
+            type: string
+            const: SimDevice
+          device:
+            type: string
+            format: "CANAccel:.+"
+          data:
+            $ref: "#/components/schemas/accelData/properties/data"
+      - properties:
+          type:
+            type: string
+            const: SimDevice
+          device:
+            type: string
+            format: "CANAIn:.+"
+          data:
+            $ref: "#/components/schemas/aiData/properties/data"
+      - properties:
+          type:
+            type: string
+            const: SimDevice
+          device:
+            type: string
+            format: "CANDIO:.+"
+          data:
+            ref: "#/components/schemas/dioData/properties/data"
+      - properties:
+          type:
+            type: string
+            const: SimDevice
+          device:
+            type: string
+            format: "CANDutyCycle:.+"
+          data:
+            $ref: "#/components/schemas/dutycycleData/properties/data"
+


### PR DESCRIPTION
We use `wpilib-ws.yaml` to auto-generate code designed to work with halsim_ws and are adding support for CAN devices. This PR:

1. Updates `wpilib-ws.yaml` to reflect the specific `SimDevice` type messages described in the CAN messages section (and hardware/DutyCycle section) of the api doc.
2. Adds and documents ``"<neutralDeadband"`` and ``"<brakeMode"`` as 2 new data properties for CANMotor messages. These are needed so that a simulated CANMotor can respond appropriately (including setting ``">motorCurrent"``  and/or ``">supplyCurrent"``) when ``"<percentOutput"`` is set.