### PR TITLE
[build] Fix CMake protobuf dependency handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,10 @@ endif()
 
 find_package(LIBSSH 0.7.1)
 
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+set(protobuf_MODULE_COMPATIBLE ON CACHE BOOL "" FORCE)
 find_package(Protobuf REQUIRED)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
 
 set(APRILTAG_DEP_REPLACE "find_dependency(apriltag)")
 set(CAMERASERVER_DEP_REPLACE_IMPL "find_dependency(cameraserver)")

--- a/wpimath/src/main/native/cpp/controller/proto/ArmFeedforwardProto.cpp
+++ b/wpimath/src/main/native/cpp/controller/proto/ArmFeedforwardProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/controller/proto/ArmFeedforwardProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "controller.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::ArmFeedforward>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufArmFeedforward>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufArmFeedforward>(arena);
 }
 
 frc::ArmFeedforward wpi::Protobuf<frc::ArmFeedforward>::Unpack(

--- a/wpimath/src/main/native/cpp/controller/proto/DifferentialDriveWheelVoltagesProto.cpp
+++ b/wpimath/src/main/native/cpp/controller/proto/DifferentialDriveWheelVoltagesProto.cpp
@@ -4,12 +4,14 @@
 
 #include "frc/controller/proto/DifferentialDriveWheelVoltagesProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "controller.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<
     frc::DifferentialDriveWheelVoltages>::New(google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufDifferentialDriveWheelVoltages>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufDifferentialDriveWheelVoltages>(
+      arena);
 }
 
 frc::DifferentialDriveWheelVoltages

--- a/wpimath/src/main/native/cpp/controller/proto/ElevatorFeedforwardProto.cpp
+++ b/wpimath/src/main/native/cpp/controller/proto/ElevatorFeedforwardProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/controller/proto/ElevatorFeedforwardProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "controller.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::ElevatorFeedforward>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufElevatorFeedforward>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufElevatorFeedforward>(arena);
 }
 
 frc::ElevatorFeedforward wpi::Protobuf<frc::ElevatorFeedforward>::Unpack(

--- a/wpimath/src/main/native/cpp/geometry/proto/Ellipse2dProto.cpp
+++ b/wpimath/src/main/native/cpp/geometry/proto/Ellipse2dProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/geometry/proto/Ellipse2dProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "geometry2d.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Ellipse2d>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufEllipse2d>(
-      arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufEllipse2d>(arena);
 }
 
 frc::Ellipse2d wpi::Protobuf<frc::Ellipse2d>::Unpack(

--- a/wpimath/src/main/native/cpp/geometry/proto/Pose2dProto.cpp
+++ b/wpimath/src/main/native/cpp/geometry/proto/Pose2dProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/geometry/proto/Pose2dProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "geometry2d.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Pose2d>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufPose2d>(
-      arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufPose2d>(arena);
 }
 
 frc::Pose2d wpi::Protobuf<frc::Pose2d>::Unpack(

--- a/wpimath/src/main/native/cpp/geometry/proto/Pose3dProto.cpp
+++ b/wpimath/src/main/native/cpp/geometry/proto/Pose3dProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/geometry/proto/Pose3dProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "geometry3d.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Pose3d>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufPose3d>(
-      arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufPose3d>(arena);
 }
 
 frc::Pose3d wpi::Protobuf<frc::Pose3d>::Unpack(

--- a/wpimath/src/main/native/cpp/geometry/proto/QuaternionProto.cpp
+++ b/wpimath/src/main/native/cpp/geometry/proto/QuaternionProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/geometry/proto/QuaternionProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "geometry3d.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Quaternion>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufQuaternion>(
-      arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufQuaternion>(arena);
 }
 
 frc::Quaternion wpi::Protobuf<frc::Quaternion>::Unpack(

--- a/wpimath/src/main/native/cpp/geometry/proto/Rectangle2dProto.cpp
+++ b/wpimath/src/main/native/cpp/geometry/proto/Rectangle2dProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/geometry/proto/Rectangle2dProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "geometry2d.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Rectangle2d>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufRectangle2d>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufRectangle2d>(arena);
 }
 
 frc::Rectangle2d wpi::Protobuf<frc::Rectangle2d>::Unpack(

--- a/wpimath/src/main/native/cpp/geometry/proto/Rotation2dProto.cpp
+++ b/wpimath/src/main/native/cpp/geometry/proto/Rotation2dProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/geometry/proto/Rotation2dProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "geometry2d.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Rotation2d>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufRotation2d>(
-      arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufRotation2d>(arena);
 }
 
 frc::Rotation2d wpi::Protobuf<frc::Rotation2d>::Unpack(

--- a/wpimath/src/main/native/cpp/geometry/proto/Rotation3dProto.cpp
+++ b/wpimath/src/main/native/cpp/geometry/proto/Rotation3dProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/geometry/proto/Rotation3dProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "geometry3d.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Rotation3d>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufRotation3d>(
-      arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufRotation3d>(arena);
 }
 
 frc::Rotation3d wpi::Protobuf<frc::Rotation3d>::Unpack(

--- a/wpimath/src/main/native/cpp/geometry/proto/Transform2dProto.cpp
+++ b/wpimath/src/main/native/cpp/geometry/proto/Transform2dProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/geometry/proto/Transform2dProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "geometry2d.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Transform2d>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufTransform2d>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufTransform2d>(arena);
 }
 
 frc::Transform2d wpi::Protobuf<frc::Transform2d>::Unpack(

--- a/wpimath/src/main/native/cpp/geometry/proto/Transform3dProto.cpp
+++ b/wpimath/src/main/native/cpp/geometry/proto/Transform3dProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/geometry/proto/Transform3dProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "geometry3d.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Transform3d>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufTransform3d>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufTransform3d>(arena);
 }
 
 frc::Transform3d wpi::Protobuf<frc::Transform3d>::Unpack(

--- a/wpimath/src/main/native/cpp/geometry/proto/Translation2dProto.cpp
+++ b/wpimath/src/main/native/cpp/geometry/proto/Translation2dProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/geometry/proto/Translation2dProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "geometry2d.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Translation2d>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufTranslation2d>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufTranslation2d>(arena);
 }
 
 frc::Translation2d wpi::Protobuf<frc::Translation2d>::Unpack(

--- a/wpimath/src/main/native/cpp/geometry/proto/Translation3dProto.cpp
+++ b/wpimath/src/main/native/cpp/geometry/proto/Translation3dProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/geometry/proto/Translation3dProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "geometry3d.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Translation3d>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufTranslation3d>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufTranslation3d>(arena);
 }
 
 frc::Translation3d wpi::Protobuf<frc::Translation3d>::Unpack(

--- a/wpimath/src/main/native/cpp/geometry/proto/Twist2dProto.cpp
+++ b/wpimath/src/main/native/cpp/geometry/proto/Twist2dProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/geometry/proto/Twist2dProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "geometry2d.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Twist2d>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufTwist2d>(
-      arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufTwist2d>(arena);
 }
 
 frc::Twist2d wpi::Protobuf<frc::Twist2d>::Unpack(

--- a/wpimath/src/main/native/cpp/geometry/proto/Twist3dProto.cpp
+++ b/wpimath/src/main/native/cpp/geometry/proto/Twist3dProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/geometry/proto/Twist3dProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "geometry3d.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Twist3d>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufTwist3d>(
-      arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufTwist3d>(arena);
 }
 
 frc::Twist3d wpi::Protobuf<frc::Twist3d>::Unpack(

--- a/wpimath/src/main/native/cpp/kinematics/proto/ChassisSpeedsProto.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/proto/ChassisSpeedsProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/kinematics/proto/ChassisSpeedsProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "kinematics.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::ChassisSpeeds>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufChassisSpeeds>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufChassisSpeeds>(arena);
 }
 
 frc::ChassisSpeeds wpi::Protobuf<frc::ChassisSpeeds>::Unpack(

--- a/wpimath/src/main/native/cpp/kinematics/proto/DifferentialDriveKinematicsProto.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/proto/DifferentialDriveKinematicsProto.cpp
@@ -4,12 +4,14 @@
 
 #include "frc/kinematics/proto/DifferentialDriveKinematicsProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "kinematics.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::DifferentialDriveKinematics>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufDifferentialDriveKinematics>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufDifferentialDriveKinematics>(
+      arena);
 }
 
 frc::DifferentialDriveKinematics

