### PR TITLE
[ci] Fix permissions for commenting on commands PR

### DIFF
--- a/.github/workflows/command-robotpy-pr.yml
+++ b/.github/workflows/command-robotpy-pr.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   comment:
     permissions:
+      issues: write
       pull-requests: write
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Third time's the charm. Apparently, you _do_ need write permissions on both `issues` _and_ `pull-requests`.