### PR TITLE
[wpimath] add cosine optimization method to SwerveModuleState

### DIFF
--- a/wpimath/src/main/native/cpp/kinematics/SwerveModuleState.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/SwerveModuleState.cpp
@@ -22,3 +22,14 @@ SwerveModuleState SwerveModuleState::Optimize(
     return {desiredState.speed, desiredState.angle};
   }
 }
+
+SwerveModuleState SwerveModuleState::CosineCompensation(
+    const SwerveModuleState& desiredState, const Rotation2d& currentAngle) {
+  auto delta = desiredState.angle - currentAngle;
+  double speed = desiredState.speed.value() * delta.Cos();
+  if (units::math::abs(delta.Degrees()) > 90_deg) {
+    return {speed, desiredState.angle + Rotation2d{180_deg}};
+  } else {
+    return {speed, desiredState.angle};
+  }
+}

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
@@ -40,11 +40,31 @@ struct WPILIB_DLLEXPORT SwerveModuleState {
    * used with the PIDController class's continuous input functionality, the
    * furthest a wheel will ever rotate is 90 degrees.
    *
+   * Note: This method should not be used together with the CosineCompensation method. 
+   * Both methods perform angle optimization, and using them together is redundant.
+   *
    * @param desiredState The desired state.
    * @param currentAngle The current module angle.
    */
   static SwerveModuleState Optimize(const SwerveModuleState& desiredState,
                                     const Rotation2d& currentAngle);
+
+  /**
+   * Scales the module speed by the cosine of the angle error. This reduces skew caused by changing direction.
+   * 
+   * For example, if the current angle of the module matches the desired angle (i.e., there is no error), 
+   * the speed of the module remains unchanged as cos(0) = 1. However, if the current angle is 90 degrees off 
+   * from the desired angle, the speed of the module becomes 0 as cos(90°) = 0. This means the module will stop 
+   * moving, allowing it to correct its angle without moving in the wrong direction.
+   * 
+   * Note: This method should not be used together with the Optimize method.
+   * Both methods perform angle optimization, and using them together is redundant.
+   * 
+   * @param desiredState The desired state.
+   * @param currentAngle The current module angle.
+   * @return The cosine compensated swerve module state.
+   */
+   static SwerveModuleState CosineCompensation(const SwerveModuleState& desiredState, const Rotation2d& currentAngle);
 };
 }  // namespace frc
 

--- a/wpimath/src/test/java/edu/wpi/first/math/kinematics/SwerveModuleStateTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/kinematics/SwerveModuleStateTest.java
@@ -50,4 +50,37 @@ class SwerveModuleStateTest {
         () -> assertEquals(-2.0, optimizedB.speedMetersPerSecond, kEpsilon),
         () -> assertEquals(-2.0, optimizedB.angle.getDegrees(), kEpsilon));
   }
+
+  @Test
+  void testCosineOptimizationNoError() {
+    var currentAngle = Rotation2d.kZero;
+    var desiredState = new SwerveModuleState(2.0, Rotation2d.kZero);
+    var optimizedState = SwerveModuleState.cosineCompensation(desiredState, currentAngle);
+
+    assertAll(
+        () -> assertEquals(2.0, optimizedState.speedMetersPerSecond, kEpsilon),
+        () -> assertEquals(0.0, optimizedState.angle.getDegrees(), kEpsilon));
+  }
+
+  @Test
+  void testCosineOptimization90DegreesError() {
+    var currentAngle = Rotation2d.kZero;
+    var desiredState = new SwerveModuleState(2.0, Rotation2d.fromDegrees(90));
+    var optimizedState = SwerveModuleState.cosineCompensation(desiredState, currentAngle);
+
+    assertAll(
+        () -> assertEquals(0.0, optimizedState.speedMetersPerSecond, kEpsilon),
+        () -> assertEquals(90.0, optimizedState.angle.getDegrees(), kEpsilon));
+  }
+
+  @Test
+  void testCosineOptimization180DegreesError() {
+    var currentAngle = Rotation2d.kZero;
+    var desiredState = new SwerveModuleState(2.0, Rotation2d.fromDegrees(180));
+    var optimizedState = SwerveModuleState.cosineCompensation(desiredState, currentAngle);
+
+    assertAll(
+        () -> assertEquals(-2.0, optimizedState.speedMetersPerSecond, kEpsilon),
+        () -> assertEquals(0.0, optimizedState.angle.getDegrees(), kEpsilon));
+  }
 }

