### PR TITLE
[upstream_utils] Disable spurious maybe-uninitialized warning from GCC 14

### DIFF
--- a/upstream_utils/eigen_patches/0001-Disable-warnings.patch
+++ b/upstream_utils/eigen_patches/0001-Disable-warnings.patch
@@ -15,7 +15,7 @@ index 32a427d852355a51dc4263d81498554ff4c3cbba..9f3e3f5b0f15518377c9a8283fd58081
  // See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89325
  #pragma GCC diagnostic ignored "-Wattributes"
  #endif
-+#if __GNUC__ >= 11 && __GNUC__ <= 13
++#if __GNUC__ >= 11
 +#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 +#endif
 +#if __GNUC__ >= 12

--- a/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/util/DisableStupidWarnings.h
+++ b/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/util/DisableStupidWarnings.h
@@ -81,7 +81,7 @@
 // See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89325
 #pragma GCC diagnostic ignored "-Wattributes"
 #endif
-#if __GNUC__ >= 11 && __GNUC__ <= 13
+#if __GNUC__ >= 11
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 #if __GNUC__ >= 12


### PR DESCRIPTION
```
In file included from /home/tav/frc/wpilib/allwpilib/wpimath/src/main/native/thirdparty/eigen/include/Eigen/Core:360,
                 from /home/tav/frc/wpilib/allwpilib/sysid/src/main/native/include/sysid/analysis/OLS.h:10,
                 from /home/tav/frc/wpilib/allwpilib/sysid/src/main/native/include/sysid/analysis/FeedforwardAnalysis.h:12,
                 from /home/tav/frc/wpilib/allwpilib/sysid/src/main/native/cpp/analysis/FeedforwardAnalysis.cpp:5:
/home/tav/frc/wpilib/allwpilib/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/products/SelfadjointMatrixVector.h: In function ‘static void Eigen::internal::selfadjoint_product_impl<Lhs, LhsMode, false, Rhs, 0, true>::run(Dest&, const Lhs&, const Rhs&, const Scalar&) [with Dest = Eigen::Block<Eigen::Matrix<double, -1, 1>, -1, 1, false>; Lhs = Eigen::Block<Eigen::Matrix<double, -1, -1> >; int LhsMode = 17; Rhs = Eigen::CwiseBinaryOp<Eigen::internal::scalar_product_op<double, double>, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, const Eigen::Matrix<double, -1, 1> >, const Eigen::Block<Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>, -1, 1, false> >]’:
/home/tav/frc/wpilib/allwpilib/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/products/SelfadjointMatrixVector.h:217:51: error: ‘result’ may be used uninitialized [-Werror=maybe-uninitialized]
  214 |     internal::selfadjoint_matrix_vector_product<
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  215 |         Scalar, Index, (internal::traits<ActualLhsTypeCleaned>::Flags & RowMajorBit) ? RowMajor : ColMajor,
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  216 |         int(LhsUpLo), bool(LhsBlasTraits::NeedToConjugate),
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  217 |         bool(RhsBlasTraits::NeedToConjugate)>::run(lhs.rows(),                              // size
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  218 |                                                    &lhs.coeffRef(0, 0), lhs.outerStride(),  // lhs info
      |                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  219 |                                                    actualRhsPtr,                            // rhs info
      |                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  220 |                                                    actualDestPtr,                           // result info
      |                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  221 |                                                    actualAlpha                              // scale factor
      |                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  222 |     );
      |     ~
/home/tav/frc/wpilib/allwpilib/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/products/SelfadjointMatrixVector.h:42:1: note: by argument 4 of type ‘const double*’ to ‘static void Eigen::internal::selfadjoint_matrix_vector_product<Scalar, Index, StorageOrder, UpLo, ConjugateLhs, ConjugateRhs, Version>::run(Index, const Scalar*, Index, const Scalar*, Scalar*, Scalar) [with Scalar = double; Index = long int; int StorageOrder = 0; int UpLo = 1; bool ConjugateLhs = false; bool ConjugateRhs = false; int Version = 0]’ declared here
   42 | selfadjoint_matrix_vector_product<Scalar, Index, StorageOrder, UpLo, ConjugateLhs, ConjugateRhs, Version>::run(
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```