### PR TITLE
[wpilibj] Suppress this-escape warning on SharpIR

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SharpIR.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SharpIR.java
@@ -80,6 +80,7 @@ public class SharpIR implements Sendable, AutoCloseable {
    * @param minCM Minimum distance to report in centimeters
    * @param maxCM Maximum distance to report in centimeters
    */
+  @SuppressWarnings("this-escape")
   public SharpIR(int channel, double a, double b, double minCM, double maxCM) {
     m_sensor = new AnalogInput(channel);
 


### PR DESCRIPTION
This was introduced by #6023, but for some reason the CI runs on `main` used the build cache for `wpilibj:compileJava` and did not get this error, and since our [checkout step](https://github.com/wpilibsuite/allwpilib/blob/e2545231b8858fc8957802e34bdfe564a7bcd99b/.github/workflows/gradle.yml#L40) only checks out the commit that triggered the CI run (the default for [actions/checkout](https://github.com/actions/checkout)) and the PR was based on an old version of main that was still on Java 11, the PR CI runs were with Java 11, which does not have the warning.

I'm concerned about the fact that this could happen (CI runs pass but local clean builds fail), but I'm not sure what the best fix for the root cause would be. (Figure out why the build cache was reused? Figure out how to avoid issues from PRs based on stale versions of main?)