### PR TITLE
[ci] Bump actions versions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,7 +35,7 @@ jobs:
         if: runner.os == 'macOS'
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.5
 
       - uses: actions/checkout@v4
 
@@ -58,13 +58,13 @@ jobs:
     name: "Build - Windows"
     runs-on: windows-2022
     steps:
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@v1.13.0
 
       - name: Install CMake
         uses: lukka/get-cmake@v3.29.3
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.5
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -41,11 +41,11 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew docs:generateJavaDocs docs:doxygen -PbuildServer ${{ env.EXTRA_GRADLE_ARGS }}
       - name: Install SSH Client 🔑
-        uses: webfactory/ssh-agent@v0.8.0
+        uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.GH_DEPLOY_KEY }}
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@v4.6.1
         with:
           ssh-key: true
           repository-name: wpilibsuite/wpilibsuite.github.io
@@ -54,7 +54,7 @@ jobs:
           single-commit: true
           folder: docs/build/docs
       - name: Trigger Workflow
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.DISPATCH_PAT_TOKEN }}
           script: |

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v3

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -112,7 +112,7 @@ jobs:
           java-version: 17
           architecture: ${{ matrix.architecture }}
       - name: Import Developer ID Certificate
-        uses: wpilibsuite/import-signing-certificate@v1
+        uses: wpilibsuite/import-signing-certificate@v2
         with:
           certificate-data: ${{ secrets.APPLE_CERTIFICATE_DATA }}
           certificate-passphrase: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -32,7 +32,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libopencv-dev libopencv4.5-java clang-14 libprotobuf-dev protobuf-compiler ninja-build
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.5
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Bump webfactory/ssh-agent to 0.9.0 (Node 20)
Switch to gradle/actions/wrapper-validation (Node 20)
Bump mozilla-actions/sccache-action to 0.0.5 (Node 20 for sanitizers only)
Bump actions/github-script to 7 (Node 20 for documentation only)
Bump wpilibsuite/import-signing-certificate to 2 (Node 20)
Bump JamesIves/github-pages-deploy-action to 4.6.1 (Node 20)
Resolves #5825.