### PR TITLE
[C++ cmd] Make CommandGenericHID as a public base class of CommandXboxController

### DIFF
--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/CommandXboxController.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/CommandXboxController.h
@@ -16,7 +16,7 @@ namespace frc2 {
  *
  * @see frc::XboxController
  */
-class CommandXboxController : CommandGenericHID {
+class CommandXboxController : public CommandGenericHID {
  public:
   /**
    * Construct an instance of a controller.


### PR DESCRIPTION
#6296 accidentally omitted the `public` specifier on `CommandGenericHID` in the base class section of `CommandXboxController`. Since `CommandXboxController` is declared using `class`, the default access for base classes is private, which prevents users outside the class from using methods declared in `CommandGenericHID`, which was the point of the PR.

I checked and the other files touched by that PR do not have the issue. I also confirmed locally that using methods declared in `CommandGenericHID` (such as `Button(int)`) on a `CommandXboxController` works with the following diff:
```diff
diff --git a/developerRobot/src/main/native/cpp/Robot.cpp b/developerRobot/src/main/native/cpp/Robot.cpp
index 238697d42..9f6075dae 100644
--- a/developerRobot/src/main/native/cpp/Robot.cpp
+++ b/developerRobot/src/main/native/cpp/Robot.cpp
@@ -3,13 +3,14 @@
 // the WPILib BSD license file in the root directory of this project.
 
 #include <frc/TimedRobot.h>
+#include <frc2/command/button/CommandXboxController.h>
 
 class Robot : public frc::TimedRobot {
   /**
    * This function is run when the robot is first started up and should be
    * used for any initialization code.
    */
-  void RobotInit() override {}
+  void RobotInit() override { m_controller.Button(0); }
 
   /**
    * This function is run once each time the robot enters autonomous mode
@@ -40,6 +41,9 @@ class Robot : public frc::TimedRobot {
    * This function is called periodically during all modes
    */
   void RobotPeriodic() override {}
+
+ private:
+  frc2::CommandXboxController m_controller{0};
 };
 
 int main() {
```