### PR TITLE
[wpilib] Propagate PWMMotorController stopMotor() and disable() to followers

### DIFF
--- a/wpilibc/src/main/native/cpp/motorcontrol/PWMMotorController.cpp
+++ b/wpilibc/src/main/native/cpp/motorcontrol/PWMMotorController.cpp
@@ -47,11 +47,25 @@ bool PWMMotorController::GetInverted() const {
 
 void PWMMotorController::Disable() {
   m_pwm.SetDisabled();
+
+  for (auto& follower : m_nonowningFollowers) {
+    follower->Disable();
+  }
+  for (auto& follower : m_owningFollowers) {
+    follower->Disable();
+  }
 }
 
 void PWMMotorController::StopMotor() {
   // Don't use Set(0) as that will feed the watch kitty
   m_pwm.SetSpeed(0);
+
+  for (auto& follower : m_nonowningFollowers) {
+    follower->StopMotor();
+  }
+  for (auto& follower : m_owningFollowers) {
+    follower->StopMotor();
+  }
 }
 
 std::string PWMMotorController::GetDescription() const {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/PWMMotorController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/PWMMotorController.java
@@ -88,12 +88,20 @@ public abstract class PWMMotorController extends MotorSafety
   @Override
   public void disable() {
     m_pwm.setDisabled();
+
+    for (var follower : m_followers) {
+      follower.disable();
+    }
   }
 
   @Override
   public void stopMotor() {
     // Don't use set(0) as that will feed the watch kitty
     m_pwm.setSpeed(0);
+
+    for (var follower : m_followers) {
+      follower.stopMotor();
+    }
   }
 
   @Override


### PR DESCRIPTION
Previously, in `MotorControllerGroup`s, calling `stopMotor()` or `disable()` stopped all the motors in that group. Now that this class is marked for deprecation, it recommends to use `PWMMotorController.addFollower()` to create groups. This functionality is not consistent in the PWMMotorController class, where calling either of these methods only applies to that motor, and not its followers. The JavaDocs also specify that the follower motor will follow the outputs of the leader. Thus, it is logical that calling either of these methods should also call them for all of that motor's followers.

This adds that functionality in both Java and C++.