--- a/wpimath/src/test/native/cpp/kinematics/SwerveModuleStateTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/SwerveModuleStateTest.cpp
@@ -56,3 +56,30 @@ TEST(SwerveModuleStateTest, Inequality) {
   EXPECT_NE(state1, state2);
   EXPECT_NE(state1, state3);
 }
+
+TEST(SwerveModuleStateTest, COSNoError) {
+  frc::Rotation2d angleA{0_deg};
+  frc::SwerveModuleState refA{2_mps, 0_deg};
+  auto optimizedA = frc::SwerveModuleState::CosineCompensation(refA, angleA);
+
+  EXPECT_NEAR(optimizedA.speed.value(), 2.0, kEpsilon);
+  EXPECT_NEAR(optimizedA.angle.Degrees().value(), 0.0, kEpsilon);
+}
+
+TEST(SwerveModuleStateTest, COS90Error) {
+  frc::Rotation2d angleA{0_deg};
+  frc::SwerveModuleState refA{2_mps, 90_deg};
+  auto optimizedA = frc::SwerveModuleState::CosineCompensation(refA, angleA);
+
+  EXPECT_NEAR(optimizedA.speed.value(), 0.0, kEpsilon);
+  EXPECT_NEAR(optimizedA.angle.Degrees().value(), 90.0, kEpsilon);
+}
+
+TEST(SwerveModuleStateTest, COS180Error) {
+  frc::Rotation2d angleA{0_deg};
+  frc::SwerveModuleState refA{2_mps, 180_deg};
+  auto optimizedA = frc::SwerveModuleState::CosineCompensation(refA, angleA);
+
+  EXPECT_NEAR(optimizedA.speed.value(), -2.0, kEpsilon);
+  EXPECT_NEAR(optimizedA.angle.Degrees().value(), 0.0, kEpsilon);
+}


### PR DESCRIPTION
# Motivation

Many teams are using so called 'cosine compensation' within their swerve drive subsystems. This optimization reduces 'skew' caused by changing direction. 

For those unfamiliar, the idea is we scale a module's desired velocity by the cosine of it's azimuth error. At the extremes:

- If a module is already pointing in the right direction (no error) there is no change.
- If a module is off by 90 degrees then speed is set to 0, allowing time for the module to correct its angle without moving in the wrong direction.
- Everything in between is scaled by the cosine of the error.

Adding this feature to wpilib would help with discoverability and may reduce ecosystem code-duplication.

## Discussion

I think there is room for discussion around the API for this feature. I see 2 possible usages:

```java
// Call 2 methods to preform both optimizations
state = SwerveModuleStates.optimize(state, currentAngle);
state = SwerveModuleStates.cosineCompensation(state, currentAngle);

// Call a single one to preform both
state = SwerveModuleStates.cosineCompensation(state, currentAngle);
```

In the case where `cosineCompensation` does *not* preform the same angle optimization users will see odd behavior. For example, if there is 180 degrees error then it would initially seem like the module is moving in the right direction (cos(180) = -1). Since it _isn't_ at the right angle we would watch the module start turning and slowing down (stopping as it passes through 90) for it to then start speeding back up again as it approaches 0.

It seems like a footgun in the world where we have 2 methods to only use `cosineCompensation`. Although, maybe preforming no optimization at-all is already a footgun.