### PR TITLE
Add protected default constructor for CallbackStore.

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/CallbackStore.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/CallbackStore.java
@@ -37,7 +37,7 @@ public class CallbackStore implements AutoCloseable {
     this.m_cancelCallbackChannel = null;
   }
 
-    /**
+  /**
    * <b>Note: This constructor is for simulation classes only. It should not be called by teams!</b>
    *
    * @param index TODO

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/CallbackStore.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/CallbackStore.java
@@ -22,12 +22,10 @@ public class CallbackStore implements AutoCloseable {
   }
 
   /**
-   * Constructs an empty CallbackStore. This constructor is to allow 3rd party
-   * sim providers (eg vendors) to subclass this class (without needing provide
-   * dummy constructing parameters) so that the register methods of their sim
-   * classes can return CallbackStores like the builtin sims. <b>Note: It should
-   * not be called by teams that are just using sims!</b>
-   *
+   * Constructs an empty CallbackStore. This constructor is to allow 3rd party sim providers (eg
+   * vendors) to subclass this class (without needing provide dummy constructing parameters) so that
+   * the register methods of their sim classes can return CallbackStores like the builtin sims.
+   * <b>Note: It should not be called by teams that are just using sims!</b>
    */
   protected CallbackStore() {
     this.m_cancelType = -1;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/CallbackStore.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/CallbackStore.java
@@ -22,6 +22,22 @@ public class CallbackStore implements AutoCloseable {
   }
 
   /**
+   * Constructs an empty CallbackStore. This constructor is to allow 3rd party
+   * sim providers (eg vendors) to subclass this class (without needing provide
+   * dummy constructing parameters) so that the register methods of their sim
+   * classes can return CallbackStores like the builtin sims. <b>Note: It should
+   * not be called by teams that are just using sims!</b>
+   *
+   */
+  protected CallbackStore() {
+    this.m_cancelType = -1;
+    this.m_index = -1;
+    this.m_uid = -1;
+    this.m_cancelCallback = null;
+    this.m_cancelCallbackChannel = null;
+  }
+
+    /**
    * <b>Note: This constructor is for simulation classes only. It should not be called by teams!</b>
    *
    * @param index TODO


### PR DESCRIPTION
This  is to allow 3rd party sim providers (eg vendors) to subclass this class so that the register methods of their sim classes can return CallbackStores like the builtin sims.

Although it was already possible to create such a subclass but passing dummy parameters to one of the other constructors, this eliminates the need to pass such dummy parameters and makes it clearer that subclassing is allowed.