### PR TITLE
[wpiutil] DataLog: Don't constantly retry log creation when low on space

### DIFF
--- a/wpiutil/src/main/native/cpp/DataLogBackgroundWriter.cpp
+++ b/wpiutil/src/main/native/cpp/DataLogBackgroundWriter.cpp
@@ -237,6 +237,7 @@ void DataLogBackgroundWriter::StartLogFile(WriterThreadState& state) {
     WPI_ERROR(m_msglog,
               "Insufficient free space ({} available), no log being saved",
               FormatBytesSize(state.freeSpace));
+    m_state = kStopped;
   } else {
     // try preferred filename, or randomize it a few times, before giving up
     for (int i = 0; i < 5; ++i) {


### PR DESCRIPTION
Accidently removed in #6590. Originally from #6468.