--- a/wpimath/src/main/native/cpp/kinematics/proto/DifferentialDriveWheelPositionsProto.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/proto/DifferentialDriveWheelPositionsProto.cpp
@@ -4,11 +4,13 @@
 
 #include "frc/kinematics/proto/DifferentialDriveWheelPositionsProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "kinematics.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<
     frc::DifferentialDriveWheelPositions>::New(google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
+  return wpi::CreateMessage<
       wpi::proto::ProtobufDifferentialDriveWheelPositions>(arena);
 }
 

--- a/wpimath/src/main/native/cpp/kinematics/proto/DifferentialDriveWheelSpeedsProto.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/proto/DifferentialDriveWheelSpeedsProto.cpp
@@ -4,12 +4,14 @@
 
 #include "frc/kinematics/proto/DifferentialDriveWheelSpeedsProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "kinematics.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<
     frc::DifferentialDriveWheelSpeeds>::New(google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufDifferentialDriveWheelSpeeds>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufDifferentialDriveWheelSpeeds>(
+      arena);
 }
 
 frc::DifferentialDriveWheelSpeeds

--- a/wpimath/src/main/native/cpp/kinematics/proto/MecanumDriveKinematicsProto.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/proto/MecanumDriveKinematicsProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/kinematics/proto/MecanumDriveKinematicsProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "kinematics.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::MecanumDriveKinematics>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufMecanumDriveKinematics>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufMecanumDriveKinematics>(arena);
 }
 
 frc::MecanumDriveKinematics wpi::Protobuf<frc::MecanumDriveKinematics>::Unpack(

--- a/wpimath/src/main/native/cpp/kinematics/proto/MecanumDriveWheelPositionsProto.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/proto/MecanumDriveWheelPositionsProto.cpp
@@ -4,12 +4,14 @@
 
 #include "frc/kinematics/proto/MecanumDriveWheelPositionsProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "kinematics.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::MecanumDriveWheelPositions>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufMecanumDriveWheelPositions>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufMecanumDriveWheelPositions>(
+      arena);
 }
 
 frc::MecanumDriveWheelPositions

