### PR TITLE
[upstream_utils] Update Sleipnir

### DIFF
--- a/upstream_utils/sleipnir_patches/0001-Remove-using-enum-declarations.patch
+++ b/upstream_utils/sleipnir_patches/0001-Remove-using-enum-declarations.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Wed, 24 Apr 2024 15:56:06 -0700
-Subject: [PATCH 1/2] Remove "using enum" declarations
+Subject: [PATCH 1/4] Remove "using enum" declarations
 
 ---
  include/sleipnir/autodiff/Expression.hpp      | 161 +++++++-----------
@@ -9,10 +9,10 @@ Subject: [PATCH 1/2] Remove "using enum" declarations
  2 files changed, 73 insertions(+), 110 deletions(-)
 
 diff --git a/include/sleipnir/autodiff/Expression.hpp b/include/sleipnir/autodiff/Expression.hpp
-index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45d27916cb 100644
+index 5b8dc5dca9bd685e6647e79f5fd4699bb9909853..802a8602a125251058cfe22447911999f035efad 100644
 --- a/include/sleipnir/autodiff/Expression.hpp
 +++ b/include/sleipnir/autodiff/Expression.hpp
-@@ -192,8 +192,6 @@ struct SLEIPNIR_DLLEXPORT Expression {
+@@ -191,8 +191,6 @@ struct SLEIPNIR_DLLEXPORT Expression {
     */
    friend SLEIPNIR_DLLEXPORT ExpressionPtr operator*(const ExpressionPtr& lhs,
                                                      const ExpressionPtr& rhs) {
@@ -21,7 +21,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
      // Prune expression
      if (lhs->IsConstant(0.0)) {
        // Return zero
-@@ -208,20 +206,22 @@ struct SLEIPNIR_DLLEXPORT Expression {
+@@ -207,20 +205,22 @@ struct SLEIPNIR_DLLEXPORT Expression {
      }
  
      // Evaluate constant
@@ -50,7 +50,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
      }
  
      return MakeExpressionPtr(
-@@ -247,8 +247,6 @@ struct SLEIPNIR_DLLEXPORT Expression {
+@@ -246,8 +246,6 @@ struct SLEIPNIR_DLLEXPORT Expression {
     */
    friend SLEIPNIR_DLLEXPORT ExpressionPtr operator/(const ExpressionPtr& lhs,
                                                      const ExpressionPtr& rhs) {
@@ -59,7 +59,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
      // Prune expression
      if (lhs->IsConstant(0.0)) {
        // Return zero
-@@ -258,16 +256,17 @@ struct SLEIPNIR_DLLEXPORT Expression {
+@@ -257,16 +255,17 @@ struct SLEIPNIR_DLLEXPORT Expression {
      }
  
      // Evaluate constant
@@ -80,7 +80,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
      }
  
      return MakeExpressionPtr(
-@@ -295,8 +294,6 @@ struct SLEIPNIR_DLLEXPORT Expression {
+@@ -294,8 +293,6 @@ struct SLEIPNIR_DLLEXPORT Expression {
     */
    friend SLEIPNIR_DLLEXPORT ExpressionPtr operator+(const ExpressionPtr& lhs,
                                                      const ExpressionPtr& rhs) {
@@ -89,7 +89,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
      // Prune expression
      if (lhs == nullptr || lhs->IsConstant(0.0)) {
        return rhs;
-@@ -305,7 +302,8 @@ struct SLEIPNIR_DLLEXPORT Expression {
+@@ -304,7 +301,8 @@ struct SLEIPNIR_DLLEXPORT Expression {
      }
  
      // Evaluate constant
@@ -99,7 +99,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        return MakeExpressionPtr(lhs->value + rhs->value);
      }
  
-@@ -333,8 +331,6 @@ struct SLEIPNIR_DLLEXPORT Expression {
+@@ -332,8 +330,6 @@ struct SLEIPNIR_DLLEXPORT Expression {
     */
    friend SLEIPNIR_DLLEXPORT ExpressionPtr operator-(const ExpressionPtr& lhs,
                                                      const ExpressionPtr& rhs) {
@@ -108,7 +108,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
      // Prune expression
      if (lhs->IsConstant(0.0)) {
        if (rhs->IsConstant(0.0)) {
-@@ -348,7 +344,8 @@ struct SLEIPNIR_DLLEXPORT Expression {
+@@ -347,7 +343,8 @@ struct SLEIPNIR_DLLEXPORT Expression {
      }
  
      // Evaluate constant
@@ -118,7 +118,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        return MakeExpressionPtr(lhs->value - rhs->value);
      }
  
-@@ -374,8 +371,6 @@ struct SLEIPNIR_DLLEXPORT Expression {
+@@ -373,8 +370,6 @@ struct SLEIPNIR_DLLEXPORT Expression {
     * @param lhs Operand of unary minus.
     */
    friend SLEIPNIR_DLLEXPORT ExpressionPtr operator-(const ExpressionPtr& lhs) {
@@ -127,7 +127,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
      // Prune expression
      if (lhs->IsConstant(0.0)) {
        // Return zero
-@@ -383,7 +378,7 @@ struct SLEIPNIR_DLLEXPORT Expression {
+@@ -382,7 +377,7 @@ struct SLEIPNIR_DLLEXPORT Expression {
      }
  
      // Evaluate constant
@@ -136,7 +136,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        return MakeExpressionPtr(-lhs->value);
      }
  
-@@ -465,8 +460,6 @@ inline void IntrusiveSharedPtrDecRefCount(Expression* expr) {
+@@ -463,8 +458,6 @@ inline constexpr void IntrusiveSharedPtrDecRefCount(Expression* expr) {
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr abs(  // NOLINT
      const ExpressionPtr& x) {
@@ -145,7 +145,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
    // Prune expression
    if (x->IsConstant(0.0)) {
      // Return zero
-@@ -474,12 +467,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr abs(  // NOLINT
+@@ -472,12 +465,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr abs(  // NOLINT
    }
  
    // Evaluate constant
@@ -160,7 +160,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double, double parentAdjoint) {
          if (x < 0.0) {
            return -parentAdjoint;
-@@ -510,20 +503,18 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr abs(  // NOLINT
+@@ -508,20 +501,18 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr abs(  // NOLINT
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr acos(  // NOLINT
      const ExpressionPtr& x) {
@@ -183,7 +183,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double, double parentAdjoint) {
          return -parentAdjoint / std::sqrt(1.0 - x * x);
        },
-@@ -542,8 +533,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr acos(  // NOLINT
+@@ -540,8 +531,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr acos(  // NOLINT
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr asin(  // NOLINT
      const ExpressionPtr& x) {
@@ -192,7 +192,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
    // Prune expression
    if (x->IsConstant(0.0)) {
      // Return zero
-@@ -551,12 +540,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr asin(  // NOLINT
+@@ -549,12 +538,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr asin(  // NOLINT
    }
  
    // Evaluate constant
@@ -207,7 +207,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double, double parentAdjoint) {
          return parentAdjoint / std::sqrt(1.0 - x * x);
        },
-@@ -575,8 +564,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr asin(  // NOLINT
+@@ -573,8 +562,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr asin(  // NOLINT
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr atan(  // NOLINT
      const ExpressionPtr& x) {
@@ -216,7 +216,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
    // Prune expression
    if (x->IsConstant(0.0)) {
      // Return zero
-@@ -584,12 +571,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr atan(  // NOLINT
+@@ -582,12 +569,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr atan(  // NOLINT
    }
  
    // Evaluate constant
@@ -231,7 +231,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double, double parentAdjoint) {
          return parentAdjoint / (1.0 + x * x);
        },
-@@ -608,8 +595,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr atan(  // NOLINT
+@@ -606,8 +593,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr atan(  // NOLINT
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr atan2(  // NOLINT
      const ExpressionPtr& y, const ExpressionPtr& x) {
@@ -240,7 +240,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
    // Prune expression
    if (y->IsConstant(0.0)) {
      // Return zero
-@@ -619,12 +604,14 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr atan2(  // NOLINT
+@@ -617,12 +602,14 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr atan2(  // NOLINT
    }
  
    // Evaluate constant
@@ -257,7 +257,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double y, double x, double parentAdjoint) {
          return parentAdjoint * x / (y * y + x * x);
        },
-@@ -649,20 +636,18 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr atan2(  // NOLINT
+@@ -647,20 +634,18 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr atan2(  // NOLINT
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr cos(  // NOLINT
      const ExpressionPtr& x) {
@@ -280,7 +280,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double, double parentAdjoint) {
          return -parentAdjoint * std::sin(x);
        },
-@@ -680,20 +665,18 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr cos(  // NOLINT
+@@ -678,20 +663,18 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr cos(  // NOLINT
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr cosh(  // NOLINT
      const ExpressionPtr& x) {
@@ -303,7 +303,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double, double parentAdjoint) {
          return parentAdjoint * std::sinh(x);
        },
-@@ -711,8 +694,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr cosh(  // NOLINT
+@@ -709,8 +692,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr cosh(  // NOLINT
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr erf(  // NOLINT
      const ExpressionPtr& x) {
@@ -312,7 +312,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
    // Prune expression
    if (x->IsConstant(0.0)) {
      // Return zero
-@@ -720,12 +701,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr erf(  // NOLINT
+@@ -718,12 +699,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr erf(  // NOLINT
    }
  
    // Evaluate constant
@@ -327,7 +327,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double, double parentAdjoint) {
          return parentAdjoint * 2.0 * std::numbers::inv_sqrtpi *
                 std::exp(-x * x);
-@@ -746,20 +727,18 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr erf(  // NOLINT
+@@ -744,20 +725,18 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr erf(  // NOLINT
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr exp(  // NOLINT
      const ExpressionPtr& x) {
@@ -350,7 +350,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double, double parentAdjoint) {
          return parentAdjoint * std::exp(x);
        },
-@@ -778,8 +757,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr exp(  // NOLINT
+@@ -776,8 +755,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr exp(  // NOLINT
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr hypot(  // NOLINT
      const ExpressionPtr& x, const ExpressionPtr& y) {
@@ -359,7 +359,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
    // Prune expression
    if (x->IsConstant(0.0)) {
      return y;
-@@ -788,12 +765,14 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr hypot(  // NOLINT
+@@ -786,12 +763,14 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr hypot(  // NOLINT
    }
  
    // Evaluate constant
@@ -376,7 +376,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double y, double parentAdjoint) {
          return parentAdjoint * x / std::hypot(x, y);
        },
-@@ -818,8 +797,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr hypot(  // NOLINT
+@@ -816,8 +795,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr hypot(  // NOLINT
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr log(  // NOLINT
      const ExpressionPtr& x) {
@@ -385,7 +385,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
    // Prune expression
    if (x->IsConstant(0.0)) {
      // Return zero
-@@ -827,12 +804,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr log(  // NOLINT
+@@ -825,12 +802,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr log(  // NOLINT
    }
  
    // Evaluate constant
@@ -400,7 +400,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double, double parentAdjoint) { return parentAdjoint / x; },
        [](const ExpressionPtr& x, const ExpressionPtr&,
           const ExpressionPtr& parentAdjoint) { return parentAdjoint / x; },
-@@ -846,8 +823,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr log(  // NOLINT
+@@ -844,8 +821,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr log(  // NOLINT
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr log10(  // NOLINT
      const ExpressionPtr& x) {
@@ -409,7 +409,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
    // Prune expression
    if (x->IsConstant(0.0)) {
      // Return zero
-@@ -855,12 +830,13 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr log10(  // NOLINT
+@@ -853,12 +828,13 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr log10(  // NOLINT
    }
  
    // Evaluate constant
@@ -425,7 +425,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double, double parentAdjoint) {
          return parentAdjoint / (std::numbers::ln10 * x);
        },
-@@ -879,8 +855,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr log10(  // NOLINT
+@@ -877,8 +853,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr log10(  // NOLINT
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr pow(  // NOLINT
      const ExpressionPtr& base, const ExpressionPtr& power) {
@@ -434,7 +434,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
    // Prune expression
    if (base->IsConstant(0.0)) {
      // Return zero
-@@ -895,12 +869,15 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr pow(  // NOLINT
+@@ -893,12 +867,15 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr pow(  // NOLINT
    }
  
    // Evaluate constant
@@ -452,7 +452,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double base, double power) { return std::pow(base, power); },
        [](double base, double power, double parentAdjoint) {
          return parentAdjoint * std::pow(base, power - 1) * power;
-@@ -941,10 +918,8 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr pow(  // NOLINT
+@@ -939,10 +916,8 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr pow(  // NOLINT
   * @param x The argument.
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr sign(const ExpressionPtr& x) {
@@ -464,7 +464,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
      if (x->value < 0.0) {
        return MakeExpressionPtr(-1.0);
      } else if (x->value == 0.0) {
-@@ -956,7 +931,7 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sign(const ExpressionPtr& x) {
+@@ -954,7 +929,7 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sign(const ExpressionPtr& x) {
    }
  
    return MakeExpressionPtr(
@@ -473,7 +473,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double) {
          if (x < 0.0) {
            return -1.0;
-@@ -982,8 +957,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sign(const ExpressionPtr& x) {
+@@ -980,8 +955,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sign(const ExpressionPtr& x) {
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr sin(  // NOLINT
      const ExpressionPtr& x) {
@@ -482,7 +482,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
    // Prune expression
    if (x->IsConstant(0.0)) {
      // Return zero
-@@ -991,12 +964,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sin(  // NOLINT
+@@ -989,12 +962,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sin(  // NOLINT
    }
  
    // Evaluate constant
@@ -497,7 +497,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double, double parentAdjoint) {
          return parentAdjoint * std::cos(x);
        },
-@@ -1013,8 +986,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sin(  // NOLINT
+@@ -1011,8 +984,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sin(  // NOLINT
   * @param x The argument.
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr sinh(const ExpressionPtr& x) {
@@ -506,7 +506,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
    // Prune expression
    if (x->IsConstant(0.0)) {
      // Return zero
-@@ -1022,12 +993,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sinh(const ExpressionPtr& x) {
+@@ -1020,12 +991,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sinh(const ExpressionPtr& x) {
    }
  
    // Evaluate constant
@@ -521,7 +521,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double, double parentAdjoint) {
          return parentAdjoint * std::cosh(x);
        },
-@@ -1045,10 +1016,8 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sinh(const ExpressionPtr& x) {
+@@ -1043,10 +1014,8 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sinh(const ExpressionPtr& x) {
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr sqrt(  // NOLINT
      const ExpressionPtr& x) {
@@ -533,7 +533,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
      if (x->value == 0.0) {
        // Return zero
        return x;
-@@ -1060,7 +1029,7 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sqrt(  // NOLINT
+@@ -1058,7 +1027,7 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sqrt(  // NOLINT
    }
  
    return MakeExpressionPtr(
@@ -542,7 +542,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double, double parentAdjoint) {
          return parentAdjoint / (2.0 * std::sqrt(x));
        },
-@@ -1079,8 +1048,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sqrt(  // NOLINT
+@@ -1077,8 +1046,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sqrt(  // NOLINT
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr tan(  // NOLINT
      const ExpressionPtr& x) {
@@ -551,7 +551,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
    // Prune expression
    if (x->IsConstant(0.0)) {
      // Return zero
-@@ -1088,12 +1055,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr tan(  // NOLINT
+@@ -1086,12 +1053,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr tan(  // NOLINT
    }
  
    // Evaluate constant
@@ -566,7 +566,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
        [](double x, double, double parentAdjoint) {
          return parentAdjoint / (std::cos(x) * std::cos(x));
        },
-@@ -1111,8 +1078,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr tan(  // NOLINT
+@@ -1109,8 +1076,6 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr tan(  // NOLINT
   * @param x The argument.
   */
  SLEIPNIR_DLLEXPORT inline ExpressionPtr tanh(const ExpressionPtr& x) {
@@ -575,7 +575,7 @@ index b60226ccffef9ac161727483ebca3d53df09dec2..fc503c10a209b4779e204e598d3bae45
    // Prune expression
    if (x->IsConstant(0.0)) {
      // Return zero
-@@ -1120,12 +1085,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr tanh(const ExpressionPtr& x) {
+@@ -1118,12 +1083,12 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr tanh(const ExpressionPtr& x) {
    }
  
    // Evaluate constant

--- a/upstream_utils/sleipnir_patches/0002-Add-implicit-typename.patch
+++ b/upstream_utils/sleipnir_patches/0002-Add-implicit-typename.patch
@@ -1,14 +1,14 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Mon, 29 Apr 2024 19:17:18 -0700
-Subject: [PATCH 2/2] Add implicit typename
+Subject: [PATCH 2/4] Add implicit typename
 
 ---
  include/sleipnir/util/SmallVector.hpp | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/include/sleipnir/util/SmallVector.hpp b/include/sleipnir/util/SmallVector.hpp
-index a4fd51931bb86b2b689805b2c4c5e0125cc560fc..e301b973f1dcd1f662bd9c9f8fd567053e5ee578 100644
+index 5e93ae49e659a29c49728d337323ebbcdd8790d3..dcf02c02b7f7fcfc32197d68f885174a1ae20307 100644
 --- a/include/sleipnir/util/SmallVector.hpp
 +++ b/include/sleipnir/util/SmallVector.hpp
 @@ -152,8 +152,8 @@ class small_vector

--- a/upstream_utils/sleipnir_patches/0003-Use-fmtlib.patch
+++ b/upstream_utils/sleipnir_patches/0003-Use-fmtlib.patch
@@ -1,0 +1,116 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tyler Veness <calcmogul@gmail.com>
+Date: Wed, 29 May 2024 16:29:55 -0700
+Subject: [PATCH 3/4] Use fmtlib
+
+---
+ include/.styleguide              |  1 +
+ include/sleipnir/util/Assert.hpp |  5 +++--
+ include/sleipnir/util/Print.hpp  | 27 ++++++++++++++-------------
+ 3 files changed, 18 insertions(+), 15 deletions(-)
+
+diff --git a/include/.styleguide b/include/.styleguide
+index f3b2f0cf9e60b3a86b9654ff2b381f9c48734ff6..8251a490677bcf5fd316d5303195b0fa4e599b75 100644
+--- a/include/.styleguide
++++ b/include/.styleguide
+@@ -8,4 +8,5 @@ cppSrcFileInclude {
+ 
+ includeOtherLibs {
+   ^Eigen/
++  ^fmt/
+ }
+diff --git a/include/sleipnir/util/Assert.hpp b/include/sleipnir/util/Assert.hpp
+index ba381ef8f48446e6d07b6d7973a8271cbda8fec9..9999544278c493f263c819811cb4fbcb407b04f1 100644
+--- a/include/sleipnir/util/Assert.hpp
++++ b/include/sleipnir/util/Assert.hpp
+@@ -3,8 +3,9 @@
+ #pragma once
+ 
+ #ifdef JORMUNGANDR
+-#include <format>
+ #include <stdexcept>
++
++#include <fmt/format.h>
+ /**
+  * Throw an exception in Python.
+  */
+@@ -12,7 +13,7 @@
+   do {                                                                         \
+     if (!(condition)) {                                                        \
+       throw std::invalid_argument(                                             \
+-          std::format("{}:{}: {}: Assertion `{}' failed.", __FILE__, __LINE__, \
++          fmt::format("{}:{}: {}: Assertion `{}' failed.", __FILE__, __LINE__, \
+                       __func__, #condition));                                  \
+     }                                                                          \
+   } while (0);
+diff --git a/include/sleipnir/util/Print.hpp b/include/sleipnir/util/Print.hpp
+index 339320bce6d017ca85025060ba445b2f025bb225..fcf2e69bfb5a081cd915bdded3caa80cd9c38518 100644
+--- a/include/sleipnir/util/Print.hpp
++++ b/include/sleipnir/util/Print.hpp
+@@ -2,52 +2,53 @@
+ 
+ #pragma once
+ 
+-#include <print>
+ #include <system_error>
+ #include <utility>
+ 
++#include <fmt/core.h>
++
+ namespace sleipnir {
+ 
+ /**
+- * Wrapper around std::print() that squelches write failure exceptions.
++ * Wrapper around fmt::print() that squelches write failure exceptions.
+  */
+ template <typename... T>
+-inline void print(std::format_string<T...> fmt, T&&... args) {
++inline void print(fmt::format_string<T...> fmt, T&&... args) {
+   try {
+-    std::print(fmt, std::forward<T>(args)...);
++    fmt::print(fmt, std::forward<T>(args)...);
+   } catch (const std::system_error&) {
+   }
+ }
+ 
+ /**
+- * Wrapper around std::print() that squelches write failure exceptions.
++ * Wrapper around fmt::print() that squelches write failure exceptions.
+  */
+ template <typename... T>
+-inline void print(std::FILE* f, std::format_string<T...> fmt, T&&... args) {
++inline void print(std::FILE* f, fmt::format_string<T...> fmt, T&&... args) {
+   try {
+-    std::print(f, fmt, std::forward<T>(args)...);
++    fmt::print(f, fmt, std::forward<T>(args)...);
+   } catch (const std::system_error&) {
+   }
+ }
+ 
+ /**
+- * Wrapper around std::println() that squelches write failure exceptions.
++ * Wrapper around fmt::println() that squelches write failure exceptions.
+  */
+ template <typename... T>
+-inline void println(std::format_string<T...> fmt, T&&... args) {
++inline void println(fmt::format_string<T...> fmt, T&&... args) {
+   try {
+-    std::println(fmt, std::forward<T>(args)...);
++    fmt::println(fmt, std::forward<T>(args)...);
+   } catch (const std::system_error&) {
+   }
+ }
+ 
+ /**
+- * Wrapper around std::println() that squelches write failure exceptions.
++ * Wrapper around fmt::println() that squelches write failure exceptions.
+  */
+ template <typename... T>
+-inline void println(std::FILE* f, std::format_string<T...> fmt, T&&... args) {
++inline void println(std::FILE* f, fmt::format_string<T...> fmt, T&&... args) {
+   try {
+-    std::println(f, fmt, std::forward<T>(args)...);
++    fmt::println(f, fmt, std::forward<T>(args)...);
+   } catch (const std::system_error&) {
+   }
+ }

--- a/upstream_utils/sleipnir_patches/0004-Remove-unsupported-constexpr.patch
+++ b/upstream_utils/sleipnir_patches/0004-Remove-unsupported-constexpr.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tyler Veness <calcmogul@gmail.com>
+Date: Mon, 20 May 2024 09:01:54 -0700
+Subject: [PATCH 4/4] Remove unsupported constexpr
+
+---
+ include/sleipnir/autodiff/Expression.hpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/include/sleipnir/autodiff/Expression.hpp b/include/sleipnir/autodiff/Expression.hpp
+index 802a8602a125251058cfe22447911999f035efad..7aa715a0aa5f4560b4e16cf5f0458f1385b88c7d 100644
+--- a/include/sleipnir/autodiff/Expression.hpp
++++ b/include/sleipnir/autodiff/Expression.hpp
+@@ -21,8 +21,8 @@ namespace sleipnir::detail {
+ 
+ struct SLEIPNIR_DLLEXPORT Expression;
+ 
+-inline constexpr void IntrusiveSharedPtrIncRefCount(Expression* expr);
+-inline constexpr void IntrusiveSharedPtrDecRefCount(Expression* expr);
++inline void IntrusiveSharedPtrIncRefCount(Expression* expr);
++inline void IntrusiveSharedPtrDecRefCount(Expression* expr);
+ 
+ /**
+  * Typedef for intrusive shared pointer to Expression.
+@@ -409,7 +409,7 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sqrt(const ExpressionPtr& x);
+  *
+  * @param expr The shared pointer's managed object.
+  */
+-inline constexpr void IntrusiveSharedPtrIncRefCount(Expression* expr) {
++inline void IntrusiveSharedPtrIncRefCount(Expression* expr) {
+   ++expr->refCount;
+ }
+ 
+@@ -418,7 +418,7 @@ inline constexpr void IntrusiveSharedPtrIncRefCount(Expression* expr) {
+  *
+  * @param expr The shared pointer's managed object.
+  */
+-inline constexpr void IntrusiveSharedPtrDecRefCount(Expression* expr) {
++inline void IntrusiveSharedPtrDecRefCount(Expression* expr) {
+   // If a deeply nested tree is being deallocated all at once, calling the
+   // Expression destructor when expr's refcount reaches zero can cause a stack
+   // overflow. Instead, we iterate over its children to decrement their

--- a/upstream_utils/update_sleipnir.py
+++ b/upstream_utils/update_sleipnir.py
@@ -15,8 +15,8 @@ from upstream_utils import (
 def main():
     upstream_root = clone_repo(
         "https://github.com/SleipnirGroup/Sleipnir",
-        # main on 2024-04-29
-        "9bac50e0f6c1b9ae20e1f611fb7db2cc305ca4fc",
+        # main on 2024-06-05
+        "57005c8b740ab163d3f7ef7e0c7c7c8774f4f925",
         shallow=False,
     )
     wpilib_root = get_repo_root()
@@ -27,6 +27,8 @@ def main():
     for f in [
         "0001-Remove-using-enum-declarations.patch",
         "0002-Add-implicit-typename.patch",
+        "0003-Use-fmtlib.patch",
+        "0004-Remove-unsupported-constexpr.patch",
     ]:
         git_am(os.path.join(wpilib_root, "upstream_utils/sleipnir_patches", f))
 

--- a/wpimath/src/main/native/thirdparty/sleipnir/.styleguide
+++ b/wpimath/src/main/native/thirdparty/sleipnir/.styleguide
@@ -17,7 +17,6 @@ modifiableFileExclude {
 includeOtherLibs {
   ^Eigen/
   ^catch2/
-  ^fmt/
   ^pybind11/
   ^sleipnir/
 }

--- a/wpimath/src/main/native/thirdparty/sleipnir/include/sleipnir/autodiff/Expression.hpp
+++ b/wpimath/src/main/native/thirdparty/sleipnir/include/sleipnir/autodiff/Expression.hpp
@@ -21,8 +21,7 @@ namespace sleipnir::detail {
 
 struct SLEIPNIR_DLLEXPORT Expression;
 
-inline constexpr void IntrusiveSharedPtrIncRefCount(Expression* expr);
-// FIXME: Make constexpr after upgrading to GCC 12+
+inline void IntrusiveSharedPtrIncRefCount(Expression* expr);
 inline void IntrusiveSharedPtrDecRefCount(Expression* expr);
 
 /**
@@ -410,7 +409,7 @@ SLEIPNIR_DLLEXPORT inline ExpressionPtr sqrt(const ExpressionPtr& x);
  *
  * @param expr The shared pointer's managed object.
  */
-inline constexpr void IntrusiveSharedPtrIncRefCount(Expression* expr) {
+inline void IntrusiveSharedPtrIncRefCount(Expression* expr) {
   ++expr->refCount;
 }
 
@@ -419,7 +418,6 @@ inline constexpr void IntrusiveSharedPtrIncRefCount(Expression* expr) {
  *
  * @param expr The shared pointer's managed object.
  */
-// FIXME: Make constexpr after upgrading to GCC 12+
 inline void IntrusiveSharedPtrDecRefCount(Expression* expr) {
   // If a deeply nested tree is being deallocated all at once, calling the
   // Expression destructor when expr's refcount reaches zero can cause a stack

--- a/wpimath/src/main/native/thirdparty/sleipnir/include/sleipnir/autodiff/VariableBlock.hpp
+++ b/wpimath/src/main/native/thirdparty/sleipnir/include/sleipnir/autodiff/VariableBlock.hpp
@@ -26,6 +26,8 @@ class VariableBlock {
 
   /**
    * Assigns a VariableBlock to the block.
+   *
+   * @param values VariableBlock of values.
    */
   VariableBlock<Mat>& operator=(const VariableBlock<Mat>& values) {
     if (this == &values) {
@@ -56,6 +58,8 @@ class VariableBlock {
 
   /**
    * Assigns a VariableBlock to the block.
+   *
+   * @param values VariableBlock of values.
    */
   VariableBlock<Mat>& operator=(VariableBlock<Mat>&& values) {
     if (this == &values) {
@@ -124,6 +128,8 @@ class VariableBlock {
    * Assigns a double to the block.
    *
    * This only works for blocks with one row and one column.
+   *
+   * @param value Value to assign.
    */
   VariableBlock<Mat>& SetValue(double value) {
     Assert(Rows() == 1 && Cols() == 1);
@@ -135,6 +141,8 @@ class VariableBlock {
 
   /**
    * Assigns an Eigen matrix to the block.
+   *
+   * @param values Eigen matrix of values to assign.
    */
   template <typename Derived>
   VariableBlock<Mat>& operator=(const Eigen::MatrixBase<Derived>& values) {
@@ -152,6 +160,8 @@ class VariableBlock {
 
   /**
    * Sets block's internal values.
+   *
+   * @param values Eigen matrix of values.
    */
   template <typename Derived>
     requires std::same_as<typename Derived::Scalar, double>
@@ -170,6 +180,8 @@ class VariableBlock {
 
   /**
    * Assigns a VariableMatrix to the block.
+   *
+   * @param values VariableMatrix of values.
    */
   VariableBlock<Mat>& operator=(const Mat& values) {
     Assert(Rows() == values.Rows());
@@ -185,6 +197,8 @@ class VariableBlock {
 
   /**
    * Assigns a VariableMatrix to the block.
+   *
+   * @param values VariableMatrix of values.
    */
   VariableBlock<Mat>& operator=(Mat&& values) {
     Assert(Rows() == values.Rows());

--- a/wpimath/src/main/native/thirdparty/sleipnir/include/sleipnir/autodiff/VariableMatrix.hpp
+++ b/wpimath/src/main/native/thirdparty/sleipnir/include/sleipnir/autodiff/VariableMatrix.hpp
@@ -137,6 +137,8 @@ class SLEIPNIR_DLLEXPORT VariableMatrix {
 
   /**
    * Constructs a VariableMatrix from an Eigen matrix.
+   *
+   * @param values Eigen matrix of values.
    */
   template <typename Derived>
   VariableMatrix(const Eigen::MatrixBase<Derived>& values)  // NOLINT
@@ -152,6 +154,8 @@ class SLEIPNIR_DLLEXPORT VariableMatrix {
 
   /**
    * Constructs a VariableMatrix from an Eigen diagonal matrix.
+   *
+   * @param values Diagonal matrix of values.
    */
   template <typename Derived>
   VariableMatrix(const Eigen::DiagonalBase<Derived>& values)  // NOLINT
@@ -171,6 +175,8 @@ class SLEIPNIR_DLLEXPORT VariableMatrix {
 
   /**
    * Assigns an Eigen matrix to a VariableMatrix.
+   *
+   * @param values Eigen matrix of values.
    */
   template <typename Derived>
   VariableMatrix& operator=(const Eigen::MatrixBase<Derived>& values) {
@@ -188,6 +194,8 @@ class SLEIPNIR_DLLEXPORT VariableMatrix {
 
   /**
    * Sets the VariableMatrix's internal values.
+   *
+   * @param values Eigen matrix of values.
    */
   template <typename Derived>
     requires std::same_as<typename Derived::Scalar, double>
@@ -206,6 +214,8 @@ class SLEIPNIR_DLLEXPORT VariableMatrix {
 
   /**
    * Constructs a scalar VariableMatrix from a Variable.
+   *
+   * @param variable Variable.
    */
   VariableMatrix(const Variable& variable)  // NOLINT
       : m_rows{1}, m_cols{1} {
@@ -214,6 +224,8 @@ class SLEIPNIR_DLLEXPORT VariableMatrix {
 
   /**
    * Constructs a scalar VariableMatrix from a Variable.
+   *
+   * @param variable Variable.
    */
   VariableMatrix(Variable&& variable) : m_rows{1}, m_cols{1} {  // NOLINT
     m_storage.emplace_back(std::move(variable));
@@ -221,6 +233,8 @@ class SLEIPNIR_DLLEXPORT VariableMatrix {
 
   /**
    * Constructs a VariableMatrix from a VariableBlock.
+   *
+   * @param values VariableBlock of values.
    */
   VariableMatrix(const VariableBlock<VariableMatrix>& values)  // NOLINT
       : m_rows{values.Rows()}, m_cols{values.Cols()} {
@@ -233,6 +247,8 @@ class SLEIPNIR_DLLEXPORT VariableMatrix {
 
   /**
    * Constructs a VariableMatrix from a VariableBlock.
+   *
+   * @param values VariableBlock of values.
    */
   VariableMatrix(const VariableBlock<const VariableMatrix>& values)  // NOLINT
       : m_rows{values.Rows()}, m_cols{values.Cols()} {

--- a/wpimath/src/main/native/thirdparty/sleipnir/include/sleipnir/util/Concepts.hpp
+++ b/wpimath/src/main/native/thirdparty/sleipnir/include/sleipnir/util/Concepts.hpp
@@ -15,6 +15,10 @@ template <typename T>
 concept ScalarLike = std::same_as<T, double> || std::same_as<T, int> ||
                      std::same_as<T, Variable>;
 
+template <typename T>
+concept SleipnirMatrixLike = std::same_as<T, VariableMatrix> ||
+                             std::same_as<T, VariableBlock<VariableMatrix>>;
+
 template <typename Derived>
 concept EigenMatrixLike =
     std::derived_from<Derived, Eigen::MatrixBase<Derived>>;
@@ -23,8 +27,6 @@ template <typename T>
 concept EigenSolver = requires(T t) { t.solve(Eigen::VectorXd{}); };
 
 template <typename T>
-concept MatrixLike =
-    std::same_as<T, VariableMatrix> ||
-    std::same_as<T, VariableBlock<VariableMatrix>> || EigenMatrixLike<T>;
+concept MatrixLike = SleipnirMatrixLike<T> || EigenMatrixLike<T>;
 
 }  // namespace sleipnir

--- a/wpimath/src/main/native/thirdparty/sleipnir/src/.styleguide
+++ b/wpimath/src/main/native/thirdparty/sleipnir/src/.styleguide
@@ -8,5 +8,4 @@ cppSrcFileInclude {
 
 includeOtherLibs {
   ^Eigen/
-  ^fmt/
 }


### PR DESCRIPTION
Upstream now uses std::format/std::print, so we have to backport it to fmtlib.