### PR TITLE
Move Java fields to edu.wpi.first.fields

### DIFF
--- a/fieldImages/src/main/java/edu/wpi/first/fields/FieldConfig.java
+++ b/fieldImages/src/main/java/edu/wpi/first/fields/FieldConfig.java
@@ -2,7 +2,7 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package edu.wpi.fields;
+package edu.wpi.first.fields;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/fieldImages/src/main/java/edu/wpi/first/fields/Fields.java
+++ b/fieldImages/src/main/java/edu/wpi/first/fields/Fields.java
@@ -2,7 +2,7 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package edu.wpi.fields;
+package edu.wpi.first.fields;
 
 public enum Fields {
   k2018PowerUp("2018-powerup.json"),

--- a/fieldImages/src/test/java/edu/wpi/first/fields/LoadConfigTest.java
+++ b/fieldImages/src/test/java/edu/wpi/first/fields/LoadConfigTest.java
@@ -2,7 +2,7 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package edu.wpi.fields;
+package edu.wpi.first.fields;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;


### PR DESCRIPTION
Doesn't make sense in edu.wpi.fields, and resources are already in edu.wpi.first.fields
This will require changes in Shuffleboard and Pathweaver