### PR TITLE
Fix robotpy PR commenting for real this time

### DIFF
--- a/.github/workflows/command-robotpy-pr.yml
+++ b/.github/workflows/command-robotpy-pr.yml
@@ -1,7 +1,7 @@
 name: Comment on PR for robotpy
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
     paths:
@@ -9,12 +9,14 @@ on:
 
 jobs:
   comment:
+    permissions:
+      pull-requests: write
+
     runs-on: ubuntu-latest
     steps:
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.COMMENT_COMMAND_PAT_TOKEN }}
           script: |
             github.rest.issues.createComment({
                 issue_number: context.issue.number,


### PR DESCRIPTION
[The docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) say that `GITHUB_TOKEN` will be given write permissions when using `pull_request_target`. Using `pull_request` means [the permissions will be read-only](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).