### PR TITLE
[hal] Initialize DIO to true in sim

### DIFF
--- a/hal/src/main/native/sim/DIO.cpp
+++ b/hal/src/main/native/sim/DIO.cpp
@@ -66,6 +66,7 @@ HAL_DigitalHandle HAL_InitializeDIOPort(HAL_PortHandle portHandle,
   SimDIOData[channel].initialized = true;
   SimDIOData[channel].isInput = input;
   SimDIOData[channel].simDevice = 0;
+  SimDIOData[channel].value = true;
   port->previousAllocation = allocationLocation ? allocationLocation : "";
 
   return handle;

--- a/wpilibc/src/test/native/cpp/simulation/DIOSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/DIOSimTest.cpp
@@ -69,12 +69,12 @@ TEST(DIOSimTest, Output) {
   BooleanCallback valueCallback;
 
   auto cb = sim.RegisterValueCallback(valueCallback.GetCallback(), false);
-  EXPECT_FALSE(output.Get());
-  EXPECT_FALSE(sim.GetValue());
+  EXPECT_TRUE(output.Get());
+  EXPECT_TRUE(sim.GetValue());
 
   EXPECT_FALSE(valueCallback.WasTriggered());
-  output.Set(true);
+  output.Set(false);
   EXPECT_TRUE(valueCallback.WasTriggered());
-  EXPECT_TRUE(valueCallback.GetLastValue());
+  EXPECT_FALSE(valueCallback.GetLastValue());
 }
 }  // namespace frc::sim

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DIOSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DIOSimTest.java
@@ -72,13 +72,13 @@ class DIOSimTest {
       BooleanCallback valueCallback = new BooleanCallback();
 
       try (CallbackStore cb = sim.registerValueCallback(valueCallback, false)) {
-        assertFalse(output.get());
-        assertFalse(sim.getValue());
+        assertTrue(output.get());
+        assertTrue(sim.getValue());
 
         assertFalse(valueCallback.wasTriggered());
-        output.set(true);
+        output.set(false);
         assertTrue(valueCallback.wasTriggered());
-        assertTrue(valueCallback.getSetValue());
+        assertFalse(valueCallback.getSetValue());
       }
     }
   }


### PR DESCRIPTION
SimDIOData already initializes the value to true, this fixes the case where you create a DIO object, set its value to false, destroy it, and create another DIO object on the same port. This always ensures the new DIO object initializes to true.