--- a/wpimath/src/main/native/cpp/kinematics/proto/MecanumDriveWheelSpeedsProto.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/proto/MecanumDriveWheelSpeedsProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/kinematics/proto/MecanumDriveWheelSpeedsProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "kinematics.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::MecanumDriveWheelSpeeds>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufMecanumDriveWheelSpeeds>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufMecanumDriveWheelSpeeds>(arena);
 }
 
 frc::MecanumDriveWheelSpeeds

--- a/wpimath/src/main/native/cpp/kinematics/proto/SwerveModulePositionProto.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/proto/SwerveModulePositionProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/kinematics/proto/SwerveModulePositionProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "kinematics.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::SwerveModulePosition>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufSwerveModulePosition>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufSwerveModulePosition>(arena);
 }
 
 frc::SwerveModulePosition wpi::Protobuf<frc::SwerveModulePosition>::Unpack(

--- a/wpimath/src/main/native/cpp/kinematics/proto/SwerveModuleStateProto.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/proto/SwerveModuleStateProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/kinematics/proto/SwerveModuleStateProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "kinematics.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::SwerveModuleState>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufSwerveModuleState>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufSwerveModuleState>(arena);
 }
 
 frc::SwerveModuleState wpi::Protobuf<frc::SwerveModuleState>::Unpack(

--- a/wpimath/src/main/native/cpp/system/plant/proto/DCMotorProto.cpp
+++ b/wpimath/src/main/native/cpp/system/plant/proto/DCMotorProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/system/plant/proto/DCMotorProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "plant.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::DCMotor>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufDCMotor>(
-      arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufDCMotor>(arena);
 }
 
 frc::DCMotor wpi::Protobuf<frc::DCMotor>::Unpack(

--- a/wpimath/src/main/native/cpp/trajectory/proto/TrajectoryProto.cpp
+++ b/wpimath/src/main/native/cpp/trajectory/proto/TrajectoryProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/trajectory/proto/TrajectoryProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "trajectory.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Trajectory>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufTrajectory>(
-      arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufTrajectory>(arena);
 }
 
 frc::Trajectory wpi::Protobuf<frc::Trajectory>::Unpack(

--- a/wpimath/src/main/native/cpp/trajectory/proto/TrajectoryStateProto.cpp
+++ b/wpimath/src/main/native/cpp/trajectory/proto/TrajectoryStateProto.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/trajectory/proto/TrajectoryStateProto.h"
 
+#include <wpi/ProtoHelper.h>
+
 #include "trajectory.pb.h"
 
 google::protobuf::Message* wpi::Protobuf<frc::Trajectory::State>::New(
     google::protobuf::Arena* arena) {
-  return google::protobuf::Arena::CreateMessage<
-      wpi::proto::ProtobufTrajectoryState>(arena);
+  return wpi::CreateMessage<wpi::proto::ProtobufTrajectoryState>(arena);
 }
 
 frc::Trajectory::State wpi::Protobuf<frc::Trajectory::State>::Unpack(

--- a/wpiutil/CMakeLists.txt
+++ b/wpiutil/CMakeLists.txt
@@ -162,11 +162,6 @@ endif()
 wpilib_target_warnings(wpiutil)
 target_link_libraries(wpiutil protobuf::libprotobuf Threads::Threads ${CMAKE_DL_LIBS})
 
-if(Protobuf_VERSION VERSION_GREATER_EQUAL 4)
-    find_package(absl REQUIRED)
-    target_link_libraries(wpiutil absl::spinlock_wait)
-endif()
-
 if(ATOMIC)
     target_link_libraries(wpiutil ${ATOMIC})
 endif()

--- a/wpiutil/src/main/native/cpp/protobuf/Protobuf.cpp
+++ b/wpiutil/src/main/native/cpp/protobuf/Protobuf.cpp
@@ -10,6 +10,7 @@
 #include <google/protobuf/io/zero_copy_stream.h>
 #include <google/protobuf/message.h>
 
+#include "wpi/ProtoHelper.h"
 #include "wpi/SmallVector.h"
 
 using namespace wpi;
@@ -170,7 +171,7 @@ static void ForEachProtobufDescriptorImpl(
                                   descproto);
   }
   if (!*descproto) {
-    *descproto = Arena::CreateMessage<FileDescriptorProto>(arena);
+    *descproto = wpi::CreateMessage<FileDescriptorProto>(arena);
   }
   (*descproto)->Clear();
   desc->CopyTo(*descproto);

--- a/wpiutil/src/main/native/cpp/protobuf/ProtobufMessageDatabase.cpp
+++ b/wpiutil/src/main/native/cpp/protobuf/ProtobufMessageDatabase.cpp
@@ -6,6 +6,8 @@
 
 #include <google/protobuf/descriptor.h>
 
+#include "wpi/ProtoHelper.h"
+
 using namespace wpi;
 
 using google::protobuf::Arena;
@@ -34,7 +36,7 @@ bool ProtobufMessageDatabase::Add(std::string_view filename,
 
   if (!file.proto) {
     file.proto = std::unique_ptr<FileDescriptorProto>{
-        Arena::CreateMessage<FileDescriptorProto>(nullptr)};
+        wpi::CreateMessage<FileDescriptorProto>(nullptr)};
   } else {
     // replacing an existing one; remove any previously existing refs
     for (auto&& dep : file.proto->dependency()) {

--- a/wpiutil/src/main/native/include/wpi/ProtoHelper.h
+++ b/wpiutil/src/main/native/include/wpi/ProtoHelper.h
@@ -8,7 +8,7 @@
 
 namespace wpi {
 template <typename T>
-T* CreateMessage(google::protobuf::Arena* arena) {
+inline T* CreateMessage(google::protobuf::Arena* arena) {
 #if GOOGLE_PROTOBUF_VERSION < 4000000
   return google::protobuf::Arena::CreateMessage<T>(arena);
 #else

--- a/wpiutil/src/main/native/include/wpi/ProtoHelper.h
+++ b/wpiutil/src/main/native/include/wpi/ProtoHelper.h
@@ -1,0 +1,18 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <google/protobuf/message.h>
+
+namespace wpi {
+template <typename T>
+T* CreateMessage(google::protobuf::Arena* arena) {
+#if GOOGLE_PROTOBUF_VERSION < 4000000
+  return google::protobuf::Arena::CreateMessage<T>(arena);
+#else
+  return google::protobuf::Arena::Create<T>(arena);
+#endif
+}
+}  // namespace wpi


### PR DESCRIPTION
Reverts #6609 since that fix didn't Just Work(tm) on Windows. (edit: or Ubuntu. Seems to have broken everything except macOS.) This PR configures CMake to try and find protobuf-config.cmake first, which allows protobuf to pull in abseil for us. If protobuf-config.cmake is not available (coprocessors which don't have a new enough protobuf installed are a common case), it will fallback to CMake's built-in FindProtobuf module, which is what we were using before.

This PR also adds `wpi::CreateMessage`, a wrapper with an ifdef to switch between `Arena::CreateMessage` and `Arena::Create`, since the former is deprecated in newer versions of protobuf. This allows forward compatibility with newer versions of protobuf.