### PR TITLE
[wpimath] Fix runtime exception thrown by LinearFilter lastValue()

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
@@ -56,6 +56,7 @@ public class LinearFilter {
   private final DoubleCircularBuffer m_outputs;
   private final double[] m_inputGains;
   private final double[] m_outputGains;
+  private double m_lastOutput;
 
   private static int instances;
 
@@ -310,6 +311,7 @@ public class LinearFilter {
       m_outputs.addFirst(retVal);
     }
 
+    m_lastOutput = retVal;
     return retVal;
   }
 
@@ -319,7 +321,7 @@ public class LinearFilter {
    * @return The last value.
    */
   public double lastValue() {
-    return m_outputs.getFirst();
+    return m_lastOutput;
   }
 
   /**

--- a/wpimath/src/main/native/include/frc/filter/LinearFilter.h
+++ b/wpimath/src/main/native/include/frc/filter/LinearFilter.h
@@ -367,6 +367,7 @@ class LinearFilter {
       m_outputs.push_front(retVal);
     }
 
+    m_lastValue = retVal;
     return retVal;
   }
 
@@ -375,13 +376,14 @@ class LinearFilter {
    *
    * @return The last value.
    */
-  T LastValue() const { return m_outputs.front(); }
+  T LastValue() const { return m_lastValue; }
 
  private:
   wpi::circular_buffer<T> m_inputs;
   wpi::circular_buffer<T> m_outputs;
   std::vector<double> m_inputGains;
   std::vector<double> m_outputGains;
+  T m_lastValue;
 
   /**
    * Factorial of n.

--- a/wpimath/src/main/native/include/frc/filter/LinearFilter.h
+++ b/wpimath/src/main/native/include/frc/filter/LinearFilter.h
@@ -367,7 +367,7 @@ class LinearFilter {
       m_outputs.push_front(retVal);
     }
 
-    m_lastValue = retVal;
+    m_lastOutput = retVal;
     return retVal;
   }
 
@@ -376,14 +376,14 @@ class LinearFilter {
    *
    * @return The last value.
    */
-  T LastValue() const { return m_lastValue; }
+  T LastValue() const { return m_lastOutput; }
 
  private:
   wpi::circular_buffer<T> m_inputs;
   wpi::circular_buffer<T> m_outputs;
   std::vector<double> m_inputGains;
   std::vector<double> m_outputGains;
-  T m_lastValue;
+  T m_lastOutput{0.0};
 
   /**
    * Factorial of n.


### PR DESCRIPTION
The current implementation of LinearFilter's lastValue() method causes a runtime exception when the size of the output gains buffer is 0, such as with a Moving Average Filter. In this case, outputs are not added to the buffer, and attempting to get the last value throws an index out-of-bounds exception. This behavior is not documented anywhere.

This fixes this issue by saving the last calculated value to a member variable and returning that when lastValue() is called, in both Java and C++.