### PR TITLE
Add AnalogEncoder.getAngle

### DIFF
--- a/wpilibc/src/main/native/cpp/AnalogEncoder.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogEncoder.cpp
@@ -4,6 +4,11 @@
 
 #include "frc/AnalogEncoder.h"
 
+#include <cmath>
+
+#include <units/angle.h>
+#include <units/constants.h>
+#include <units/math.h>
 #include <wpi/NullDeleter.h>
 #include <wpi/sendable/SendableBuilder.h>
 
@@ -115,6 +120,10 @@ double AnalogEncoder::MapSensorRange(double pos) const {
   }
   pos = (pos - m_sensorMin) / (m_sensorMax - m_sensorMin);
   return pos;
+}
+
+units::angle_unit auto AnalogEncoder::GetAngle() const {
+  return Get() * 360_deg;
 }
 
 void AnalogEncoder::InitSendable(wpi::SendableBuilder& builder) {

--- a/wpilibc/src/main/native/cpp/AnalogEncoder.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogEncoder.cpp
@@ -126,6 +126,14 @@ units::angle_unit auto AnalogEncoder::GetAngle() const {
   return Get() * 360_deg;
 }
 
+units::radian_t AnalogEncoder::GetRadians() const {
+  return GetAngle();
+}
+
+units::degree_t AnalogEncoder::GetDegrees() const {
+  return GetAngle();
+}
+
 void AnalogEncoder::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("AbsoluteEncoder");
   builder.AddDoubleProperty(

--- a/wpilibc/src/main/native/include/frc/AnalogEncoder.h
+++ b/wpilibc/src/main/native/include/frc/AnalogEncoder.h
@@ -139,6 +139,20 @@ class AnalogEncoder : public wpi::Sendable,
    */
   units::angle_unit auto GetAngle() const;
 
+  /**
+   * Gets the angle of the encoder in radians.
+   *
+   * @return The radians of the encoder angle.
+   */
+  units::radian_t GetRadians() const;
+
+  /**
+   * Gets the angle of the encoder in degrees.
+   *
+   * @return The degrees of the encoder angle.
+   */
+  units::degree_t GetDegrees() const;
+
   void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:

--- a/wpilibc/src/main/native/include/frc/AnalogEncoder.h
+++ b/wpilibc/src/main/native/include/frc/AnalogEncoder.h
@@ -8,6 +8,7 @@
 
 #include <hal/SimDevice.h>
 #include <hal/Types.h>
+#include <units/angle.h>
 #include <wpi/sendable/Sendable.h>
 #include <wpi/sendable/SendableHelper.h>
 
@@ -130,6 +131,13 @@ class AnalogEncoder : public wpi::Sendable,
    * @return The channel number.
    */
   int GetChannel() const;
+
+  /**
+   * Gets the angle of the encoder.
+   *
+   * @return The angle of the encoder.
+   */
+  units::angle_unit auto GetAngle() const;
 
   void InitSendable(wpi::SendableBuilder& builder) override;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogEncoder.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogEncoder.java
@@ -159,6 +159,24 @@ public class AnalogEncoder implements Sendable, AutoCloseable {
     return m_analogInput.getChannel();
   }
 
+  /**
+   * Gets the angle of the encoder in radians.
+   *
+   * @return The radians of the encoder angle.
+   */
+  public double getRadians() {
+    return MathUtil.angleModulus(get() * 2 * Math.PI);
+  }
+
+  /**
+   * Gets the angle of the encoder in degrees.
+   *
+   * @return The degrees of the encoder angle.
+   */
+  public double getDegrees() {
+    return MathUtil.angleModulus(get() * 360);
+  }
+
   @Override
   public void close() {
     if (m_ownsAnalogInput) {


### PR DESCRIPTION
Resolves https://github.com/wpilibsuite/allwpilib/issues/4063

~~The API differs between Java and C++ as C++ having units used everywhere can have one function that implicitly converts between different units vs in Java units need to be explicitly converted. This means C++ has GetAngle and Java has getDegrees and getRadians.~~
Now C++ just has the extra GetAngle function