### PR TITLE
Units API Rewrite

### DIFF
--- a/wpiunits/src/main/java/edu/wpi/first/units/angle/Angle.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/angle/Angle.java
@@ -1,0 +1,410 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.units.angle;
+
+import java.util.Objects;
+
+import edu.wpi.first.units.angularvelocity.AngularVelocity;
+import edu.wpi.first.units.time.Time;
+
+/**
+ * A measure holds the magnitude and unit of some dimension, such as distance,
+ * time, or speed. An
+ * immutable measure is <i>immutable</i> and <i>type safe</i>, making it easy to
+ * use in concurrent
+ * situations and gives compile-time safety. Two measures with the same
+ * <i>unit</i> and
+ * <i>magnitude</i> are effectively equivalent objects.
+ *
+ */
+public class Angle implements Comparable<Angle> {
+
+  /**
+   * The threshold for two measures to be considered equivalent if converted to
+   * the same unit. This
+   * is only needed due to floating-point error.
+   */
+  static double EQUIVALENCE_THRESHOLD = 1e-12;
+
+  protected double m_magnitude;
+  protected double m_baseUnitMagnitude;
+  protected AngleUnit m_unit;
+
+  /**
+   * Creates a new immutable Dimensionless measure instance. This shouldn't be used
+   * directly; prefer one of the
+   * factory methods instead.
+   *
+   * @param magnitude the magnitude of this measure
+   * @param unit      the unit of this measure.
+   */
+  Angle(double magnitude, double baseUnitMagnitude, AngleUnit unit) {
+    Objects.requireNonNull(unit, "Unit cannot be null");
+    m_magnitude = magnitude;
+    m_baseUnitMagnitude = baseUnitMagnitude;
+    m_unit = unit;
+  }
+
+  /**
+   * Gets the unitless magnitude of this measure.
+   *
+   * @return the magnitude in terms of {@link #unit() the unit}.
+   */
+  public double magnitude() {
+    return m_magnitude;
+  }
+
+  /**
+   * Gets the magnitude of this measure in terms of the base unit. If the unit is
+   * the base unit for
+   * its system of measure, then the value will be equivalent to
+   * {@link #magnitude()}.
+   *
+   * @return the magnitude in terms of the base unit
+   */
+  public double baseUnitMagnitude() {
+    return m_baseUnitMagnitude;
+  }
+
+  /**
+   * Gets the units of this measure.
+   *
+   * @return the unit
+   */
+  public AngleUnit unit() {
+    return m_unit;
+  }
+
+  /**
+   * Converts this measure to a measure with a different unit of the same type, eg
+   * minutes to
+   * seconds. Converting to the same unit is equivalent to calling
+   * {@link #magnitude()}.
+   *
+   * <pre>
+   *   Meters.of(12).in(Feet) // 39.3701
+   *   Seconds.of(15).in(Minutes) // 0.25
+   * </pre>
+   *
+   * @param unit the unit to convert this measure to
+   * @return the value of this measure in the given unit
+   */
+  public double in(AngleUnit unit) {
+    if (this.unit().equals(unit)) {
+      return magnitude();
+    } else {
+      return unit.fromBaseUnits(baseUnitMagnitude());
+    }
+  }
+
+  /**
+   * Multiplies this measurement by some constant multiplier and returns the
+   * result. The magnitude
+   * of the result will be the <i>base</i> magnitude multiplied by the scalar
+   * value. If the measure
+   * uses a unit with a non-linear relation to its base unit (such as Fahrenheit
+   * for temperature),
+   * then the result will only be a multiple <i>in terms of the base unit</i>.
+   *
+   * @param multiplier the constant to multiply by
+   * @return the resulting measure
+   */
+  public Angle times(double multiplier) {
+    return Angle.ofBaseUnits(baseUnitMagnitude() * multiplier, unit());
+  }
+
+  /**
+   * Divides this measurement by some constant divisor and returns the result.
+   * This is equivalent to
+   * {@code times(1 / divisor)}
+   *
+   * @param divisor the constant to divide by
+   * @return the resulting measure
+   * @see #times(double)
+   */
+  public Angle divide(double divisor) {
+    return times(1 / divisor);
+  }
+
+  /**
+   * Adds another measure to this one. The resulting measure has the same unit as
+   * this one.
+   *
+   * @param other the measure to add to this one
+   * @return a new measure containing the result
+   */
+  public Angle plus(Angle other) {
+    return unit().ofBaseUnits(baseUnitMagnitude() + other.baseUnitMagnitude());
+  }
+
+  /**
+   * Subtracts another measure from this one. The resulting measure has the same
+   * unit as this one.
+   *
+   * @param other the measure to subtract from this one
+   * @return a new measure containing the result
+   */
+  public Angle minus(Angle other) {
+    return unit().ofBaseUnits(baseUnitMagnitude() - other.baseUnitMagnitude());
+  }
+
+  /**
+   * Negates this measure and returns the result.
+   *
+   * @return the resulting measure
+   */
+  public Angle negate() {
+    return times(-1);
+  }
+
+  /**
+   * Returns an immutable copy of this measure. The copy can be used freely and is
+   * guaranteed never
+   * to change.
+   *
+   * @return the copied measure
+   */
+  public Angle copy() {
+    return new Angle(m_magnitude, m_baseUnitMagnitude, m_unit);
+  }
+
+  /**
+   * Creates a new mutable copy of this measure.
+   *
+   * @return a mutable measure initialized to be identical to this measure
+   */
+  public MutableAngle mutableCopy() {
+    return MutableAngle.mutable(this);
+  }
+
+  /**
+   * Checks if this measure is near another measure of the same unit. Provide a
+   * variance threshold
+   * for use for a +/- scalar, such as 0.05 for +/- 5%.
+   *
+   * <pre>
+   *   Inches.of(11).isNear(Inches.of(10), 0.1) // true
+   *   Inches.of(12).isNear(Inches.of(10), 0.1) // false
+   * </pre>
+   *
+   * @param other             the other measurement to compare against
+   * @param varianceThreshold the acceptable variance threshold, in terms of an
+   *                          acceptable +/- error
+   *                          range multiplier. Checking if a value is within 10%
+   *                          means a value of 0.1 should be passed;
+   *                          checking if a value is within 1% means a value of
+   *                          0.01 should be passed, and so on.
+   * @return true if this unit is near the other measure, otherwise false
+   */
+  public boolean isNear(Angle other, double varianceThreshold) {
+    // abs so negative inputs are calculated correctly
+    var tolerance = Math.abs(other.baseUnitMagnitude() * varianceThreshold);
+
+    return Math.abs(this.baseUnitMagnitude() - other.baseUnitMagnitude()) <= tolerance;
+  }
+
+  /**
+   * Checks if this measure is near another measure of the same unit, with a
+   * specified tolerance of
+   * the same unit.
+   *
+   * <pre>
+   *     Meters.of(1).isNear(Meters.of(1.2), Millimeters.of(300)) // true
+   *     Degrees.of(90).isNear(Rotations.of(0.5), Degrees.of(45)) // false
+   * </pre>
+   *
+   * @param other     the other measure to compare against.
+   * @param tolerance the tolerance allowed in which the two measures are defined
+   *                  as near each
+   *                  other.
+   * @return true if this unit is near the other measure, otherwise false.
+   */
+  public boolean isNear(Angle other, Angle tolerance) {
+    return Math.abs(this.baseUnitMagnitude() - other.baseUnitMagnitude()) <= Math
+        .abs(tolerance.baseUnitMagnitude());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int compareTo(Angle o) {
+    return Double.compare(this.baseUnitMagnitude(), o.baseUnitMagnitude());
+  }
+
+  /**
+   * Checks if this measure is greater than another measure of the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has a greater equivalent magnitude, false
+   *         otherwise
+   */
+  public boolean gt(Angle o) {
+    return compareTo(o) > 0;
+  }
+
+  /**
+   * Checks if this measure is greater than or equal to another measure of
+   * the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has an equal or greater magnitude,
+   *         false otherwise
+   */
+  public boolean gte(Angle o) {
+    return compareTo(o) > 0 || equals(o);
+  }
+
+  /**
+   * Checks if this measure is less than another measure of the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has a lesser equivalent magnitude, false
+   *         otherwise
+   */
+  public boolean lt(Angle o) {
+    return compareTo(o) < 0;
+  }
+
+  /**
+   * Checks if this measure is less than or equal to another measure of
+   * the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has an equal or lesser equivalent magnitude,
+   *         false otherwise
+   */
+  public boolean lte(Angle o) {
+    return compareTo(o) < 0 || equals(o);
+  }
+
+  /**
+   * Returns the measure with the absolute value closest to positive infinity.
+   *
+   * @param <U>      the type of the units of the measures
+   * @param measures the set of measures to compare
+   * @return the measure with the greatest positive magnitude, or null if no
+   *         measures were provided
+   */
+  static Angle max(Angle... measures) {
+    if (measures.length == 0) {
+      return null; // nothing to compare
+    }
+
+    Angle max = null;
+    for (Angle measure : measures) {
+      if (max == null || measure.gt(max)) {
+        max = measure;
+      }
+    }
+
+    return max;
+  }
+
+  /**
+   * Returns the measure with the absolute value closest to negative infinity.
+   *
+   * @param <U>      the type of the units of the measures
+   * @param measures the set of measures to compare
+   * @return the measure with the greatest negative magnitude
+   */
+  static Angle min(Angle... measures) {
+    if (measures.length == 0) {
+      return null; // nothing to compare
+    }
+
+    Angle max = null;
+    for (Angle measure : measures) {
+      if (max == null || measure.lt(max)) {
+        max = measure;
+      }
+    }
+
+    return max;
+  }
+
+  /**
+   * Returns a string representation of this measurement in a shorthand form. The
+   * symbol of the
+   * backing unit is used, rather than the full name, and the magnitude is
+   * represented in scientific
+   * notation.
+   *
+   * @return the short form representation of this measurement
+   */
+  public String toShortString() {
+    // eg 1.234e+04 V/m (1234 Volt per Meter in long form)
+    return String.format("%.3e %s", magnitude(), unit().symbol());
+  }
+
+  /**
+   * Returns a string representation of this measurement in a longhand form. The
+   * name of the backing
+   * unit is used, rather than its symbol, and the magnitude is represented in a
+   * full string, not
+   * scientific notation. (Very large values may be represented in scientific
+   * notation, however)
+   *
+   * @return the long form representation of this measurement
+   */
+  public String toLongString() {
+    // eg 1234 Volt per Meter (1.234e+04 V/m in short form)
+    return String.format("%s %s", magnitude(), unit().name());
+  }
+
+  /**
+   * Creates a new measure in the given unit with a magnitude equal to the given
+   * one in base units.
+   *
+   * @param <U>               the type of the units of measure
+   * @param baseUnitMagnitude the magnitude of the measure, in terms of the base
+   *                          unit of measure
+   * @param unit              the unit of measure
+   * @return a new measure
+   */
+  public static Angle ofBaseUnits(
+      double baseUnitMagnitude, AngleUnit unit) {
+    return new Angle(unit.fromBaseUnits(baseUnitMagnitude), baseUnitMagnitude, unit);
+  }
+
+  /**
+   * Creates a new measure in the given unit with a magnitude in terms of that
+   * unit.
+   *
+   * @param <U>               the type of the units of measure
+   * @param relativeMagnitude the magnitude of the measure
+   * @param unit              the unit of measure
+   * @return a new measure
+   */
+  public static Angle ofRelativeUnits(
+      double relativeMagnitude, AngleUnit unit) {
+    return new Angle(relativeMagnitude, unit.toBaseUnits(relativeMagnitude), unit);
+  }
+
+  /**
+   * Checks for <i>object equality</i>. To check if two measures are
+   * <i>equivalent</i>, use {@link
+   * #isEquivalent(Measure) isEquivalent}.
+   */
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof Angle other
+        && Objects.equals(m_unit, other.unit())
+        && Math.abs(baseUnitMagnitude() - other.baseUnitMagnitude()) <= EQUIVALENCE_THRESHOLD;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(m_magnitude, m_unit);
+  }
+
+  @Override
+  public String toString() {
+    return toShortString();
+  }
+
+  public AngularVelocity divide(Time time){
+    return AngularVelocity.combine(this, time);    
+  } 
+
+}

--- a/wpiunits/src/main/java/edu/wpi/first/units/angle/AngleUnit.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/angle/AngleUnit.java
@@ -1,0 +1,350 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.units.angle;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.UnaryFunction;
+import edu.wpi.first.units.angularvelocity.AngularVelocityUnit;
+import edu.wpi.first.units.time.TimeUnit;
+
+/**
+ * Unit of measurement that defines an angle, such as radians, rotations, or
+ * degrees.
+ *
+ */
+public class AngleUnit {
+
+  public static final AngleUnit Radians = new AngleUnit();
+
+  public static final AngleUnit Radian = Radians;
+
+  public static final AngleUnit Revolutions = new AngleUnit(2 * Math.PI, "Revolution", "rev");
+
+  public static final AngleUnit Revolution = Revolutions;
+
+  public static final AngleUnit Rotations = new AngleUnit(Revolutions, "Rotation", "rot");
+
+  public static final AngleUnit Degrees = new AngleUnit(2 * Math.PI / 360, "Degree", "°");
+
+  public static final AngleUnit Degree = Degrees;
+
+  private final UnaryFunction m_toBaseConverter;
+  private final UnaryFunction m_fromBaseConverter;
+
+  private final Optional<AngleUnit> m_baseUnit;
+
+  private Angle m_zero;
+  private Angle m_one;
+
+  private final String m_name;
+  private final String m_symbol;
+
+  /**
+   * Creates a new angle unit defined by its relationship to the S.I. base angle
+   * unit (i.e. Radians).
+   *
+   * @param toBaseConverter   a function for converting units of this type to
+   *                          Radians.
+   * @param fromBaseConverter a function for converting units of the other unit to
+   *                          Radians.
+   * @param name              the name of the angle unit. This should be a
+   *                          singular noun
+   *                          (so "Degree", not "Degrees")
+   * @param symbol            the short symbol for the unit, such as "rad" for
+   *                          Radians or "rev" for Revolutions.
+   */
+  public AngleUnit(
+      UnaryFunction toBaseConverter,
+      UnaryFunction fromBaseConverter,
+      String name,
+      String symbol) {
+    m_baseUnit = Optional.of(Radians);
+    m_toBaseConverter = Objects.requireNonNull(toBaseConverter);
+    m_fromBaseConverter = Objects.requireNonNull(fromBaseConverter);
+    m_name = Objects.requireNonNull(name);
+    m_symbol = Objects.requireNonNull(symbol);
+  }
+
+  /**
+   * Creates a new unit with the given name and multiplier to the S.I. base angle
+   * unit (i.e. Radians).
+   *
+   * @param baseUnitEquivalent the multiplier to convert this unit to the other
+   *                           unit of this type.
+   *                           For example, meters has a multiplier of 1, mm has a
+   *                           multiplier of 1e3, and km has
+   *                           multiplier of 1e-3.
+   * @param name               the name of the angle unit. This should be a
+   *                           singular noun
+   *                           (so "Degree", not "Degrees")
+   * @param symbol             the short symbol for the unit, such as "rad" for
+   *                           Radians or "rev" for Revolutions.
+   */
+  public AngleUnit(
+      double baseUnitEquivalent,
+      String name,
+      String symbol) {
+    this(
+        x -> x * baseUnitEquivalent,
+        x -> x / baseUnitEquivalent,
+        name,
+        symbol);
+  }
+
+  /**
+   * Creates a new unit that is identical to other, but with a different name and
+   * symbol.
+   *
+   * @param other  the other angle that this one is identical to.
+   * @param name   the name of the angle unit. This should be a
+   *               singular noun
+   *               (so "Degree", not "Degrees")
+   * @param symbol the short symbol for the unit, such as "rad" for
+   *               Radians or "rev" for Revolutions.
+   */
+  public AngleUnit(
+      AngleUnit other,
+      String name,
+      String symbol) {
+    this(
+        other.m_toBaseConverter,
+        other.m_fromBaseConverter,
+        name,
+        symbol);
+  }
+
+  /**
+   * Instantiates the base unit for angles (i.e. Radians). Only used once by the
+   * static field Radians.
+   */
+  private AngleUnit() {
+    m_baseUnit = Optional.empty();
+    m_fromBaseConverter = x -> x;
+    m_toBaseConverter = x -> x;
+    m_name = "Radian";
+    m_symbol = "rad";
+  }
+
+  /**
+   * Gets the base unit of measurement that this unit is derived from. If the unit
+   * is the base unit,
+   * the unit will be returned.
+   *
+   * <pre>
+   * <code>
+   *   Unit baseUnit = new Unit(null, ...);
+   *   baseUnit.getBaseUnit(); // returns baseUnit
+   *
+   *   Unit derivedUnit = new Unit(baseUnit, ...);
+   *   derivedUnit.getBaseUnit(); // returns baseUnit
+   * </code>
+   * </pre>
+   *
+   * @return the base unit
+   */
+  public Optional<AngleUnit> getBaseUnit() {
+    return m_baseUnit;
+  }
+
+  /**
+   * Checks if this unit is the base unit for its own system of measurement.
+   *
+   * @return true if this is the base unit, false if not
+   */
+  public boolean isBaseUnit() {
+    return this.equals(getBaseUnit().get());
+  }
+
+  /**
+   * Checks if this unit is equivalent to another one. Equivalence is determined
+   * by both units
+   * having the same base type and treat the same base unit magnitude as the same
+   * magnitude in their
+   * own units, to within {@link Measure#EQUIVALENCE_THRESHOLD}.
+   *
+   * @param other the unit to compare to.
+   * @return true if both units are equivalent, false if not
+   */
+  public boolean equivalent(AngleUnit other) {
+
+    double arbitrary = 16_777.214; // 2^24 / 1e3
+
+    return Math.abs(
+        this.m_fromBaseConverter.apply(arbitrary)
+            - other.m_fromBaseConverter.apply(arbitrary)) <= Angle.EQUIVALENCE_THRESHOLD
+        && Math.abs(
+            this.m_toBaseConverter.apply(arbitrary)
+                - other.m_toBaseConverter.apply(arbitrary)) <= Angle.EQUIVALENCE_THRESHOLD;
+  }
+
+  /**
+   * Converts a value in terms of base units to a value in terms of this unit.
+   *
+   * @param valueInBaseUnits the value in base units to convert
+   * @return the equivalent value in terms of this unit
+   */
+  public double fromBaseUnits(double valueInBaseUnits) {
+    return m_fromBaseConverter.apply(valueInBaseUnits);
+  }
+
+  /**
+   * Converts a value in terms of this unit to a value in terms of the base unit.
+   *
+   * @param valueInNativeUnits the value in terms of this unit to convert
+   * @return the equivalent value in terms of the base unit
+   */
+  public double toBaseUnits(double valueInNativeUnits) {
+    return m_toBaseConverter.apply(valueInNativeUnits);
+  }
+
+  /**
+   * Converts a magnitude in terms of another unit of the same dimension to a
+   * magnitude in terms of
+   * this unit.
+   *
+   * <pre>
+   *   Inches.convertFrom(12, Feet) // 144.0
+   *   Kilograms.convertFrom(2.2, Pounds) // 0.9979024
+   * </pre>
+   *
+   * @param magnitude a magnitude measured in another unit
+   * @param otherUnit the unit to convert the magnitude to
+   * @return the corresponding value in terms of this unit.
+   */
+  public double convertFrom(double magnitude, AngleUnit otherUnit) {
+    if (this.equivalent(otherUnit.getBaseUnit().get())) {
+      // same unit, don't bother converting
+      return magnitude;
+    }
+    return this.fromBaseUnits(otherUnit.toBaseUnits(magnitude));
+  }
+
+  /**
+   * Gets the conversion function used to convert values to base unit terms. This
+   * generally
+   * shouldn't need to be used directly; prefer {@link #toBaseUnits(double)}
+   * instead.
+   *
+   * @return the conversion function
+   */
+  public UnaryFunction getConverterToBase() {
+    return m_toBaseConverter;
+  }
+
+  /**
+   * Gets the conversion function used to convert values to terms of this unit.
+   * This generally
+   * shouldn't need to be used directly; prefer {@link #fromBaseUnits(double)}
+   * instead.
+   *
+   * @return the conversion function
+   */
+  public UnaryFunction getConverterFromBase() {
+    return m_fromBaseConverter;
+  }
+
+  /**
+   * Creates a new measure of this unit with the given value. The resulting
+   * measure is
+   * <i>immutable</i> and cannot have its value modified.
+   *
+   * @param magnitude the magnitude of the measure to create
+   * @return the measure
+   */
+  public Angle of(double magnitude) {
+    if (magnitude == 0) {
+      // reuse static object
+      return zero();
+    }
+    if (magnitude == 1) {
+      // reuse static object
+      return one();
+    }
+    return Angle.ofRelativeUnits(magnitude, this);
+  }
+
+  /**
+   * Creates a new measure with a magnitude equal to the given base unit
+   * magnitude, converted to be
+   * in terms of this unit.
+   *
+   * @param baseUnitMagnitude the magnitude of the measure in terms of the base
+   *                          unit
+   * @return the measure
+   */
+  public Angle ofBaseUnits(double baseUnitMagnitude) {
+    return Angle.ofBaseUnits(baseUnitMagnitude, this);
+  }
+
+  /**
+   * Gets a measure with a magnitude of 0 in terms of this unit.
+   *
+   * @return the zero-valued measure
+   */
+  public Angle zero() {
+    // lazy init because 'this' is null in object initialization
+    if (m_zero == null) {
+      m_zero = Angle.ofRelativeUnits(0, this);
+    }
+    return m_zero;
+  }
+
+  /**
+   * Gets a measure with a magnitude of 1 in terms of this unit.
+   *
+   * @return the 1-valued measure
+   */
+  public Angle one() {
+    // lazy init because 'this' is null in object initialization
+    if (m_one == null) {
+      m_one = Angle.ofRelativeUnits(1, this);
+    }
+    return m_one;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return this == o
+        || o instanceof AngleUnit that
+            && m_name.equals(that.m_name)
+            && m_symbol.equals(that.m_symbol)
+            && this.equivalent(that);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(m_toBaseConverter, m_fromBaseConverter, m_name, m_symbol);
+  }
+
+  /**
+   * Gets the name of this unit.
+   *
+   * @return the unit's name
+   */
+  public String name() {
+    return m_name;
+  }
+
+  /**
+   * Gets the symbol of this unit.
+   *
+   * @return the unit's symbol
+   */
+  public String symbol() {
+    return m_symbol;
+  }
+
+  @Override
+  public String toString() {
+    return name();
+  }
+
+  public AngularVelocityUnit per(TimeUnit timeUnit){
+    return new AngularVelocityUnit(this, timeUnit);
+  }
+}

--- a/wpiunits/src/main/java/edu/wpi/first/units/angle/MutableAngle.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/angle/MutableAngle.java
@@ -1,6 +1,10 @@
 package edu.wpi.first.units.angle;
 
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.angularvelocity.AngularVelocity;
+import edu.wpi.first.units.angularvelocity.MutableAngularVelocity;
 import edu.wpi.first.units.dimensionless.Dimensionless;
+import edu.wpi.first.units.time.Time;
 
 public class MutableAngle extends Angle {
 
@@ -261,4 +265,10 @@ public class MutableAngle extends Angle {
   public MutableAngle mut_divide(Dimensionless divisor) {
     return mut_divide(divisor.baseUnitMagnitude());
   }
+
+  @Override
+  public MutableAngularVelocity divide(Time time) {
+    return AngularVelocity.combine(this, time).mutableCopy();
+  }   
+
 }

--- a/wpiunits/src/main/java/edu/wpi/first/units/angle/MutableAngle.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/angle/MutableAngle.java
@@ -1,0 +1,264 @@
+package edu.wpi.first.units.angle;
+
+import edu.wpi.first.units.dimensionless.Dimensionless;
+
+public class MutableAngle extends Angle {
+
+  /**
+   * Creates a new mutable measure that is a copy of the given one.
+   *
+   * @param measure the measure to create a mutable copy of
+   * @return a new mutable measure with an initial state equal to the given
+   *         measure
+   */
+  public static MutableAngle mutable(Angle measure) {
+    return new MutableAngle(measure.magnitude(), measure.baseUnitMagnitude(),
+        measure.unit());
+  }
+
+  /**
+   * Creates a new mutable measure with a magnitude of 0 in the given unit.
+   *
+   * @param unit the unit of measure
+   * @return a new mutable measure
+   */
+  public static MutableAngle zero(AngleUnit unit) {
+    return mutable(unit.zero());
+  }
+
+  /**
+   * Creates a new mutable measure in the given unit with a magnitude equal to
+   * the
+   * given one in base
+   * units.
+   *
+   * @param baseUnitMagnitude the magnitude of the measure, in terms of the base
+   *                          unit of measure
+   * @param unit              the unit of measure
+   * @return a new mutable measure
+   */
+  public static MutableAngle ofBaseUnits(double baseUnitMagnitude, AngleUnit unit) {
+    return new MutableAngle(unit.fromBaseUnits(baseUnitMagnitude),
+        baseUnitMagnitude, unit);
+  }
+
+  /**
+   * Creates a new mutable measure in the given unit with a magnitude in terms
+   * of
+   * that unit.
+   *
+   * @param <U>               the type of the units of measure
+   * @param relativeMagnitude the magnitude of the measure
+   * @param unit              the unit of measure
+   * @return a new mutable measure
+   */
+  public static MutableAngle ofRelativeUnits(double relativeMagnitude, AngleUnit unit) {
+    return new MutableAngle(relativeMagnitude, unit.toBaseUnits(relativeMagnitude), unit);
+  }
+
+  private MutableAngle(double initialMagnitude, double baseUnitMagnitude, AngleUnit unit) {
+    super(initialMagnitude, baseUnitMagnitude, unit);
+  }
+
+  // UNSAFE
+
+  /**
+   * Sets the new magnitude of the measurement. The magnitude must be in terms
+   * of
+   * the {@link
+   * #unit()}.
+   *
+   * @param magnitude the new magnitude of the measurement
+   */
+  public void mut_setMagnitude(double magnitude) {
+    m_magnitude = magnitude;
+    m_baseUnitMagnitude = m_unit.toBaseUnits(magnitude);
+  }
+
+  /**
+   * Sets the new magnitude of the measurement. The magnitude must be in terms
+   * of
+   * the base unit of
+   * the current unit.
+   *
+   * @param baseUnitMagnitude the new magnitude of the measurement
+   */
+  public void mut_setBaseUnitMagnitude(double baseUnitMagnitude) {
+    m_baseUnitMagnitude = baseUnitMagnitude;
+    m_magnitude = m_unit.fromBaseUnits(baseUnitMagnitude);
+  }
+
+  /**
+   * Overwrites the state of this measure and replaces it with values from the
+   * given one.
+   *
+   * @param other the other measure to copy values from
+   * @return this measure
+   */
+  public MutableAngle mut_replace(Angle other) {
+    m_magnitude = other.magnitude();
+    m_baseUnitMagnitude = other.baseUnitMagnitude();
+    m_unit = other.unit();
+    return this;
+  }
+
+  /**
+   * Overwrites the state of this measure with new values.
+   *
+   * @param magnitude the new magnitude in terms of the new unit
+   * @param unit      the new unit
+   * @return this measure
+   */
+  public MutableAngle mut_replace(double magnitude, AngleUnit unit) {
+    this.m_magnitude = magnitude;
+    this.m_baseUnitMagnitude = unit.toBaseUnits(magnitude);
+    this.m_unit = unit;
+    return this;
+  }
+
+  /**
+   * Increments (or decrements)
+   * the current magnitude of the measure by the given value. The value
+   * must be in terms
+   * of the current {@link #unit() unit}.
+   *
+   * @param raw the raw value to increment by
+   * @return the measure
+   */
+  public MutableAngle mut_increment(double raw) {
+    this.m_magnitude += raw;
+    this.m_baseUnitMagnitude += m_unit.toBaseUnits(raw);
+    return this;
+  }
+
+  /**
+   * Increments (or decrements) the current magnitude
+   * of the measure by the amount of the given measure.
+   *
+   * @param other the measure whose value should be added to this one
+   * @return the measure
+   */
+  public MutableAngle mut_increment(Angle other) {
+    m_baseUnitMagnitude += other.baseUnitMagnitude();
+    // can't naively use m_magnitude += other.in(m_unit) because the units may
+    // not
+    // be scalar multiples (eg adding 0C to 100K should result in 373.15K, not
+    // 100K)
+    m_magnitude = m_unit.fromBaseUnits(m_baseUnitMagnitude);
+    return this;
+  }
+
+  // Math
+
+  /**
+   * Adds another measurement to this one. This will mutate the object instead of
+   * generating a new
+   * measurement object.
+   *
+   * @param other the measurement to add
+   * @return this measure
+   */
+  public MutableAngle mut_plus(Angle other) {
+    return mut_plus(other.magnitude(), other.unit());
+  }
+
+  /**
+   * Adds another measurement to this one. This will mutate the object instead
+   * of
+   * generating a new
+   * measurement object. This is a denormalized version of
+   * {@link #mut_plus(Measure)} to avoid
+   * having to wrap raw numbers in a {@code Measure} object and pay for an
+   * object
+   * allocation.
+   *
+   * @param magnitude the magnitude of the other measurement.
+   * @param unit      the unit of the other measurement
+   * @return this measure
+   */
+  public MutableAngle mut_plus(double magnitude, AngleUnit unit) {
+    mut_setBaseUnitMagnitude(m_baseUnitMagnitude + unit.toBaseUnits(magnitude));
+    return this;
+  }
+
+  /**
+   * Subtracts another measurement to this one. This will mutate the object
+   * instead of generating a
+   * new measurement object.
+   *
+   * @param other the measurement to add
+   * @return this measure
+   */
+  public MutableAngle mut_minus(Angle other) {
+    return mut_minus(other.magnitude(), other.unit());
+  }
+
+  /**
+   * Subtracts another measurement to this one. This will mutate the object
+   * instead of generating a
+   * new measurement object. This is a denormalized version of
+   * {@link #mut_minus(Measure)} to avoid
+   * having to wrap raw numbers in a {@code Measure} object and pay for an
+   * object
+   * allocation.
+   *
+   * @param magnitude the magnitude of the other measurement.
+   * @param unit      the unit of the other measurement
+   * @return this measure
+   */
+  public MutableAngle mut_minus(double magnitude, AngleUnit unit) {
+    return mut_plus(-magnitude, unit);
+  }
+
+  /**
+   * Multiplies this measurement by some constant value. This will mutate the
+   * object instead of
+   * generating a new measurement object.
+   *
+   * @param multiplier the multiplier to scale the measurement by
+   * @return this measure
+   */
+  public MutableAngle mut_times(double multiplier) {
+    mut_setBaseUnitMagnitude(m_baseUnitMagnitude * multiplier);
+    return this;
+  }
+
+  /**
+   * Multiplies this measurement by some constant value. This will mutate the
+   * object instead of
+   * generating a new measurement object.
+   *
+   * @param multiplier the multiplier to scale the measurement by
+   * @return this measure
+   */
+  public MutableAngle mut_times(Dimensionless multiplier) {
+    return mut_times(multiplier.baseUnitMagnitude());
+  }
+
+  /**
+   * Divides this measurement by some constant value. This will mutate the
+   * object
+   * instead of
+   * generating a new measurement object.
+   *
+   * @param divisor the divisor to scale the measurement by
+   * @return this measure
+   */
+  public MutableAngle mut_divide(double divisor) {
+    mut_setBaseUnitMagnitude(m_baseUnitMagnitude / divisor);
+    return this;
+  }
+
+  /**
+   * Divides this measurement by some constant value. This will mutate the
+   * object
+   * instead of
+   * generating a new measurement object.
+   *
+   * @param divisor the divisor to scale the measurement by
+   * @return this measure
+   */
+  public MutableAngle mut_divide(Dimensionless divisor) {
+    return mut_divide(divisor.baseUnitMagnitude());
+  }
+}

--- a/wpiunits/src/main/java/edu/wpi/first/units/angularacceleration/AngularAcceleration.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/angularacceleration/AngularAcceleration.java
@@ -2,22 +2,20 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package edu.wpi.first.units.angularvelocity;
+package edu.wpi.first.units.angularacceleration;
 
-import static edu.wpi.first.units.angle.AngleUnit.Degrees;
-import static edu.wpi.first.units.angle.AngleUnit.Radians;
-import static edu.wpi.first.units.angle.AngleUnit.Revolutions;
-import static edu.wpi.first.units.time.TimeUnit.Minute;
 import static edu.wpi.first.units.time.TimeUnit.Seconds;
-import static edu.wpi.first.units.angularvelocity.AngularVelocityUnit.RPM;
+import static edu.wpi.first.units.angularacceleration.AngularAccelerationUnit.RadiansPerSecondPerSecond;
+import static edu.wpi.first.units.angularacceleration.AngularAccelerationUnit.RotationsPerSecondPerSecond;
+import static edu.wpi.first.units.angularvelocity.AngularVelocityUnit.DegreesPerSecond;
 import static edu.wpi.first.units.angularvelocity.AngularVelocityUnit.RadiansPerSecond;
-import static edu.wpi.first.units.angularvelocity.AngularVelocityUnit.RevolutionsPerSecond;
+import static edu.wpi.first.units.angularvelocity.AngularVelocityUnit.RotationsPerSecond;
+import static edu.wpi.first.units.angularacceleration.AngularAccelerationUnit.DegreesPerSecondPerSecond;
 
 import java.util.Objects;
 
 import edu.wpi.first.units.Measure;
-import edu.wpi.first.units.angle.Angle;
-import edu.wpi.first.units.angularacceleration.AngularAcceleration;
+import edu.wpi.first.units.angularvelocity.AngularVelocity;
 import edu.wpi.first.units.time.Time;
 
 /**
@@ -30,7 +28,7 @@ import edu.wpi.first.units.time.Time;
  * <i>magnitude</i> are effectively equivalent objects.
  *
  */
-public class AngularVelocity implements Comparable<AngularVelocity> {
+public class AngularAcceleration implements Comparable<AngularAcceleration> {
 
   /**
    * The threshold for two measures to be considered equivalent if converted to
@@ -41,7 +39,7 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
 
   protected double m_magnitude;
   protected double m_baseUnitMagnitude;
-  protected AngularVelocityUnit m_unit;
+  protected AngularAccelerationUnit m_unit;
 
   /**
    * Creates a new immutable Dimensionless measure instance. This shouldn't be
@@ -52,7 +50,7 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @param magnitude the magnitude of this measure
    * @param unit      the unit of this measure.
    */
-  AngularVelocity(double magnitude, double baseUnitMagnitude, AngularVelocityUnit unit) {
+  AngularAcceleration(double magnitude, double baseUnitMagnitude, AngularAccelerationUnit unit) {
     Objects.requireNonNull(unit, "Unit cannot be null");
     m_magnitude = magnitude;
     m_baseUnitMagnitude = baseUnitMagnitude;
@@ -85,7 +83,7 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    *
    * @return the unit
    */
-  public AngularVelocityUnit unit() {
+  public AngularAccelerationUnit unit() {
     return m_unit;
   }
 
@@ -103,7 +101,7 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @param unit the unit to convert this measure to
    * @return the value of this measure in the given unit
    */
-  public double in(AngularVelocityUnit unit) {
+  public double in(AngularAccelerationUnit unit) {
     if (this.unit().equals(unit)) {
       return magnitude();
     } else {
@@ -123,8 +121,8 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @param multiplier the constant to multiply by
    * @return the resulting measure
    */
-  public AngularVelocity times(double multiplier) {
-    return AngularVelocity.ofBaseUnits(baseUnitMagnitude() * multiplier, unit());
+  public AngularAcceleration times(double multiplier) {
+    return AngularAcceleration.ofBaseUnits(baseUnitMagnitude() * multiplier, unit());
   }
 
   /**
@@ -136,7 +134,7 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @return the resulting measure
    * @see #times(double)
    */
-  public AngularVelocity divide(double divisor) {
+  public AngularAcceleration divide(double divisor) {
     return times(1 / divisor);
   }
 
@@ -147,7 +145,7 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @param other the measure to add to this one
    * @return a new measure containing the result
    */
-  public AngularVelocity plus(AngularVelocity other) {
+  public AngularAcceleration plus(AngularAcceleration other) {
     return unit().ofBaseUnits(baseUnitMagnitude() + other.baseUnitMagnitude());
   }
 
@@ -158,7 +156,7 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @param other the measure to subtract from this one
    * @return a new measure containing the result
    */
-  public AngularVelocity minus(AngularVelocity other) {
+  public AngularAcceleration minus(AngularAcceleration other) {
     return unit().ofBaseUnits(baseUnitMagnitude() - other.baseUnitMagnitude());
   }
 
@@ -167,7 +165,7 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    *
    * @return the resulting measure
    */
-  public AngularVelocity negate() {
+  public AngularAcceleration negate() {
     return times(-1);
   }
 
@@ -178,8 +176,8 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    *
    * @return the copied measure
    */
-  public AngularVelocity copy() {
-    return new AngularVelocity(m_magnitude, m_baseUnitMagnitude, m_unit);
+  public AngularAcceleration copy() {
+    return new AngularAcceleration(m_magnitude, m_baseUnitMagnitude, m_unit);
   }
 
   /**
@@ -187,8 +185,8 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    *
    * @return a mutable measure initialized to be identical to this measure
    */
-  public MutableAngularVelocity mutableCopy() {
-    return MutableAngularVelocity.mutable(this);
+  public MutableAngularAcceleration mutableCopy() {
+    return MutableAngularAcceleration.mutable(this);
   }
 
   /**
@@ -210,7 +208,7 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    *                          0.01 should be passed, and so on.
    * @return true if this unit is near the other measure, otherwise false
    */
-  public boolean isNear(AngularVelocity other, double varianceThreshold) {
+  public boolean isNear(AngularAcceleration other, double varianceThreshold) {
     // abs so negative inputs are calculated correctly
     var tolerance = Math.abs(other.baseUnitMagnitude() * varianceThreshold);
 
@@ -233,14 +231,14 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    *                  other.
    * @return true if this unit is near the other measure, otherwise false.
    */
-  public boolean isNear(AngularVelocity other, AngularVelocity tolerance) {
+  public boolean isNear(AngularAcceleration other, AngularAcceleration tolerance) {
     return Math.abs(this.baseUnitMagnitude() - other.baseUnitMagnitude()) <= Math
         .abs(tolerance.baseUnitMagnitude());
   }
 
   /** {@inheritDoc} */
   @Override
-  public int compareTo(AngularVelocity o) {
+  public int compareTo(AngularAcceleration o) {
     return Double.compare(this.baseUnitMagnitude(), o.baseUnitMagnitude());
   }
 
@@ -251,7 +249,7 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @return true if this measure has a greater equivalent magnitude, false
    *         otherwise
    */
-  public boolean gt(AngularVelocity o) {
+  public boolean gt(AngularAcceleration o) {
     return compareTo(o) > 0;
   }
 
@@ -263,7 +261,7 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @return true if this measure has an equal or greater magnitude,
    *         false otherwise
    */
-  public boolean gte(AngularVelocity o) {
+  public boolean gte(AngularAcceleration o) {
     return compareTo(o) > 0 || equals(o);
   }
 
@@ -274,7 +272,7 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @return true if this measure has a lesser equivalent magnitude, false
    *         otherwise
    */
-  public boolean lt(AngularVelocity o) {
+  public boolean lt(AngularAcceleration o) {
     return compareTo(o) < 0;
   }
 
@@ -286,7 +284,7 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @return true if this measure has an equal or lesser equivalent magnitude,
    *         false otherwise
    */
-  public boolean lte(AngularVelocity o) {
+  public boolean lte(AngularAcceleration o) {
     return compareTo(o) < 0 || equals(o);
   }
 
@@ -300,23 +298,21 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @return the angular velocity measurement
    */
 
-  public static AngularVelocity combine(Angle angle, Time time) {
-    AngularVelocityUnit angularVelocityUnit = null;
-    if (angle.unit().equals(Radians) && time.unit().equals(Seconds)) {
-      angularVelocityUnit = RadiansPerSecond;
-    } else if (angle.unit().equals(Revolutions) && time.unit().equals(Seconds)) {
-      angularVelocityUnit = RevolutionsPerSecond;
-    } else if (angle.unit().equals(Degrees) && time.unit().equals(Seconds)) {
-      angularVelocityUnit = RevolutionsPerSecond;
-    } else if (angle.unit().equals(Revolutions) && time.unit().equals(Minute)) {
-      angularVelocityUnit = RPM;
+  public static AngularAcceleration combine(AngularVelocity angle, Time time) {
+    AngularAccelerationUnit unit = null;
+    if (angle.unit().equals(RadiansPerSecond) && time.unit().equals(Seconds)) {
+      unit = RadiansPerSecondPerSecond;
+    } else if (angle.unit().equals(DegreesPerSecond) && time.unit().equals(Seconds)) {
+      unit = DegreesPerSecondPerSecond;
+    } else if (angle.unit().equals(RotationsPerSecond) && time.unit().equals(Seconds)) {
+      unit = RotationsPerSecondPerSecond;
     } else {
-      angularVelocityUnit = angle.unit().per(time.unit());
+      unit = angle.unit().per(time.unit());
     }
-    return new AngularVelocity(
+    return new AngularAcceleration(
         angle.magnitude() / time.magnitude(),
         angle.baseUnitMagnitude() / time.baseUnitMagnitude(),
-        angularVelocityUnit);
+        unit);
   }
 
   /**
@@ -327,13 +323,13 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @return the measure with the greatest positive magnitude, or null if no
    *         measures were provided
    */
-  static AngularVelocity max(AngularVelocity... measures) {
+  static AngularAcceleration max(AngularAcceleration... measures) {
     if (measures.length == 0) {
       return null; // nothing to compare
     }
 
-    AngularVelocity max = null;
-    for (AngularVelocity measure : measures) {
+    AngularAcceleration max = null;
+    for (AngularAcceleration measure : measures) {
       if (max == null || measure.gt(max)) {
         max = measure;
       }
@@ -349,13 +345,13 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @param measures the set of measures to compare
    * @return the measure with the greatest negative magnitude
    */
-  static AngularVelocity min(AngularVelocity... measures) {
+  static AngularAcceleration min(AngularAcceleration... measures) {
     if (measures.length == 0) {
       return null; // nothing to compare
     }
 
-    AngularVelocity max = null;
-    for (AngularVelocity measure : measures) {
+    AngularAcceleration max = null;
+    for (AngularAcceleration measure : measures) {
       if (max == null || measure.lt(max)) {
         max = measure;
       }
@@ -403,9 +399,9 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @param unit              the unit of measure
    * @return a new measure
    */
-  public static AngularVelocity ofBaseUnits(
-      double baseUnitMagnitude, AngularVelocityUnit unit) {
-    return new AngularVelocity(unit.fromBaseUnits(baseUnitMagnitude), baseUnitMagnitude, unit);
+  public static AngularAcceleration ofBaseUnits(
+      double baseUnitMagnitude, AngularAccelerationUnit unit) {
+    return new AngularAcceleration(unit.fromBaseUnits(baseUnitMagnitude), baseUnitMagnitude, unit);
   }
 
   /**
@@ -417,9 +413,9 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    * @param unit              the unit of measure
    * @return a new measure
    */
-  public static AngularVelocity ofRelativeUnits(
-      double relativeMagnitude, AngularVelocityUnit unit) {
-    return new AngularVelocity(relativeMagnitude, unit.toBaseUnits(relativeMagnitude), unit);
+  public static AngularAcceleration ofRelativeUnits(
+      double relativeMagnitude, AngularAccelerationUnit unit) {
+    return new AngularAcceleration(relativeMagnitude, unit.toBaseUnits(relativeMagnitude), unit);
   }
 
   /**
@@ -429,7 +425,7 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
    */
   @Override
   public boolean equals(Object o) {
-    return o instanceof AngularVelocity other
+    return o instanceof AngularAcceleration other
         && Objects.equals(m_unit, other.unit())
         && Math.abs(baseUnitMagnitude() - other.baseUnitMagnitude()) <= EQUIVALENCE_THRESHOLD;
   }
@@ -442,10 +438,6 @@ public class AngularVelocity implements Comparable<AngularVelocity> {
   @Override
   public String toString() {
     return toShortString();
-  }
-
-  public AngularAcceleration divide(Time time) {
-    return AngularAcceleration.combine(this, time);
   }
 
 }

--- a/wpiunits/src/main/java/edu/wpi/first/units/angularacceleration/AngularAccelerationUnit.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/angularacceleration/AngularAccelerationUnit.java
@@ -2,21 +2,18 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package edu.wpi.first.units.angularvelocity;
+package edu.wpi.first.units.angularacceleration;
 
-import static edu.wpi.first.units.time.TimeUnit.Minute;
 import static edu.wpi.first.units.time.TimeUnit.Second;
-import static edu.wpi.first.units.angle.AngleUnit.Degrees;
-import static edu.wpi.first.units.angle.AngleUnit.Revolutions;
-import static edu.wpi.first.units.angle.AngleUnit.Rotations;
+import static edu.wpi.first.units.angularvelocity.AngularVelocityUnit.RotationsPerSecond;
+import static edu.wpi.first.units.angularvelocity.AngularVelocityUnit.DegreesPerSecond;
 
 import java.util.Objects;
 import java.util.Optional;
 
 import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.UnaryFunction;
-import edu.wpi.first.units.angle.AngleUnit;
-import edu.wpi.first.units.angularacceleration.AngularAccelerationUnit;
+import edu.wpi.first.units.angularvelocity.AngularVelocityUnit;
 import edu.wpi.first.units.time.TimeUnit;
 
 /**
@@ -24,25 +21,21 @@ import edu.wpi.first.units.time.TimeUnit;
  * degrees.
  *
  */
-public class AngularVelocityUnit {
+public class AngularAccelerationUnit {
 
-  public static final AngularVelocityUnit RadiansPerSecond = new AngularVelocityUnit();
+  public static final AngularAccelerationUnit RadiansPerSecondPerSecond = new AngularAccelerationUnit();
 
-  public static final AngularVelocityUnit RevolutionsPerSecond = Revolutions.per(Second);
+  public static final AngularAccelerationUnit RotationsPerSecondPerSecond = RotationsPerSecond.per(Second);
 
-  public static final AngularVelocityUnit RotationsPerSecond = Rotations.per(Second);
-
-  public static final AngularVelocityUnit DegreesPerSecond = Degrees.per(Second);
-
-  public static final AngularVelocityUnit RPM = Revolutions.per(Minute);
+  public static final AngularAccelerationUnit DegreesPerSecondPerSecond = DegreesPerSecond.per(Second);
 
   private final UnaryFunction m_toBaseConverter;
   private final UnaryFunction m_fromBaseConverter;
 
-  private final Optional<AngularVelocityUnit> m_baseUnit;
+  private final Optional<AngularAccelerationUnit> m_baseUnit;
 
-  private AngularVelocity m_zero;
-  private AngularVelocity m_one;
+  private AngularAcceleration m_zero;
+  private AngularAcceleration m_one;
 
   private final String m_name;
   private final String m_symbol;
@@ -53,15 +46,15 @@ public class AngularVelocityUnit {
    * @param angleUnit the angle unit.
    * @param timeUnit  the time unit.
    */
-  public AngularVelocityUnit(
-      AngleUnit angleUnit,
+  public AngularAccelerationUnit(
+      AngularVelocityUnit angleUnit,
       TimeUnit timeUnit) {
     var angleUnitToBaseConverter = Objects.requireNonNull(angleUnit).getConverterToBase();
     var angleUnitFromBaseConverter = Objects.requireNonNull(angleUnit).getConverterFromBase();
     var timeUnitToBaseConverter = Objects.requireNonNull(timeUnit).getConverterToBase();
     var timeUnitFromBaseConverter = Objects.requireNonNull(timeUnit).getConverterFromBase();
 
-    m_baseUnit = Optional.of(RadiansPerSecond);
+    m_baseUnit = Optional.of(RadiansPerSecondPerSecond);
     m_toBaseConverter = x -> angleUnitToBaseConverter.apply(x) / timeUnitToBaseConverter.apply(x);
     m_fromBaseConverter = x -> angleUnitFromBaseConverter.apply(x) / timeUnitFromBaseConverter.apply(x);
     m_name = angleUnit.name() + " per " + timeUnit.name();
@@ -80,11 +73,11 @@ public class AngularVelocityUnit {
    * @param symbol the short symbol for the unit, such as "rad" for
    *               Radians or "rev" for Revolutions.
    */
-  public AngularVelocityUnit(
-      AngularVelocityUnit other,
+  public AngularAccelerationUnit(
+      AngularAccelerationUnit other,
       String name,
       String symbol) {
-    m_baseUnit = Optional.of(RadiansPerSecond);
+    m_baseUnit = Optional.of(RadiansPerSecondPerSecond);
     m_toBaseConverter = other.m_toBaseConverter;
     m_fromBaseConverter = other.m_fromBaseConverter;
     m_name = name;
@@ -95,7 +88,7 @@ public class AngularVelocityUnit {
    * Instantiates the base unit for angles (i.e. Radians). Only used once by the
    * static field Radians.
    */
-  private AngularVelocityUnit() {
+  private AngularAccelerationUnit() {
     m_baseUnit = Optional.empty();
     m_fromBaseConverter = x -> x;
     m_toBaseConverter = x -> x;
@@ -120,7 +113,7 @@ public class AngularVelocityUnit {
    *
    * @return the base unit
    */
-  public Optional<AngularVelocityUnit> getBaseUnit() {
+  public Optional<AngularAccelerationUnit> getBaseUnit() {
     return m_baseUnit;
   }
 
@@ -143,16 +136,16 @@ public class AngularVelocityUnit {
    * @param other the unit to compare to.
    * @return true if both units are equivalent, false if not
    */
-  public boolean equivalent(AngularVelocityUnit other) {
+  public boolean equivalent(AngularAccelerationUnit other) {
 
     double arbitrary = 16_777.214; // 2^24 / 1e3
 
     return Math.abs(
         this.m_fromBaseConverter.apply(arbitrary)
-            - other.m_fromBaseConverter.apply(arbitrary)) <= AngularVelocity.EQUIVALENCE_THRESHOLD
+            - other.m_fromBaseConverter.apply(arbitrary)) <= AngularAcceleration.EQUIVALENCE_THRESHOLD
         && Math.abs(
             this.m_toBaseConverter.apply(arbitrary)
-                - other.m_toBaseConverter.apply(arbitrary)) <= AngularVelocity.EQUIVALENCE_THRESHOLD;
+                - other.m_toBaseConverter.apply(arbitrary)) <= AngularAcceleration.EQUIVALENCE_THRESHOLD;
   }
 
   /**
@@ -189,7 +182,7 @@ public class AngularVelocityUnit {
    * @param otherUnit the unit to convert the magnitude to
    * @return the corresponding value in terms of this unit.
    */
-  public double convertFrom(double magnitude, AngularVelocityUnit otherUnit) {
+  public double convertFrom(double magnitude, AngularAccelerationUnit otherUnit) {
     if (this.equivalent(otherUnit.getBaseUnit().get())) {
       // same unit, don't bother converting
       return magnitude;
@@ -229,7 +222,7 @@ public class AngularVelocityUnit {
    * @param magnitude the magnitude of the measure to create
    * @return the measure
    */
-  public AngularVelocity of(double magnitude) {
+  public AngularAcceleration of(double magnitude) {
     if (magnitude == 0) {
       // reuse static object
       return zero();
@@ -238,7 +231,7 @@ public class AngularVelocityUnit {
       // reuse static object
       return one();
     }
-    return AngularVelocity.ofRelativeUnits(magnitude, this);
+    return AngularAcceleration.ofRelativeUnits(magnitude, this);
   }
 
   /**
@@ -250,8 +243,8 @@ public class AngularVelocityUnit {
    *                          unit
    * @return the measure
    */
-  public AngularVelocity ofBaseUnits(double baseUnitMagnitude) {
-    return AngularVelocity.ofBaseUnits(baseUnitMagnitude, this);
+  public AngularAcceleration ofBaseUnits(double baseUnitMagnitude) {
+    return AngularAcceleration.ofBaseUnits(baseUnitMagnitude, this);
   }
 
   /**
@@ -259,10 +252,10 @@ public class AngularVelocityUnit {
    *
    * @return the zero-valued measure
    */
-  public AngularVelocity zero() {
+  public AngularAcceleration zero() {
     // lazy init because 'this' is null in object initialization
     if (m_zero == null) {
-      m_zero = AngularVelocity.ofRelativeUnits(0, this);
+      m_zero = AngularAcceleration.ofRelativeUnits(0, this);
     }
     return m_zero;
   }
@@ -272,10 +265,10 @@ public class AngularVelocityUnit {
    *
    * @return the 1-valued measure
    */
-  public AngularVelocity one() {
+  public AngularAcceleration one() {
     // lazy init because 'this' is null in object initialization
     if (m_one == null) {
-      m_one = AngularVelocity.ofRelativeUnits(1, this);
+      m_one = AngularAcceleration.ofRelativeUnits(1, this);
     }
     return m_one;
   }
@@ -283,7 +276,7 @@ public class AngularVelocityUnit {
   @Override
   public boolean equals(Object o) {
     return this == o
-        || o instanceof AngularVelocityUnit that
+        || o instanceof AngularAccelerationUnit that
             && m_name.equals(that.m_name)
             && m_symbol.equals(that.m_symbol)
             && this.equivalent(that);
@@ -315,9 +308,5 @@ public class AngularVelocityUnit {
   @Override
   public String toString() {
     return name();
-  }
-
-  public AngularAccelerationUnit per(TimeUnit timeUnit) {
-    return new AngularAccelerationUnit(this, timeUnit);
   }
 }

--- a/wpiunits/src/main/java/edu/wpi/first/units/angularacceleration/MutableAngularAcceleration.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/angularacceleration/MutableAngularAcceleration.java
@@ -1,12 +1,12 @@
-package edu.wpi.first.units.angularvelocity;
+package edu.wpi.first.units.angularacceleration;
 
 import edu.wpi.first.units.Measure;
-import edu.wpi.first.units.angularacceleration.AngularAcceleration;
-import edu.wpi.first.units.angularacceleration.MutableAngularAcceleration;
+import edu.wpi.first.units.angularvelocity.AngularVelocity;
+import edu.wpi.first.units.angularvelocity.MutableAngularVelocity;
 import edu.wpi.first.units.dimensionless.Dimensionless;
 import edu.wpi.first.units.time.Time;
 
-public class MutableAngularVelocity extends AngularVelocity {
+public class MutableAngularAcceleration extends AngularAcceleration {
 
   /**
    * Creates a new mutable measure that is a copy of the given one.
@@ -15,8 +15,8 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @return a new mutable measure with an initial state equal to the given
    *         measure
    */
-  public static MutableAngularVelocity mutable(AngularVelocity measure) {
-    return new MutableAngularVelocity(measure.magnitude(), measure.baseUnitMagnitude(),
+  public static MutableAngularAcceleration mutable(AngularAcceleration measure) {
+    return new MutableAngularAcceleration(measure.magnitude(), measure.baseUnitMagnitude(),
         measure.unit());
   }
 
@@ -26,7 +26,7 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param unit the unit of measure
    * @return a new mutable measure
    */
-  public static MutableAngularVelocity zero(AngularVelocityUnit unit) {
+  public static MutableAngularAcceleration zero(AngularAccelerationUnit unit) {
     return mutable(unit.zero());
   }
 
@@ -41,8 +41,8 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param unit              the unit of measure
    * @return a new mutable measure
    */
-  public static MutableAngularVelocity ofBaseUnits(double baseUnitMagnitude, AngularVelocityUnit unit) {
-    return new MutableAngularVelocity(unit.fromBaseUnits(baseUnitMagnitude),
+  public static MutableAngularAcceleration ofBaseUnits(double baseUnitMagnitude, AngularAccelerationUnit unit) {
+    return new MutableAngularAcceleration(unit.fromBaseUnits(baseUnitMagnitude),
         baseUnitMagnitude, unit);
   }
 
@@ -56,11 +56,11 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param unit              the unit of measure
    * @return a new mutable measure
    */
-  public static MutableAngularVelocity ofRelativeUnits(double relativeMagnitude, AngularVelocityUnit unit) {
-    return new MutableAngularVelocity(relativeMagnitude, unit.toBaseUnits(relativeMagnitude), unit);
+  public static MutableAngularAcceleration ofRelativeUnits(double relativeMagnitude, AngularAccelerationUnit unit) {
+    return new MutableAngularAcceleration(relativeMagnitude, unit.toBaseUnits(relativeMagnitude), unit);
   }
 
-  private MutableAngularVelocity(double initialMagnitude, double baseUnitMagnitude, AngularVelocityUnit unit) {
+  private MutableAngularAcceleration(double initialMagnitude, double baseUnitMagnitude, AngularAccelerationUnit unit) {
     super(initialMagnitude, baseUnitMagnitude, unit);
   }
 
@@ -99,7 +99,7 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param other the other measure to copy values from
    * @return this measure
    */
-  public MutableAngularVelocity mut_replace(AngularVelocity other) {
+  public MutableAngularAcceleration mut_replace(AngularAcceleration other) {
     m_magnitude = other.magnitude();
     m_baseUnitMagnitude = other.baseUnitMagnitude();
     m_unit = other.unit();
@@ -113,7 +113,7 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param unit      the new unit
    * @return this measure
    */
-  public MutableAngularVelocity mut_replace(double magnitude, AngularVelocityUnit unit) {
+  public MutableAngularAcceleration mut_replace(double magnitude, AngularAccelerationUnit unit) {
     this.m_magnitude = magnitude;
     this.m_baseUnitMagnitude = unit.toBaseUnits(magnitude);
     this.m_unit = unit;
@@ -129,7 +129,7 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param raw the raw value to increment by
    * @return the measure
    */
-  public MutableAngularVelocity mut_increment(double raw) {
+  public MutableAngularAcceleration mut_increment(double raw) {
     this.m_magnitude += raw;
     this.m_baseUnitMagnitude += m_unit.toBaseUnits(raw);
     return this;
@@ -142,7 +142,7 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param other the measure whose value should be added to this one
    * @return the measure
    */
-  public MutableAngularVelocity mut_increment(AngularVelocity other) {
+  public MutableAngularAcceleration mut_increment(AngularAcceleration other) {
     m_baseUnitMagnitude += other.baseUnitMagnitude();
     // can't naively use m_magnitude += other.in(m_unit) because the units may
     // not
@@ -162,7 +162,7 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param other the measurement to add
    * @return this measure
    */
-  public MutableAngularVelocity mut_plus(AngularVelocity other) {
+  public MutableAngularAcceleration mut_plus(AngularAcceleration other) {
     return mut_plus(other.magnitude(), other.unit());
   }
 
@@ -180,7 +180,7 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param unit      the unit of the other measurement
    * @return this measure
    */
-  public MutableAngularVelocity mut_plus(double magnitude, AngularVelocityUnit unit) {
+  public MutableAngularAcceleration mut_plus(double magnitude, AngularAccelerationUnit unit) {
     mut_setBaseUnitMagnitude(m_baseUnitMagnitude + unit.toBaseUnits(magnitude));
     return this;
   }
@@ -193,7 +193,7 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param other the measurement to add
    * @return this measure
    */
-  public MutableAngularVelocity mut_minus(AngularVelocity other) {
+  public MutableAngularAcceleration mut_minus(AngularAcceleration other) {
     return mut_minus(other.magnitude(), other.unit());
   }
 
@@ -210,7 +210,7 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param unit      the unit of the other measurement
    * @return this measure
    */
-  public MutableAngularVelocity mut_minus(double magnitude, AngularVelocityUnit unit) {
+  public MutableAngularAcceleration mut_minus(double magnitude, AngularAccelerationUnit unit) {
     return mut_plus(-magnitude, unit);
   }
 
@@ -222,7 +222,7 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param multiplier the multiplier to scale the measurement by
    * @return this measure
    */
-  public MutableAngularVelocity mut_times(double multiplier) {
+  public MutableAngularAcceleration mut_times(double multiplier) {
     mut_setBaseUnitMagnitude(m_baseUnitMagnitude * multiplier);
     return this;
   }
@@ -235,7 +235,7 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param multiplier the multiplier to scale the measurement by
    * @return this measure
    */
-  public MutableAngularVelocity mut_times(Dimensionless multiplier) {
+  public MutableAngularAcceleration mut_times(Dimensionless multiplier) {
     return mut_times(multiplier.baseUnitMagnitude());
   }
 
@@ -248,7 +248,7 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param divisor the divisor to scale the measurement by
    * @return this measure
    */
-  public MutableAngularVelocity mut_divide(double divisor) {
+  public MutableAngularAcceleration mut_divide(double divisor) {
     mut_setBaseUnitMagnitude(m_baseUnitMagnitude / divisor);
     return this;
   }
@@ -262,12 +262,10 @@ public class MutableAngularVelocity extends AngularVelocity {
    * @param divisor the divisor to scale the measurement by
    * @return this measure
    */
-  public MutableAngularVelocity mut_divide(Dimensionless divisor) {
+  public MutableAngularAcceleration mut_divide(Dimensionless divisor) {
     return mut_divide(divisor.baseUnitMagnitude());
   }
 
-  @Override
-  public MutableAngularAcceleration divide(Time time) {
-    return AngularAcceleration.combine(this, time).mutableCopy();
-  }  
+ 
+
 }

--- a/wpiunits/src/main/java/edu/wpi/first/units/angularvelocity/AngularVelocity.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/angularvelocity/AngularVelocity.java
@@ -1,0 +1,445 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.units.angularvelocity;
+
+import static edu.wpi.first.units.angle.AngleUnit.Degrees;
+import static edu.wpi.first.units.angle.AngleUnit.Radians;
+import static edu.wpi.first.units.angle.AngleUnit.Revolutions;
+import static edu.wpi.first.units.time.TimeUnit.Minute;
+import static edu.wpi.first.units.time.TimeUnit.Seconds;
+import static edu.wpi.first.units.angularvelocity.AngularVelocityUnit.RPM;
+import static edu.wpi.first.units.angularvelocity.AngularVelocityUnit.RadiansPerSecond;
+import static edu.wpi.first.units.angularvelocity.AngularVelocityUnit.RevolutionsPerSecond;
+
+import java.util.Objects;
+
+import edu.wpi.first.units.angle.Angle;
+import edu.wpi.first.units.time.Time;
+
+/**
+ * A measure holds the magnitude and unit of some dimension, such as distance,
+ * time, or speed. An
+ * immutable measure is <i>immutable</i> and <i>type safe</i>, making it easy to
+ * use in concurrent
+ * situations and gives compile-time safety. Two measures with the same
+ * <i>unit</i> and
+ * <i>magnitude</i> are effectively equivalent objects.
+ *
+ */
+public class AngularVelocity implements Comparable<AngularVelocity> {
+
+  /**
+   * The threshold for two measures to be considered equivalent if converted to
+   * the same unit. This
+   * is only needed due to floating-point error.
+   */
+  static double EQUIVALENCE_THRESHOLD = 1e-12;
+
+  protected double m_magnitude;
+  protected double m_baseUnitMagnitude;
+  protected AngularVelocityUnit m_unit;
+
+  /**
+   * Creates a new immutable Dimensionless measure instance. This shouldn't be
+   * used
+   * directly; prefer one of the
+   * factory methods instead.
+   *
+   * @param magnitude the magnitude of this measure
+   * @param unit      the unit of this measure.
+   */
+  AngularVelocity(double magnitude, double baseUnitMagnitude, AngularVelocityUnit unit) {
+    Objects.requireNonNull(unit, "Unit cannot be null");
+    m_magnitude = magnitude;
+    m_baseUnitMagnitude = baseUnitMagnitude;
+    m_unit = unit;
+  }
+
+  /**
+   * Gets the unitless magnitude of this measure.
+   *
+   * @return the magnitude in terms of {@link #unit() the unit}.
+   */
+  public double magnitude() {
+    return m_magnitude;
+  }
+
+  /**
+   * Gets the magnitude of this measure in terms of the base unit. If the unit is
+   * the base unit for
+   * its system of measure, then the value will be equivalent to
+   * {@link #magnitude()}.
+   *
+   * @return the magnitude in terms of the base unit
+   */
+  public double baseUnitMagnitude() {
+    return m_baseUnitMagnitude;
+  }
+
+  /**
+   * Gets the units of this measure.
+   *
+   * @return the unit
+   */
+  public AngularVelocityUnit unit() {
+    return m_unit;
+  }
+
+  /**
+   * Converts this measure to a measure with a different unit of the same type, eg
+   * minutes to
+   * seconds. Converting to the same unit is equivalent to calling
+   * {@link #magnitude()}.
+   *
+   * <pre>
+   *   Meters.of(12).in(Feet) // 39.3701
+   *   Seconds.of(15).in(Minutes) // 0.25
+   * </pre>
+   *
+   * @param unit the unit to convert this measure to
+   * @return the value of this measure in the given unit
+   */
+  public double in(AngularVelocityUnit unit) {
+    if (this.unit().equals(unit)) {
+      return magnitude();
+    } else {
+      return unit.fromBaseUnits(baseUnitMagnitude());
+    }
+  }
+
+  /**
+   * Multiplies this measurement by some constant multiplier and returns the
+   * result. The magnitude
+   * of the result will be the <i>base</i> magnitude multiplied by the scalar
+   * value. If the measure
+   * uses a unit with a non-linear relation to its base unit (such as Fahrenheit
+   * for temperature),
+   * then the result will only be a multiple <i>in terms of the base unit</i>.
+   *
+   * @param multiplier the constant to multiply by
+   * @return the resulting measure
+   */
+  public AngularVelocity times(double multiplier) {
+    return AngularVelocity.ofBaseUnits(baseUnitMagnitude() * multiplier, unit());
+  }
+
+  /**
+   * Divides this measurement by some constant divisor and returns the result.
+   * This is equivalent to
+   * {@code times(1 / divisor)}
+   *
+   * @param divisor the constant to divide by
+   * @return the resulting measure
+   * @see #times(double)
+   */
+  public AngularVelocity divide(double divisor) {
+    return times(1 / divisor);
+  }
+
+  /**
+   * Adds another measure to this one. The resulting measure has the same unit as
+   * this one.
+   *
+   * @param other the measure to add to this one
+   * @return a new measure containing the result
+   */
+  public AngularVelocity plus(AngularVelocity other) {
+    return unit().ofBaseUnits(baseUnitMagnitude() + other.baseUnitMagnitude());
+  }
+
+  /**
+   * Subtracts another measure from this one. The resulting measure has the same
+   * unit as this one.
+   *
+   * @param other the measure to subtract from this one
+   * @return a new measure containing the result
+   */
+  public AngularVelocity minus(AngularVelocity other) {
+    return unit().ofBaseUnits(baseUnitMagnitude() - other.baseUnitMagnitude());
+  }
+
+  /**
+   * Negates this measure and returns the result.
+   *
+   * @return the resulting measure
+   */
+  public AngularVelocity negate() {
+    return times(-1);
+  }
+
+  /**
+   * Returns an immutable copy of this measure. The copy can be used freely and is
+   * guaranteed never
+   * to change.
+   *
+   * @return the copied measure
+   */
+  public AngularVelocity copy() {
+    return new AngularVelocity(m_magnitude, m_baseUnitMagnitude, m_unit);
+  }
+
+  /**
+   * Creates a new mutable copy of this measure.
+   *
+   * @return a mutable measure initialized to be identical to this measure
+   */
+  public MutableAngularVelocity mutableCopy() {
+    return MutableAngularVelocity.mutable(this);
+  }
+
+  /**
+   * Checks if this measure is near another measure of the same unit. Provide a
+   * variance threshold
+   * for use for a +/- scalar, such as 0.05 for +/- 5%.
+   *
+   * <pre>
+   *   Inches.of(11).isNear(Inches.of(10), 0.1) // true
+   *   Inches.of(12).isNear(Inches.of(10), 0.1) // false
+   * </pre>
+   *
+   * @param other             the other measurement to compare against
+   * @param varianceThreshold the acceptable variance threshold, in terms of an
+   *                          acceptable +/- error
+   *                          range multiplier. Checking if a value is within 10%
+   *                          means a value of 0.1 should be passed;
+   *                          checking if a value is within 1% means a value of
+   *                          0.01 should be passed, and so on.
+   * @return true if this unit is near the other measure, otherwise false
+   */
+  public boolean isNear(AngularVelocity other, double varianceThreshold) {
+    // abs so negative inputs are calculated correctly
+    var tolerance = Math.abs(other.baseUnitMagnitude() * varianceThreshold);
+
+    return Math.abs(this.baseUnitMagnitude() - other.baseUnitMagnitude()) <= tolerance;
+  }
+
+  /**
+   * Checks if this measure is near another measure of the same unit, with a
+   * specified tolerance of
+   * the same unit.
+   *
+   * <pre>
+   *     Meters.of(1).isNear(Meters.of(1.2), Millimeters.of(300)) // true
+   *     Degrees.of(90).isNear(Rotations.of(0.5), Degrees.of(45)) // false
+   * </pre>
+   *
+   * @param other     the other measure to compare against.
+   * @param tolerance the tolerance allowed in which the two measures are defined
+   *                  as near each
+   *                  other.
+   * @return true if this unit is near the other measure, otherwise false.
+   */
+  public boolean isNear(AngularVelocity other, AngularVelocity tolerance) {
+    return Math.abs(this.baseUnitMagnitude() - other.baseUnitMagnitude()) <= Math
+        .abs(tolerance.baseUnitMagnitude());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int compareTo(AngularVelocity o) {
+    return Double.compare(this.baseUnitMagnitude(), o.baseUnitMagnitude());
+  }
+
+  /**
+   * Checks if this measure is greater than another measure of the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has a greater equivalent magnitude, false
+   *         otherwise
+   */
+  public boolean gt(AngularVelocity o) {
+    return compareTo(o) > 0;
+  }
+
+  /**
+   * Checks if this measure is greater than or equal to another measure of
+   * the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has an equal or greater magnitude,
+   *         false otherwise
+   */
+  public boolean gte(AngularVelocity o) {
+    return compareTo(o) > 0 || equals(o);
+  }
+
+  /**
+   * Checks if this measure is less than another measure of the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has a lesser equivalent magnitude, false
+   *         otherwise
+   */
+  public boolean lt(AngularVelocity o) {
+    return compareTo(o) < 0;
+  }
+
+  /**
+   * Checks if this measure is less than or equal to another measure of
+   * the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has an equal or lesser equivalent magnitude,
+   *         false otherwise
+   */
+  public boolean lte(AngularVelocity o) {
+    return compareTo(o) < 0 || equals(o);
+  }
+
+  /**
+   * Creates a new angular velocity measurement from an angle measurement and a
+   * time measurement.
+   * The resulting measurement is immutable.
+   *
+   * @param angle the angle measurement.
+   * @param time  the time measurement.
+   * @return the angular velocity measurement
+   */
+
+  public static AngularVelocity combine(Angle angle, Time time) {
+    AngularVelocityUnit angularVelocityUnit = null;
+    if (angle.unit().equals(Radians) && time.unit().equals(Seconds)) {
+      angularVelocityUnit = RadiansPerSecond;
+    } else if (angle.unit().equals(Revolutions) && time.unit().equals(Seconds)) {
+      angularVelocityUnit = RevolutionsPerSecond;
+    } else if (angle.unit().equals(Degrees) && time.unit().equals(Seconds)) {
+      angularVelocityUnit = RevolutionsPerSecond;
+    } else if (angle.unit().equals(Revolutions) && time.unit().equals(Minute)) {
+      angularVelocityUnit = RPM;
+    } else {
+      angularVelocityUnit = angle.unit().per(time.unit());
+    }
+    return new AngularVelocity(
+        angle.magnitude() / time.magnitude(),
+        angle.baseUnitMagnitude() / time.baseUnitMagnitude(),
+        angularVelocityUnit);
+  }
+
+  /**
+   * Returns the measure with the absolute value closest to positive infinity.
+   *
+   * @param <U>      the type of the units of the measures
+   * @param measures the set of measures to compare
+   * @return the measure with the greatest positive magnitude, or null if no
+   *         measures were provided
+   */
+  static AngularVelocity max(AngularVelocity... measures) {
+    if (measures.length == 0) {
+      return null; // nothing to compare
+    }
+
+    AngularVelocity max = null;
+    for (AngularVelocity measure : measures) {
+      if (max == null || measure.gt(max)) {
+        max = measure;
+      }
+    }
+
+    return max;
+  }
+
+  /**
+   * Returns the measure with the absolute value closest to negative infinity.
+   *
+   * @param <U>      the type of the units of the measures
+   * @param measures the set of measures to compare
+   * @return the measure with the greatest negative magnitude
+   */
+  static AngularVelocity min(AngularVelocity... measures) {
+    if (measures.length == 0) {
+      return null; // nothing to compare
+    }
+
+    AngularVelocity max = null;
+    for (AngularVelocity measure : measures) {
+      if (max == null || measure.lt(max)) {
+        max = measure;
+      }
+    }
+
+    return max;
+  }
+
+  /**
+   * Returns a string representation of this measurement in a shorthand form. The
+   * symbol of the
+   * backing unit is used, rather than the full name, and the magnitude is
+   * represented in scientific
+   * notation.
+   *
+   * @return the short form representation of this measurement
+   */
+  public String toShortString() {
+    // eg 1.234e+04 V/m (1234 Volt per Meter in long form)
+    return String.format("%.3e %s", magnitude(), unit().symbol());
+  }
+
+  /**
+   * Returns a string representation of this measurement in a longhand form. The
+   * name of the backing
+   * unit is used, rather than its symbol, and the magnitude is represented in a
+   * full string, not
+   * scientific notation. (Very large values may be represented in scientific
+   * notation, however)
+   *
+   * @return the long form representation of this measurement
+   */
+  public String toLongString() {
+    // eg 1234 Volt per Meter (1.234e+04 V/m in short form)
+    return String.format("%s %s", magnitude(), unit().name());
+  }
+
+  /**
+   * Creates a new measure in the given unit with a magnitude equal to the given
+   * one in base units.
+   *
+   * @param <U>               the type of the units of measure
+   * @param baseUnitMagnitude the magnitude of the measure, in terms of the base
+   *                          unit of measure
+   * @param unit              the unit of measure
+   * @return a new measure
+   */
+  public static AngularVelocity ofBaseUnits(
+      double baseUnitMagnitude, AngularVelocityUnit unit) {
+    return new AngularVelocity(unit.fromBaseUnits(baseUnitMagnitude), baseUnitMagnitude, unit);
+  }
+
+  /**
+   * Creates a new measure in the given unit with a magnitude in terms of that
+   * unit.
+   *
+   * @param <U>               the type of the units of measure
+   * @param relativeMagnitude the magnitude of the measure
+   * @param unit              the unit of measure
+   * @return a new measure
+   */
+  public static AngularVelocity ofRelativeUnits(
+      double relativeMagnitude, AngularVelocityUnit unit) {
+    return new AngularVelocity(relativeMagnitude, unit.toBaseUnits(relativeMagnitude), unit);
+  }
+
+  /**
+   * Checks for <i>object equality</i>. To check if two measures are
+   * <i>equivalent</i>, use {@link
+   * #isEquivalent(Measure) isEquivalent}.
+   */
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof AngularVelocity other
+        && Objects.equals(m_unit, other.unit())
+        && Math.abs(baseUnitMagnitude() - other.baseUnitMagnitude()) <= EQUIVALENCE_THRESHOLD;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(m_magnitude, m_unit);
+  }
+
+  @Override
+  public String toString() {
+    return toShortString();
+  }
+
+}

--- a/wpiunits/src/main/java/edu/wpi/first/units/angularvelocity/AngularVelocityUnit.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/angularvelocity/AngularVelocityUnit.java
@@ -1,0 +1,318 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.units.angularvelocity;
+
+import static edu.wpi.first.units.time.TimeUnit.Minute;
+import static edu.wpi.first.units.time.TimeUnit.Second;
+import static edu.wpi.first.units.angle.AngleUnit.Degrees;
+import static edu.wpi.first.units.angle.AngleUnit.Revolutions;
+import static edu.wpi.first.units.angle.AngleUnit.Rotations;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.UnaryFunction;
+import edu.wpi.first.units.angle.AngleUnit;
+import edu.wpi.first.units.time.TimeUnit;
+
+/**
+ * Unit of measurement that defines an angle, such as radians, rotations, or
+ * degrees.
+ *
+ */
+public class AngularVelocityUnit {
+
+  public static final AngularVelocityUnit RadiansPerSecond = new AngularVelocityUnit();
+
+  public static final AngularVelocityUnit RevolutionsPerSecond = Revolutions.per(Second);
+
+  public static final AngularVelocityUnit RotationsPerSecond = Rotations.per(Second);
+
+  public static final AngularVelocityUnit DegreesPerSecond = Degrees.per(Second);
+
+  public static final AngularVelocityUnit RPM = Revolutions.per(Minute);
+
+  private final UnaryFunction m_toBaseConverter;
+  private final UnaryFunction m_fromBaseConverter;
+
+  private final Optional<AngularVelocityUnit> m_baseUnit;
+
+  private AngularVelocity m_zero;
+  private AngularVelocity m_one;
+
+  private final String m_name;
+  private final String m_symbol;
+
+  /**
+   * Creates a new angle unit defined by an AngleUnit and a TimeUnit.
+   *
+   * @param angleUnit the angle unit.
+   * @param timeUnit  the time unit.
+   */
+  public AngularVelocityUnit(
+      AngleUnit angleUnit,
+      TimeUnit timeUnit) {
+    var angleUnitToBaseConverter = Objects.requireNonNull(angleUnit).getConverterToBase();
+    var angleUnitFromBaseConverter = Objects.requireNonNull(angleUnit).getConverterFromBase();
+    var timeUnitToBaseConverter = Objects.requireNonNull(timeUnit).getConverterToBase();
+    var timeUnitFromBaseConverter = Objects.requireNonNull(timeUnit).getConverterFromBase();
+
+    m_baseUnit = Optional.of(RadiansPerSecond);
+    m_toBaseConverter = x -> angleUnitToBaseConverter.apply(x) / timeUnitToBaseConverter.apply(x);
+    m_fromBaseConverter = x -> angleUnitFromBaseConverter.apply(x) / timeUnitFromBaseConverter.apply(x);
+    m_name = angleUnit.name() + " per " + timeUnit.name();
+    m_symbol = angleUnit.symbol() + "/" + timeUnit.symbol();
+
+  }
+
+  /**
+   * Creates a new unit that is identical to other, but with a different name and
+   * symbol.
+   *
+   * @param other  the other angle that this one is identical to.
+   * @param name   the name of the angle unit. This should be a
+   *               singular noun
+   *               (so "Degree", not "Degrees")
+   * @param symbol the short symbol for the unit, such as "rad" for
+   *               Radians or "rev" for Revolutions.
+   */
+  public AngularVelocityUnit(
+      AngularVelocityUnit other,
+      String name,
+      String symbol) {
+    m_baseUnit = Optional.of(RadiansPerSecond);
+    m_toBaseConverter = other.m_toBaseConverter;
+    m_fromBaseConverter = other.m_fromBaseConverter;
+    m_name = name;
+    m_symbol = symbol;
+  }
+
+  /**
+   * Instantiates the base unit for angles (i.e. Radians). Only used once by the
+   * static field Radians.
+   */
+  private AngularVelocityUnit() {
+    m_baseUnit = Optional.empty();
+    m_fromBaseConverter = x -> x;
+    m_toBaseConverter = x -> x;
+    m_name = "Radian per Second";
+    m_symbol = "rad/s";
+  }
+
+  /**
+   * Gets the base unit of measurement that this unit is derived from. If the unit
+   * is the base unit,
+   * the unit will be returned.
+   *
+   * <pre>
+   * <code>
+   *   Unit baseUnit = new Unit(null, ...);
+   *   baseUnit.getBaseUnit(); // returns baseUnit
+   *
+   *   Unit derivedUnit = new Unit(baseUnit, ...);
+   *   derivedUnit.getBaseUnit(); // returns baseUnit
+   * </code>
+   * </pre>
+   *
+   * @return the base unit
+   */
+  public Optional<AngularVelocityUnit> getBaseUnit() {
+    return m_baseUnit;
+  }
+
+  /**
+   * Checks if this unit is the base unit for its own system of measurement.
+   *
+   * @return true if this is the base unit, false if not
+   */
+  public boolean isBaseUnit() {
+    return this.equals(getBaseUnit().get());
+  }
+
+  /**
+   * Checks if this unit is equivalent to another one. Equivalence is determined
+   * by both units
+   * having the same base type and treat the same base unit magnitude as the same
+   * magnitude in their
+   * own units, to within {@link Measure#EQUIVALENCE_THRESHOLD}.
+   *
+   * @param other the unit to compare to.
+   * @return true if both units are equivalent, false if not
+   */
+  public boolean equivalent(AngularVelocityUnit other) {
+
+    double arbitrary = 16_777.214; // 2^24 / 1e3
+
+    return Math.abs(
+        this.m_fromBaseConverter.apply(arbitrary)
+            - other.m_fromBaseConverter.apply(arbitrary)) <= AngularVelocity.EQUIVALENCE_THRESHOLD
+        && Math.abs(
+            this.m_toBaseConverter.apply(arbitrary)
+                - other.m_toBaseConverter.apply(arbitrary)) <= AngularVelocity.EQUIVALENCE_THRESHOLD;
+  }
+
+  /**
+   * Converts a value in terms of base units to a value in terms of this unit.
+   *
+   * @param valueInBaseUnits the value in base units to convert
+   * @return the equivalent value in terms of this unit
+   */
+  public double fromBaseUnits(double valueInBaseUnits) {
+    return m_fromBaseConverter.apply(valueInBaseUnits);
+  }
+
+  /**
+   * Converts a value in terms of this unit to a value in terms of the base unit.
+   *
+   * @param valueInNativeUnits the value in terms of this unit to convert
+   * @return the equivalent value in terms of the base unit
+   */
+  public double toBaseUnits(double valueInNativeUnits) {
+    return m_toBaseConverter.apply(valueInNativeUnits);
+  }
+
+  /**
+   * Converts a magnitude in terms of another unit of the same dimension to a
+   * magnitude in terms of
+   * this unit.
+   *
+   * <pre>
+   *   Inches.convertFrom(12, Feet) // 144.0
+   *   Kilograms.convertFrom(2.2, Pounds) // 0.9979024
+   * </pre>
+   *
+   * @param magnitude a magnitude measured in another unit
+   * @param otherUnit the unit to convert the magnitude to
+   * @return the corresponding value in terms of this unit.
+   */
+  public double convertFrom(double magnitude, AngularVelocityUnit otherUnit) {
+    if (this.equivalent(otherUnit.getBaseUnit().get())) {
+      // same unit, don't bother converting
+      return magnitude;
+    }
+    return this.fromBaseUnits(otherUnit.toBaseUnits(magnitude));
+  }
+
+  /**
+   * Gets the conversion function used to convert values to base unit terms. This
+   * generally
+   * shouldn't need to be used directly; prefer {@link #toBaseUnits(double)}
+   * instead.
+   *
+   * @return the conversion function
+   */
+  public UnaryFunction getConverterToBase() {
+    return m_toBaseConverter;
+  }
+
+  /**
+   * Gets the conversion function used to convert values to terms of this unit.
+   * This generally
+   * shouldn't need to be used directly; prefer {@link #fromBaseUnits(double)}
+   * instead.
+   *
+   * @return the conversion function
+   */
+  public UnaryFunction getConverterFromBase() {
+    return m_fromBaseConverter;
+  }
+
+  /**
+   * Creates a new measure of this unit with the given value. The resulting
+   * measure is
+   * <i>immutable</i> and cannot have its value modified.
+   *
+   * @param magnitude the magnitude of the measure to create
+   * @return the measure
+   */
+  public AngularVelocity of(double magnitude) {
+    if (magnitude == 0) {
+      // reuse static object
+      return zero();
+    }
+    if (magnitude == 1) {
+      // reuse static object
+      return one();
+    }
+    return AngularVelocity.ofRelativeUnits(magnitude, this);
+  }
+
+  /**
+   * Creates a new measure with a magnitude equal to the given base unit
+   * magnitude, converted to be
+   * in terms of this unit.
+   *
+   * @param baseUnitMagnitude the magnitude of the measure in terms of the base
+   *                          unit
+   * @return the measure
+   */
+  public AngularVelocity ofBaseUnits(double baseUnitMagnitude) {
+    return AngularVelocity.ofBaseUnits(baseUnitMagnitude, this);
+  }
+
+  /**
+   * Gets a measure with a magnitude of 0 in terms of this unit.
+   *
+   * @return the zero-valued measure
+   */
+  public AngularVelocity zero() {
+    // lazy init because 'this' is null in object initialization
+    if (m_zero == null) {
+      m_zero = AngularVelocity.ofRelativeUnits(0, this);
+    }
+    return m_zero;
+  }
+
+  /**
+   * Gets a measure with a magnitude of 1 in terms of this unit.
+   *
+   * @return the 1-valued measure
+   */
+  public AngularVelocity one() {
+    // lazy init because 'this' is null in object initialization
+    if (m_one == null) {
+      m_one = AngularVelocity.ofRelativeUnits(1, this);
+    }
+    return m_one;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return this == o
+        || o instanceof AngularVelocityUnit that
+            && m_name.equals(that.m_name)
+            && m_symbol.equals(that.m_symbol)
+            && this.equivalent(that);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(m_toBaseConverter, m_fromBaseConverter, m_name, m_symbol);
+  }
+
+  /**
+   * Gets the name of this unit.
+   *
+   * @return the unit's name
+   */
+  public String name() {
+    return m_name;
+  }
+
+  /**
+   * Gets the symbol of this unit.
+   *
+   * @return the unit's symbol
+   */
+  public String symbol() {
+    return m_symbol;
+  }
+
+  @Override
+  public String toString() {
+    return name();
+  }
+}

--- a/wpiunits/src/main/java/edu/wpi/first/units/angularvelocity/MutableAngularVelocity.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/angularvelocity/MutableAngularVelocity.java
@@ -1,0 +1,264 @@
+package edu.wpi.first.units.angularvelocity;
+
+import edu.wpi.first.units.dimensionless.Dimensionless;
+
+public class MutableAngularVelocity extends AngularVelocity {
+
+  /**
+   * Creates a new mutable measure that is a copy of the given one.
+   *
+   * @param measure the measure to create a mutable copy of
+   * @return a new mutable measure with an initial state equal to the given
+   *         measure
+   */
+  public static MutableAngularVelocity mutable(AngularVelocity measure) {
+    return new MutableAngularVelocity(measure.magnitude(), measure.baseUnitMagnitude(),
+        measure.unit());
+  }
+
+  /**
+   * Creates a new mutable measure with a magnitude of 0 in the given unit.
+   *
+   * @param unit the unit of measure
+   * @return a new mutable measure
+   */
+  public static MutableAngularVelocity zero(AngularVelocityUnit unit) {
+    return mutable(unit.zero());
+  }
+
+  /**
+   * Creates a new mutable measure in the given unit with a magnitude equal to
+   * the
+   * given one in base
+   * units.
+   *
+   * @param baseUnitMagnitude the magnitude of the measure, in terms of the base
+   *                          unit of measure
+   * @param unit              the unit of measure
+   * @return a new mutable measure
+   */
+  public static MutableAngularVelocity ofBaseUnits(double baseUnitMagnitude, AngularVelocityUnit unit) {
+    return new MutableAngularVelocity(unit.fromBaseUnits(baseUnitMagnitude),
+        baseUnitMagnitude, unit);
+  }
+
+  /**
+   * Creates a new mutable measure in the given unit with a magnitude in terms
+   * of
+   * that unit.
+   *
+   * @param <U>               the type of the units of measure
+   * @param relativeMagnitude the magnitude of the measure
+   * @param unit              the unit of measure
+   * @return a new mutable measure
+   */
+  public static MutableAngularVelocity ofRelativeUnits(double relativeMagnitude, AngularVelocityUnit unit) {
+    return new MutableAngularVelocity(relativeMagnitude, unit.toBaseUnits(relativeMagnitude), unit);
+  }
+
+  private MutableAngularVelocity(double initialMagnitude, double baseUnitMagnitude, AngularVelocityUnit unit) {
+    super(initialMagnitude, baseUnitMagnitude, unit);
+  }
+
+  // UNSAFE
+
+  /**
+   * Sets the new magnitude of the measurement. The magnitude must be in terms
+   * of
+   * the {@link
+   * #unit()}.
+   *
+   * @param magnitude the new magnitude of the measurement
+   */
+  public void mut_setMagnitude(double magnitude) {
+    m_magnitude = magnitude;
+    m_baseUnitMagnitude = m_unit.toBaseUnits(magnitude);
+  }
+
+  /**
+   * Sets the new magnitude of the measurement. The magnitude must be in terms
+   * of
+   * the base unit of
+   * the current unit.
+   *
+   * @param baseUnitMagnitude the new magnitude of the measurement
+   */
+  public void mut_setBaseUnitMagnitude(double baseUnitMagnitude) {
+    m_baseUnitMagnitude = baseUnitMagnitude;
+    m_magnitude = m_unit.fromBaseUnits(baseUnitMagnitude);
+  }
+
+  /**
+   * Overwrites the state of this measure and replaces it with values from the
+   * given one.
+   *
+   * @param other the other measure to copy values from
+   * @return this measure
+   */
+  public MutableAngularVelocity mut_replace(AngularVelocity other) {
+    m_magnitude = other.magnitude();
+    m_baseUnitMagnitude = other.baseUnitMagnitude();
+    m_unit = other.unit();
+    return this;
+  }
+
+  /**
+   * Overwrites the state of this measure with new values.
+   *
+   * @param magnitude the new magnitude in terms of the new unit
+   * @param unit      the new unit
+   * @return this measure
+   */
+  public MutableAngularVelocity mut_replace(double magnitude, AngularVelocityUnit unit) {
+    this.m_magnitude = magnitude;
+    this.m_baseUnitMagnitude = unit.toBaseUnits(magnitude);
+    this.m_unit = unit;
+    return this;
+  }
+
+  /**
+   * Increments (or decrements)
+   * the current magnitude of the measure by the given value. The value
+   * must be in terms
+   * of the current {@link #unit() unit}.
+   *
+   * @param raw the raw value to increment by
+   * @return the measure
+   */
+  public MutableAngularVelocity mut_increment(double raw) {
+    this.m_magnitude += raw;
+    this.m_baseUnitMagnitude += m_unit.toBaseUnits(raw);
+    return this;
+  }
+
+  /**
+   * Increments (or decrements) the current magnitude
+   * of the measure by the amount of the given measure.
+   *
+   * @param other the measure whose value should be added to this one
+   * @return the measure
+   */
+  public MutableAngularVelocity mut_increment(AngularVelocity other) {
+    m_baseUnitMagnitude += other.baseUnitMagnitude();
+    // can't naively use m_magnitude += other.in(m_unit) because the units may
+    // not
+    // be scalar multiples (eg adding 0C to 100K should result in 373.15K, not
+    // 100K)
+    m_magnitude = m_unit.fromBaseUnits(m_baseUnitMagnitude);
+    return this;
+  }
+
+  // Math
+
+  /**
+   * Adds another measurement to this one. This will mutate the object instead of
+   * generating a new
+   * measurement object.
+   *
+   * @param other the measurement to add
+   * @return this measure
+   */
+  public MutableAngularVelocity mut_plus(AngularVelocity other) {
+    return mut_plus(other.magnitude(), other.unit());
+  }
+
+  /**
+   * Adds another measurement to this one. This will mutate the object instead
+   * of
+   * generating a new
+   * measurement object. This is a denormalized version of
+   * {@link #mut_plus(Measure)} to avoid
+   * having to wrap raw numbers in a {@code Measure} object and pay for an
+   * object
+   * allocation.
+   *
+   * @param magnitude the magnitude of the other measurement.
+   * @param unit      the unit of the other measurement
+   * @return this measure
+   */
+  public MutableAngularVelocity mut_plus(double magnitude, AngularVelocityUnit unit) {
+    mut_setBaseUnitMagnitude(m_baseUnitMagnitude + unit.toBaseUnits(magnitude));
+    return this;
+  }
+
+  /**
+   * Subtracts another measurement to this one. This will mutate the object
+   * instead of generating a
+   * new measurement object.
+   *
+   * @param other the measurement to add
+   * @return this measure
+   */
+  public MutableAngularVelocity mut_minus(AngularVelocity other) {
+    return mut_minus(other.magnitude(), other.unit());
+  }
+
+  /**
+   * Subtracts another measurement to this one. This will mutate the object
+   * instead of generating a
+   * new measurement object. This is a denormalized version of
+   * {@link #mut_minus(Measure)} to avoid
+   * having to wrap raw numbers in a {@code Measure} object and pay for an
+   * object
+   * allocation.
+   *
+   * @param magnitude the magnitude of the other measurement.
+   * @param unit      the unit of the other measurement
+   * @return this measure
+   */
+  public MutableAngularVelocity mut_minus(double magnitude, AngularVelocityUnit unit) {
+    return mut_plus(-magnitude, unit);
+  }
+
+  /**
+   * Multiplies this measurement by some constant value. This will mutate the
+   * object instead of
+   * generating a new measurement object.
+   *
+   * @param multiplier the multiplier to scale the measurement by
+   * @return this measure
+   */
+  public MutableAngularVelocity mut_times(double multiplier) {
+    mut_setBaseUnitMagnitude(m_baseUnitMagnitude * multiplier);
+    return this;
+  }
+
+  /**
+   * Multiplies this measurement by some constant value. This will mutate the
+   * object instead of
+   * generating a new measurement object.
+   *
+   * @param multiplier the multiplier to scale the measurement by
+   * @return this measure
+   */
+  public MutableAngularVelocity mut_times(Dimensionless multiplier) {
+    return mut_times(multiplier.baseUnitMagnitude());
+  }
+
+  /**
+   * Divides this measurement by some constant value. This will mutate the
+   * object
+   * instead of
+   * generating a new measurement object.
+   *
+   * @param divisor the divisor to scale the measurement by
+   * @return this measure
+   */
+  public MutableAngularVelocity mut_divide(double divisor) {
+    mut_setBaseUnitMagnitude(m_baseUnitMagnitude / divisor);
+    return this;
+  }
+
+  /**
+   * Divides this measurement by some constant value. This will mutate the
+   * object
+   * instead of
+   * generating a new measurement object.
+   *
+   * @param divisor the divisor to scale the measurement by
+   * @return this measure
+   */
+  public MutableAngularVelocity mut_divide(Dimensionless divisor) {
+    return mut_divide(divisor.baseUnitMagnitude());
+  }
+}

--- a/wpiunits/src/main/java/edu/wpi/first/units/dimensionless/Dimensionless.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/dimensionless/Dimensionless.java
@@ -1,0 +1,403 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.units.dimensionless;
+
+import java.util.Objects;
+
+/**
+ * A measure holds the magnitude and unit of some dimension, such as distance,
+ * time, or speed. An
+ * immutable measure is <i>immutable</i> and <i>type safe</i>, making it easy to
+ * use in concurrent
+ * situations and gives compile-time safety. Two measures with the same
+ * <i>unit</i> and
+ * <i>magnitude</i> are effectively equivalent objects.
+ *
+ */
+public class Dimensionless implements Comparable<Dimensionless> {
+
+  /**
+   * The threshold for two measures to be considered equivalent if converted to
+   * the same unit. This
+   * is only needed due to floating-point error.
+   */
+  static double EQUIVALENCE_THRESHOLD = 1e-12;
+
+  protected double m_magnitude;
+  protected double m_baseUnitMagnitude;
+  protected DimensionlessUnit m_unit;
+
+  /**
+   * Creates a new immutable Dimensionless measure instance. This shouldn't be used
+   * directly; prefer one of the
+   * factory methods instead.
+   *
+   * @param magnitude the magnitude of this measure
+   * @param unit      the unit of this measure.
+   */
+  Dimensionless(double magnitude, double baseUnitMagnitude, DimensionlessUnit unit) {
+    Objects.requireNonNull(unit, "Unit cannot be null");
+    m_magnitude = magnitude;
+    m_baseUnitMagnitude = baseUnitMagnitude;
+    m_unit = unit;
+  }
+
+  /**
+   * Gets the unitless magnitude of this measure.
+   *
+   * @return the magnitude in terms of {@link #unit() the unit}.
+   */
+  public double magnitude() {
+    return m_magnitude;
+  }
+
+  /**
+   * Gets the magnitude of this measure in terms of the base unit. If the unit is
+   * the base unit for
+   * its system of measure, then the value will be equivalent to
+   * {@link #magnitude()}.
+   *
+   * @return the magnitude in terms of the base unit
+   */
+  public double baseUnitMagnitude() {
+    return m_baseUnitMagnitude;
+  }
+
+  /**
+   * Gets the units of this measure.
+   *
+   * @return the unit
+   */
+  public DimensionlessUnit unit() {
+    return m_unit;
+  }
+
+  /**
+   * Converts this measure to a measure with a different unit of the same type, eg
+   * minutes to
+   * seconds. Converting to the same unit is equivalent to calling
+   * {@link #magnitude()}.
+   *
+   * <pre>
+   *   Meters.of(12).in(Feet) // 39.3701
+   *   Seconds.of(15).in(Minutes) // 0.25
+   * </pre>
+   *
+   * @param unit the unit to convert this measure to
+   * @return the value of this measure in the given unit
+   */
+  public double in(DimensionlessUnit unit) {
+    if (this.unit().equals(unit)) {
+      return magnitude();
+    } else {
+      return unit.fromBaseUnits(baseUnitMagnitude());
+    }
+  }
+
+  /**
+   * Multiplies this measurement by some constant multiplier and returns the
+   * result. The magnitude
+   * of the result will be the <i>base</i> magnitude multiplied by the scalar
+   * value. If the measure
+   * uses a unit with a non-linear relation to its base unit (such as Fahrenheit
+   * for temperature),
+   * then the result will only be a multiple <i>in terms of the base unit</i>.
+   *
+   * @param multiplier the constant to multiply by
+   * @return the resulting measure
+   */
+  public Dimensionless times(double multiplier) {
+    return Dimensionless.ofBaseUnits(baseUnitMagnitude() * multiplier, unit());
+  }
+
+  /**
+   * Divides this measurement by some constant divisor and returns the result.
+   * This is equivalent to
+   * {@code times(1 / divisor)}
+   *
+   * @param divisor the constant to divide by
+   * @return the resulting measure
+   * @see #times(double)
+   */
+  public Dimensionless divide(double divisor) {
+    return times(1 / divisor);
+  }
+
+  /**
+   * Adds another measure to this one. The resulting measure has the same unit as
+   * this one.
+   *
+   * @param other the measure to add to this one
+   * @return a new measure containing the result
+   */
+  public Dimensionless plus(Dimensionless other) {
+    return unit().ofBaseUnits(baseUnitMagnitude() + other.baseUnitMagnitude());
+  }
+
+  /**
+   * Subtracts another measure from this one. The resulting measure has the same
+   * unit as this one.
+   *
+   * @param other the measure to subtract from this one
+   * @return a new measure containing the result
+   */
+  public Dimensionless minus(Dimensionless other) {
+    return unit().ofBaseUnits(baseUnitMagnitude() - other.baseUnitMagnitude());
+  }
+
+  /**
+   * Negates this measure and returns the result.
+   *
+   * @return the resulting measure
+   */
+  public Dimensionless negate() {
+    return times(-1);
+  }
+
+  /**
+   * Returns an immutable copy of this measure. The copy can be used freely and is
+   * guaranteed never
+   * to change.
+   *
+   * @return the copied measure
+   */
+  public Dimensionless copy() {
+    return new Dimensionless(m_magnitude, m_baseUnitMagnitude, m_unit);
+  }
+
+  /**
+   * Creates a new mutable copy of this measure.
+   *
+   * @return a mutable measure initialized to be identical to this measure
+   */
+  public MutableDimensionless mutableCopy() {
+    return MutableDimensionless.mutable(this);
+  }
+
+  /**
+   * Checks if this measure is near another measure of the same unit. Provide a
+   * variance threshold
+   * for use for a +/- scalar, such as 0.05 for +/- 5%.
+   *
+   * <pre>
+   *   Inches.of(11).isNear(Inches.of(10), 0.1) // true
+   *   Inches.of(12).isNear(Inches.of(10), 0.1) // false
+   * </pre>
+   *
+   * @param other             the other measurement to compare against
+   * @param varianceThreshold the acceptable variance threshold, in terms of an
+   *                          acceptable +/- error
+   *                          range multiplier. Checking if a value is within 10%
+   *                          means a value of 0.1 should be passed;
+   *                          checking if a value is within 1% means a value of
+   *                          0.01 should be passed, and so on.
+   * @return true if this unit is near the other measure, otherwise false
+   */
+  public boolean isNear(Dimensionless other, double varianceThreshold) {
+    // abs so negative inputs are calculated correctly
+    var tolerance = Math.abs(other.baseUnitMagnitude() * varianceThreshold);
+
+    return Math.abs(this.baseUnitMagnitude() - other.baseUnitMagnitude()) <= tolerance;
+  }
+
+  /**
+   * Checks if this measure is near another measure of the same unit, with a
+   * specified tolerance of
+   * the same unit.
+   *
+   * <pre>
+   *     Meters.of(1).isNear(Meters.of(1.2), Millimeters.of(300)) // true
+   *     Degrees.of(90).isNear(Rotations.of(0.5), Degrees.of(45)) // false
+   * </pre>
+   *
+   * @param other     the other measure to compare against.
+   * @param tolerance the tolerance allowed in which the two measures are defined
+   *                  as near each
+   *                  other.
+   * @return true if this unit is near the other measure, otherwise false.
+   */
+  public boolean isNear(Dimensionless other, Dimensionless tolerance) {
+    return Math.abs(this.baseUnitMagnitude() - other.baseUnitMagnitude()) <= Math
+        .abs(tolerance.baseUnitMagnitude());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int compareTo(Dimensionless o) {
+    return Double.compare(this.baseUnitMagnitude(), o.baseUnitMagnitude());
+  }
+
+  /**
+   * Checks if this measure is greater than another measure of the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has a greater equivalent magnitude, false
+   *         otherwise
+   */
+  public boolean gt(Dimensionless o) {
+    return compareTo(o) > 0;
+  }
+
+  /**
+   * Checks if this measure is greater than or equal to another measure of
+   * the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has an equal or greater magnitude,
+   *         false otherwise
+   */
+  public boolean gte(Dimensionless o) {
+    return compareTo(o) > 0 || equals(o);
+  }
+
+  /**
+   * Checks if this measure is less than another measure of the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has a lesser equivalent magnitude, false
+   *         otherwise
+   */
+  public boolean lt(Dimensionless o) {
+    return compareTo(o) < 0;
+  }
+
+  /**
+   * Checks if this measure is less than or equal to another measure of
+   * the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has an equal or lesser equivalent magnitude,
+   *         false otherwise
+   */
+  public boolean lte(Dimensionless o) {
+    return compareTo(o) < 0 || equals(o);
+  }
+
+  /**
+   * Returns the measure with the absolute value closest to positive infinity.
+   *
+   * @param <U>      the type of the units of the measures
+   * @param measures the set of measures to compare
+   * @return the measure with the greatest positive magnitude, or null if no
+   *         measures were provided
+   */
+  static Dimensionless max(Dimensionless... measures) {
+    if (measures.length == 0) {
+      return null; // nothing to compare
+    }
+
+    Dimensionless max = null;
+    for (Dimensionless measure : measures) {
+      if (max == null || measure.gt(max)) {
+        max = measure;
+      }
+    }
+
+    return max;
+  }
+
+  /**
+   * Returns the measure with the absolute value closest to negative infinity.
+   *
+   * @param <U>      the type of the units of the measures
+   * @param measures the set of measures to compare
+   * @return the measure with the greatest negative magnitude
+   */
+  static Dimensionless min(Dimensionless... measures) {
+    if (measures.length == 0) {
+      return null; // nothing to compare
+    }
+
+    Dimensionless max = null;
+    for (Dimensionless measure : measures) {
+      if (max == null || measure.lt(max)) {
+        max = measure;
+      }
+    }
+
+    return max;
+  }
+
+  /**
+   * Returns a string representation of this measurement in a shorthand form. The
+   * symbol of the
+   * backing unit is used, rather than the full name, and the magnitude is
+   * represented in scientific
+   * notation.
+   *
+   * @return the short form representation of this measurement
+   */
+  public String toShortString() {
+    // eg 1.234e+04 V/m (1234 Volt per Meter in long form)
+    return String.format("%.3e %s", magnitude(), unit().symbol());
+  }
+
+  /**
+   * Returns a string representation of this measurement in a longhand form. The
+   * name of the backing
+   * unit is used, rather than its symbol, and the magnitude is represented in a
+   * full string, not
+   * scientific notation. (Very large values may be represented in scientific
+   * notation, however)
+   *
+   * @return the long form representation of this measurement
+   */
+  public String toLongString() {
+    // eg 1234 Volt per Meter (1.234e+04 V/m in short form)
+    return String.format("%s %s", magnitude(), unit().name());
+  }
+
+  /**
+   * Creates a new measure in the given unit with a magnitude equal to the given
+   * one in base units.
+   *
+   * @param <U>               the type of the units of measure
+   * @param baseUnitMagnitude the magnitude of the measure, in terms of the base
+   *                          unit of measure
+   * @param unit              the unit of measure
+   * @return a new measure
+   */
+  public static Dimensionless ofBaseUnits(
+      double baseUnitMagnitude, DimensionlessUnit unit) {
+    return new Dimensionless(unit.fromBaseUnits(baseUnitMagnitude), baseUnitMagnitude, unit);
+  }
+
+  /**
+   * Creates a new measure in the given unit with a magnitude in terms of that
+   * unit.
+   *
+   * @param <U>               the type of the units of measure
+   * @param relativeMagnitude the magnitude of the measure
+   * @param unit              the unit of measure
+   * @return a new measure
+   */
+  public static Dimensionless ofRelativeUnits(
+      double relativeMagnitude, DimensionlessUnit unit) {
+    return new Dimensionless(relativeMagnitude, unit.toBaseUnits(relativeMagnitude), unit);
+  }
+
+  /**
+   * Checks for <i>object equality</i>. To check if two measures are
+   * <i>equivalent</i>, use {@link
+   * #isEquivalent(Measure) isEquivalent}.
+   */
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof Dimensionless other
+        && Objects.equals(m_unit, other.unit())
+        && Math.abs(baseUnitMagnitude() - other.baseUnitMagnitude()) <= EQUIVALENCE_THRESHOLD;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(m_magnitude, m_unit);
+  }
+
+  @Override
+  public String toString() {
+    return toShortString();
+  }
+
+}

--- a/wpiunits/src/main/java/edu/wpi/first/units/dimensionless/DimensionlessUnit.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/dimensionless/DimensionlessUnit.java
@@ -1,0 +1,339 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.units.dimensionless;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.UnaryFunction;
+
+/**
+ * Unit of measurement that defines an Dimensionless, such as radians,
+ * rotations, or
+ * degrees.
+ *
+ */
+public class DimensionlessUnit {
+
+  public static final DimensionlessUnit Value = new DimensionlessUnit();
+
+  public static final DimensionlessUnit Percent = new DimensionlessUnit(1.0 / 100.0, "Percent", "%");
+
+  private final UnaryFunction m_toBaseConverter;
+  private final UnaryFunction m_fromBaseConverter;
+
+  private final Optional<DimensionlessUnit> m_baseUnit;
+
+  private Dimensionless m_zero;
+  private Dimensionless m_one;
+
+  private final String m_name;
+  private final String m_symbol;
+
+  /**
+   * Creates a new Dimensionless unit defined by its relationship to the S.I. base
+   * Dimensionless
+   * unit (i.e. Value).
+   *
+   * @param toBaseConverter   a function for converting units of this type to
+   *                          Radians.
+   * @param fromBaseConverter a function for converting units of the other unit to
+   *                          Radians.
+   * @param name              the name of the Dimensionless unit. This should be a
+   *                          singular noun
+   *                          (so "Degree", not "Degrees")
+   * @param symbol            the short symbol for the unit, such as "rad" for
+   *                          Radians or "rev" for Revolutions.
+   */
+  public DimensionlessUnit(
+      UnaryFunction toBaseConverter,
+      UnaryFunction fromBaseConverter,
+      String name,
+      String symbol) {
+    m_baseUnit = Optional.of(Value);
+    m_toBaseConverter = Objects.requireNonNull(toBaseConverter);
+    m_fromBaseConverter = Objects.requireNonNull(fromBaseConverter);
+    m_name = Objects.requireNonNull(name);
+    m_symbol = Objects.requireNonNull(symbol);
+  }
+
+  /**
+   * Creates a new unit with the given name and multiplier to the S.I. base
+   * Dimensionless
+   * unit (i.e. Radians).
+   *
+   * @param baseUnitEquivalent the multiplier to convert this unit to the other
+   *                           unit of this type.
+   *                           For example, meters has a multiplier of 1, mm has a
+   *                           multiplier of 1e3, and km has
+   *                           multiplier of 1e-3.
+   * @param name               the name of the Dimensionless unit. This should be
+   *                           a
+   *                           singular noun
+   *                           (so "Degree", not "Degrees")
+   * @param symbol             the short symbol for the unit, such as "rad" for
+   *                           Radians or "rev" for Revolutions.
+   */
+  public DimensionlessUnit(
+      double baseUnitEquivalent,
+      String name,
+      String symbol) {
+    this(
+        x -> x * baseUnitEquivalent,
+        x -> x / baseUnitEquivalent,
+        name,
+        symbol);
+  }
+
+  /**
+   * Creates a new unit that is identical to other, but with a different name and
+   * symbol.
+   *
+   * @param other  the other Dimensionless that this one is identical to.
+   * @param name   the name of the Dimensionless unit. This should be a
+   *               singular noun
+   *               (so "Degree", not "Degrees")
+   * @param symbol the short symbol for the unit, such as "rad" for
+   *               Radians or "rev" for Revolutions.
+   */
+  public DimensionlessUnit(
+      DimensionlessUnit other,
+      String name,
+      String symbol) {
+    this(
+        other.m_toBaseConverter,
+        other.m_fromBaseConverter,
+        name,
+        symbol);
+  }
+
+  /**
+   * Instantiates the base unit for Dimensionlesss (i.e. Radians). Only used once
+   * by the
+   * static field Radians.
+   */
+  private DimensionlessUnit() {
+    m_baseUnit = Optional.empty();
+    m_fromBaseConverter = x -> x;
+    m_toBaseConverter = x -> x;
+    m_name = "<>";
+    m_symbol = "<>";
+  }
+
+  /**
+   * Gets the base unit of measurement that this unit is derived from. If the unit
+   * is the base unit,
+   * the unit will be returned.
+   *
+   * <pre>
+   * <code>
+   *   Unit baseUnit = new Unit(null, ...);
+   *   baseUnit.getBaseUnit(); // returns baseUnit
+   *
+   *   Unit derivedUnit = new Unit(baseUnit, ...);
+   *   derivedUnit.getBaseUnit(); // returns baseUnit
+   * </code>
+   * </pre>
+   *
+   * @return the base unit
+   */
+  public DimensionlessUnit getBaseUnit() {
+    return m_baseUnit.orElse(Value);
+  }
+
+  /**
+   * Checks if this unit is the base unit for its own system of measurement.
+   *
+   * @return true if this is the base unit, false if not
+   */
+  public boolean isBaseUnit() {
+    return this.equals(getBaseUnit());
+  }
+
+  /**
+   * Checks if this unit is equivalent to another one. Equivalence is determined
+   * by both units
+   * having the same base type and treat the same base unit magnitude as the same
+   * magnitude in their
+   * own units, to within {@link Measure#EQUIVALENCE_THRESHOLD}.
+   *
+   * @param other the unit to compare to.
+   * @return true if both units are equivalent, false if not
+   */
+  public boolean equivalent(DimensionlessUnit other) {
+
+    double arbitrary = 16_777.214; // 2^24 / 1e3
+
+    return Math.abs(
+        this.m_fromBaseConverter.apply(arbitrary)
+            - other.m_fromBaseConverter.apply(arbitrary)) <= Dimensionless.EQUIVALENCE_THRESHOLD
+        && Math.abs(
+            this.m_toBaseConverter.apply(arbitrary)
+                - other.m_toBaseConverter.apply(arbitrary)) <= Dimensionless.EQUIVALENCE_THRESHOLD;
+  }
+
+  /**
+   * Converts a value in terms of base units to a value in terms of this unit.
+   *
+   * @param valueInBaseUnits the value in base units to convert
+   * @return the equivalent value in terms of this unit
+   */
+  public double fromBaseUnits(double valueInBaseUnits) {
+    return m_fromBaseConverter.apply(valueInBaseUnits);
+  }
+
+  /**
+   * Converts a value in terms of this unit to a value in terms of the base unit.
+   *
+   * @param valueInNativeUnits the value in terms of this unit to convert
+   * @return the equivalent value in terms of the base unit
+   */
+  public double toBaseUnits(double valueInNativeUnits) {
+    return m_toBaseConverter.apply(valueInNativeUnits);
+  }
+
+  /**
+   * Converts a magnitude in terms of another unit of the same dimension to a
+   * magnitude in terms of
+   * this unit.
+   *
+   * <pre>
+   *   Inches.convertFrom(12, Feet) // 144.0
+   *   Kilograms.convertFrom(2.2, Pounds) // 0.9979024
+   * </pre>
+   *
+   * @param magnitude a magnitude measured in another unit
+   * @param otherUnit the unit to convert the magnitude to
+   * @return the corresponding value in terms of this unit.
+   */
+  public double convertFrom(double magnitude, DimensionlessUnit otherUnit) {
+    if (this.equivalent(otherUnit.getBaseUnit())) {
+      // same unit, don't bother converting
+      return magnitude;
+    }
+    return this.fromBaseUnits(otherUnit.toBaseUnits(magnitude));
+  }
+
+  /**
+   * Gets the conversion function used to convert values to base unit terms. This
+   * generally
+   * shouldn't need to be used directly; prefer {@link #toBaseUnits(double)}
+   * instead.
+   *
+   * @return the conversion function
+   */
+  public UnaryFunction getConverterToBase() {
+    return m_toBaseConverter;
+  }
+
+  /**
+   * Gets the conversion function used to convert values to terms of this unit.
+   * This generally
+   * shouldn't need to be used directly; prefer {@link #fromBaseUnits(double)}
+   * instead.
+   *
+   * @return the conversion function
+   */
+  public UnaryFunction getConverterFromBase() {
+    return m_fromBaseConverter;
+  }
+
+  /**
+   * Creates a new measure of this unit with the given value. The resulting
+   * measure is
+   * <i>immutable</i> and cannot have its value modified.
+   *
+   * @param magnitude the magnitude of the measure to create
+   * @return the measure
+   */
+  public Dimensionless of(double magnitude) {
+    if (magnitude == 0) {
+      // reuse static object
+      return zero();
+    }
+    if (magnitude == 1) {
+      // reuse static object
+      return one();
+    }
+    return Dimensionless.ofRelativeUnits(magnitude, this);
+  }
+
+  /**
+   * Creates a new measure with a magnitude equal to the given base unit
+   * magnitude, converted to be
+   * in terms of this unit.
+   *
+   * @param baseUnitMagnitude the magnitude of the measure in terms of the base
+   *                          unit
+   * @return the measure
+   */
+  public Dimensionless ofBaseUnits(double baseUnitMagnitude) {
+    return Dimensionless.ofBaseUnits(baseUnitMagnitude, this);
+  }
+
+  /**
+   * Gets a measure with a magnitude of 0 in terms of this unit.
+   *
+   * @return the zero-valued measure
+   */
+  public Dimensionless zero() {
+    // lazy init because 'this' is null in object initialization
+    if (m_zero == null) {
+      m_zero = Dimensionless.ofRelativeUnits(0, this);
+    }
+    return m_zero;
+  }
+
+  /**
+   * Gets a measure with a magnitude of 1 in terms of this unit.
+   *
+   * @return the 1-valued measure
+   */
+  public Dimensionless one() {
+    // lazy init because 'this' is null in object initialization
+    if (m_one == null) {
+      m_one = Dimensionless.ofRelativeUnits(1, this);
+    }
+    return m_one;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return this == o
+        || o instanceof DimensionlessUnit that
+            && m_name.equals(that.m_name)
+            && m_symbol.equals(that.m_symbol)
+            && this.equivalent(that);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(m_toBaseConverter, m_fromBaseConverter, m_name, m_symbol);
+  }
+
+  /**
+   * Gets the name of this unit.
+   *
+   * @return the unit's name
+   */
+  public String name() {
+    return m_name;
+  }
+
+  /**
+   * Gets the symbol of this unit.
+   *
+   * @return the unit's symbol
+   */
+  public String symbol() {
+    return m_symbol;
+  }
+
+  @Override
+  public String toString() {
+    return name();
+  }
+}

--- a/wpiunits/src/main/java/edu/wpi/first/units/dimensionless/MutableDimensionless.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/dimensionless/MutableDimensionless.java
@@ -1,0 +1,262 @@
+package edu.wpi.first.units.dimensionless;
+
+public class MutableDimensionless extends Dimensionless {
+
+  /**
+   * Creates a new mutable measure that is a copy of the given one.
+   *
+   * @param measure the measure to create a mutable copy of
+   * @return a new mutable measure with an initial state equal to the given
+   *         measure
+   */
+  public static MutableDimensionless mutable(Dimensionless measure) {
+    return new MutableDimensionless(measure.magnitude(), measure.baseUnitMagnitude(),
+        measure.unit());
+  }
+
+  /**
+   * Creates a new mutable measure with a magnitude of 0 in the given unit.
+   *
+   * @param unit the unit of measure
+   * @return a new mutable measure
+   */
+  public static MutableDimensionless zero(DimensionlessUnit unit) {
+    return mutable(unit.zero());
+  }
+
+  /**
+   * Creates a new mutable measure in the given unit with a magnitude equal to
+   * the
+   * given one in base
+   * units.
+   *
+   * @param baseUnitMagnitude the magnitude of the measure, in terms of the base
+   *                          unit of measure
+   * @param unit              the unit of measure
+   * @return a new mutable measure
+   */
+  public static MutableDimensionless ofBaseUnits(double baseUnitMagnitude, DimensionlessUnit unit) {
+    return new MutableDimensionless(unit.fromBaseUnits(baseUnitMagnitude),
+        baseUnitMagnitude, unit);
+  }
+
+  /**
+   * Creates a new mutable measure in the given unit with a magnitude in terms
+   * of
+   * that unit.
+   *
+   * @param <U>               the type of the units of measure
+   * @param relativeMagnitude the magnitude of the measure
+   * @param unit              the unit of measure
+   * @return a new mutable measure
+   */
+  public static MutableDimensionless ofRelativeUnits(double relativeMagnitude, DimensionlessUnit unit) {
+    return new MutableDimensionless(relativeMagnitude, unit.toBaseUnits(relativeMagnitude), unit);
+  }
+
+  private MutableDimensionless(double initialMagnitude, double baseUnitMagnitude, DimensionlessUnit unit) {
+    super(initialMagnitude, baseUnitMagnitude, unit);
+  }
+
+  // UNSAFE
+
+  /**
+   * Sets the new magnitude of the measurement. The magnitude must be in terms
+   * of
+   * the {@link
+   * #unit()}.
+   *
+   * @param magnitude the new magnitude of the measurement
+   */
+  public void mut_setMagnitude(double magnitude) {
+    m_magnitude = magnitude;
+    m_baseUnitMagnitude = m_unit.toBaseUnits(magnitude);
+  }
+
+  /**
+   * Sets the new magnitude of the measurement. The magnitude must be in terms
+   * of
+   * the base unit of
+   * the current unit.
+   *
+   * @param baseUnitMagnitude the new magnitude of the measurement
+   */
+  public void mut_setBaseUnitMagnitude(double baseUnitMagnitude) {
+    m_baseUnitMagnitude = baseUnitMagnitude;
+    m_magnitude = m_unit.fromBaseUnits(baseUnitMagnitude);
+  }
+
+  /**
+   * Overwrites the state of this measure and replaces it with values from the
+   * given one.
+   *
+   * @param other the other measure to copy values from
+   * @return this measure
+   */
+  public MutableDimensionless mut_replace(Dimensionless other) {
+    m_magnitude = other.magnitude();
+    m_baseUnitMagnitude = other.baseUnitMagnitude();
+    m_unit = other.unit();
+    return this;
+  }
+
+  /**
+   * Overwrites the state of this measure with new values.
+   *
+   * @param magnitude the new magnitude in terms of the new unit
+   * @param unit      the new unit
+   * @return this measure
+   */
+  public MutableDimensionless mut_replace(double magnitude, DimensionlessUnit unit) {
+    this.m_magnitude = magnitude;
+    this.m_baseUnitMagnitude = unit.toBaseUnits(magnitude);
+    this.m_unit = unit;
+    return this;
+  }
+
+  /**
+   * Increments (or decrements)
+   * the current magnitude of the measure by the given value. The value
+   * must be in terms
+   * of the current {@link #unit() unit}.
+   *
+   * @param raw the raw value to increment by
+   * @return the measure
+   */
+  public MutableDimensionless mut_increment(double raw) {
+    this.m_magnitude += raw;
+    this.m_baseUnitMagnitude += m_unit.toBaseUnits(raw);
+    return this;
+  }
+
+  /**
+   * Increments (or decrements) the current magnitude
+   * of the measure by the amount of the given measure.
+   *
+   * @param other the measure whose value should be added to this one
+   * @return the measure
+   */
+  public MutableDimensionless mut_increment(Dimensionless other) {
+    m_baseUnitMagnitude += other.baseUnitMagnitude();
+    // can't naively use m_magnitude += other.in(m_unit) because the units may
+    // not
+    // be scalar multiples (eg adding 0C to 100K should result in 373.15K, not
+    // 100K)
+    m_magnitude = m_unit.fromBaseUnits(m_baseUnitMagnitude);
+    return this;
+  }
+
+  // Math
+
+  /**
+   * Adds another measurement to this one. This will mutate the object instead of
+   * generating a new
+   * measurement object.
+   *
+   * @param other the measurement to add
+   * @return this measure
+   */
+  public MutableDimensionless mut_plus(Dimensionless other) {
+    return mut_plus(other.magnitude(), other.unit());
+  }
+
+  /**
+   * Adds another measurement to this one. This will mutate the object instead
+   * of
+   * generating a new
+   * measurement object. This is a denormalized version of
+   * {@link #mut_plus(Measure)} to avoid
+   * having to wrap raw numbers in a {@code Measure} object and pay for an
+   * object
+   * allocation.
+   *
+   * @param magnitude the magnitude of the other measurement.
+   * @param unit      the unit of the other measurement
+   * @return this measure
+   */
+  public MutableDimensionless mut_plus(double magnitude, DimensionlessUnit unit) {
+    mut_setBaseUnitMagnitude(m_baseUnitMagnitude + unit.toBaseUnits(magnitude));
+    return this;
+  }
+
+  /**
+   * Subtracts another measurement to this one. This will mutate the object
+   * instead of generating a
+   * new measurement object.
+   *
+   * @param other the measurement to add
+   * @return this measure
+   */
+  public MutableDimensionless mut_minus(Dimensionless other) {
+    return mut_minus(other.magnitude(), other.unit());
+  }
+
+  /**
+   * Subtracts another measurement to this one. This will mutate the object
+   * instead of generating a
+   * new measurement object. This is a denormalized version of
+   * {@link #mut_minus(Measure)} to avoid
+   * having to wrap raw numbers in a {@code Measure} object and pay for an
+   * object
+   * allocation.
+   *
+   * @param magnitude the magnitude of the other measurement.
+   * @param unit      the unit of the other measurement
+   * @return this measure
+   */
+  public MutableDimensionless mut_minus(double magnitude, DimensionlessUnit unit) {
+    return mut_plus(-magnitude, unit);
+  }
+
+  /**
+   * Multiplies this measurement by some constant value. This will mutate the
+   * object instead of
+   * generating a new measurement object.
+   *
+   * @param multiplier the multiplier to scale the measurement by
+   * @return this measure
+   */
+  public MutableDimensionless mut_times(double multiplier) {
+    mut_setBaseUnitMagnitude(m_baseUnitMagnitude * multiplier);
+    return this;
+  }
+
+  /**
+   * Multiplies this measurement by some constant value. This will mutate the
+   * object instead of
+   * generating a new measurement object.
+   *
+   * @param multiplier the multiplier to scale the measurement by
+   * @return this measure
+   */
+  public MutableDimensionless mut_times(Dimensionless multiplier) {
+    return mut_times(multiplier.baseUnitMagnitude());
+  }
+
+  /**
+   * Divides this measurement by some constant value. This will mutate the
+   * object
+   * instead of
+   * generating a new measurement object.
+   *
+   * @param divisor the divisor to scale the measurement by
+   * @return this measure
+   */
+  public MutableDimensionless mut_divide(double divisor) {
+    mut_setBaseUnitMagnitude(m_baseUnitMagnitude / divisor);
+    return this;
+  }
+
+  /**
+   * Divides this measurement by some constant value. This will mutate the
+   * object
+   * instead of
+   * generating a new measurement object.
+   *
+   * @param divisor the divisor to scale the measurement by
+   * @return this measure
+   */
+  public MutableDimensionless mut_divide(Dimensionless divisor) {
+    return mut_divide(divisor.baseUnitMagnitude());
+  }
+}

--- a/wpiunits/src/main/java/edu/wpi/first/units/time/MutableTime.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/time/MutableTime.java
@@ -1,0 +1,264 @@
+package edu.wpi.first.units.time;
+
+import edu.wpi.first.units.dimensionless.Dimensionless;
+
+public class MutableTime extends Time {
+
+  /**
+   * Creates a new mutable measure that is a copy of the given one.
+   *
+   * @param measure the measure to create a mutable copy of
+   * @return a new mutable measure with an initial state equal to the given
+   *         measure
+   */
+  public static MutableTime mutable(Time measure) {
+    return new MutableTime(measure.magnitude(), measure.baseUnitMagnitude(),
+        measure.unit());
+  }
+
+  /**
+   * Creates a new mutable measure with a magnitude of 0 in the given unit.
+   *
+   * @param unit the unit of measure
+   * @return a new mutable measure
+   */
+  public static MutableTime zero(TimeUnit unit) {
+    return mutable(unit.zero());
+  }
+
+  /**
+   * Creates a new mutable measure in the given unit with a magnitude equal to
+   * the
+   * given one in base
+   * units.
+   *
+   * @param baseUnitMagnitude the magnitude of the measure, in terms of the base
+   *                          unit of measure
+   * @param unit              the unit of measure
+   * @return a new mutable measure
+   */
+  public static MutableTime ofBaseUnits(double baseUnitMagnitude, TimeUnit unit) {
+    return new MutableTime(unit.fromBaseUnits(baseUnitMagnitude),
+        baseUnitMagnitude, unit);
+  }
+
+  /**
+   * Creates a new mutable measure in the given unit with a magnitude in terms
+   * of
+   * that unit.
+   *
+   * @param <U>               the type of the units of measure
+   * @param relativeMagnitude the magnitude of the measure
+   * @param unit              the unit of measure
+   * @return a new mutable measure
+   */
+  public static MutableTime ofRelativeUnits(double relativeMagnitude, TimeUnit unit) {
+    return new MutableTime(relativeMagnitude, unit.toBaseUnits(relativeMagnitude), unit);
+  }
+
+  private MutableTime(double initialMagnitude, double baseUnitMagnitude, TimeUnit unit) {
+    super(initialMagnitude, baseUnitMagnitude, unit);
+  }
+
+  // UNSAFE
+
+  /**
+   * Sets the new magnitude of the measurement. The magnitude must be in terms
+   * of
+   * the {@link
+   * #unit()}.
+   *
+   * @param magnitude the new magnitude of the measurement
+   */
+  public void mut_setMagnitude(double magnitude) {
+    m_magnitude = magnitude;
+    m_baseUnitMagnitude = m_unit.toBaseUnits(magnitude);
+  }
+
+  /**
+   * Sets the new magnitude of the measurement. The magnitude must be in terms
+   * of
+   * the base unit of
+   * the current unit.
+   *
+   * @param baseUnitMagnitude the new magnitude of the measurement
+   */
+  public void mut_setBaseUnitMagnitude(double baseUnitMagnitude) {
+    m_baseUnitMagnitude = baseUnitMagnitude;
+    m_magnitude = m_unit.fromBaseUnits(baseUnitMagnitude);
+  }
+
+  /**
+   * Overwrites the state of this measure and replaces it with values from the
+   * given one.
+   *
+   * @param other the other measure to copy values from
+   * @return this measure
+   */
+  public MutableTime mut_replace(Time other) {
+    m_magnitude = other.magnitude();
+    m_baseUnitMagnitude = other.baseUnitMagnitude();
+    m_unit = other.unit();
+    return this;
+  }
+
+  /**
+   * Overwrites the state of this measure with new values.
+   *
+   * @param magnitude the new magnitude in terms of the new unit
+   * @param unit      the new unit
+   * @return this measure
+   */
+  public MutableTime mut_replace(double magnitude, TimeUnit unit) {
+    this.m_magnitude = magnitude;
+    this.m_baseUnitMagnitude = unit.toBaseUnits(magnitude);
+    this.m_unit = unit;
+    return this;
+  }
+
+  /**
+   * Increments (or decrements)
+   * the current magnitude of the measure by the given value. The value
+   * must be in terms
+   * of the current {@link #unit() unit}.
+   *
+   * @param raw the raw value to increment by
+   * @return the measure
+   */
+  public MutableTime mut_increment(double raw) {
+    this.m_magnitude += raw;
+    this.m_baseUnitMagnitude += m_unit.toBaseUnits(raw);
+    return this;
+  }
+
+  /**
+   * Increments (or decrements) the current magnitude
+   * of the measure by the amount of the given measure.
+   *
+   * @param other the measure whose value should be added to this one
+   * @return the measure
+   */
+  public MutableTime mut_increment(Time other) {
+    m_baseUnitMagnitude += other.baseUnitMagnitude();
+    // can't naively use m_magnitude += other.in(m_unit) because the units may
+    // not
+    // be scalar multiples (eg adding 0C to 100K should result in 373.15K, not
+    // 100K)
+    m_magnitude = m_unit.fromBaseUnits(m_baseUnitMagnitude);
+    return this;
+  }
+
+  // Math
+
+  /**
+   * Adds another measurement to this one. This will mutate the object instead of
+   * generating a new
+   * measurement object.
+   *
+   * @param other the measurement to add
+   * @return this measure
+   */
+  public MutableTime mut_plus(Time other) {
+    return mut_plus(other.magnitude(), other.unit());
+  }
+
+  /**
+   * Adds another measurement to this one. This will mutate the object instead
+   * of
+   * generating a new
+   * measurement object. This is a denormalized version of
+   * {@link #mut_plus(Measure)} to avoid
+   * having to wrap raw numbers in a {@code Measure} object and pay for an
+   * object
+   * allocation.
+   *
+   * @param magnitude the magnitude of the other measurement.
+   * @param unit      the unit of the other measurement
+   * @return this measure
+   */
+  public MutableTime mut_plus(double magnitude, TimeUnit unit) {
+    mut_setBaseUnitMagnitude(m_baseUnitMagnitude + unit.toBaseUnits(magnitude));
+    return this;
+  }
+
+  /**
+   * Subtracts another measurement to this one. This will mutate the object
+   * instead of generating a
+   * new measurement object.
+   *
+   * @param other the measurement to add
+   * @return this measure
+   */
+  public MutableTime mut_minus(Time other) {
+    return mut_minus(other.magnitude(), other.unit());
+  }
+
+  /**
+   * Subtracts another measurement to this one. This will mutate the object
+   * instead of generating a
+   * new measurement object. This is a denormalized version of
+   * {@link #mut_minus(Measure)} to avoid
+   * having to wrap raw numbers in a {@code Measure} object and pay for an
+   * object
+   * allocation.
+   *
+   * @param magnitude the magnitude of the other measurement.
+   * @param unit      the unit of the other measurement
+   * @return this measure
+   */
+  public MutableTime mut_minus(double magnitude, TimeUnit unit) {
+    return mut_plus(-magnitude, unit);
+  }
+
+  /**
+   * Multiplies this measurement by some constant value. This will mutate the
+   * object instead of
+   * generating a new measurement object.
+   *
+   * @param multiplier the multiplier to scale the measurement by
+   * @return this measure
+   */
+  public MutableTime mut_times(double multiplier) {
+    mut_setBaseUnitMagnitude(m_baseUnitMagnitude * multiplier);
+    return this;
+  }
+
+  /**
+   * Multiplies this measurement by some constant value. This will mutate the
+   * object instead of
+   * generating a new measurement object.
+   *
+   * @param multiplier the multiplier to scale the measurement by
+   * @return this measure
+   */
+  public MutableTime mut_times(Dimensionless multiplier) {
+    return mut_times(multiplier.baseUnitMagnitude());
+  }
+
+  /**
+   * Divides this measurement by some constant value. This will mutate the
+   * object
+   * instead of
+   * generating a new measurement object.
+   *
+   * @param divisor the divisor to scale the measurement by
+   * @return this measure
+   */
+  public MutableTime mut_divide(double divisor) {
+    mut_setBaseUnitMagnitude(m_baseUnitMagnitude / divisor);
+    return this;
+  }
+
+  /**
+   * Divides this measurement by some constant value. This will mutate the
+   * object
+   * instead of
+   * generating a new measurement object.
+   *
+   * @param divisor the divisor to scale the measurement by
+   * @return this measure
+   */
+  public MutableTime mut_divide(Dimensionless divisor) {
+    return mut_divide(divisor.baseUnitMagnitude());
+  }
+}

--- a/wpiunits/src/main/java/edu/wpi/first/units/time/Time.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/time/Time.java
@@ -1,0 +1,403 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.units.time;
+
+import java.util.Objects;
+
+/**
+ * A measure holds the magnitude and unit of some dimension, such as distance,
+ * time, or speed. An
+ * immutable measure is <i>immutable</i> and <i>type safe</i>, making it easy to
+ * use in concurrent
+ * situations and gives compile-time safety. Two measures with the same
+ * <i>unit</i> and
+ * <i>magnitude</i> are effectively equivalent objects.
+ *
+ */
+public class Time implements Comparable<Time> {
+
+  /**
+   * The threshold for two measures to be considered equivalent if converted to
+   * the same unit. This
+   * is only needed due to floating-point error.
+   */
+  static double EQUIVALENCE_THRESHOLD = 1e-12;
+
+  protected double m_magnitude;
+  protected double m_baseUnitMagnitude;
+  protected TimeUnit m_unit;
+
+  /**
+   * Creates a new immutable Dimensionless measure instance. This shouldn't be used
+   * directly; prefer one of the
+   * factory methods instead.
+   *
+   * @param magnitude the magnitude of this measure
+   * @param unit      the unit of this measure.
+   */
+  Time(double magnitude, double baseUnitMagnitude, TimeUnit unit) {
+    Objects.requireNonNull(unit, "Unit cannot be null");
+    m_magnitude = magnitude;
+    m_baseUnitMagnitude = baseUnitMagnitude;
+    m_unit = unit;
+  }
+
+  /**
+   * Gets the unitless magnitude of this measure.
+   *
+   * @return the magnitude in terms of {@link #unit() the unit}.
+   */
+  public double magnitude() {
+    return m_magnitude;
+  }
+
+  /**
+   * Gets the magnitude of this measure in terms of the base unit. If the unit is
+   * the base unit for
+   * its system of measure, then the value will be equivalent to
+   * {@link #magnitude()}.
+   *
+   * @return the magnitude in terms of the base unit
+   */
+  public double baseUnitMagnitude() {
+    return m_baseUnitMagnitude;
+  }
+
+  /**
+   * Gets the units of this measure.
+   *
+   * @return the unit
+   */
+  public TimeUnit unit() {
+    return m_unit;
+  }
+
+  /**
+   * Converts this measure to a measure with a different unit of the same type, eg
+   * minutes to
+   * seconds. Converting to the same unit is equivalent to calling
+   * {@link #magnitude()}.
+   *
+   * <pre>
+   *   Meters.of(12).in(Feet) // 39.3701
+   *   Seconds.of(15).in(Minutes) // 0.25
+   * </pre>
+   *
+   * @param unit the unit to convert this measure to
+   * @return the value of this measure in the given unit
+   */
+  public double in(TimeUnit unit) {
+    if (this.unit().equals(unit)) {
+      return magnitude();
+    } else {
+      return unit.fromBaseUnits(baseUnitMagnitude());
+    }
+  }
+
+  /**
+   * Multiplies this measurement by some constant multiplier and returns the
+   * result. The magnitude
+   * of the result will be the <i>base</i> magnitude multiplied by the scalar
+   * value. If the measure
+   * uses a unit with a non-linear relation to its base unit (such as Fahrenheit
+   * for temperature),
+   * then the result will only be a multiple <i>in terms of the base unit</i>.
+   *
+   * @param multiplier the constant to multiply by
+   * @return the resulting measure
+   */
+  public Time times(double multiplier) {
+    return Time.ofBaseUnits(baseUnitMagnitude() * multiplier, unit());
+  }
+
+  /**
+   * Divides this measurement by some constant divisor and returns the result.
+   * This is equivalent to
+   * {@code times(1 / divisor)}
+   *
+   * @param divisor the constant to divide by
+   * @return the resulting measure
+   * @see #times(double)
+   */
+  public Time divide(double divisor) {
+    return times(1 / divisor);
+  }
+
+  /**
+   * Adds another measure to this one. The resulting measure has the same unit as
+   * this one.
+   *
+   * @param other the measure to add to this one
+   * @return a new measure containing the result
+   */
+  public Time plus(Time other) {
+    return unit().ofBaseUnits(baseUnitMagnitude() + other.baseUnitMagnitude());
+  }
+
+  /**
+   * Subtracts another measure from this one. The resulting measure has the same
+   * unit as this one.
+   *
+   * @param other the measure to subtract from this one
+   * @return a new measure containing the result
+   */
+  public Time minus(Time other) {
+    return unit().ofBaseUnits(baseUnitMagnitude() - other.baseUnitMagnitude());
+  }
+
+  /**
+   * Negates this measure and returns the result.
+   *
+   * @return the resulting measure
+   */
+  public Time negate() {
+    return times(-1);
+  }
+
+  /**
+   * Returns an immutable copy of this measure. The copy can be used freely and is
+   * guaranteed never
+   * to change.
+   *
+   * @return the copied measure
+   */
+  public Time copy() {
+    return new Time(m_magnitude, m_baseUnitMagnitude, m_unit);
+  }
+
+  /**
+   * Creates a new mutable copy of this measure.
+   *
+   * @return a mutable measure initialized to be identical to this measure
+   */
+  public MutableTime mutableCopy() {
+    return MutableTime.mutable(this);
+  }
+
+  /**
+   * Checks if this measure is near another measure of the same unit. Provide a
+   * variance threshold
+   * for use for a +/- scalar, such as 0.05 for +/- 5%.
+   *
+   * <pre>
+   *   Inches.of(11).isNear(Inches.of(10), 0.1) // true
+   *   Inches.of(12).isNear(Inches.of(10), 0.1) // false
+   * </pre>
+   *
+   * @param other             the other measurement to compare against
+   * @param varianceThreshold the acceptable variance threshold, in terms of an
+   *                          acceptable +/- error
+   *                          range multiplier. Checking if a value is within 10%
+   *                          means a value of 0.1 should be passed;
+   *                          checking if a value is within 1% means a value of
+   *                          0.01 should be passed, and so on.
+   * @return true if this unit is near the other measure, otherwise false
+   */
+  public boolean isNear(Time other, double varianceThreshold) {
+    // abs so negative inputs are calculated correctly
+    var tolerance = Math.abs(other.baseUnitMagnitude() * varianceThreshold);
+
+    return Math.abs(this.baseUnitMagnitude() - other.baseUnitMagnitude()) <= tolerance;
+  }
+
+  /**
+   * Checks if this measure is near another measure of the same unit, with a
+   * specified tolerance of
+   * the same unit.
+   *
+   * <pre>
+   *     Meters.of(1).isNear(Meters.of(1.2), Millimeters.of(300)) // true
+   *     Degrees.of(90).isNear(Rotations.of(0.5), Degrees.of(45)) // false
+   * </pre>
+   *
+   * @param other     the other measure to compare against.
+   * @param tolerance the tolerance allowed in which the two measures are defined
+   *                  as near each
+   *                  other.
+   * @return true if this unit is near the other measure, otherwise false.
+   */
+  public boolean isNear(Time other, Time tolerance) {
+    return Math.abs(this.baseUnitMagnitude() - other.baseUnitMagnitude()) <= Math
+        .abs(tolerance.baseUnitMagnitude());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int compareTo(Time o) {
+    return Double.compare(this.baseUnitMagnitude(), o.baseUnitMagnitude());
+  }
+
+  /**
+   * Checks if this measure is greater than another measure of the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has a greater equivalent magnitude, false
+   *         otherwise
+   */
+  public boolean gt(Time o) {
+    return compareTo(o) > 0;
+  }
+
+  /**
+   * Checks if this measure is greater than or equal to another measure of
+   * the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has an equal or greater magnitude,
+   *         false otherwise
+   */
+  public boolean gte(Time o) {
+    return compareTo(o) > 0 || equals(o);
+  }
+
+  /**
+   * Checks if this measure is less than another measure of the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has a lesser equivalent magnitude, false
+   *         otherwise
+   */
+  public boolean lt(Time o) {
+    return compareTo(o) < 0;
+  }
+
+  /**
+   * Checks if this measure is less than or equal to another measure of
+   * the same unit.
+   *
+   * @param o the other measure to compare to
+   * @return true if this measure has an equal or lesser equivalent magnitude,
+   *         false otherwise
+   */
+  public boolean lte(Time o) {
+    return compareTo(o) < 0 || equals(o);
+  }
+
+  /**
+   * Returns the measure with the absolute value closest to positive infinity.
+   *
+   * @param <U>      the type of the units of the measures
+   * @param measures the set of measures to compare
+   * @return the measure with the greatest positive magnitude, or null if no
+   *         measures were provided
+   */
+  static Time max(Time... measures) {
+    if (measures.length == 0) {
+      return null; // nothing to compare
+    }
+
+    Time max = null;
+    for (Time measure : measures) {
+      if (max == null || measure.gt(max)) {
+        max = measure;
+      }
+    }
+
+    return max;
+  }
+
+  /**
+   * Returns the measure with the absolute value closest to negative infinity.
+   *
+   * @param <U>      the type of the units of the measures
+   * @param measures the set of measures to compare
+   * @return the measure with the greatest negative magnitude
+   */
+  static Time min(Time... measures) {
+    if (measures.length == 0) {
+      return null; // nothing to compare
+    }
+
+    Time max = null;
+    for (Time measure : measures) {
+      if (max == null || measure.lt(max)) {
+        max = measure;
+      }
+    }
+
+    return max;
+  }
+
+  /**
+   * Returns a string representation of this measurement in a shorthand form. The
+   * symbol of the
+   * backing unit is used, rather than the full name, and the magnitude is
+   * represented in scientific
+   * notation.
+   *
+   * @return the short form representation of this measurement
+   */
+  public String toShortString() {
+    // eg 1.234e+04 V/m (1234 Volt per Meter in long form)
+    return String.format("%.3e %s", magnitude(), unit().symbol());
+  }
+
+  /**
+   * Returns a string representation of this measurement in a longhand form. The
+   * name of the backing
+   * unit is used, rather than its symbol, and the magnitude is represented in a
+   * full string, not
+   * scientific notation. (Very large values may be represented in scientific
+   * notation, however)
+   *
+   * @return the long form representation of this measurement
+   */
+  public String toLongString() {
+    // eg 1234 Volt per Meter (1.234e+04 V/m in short form)
+    return String.format("%s %s", magnitude(), unit().name());
+  }
+
+  /**
+   * Creates a new measure in the given unit with a magnitude equal to the given
+   * one in base units.
+   *
+   * @param <U>               the type of the units of measure
+   * @param baseUnitMagnitude the magnitude of the measure, in terms of the base
+   *                          unit of measure
+   * @param unit              the unit of measure
+   * @return a new measure
+   */
+  public static Time ofBaseUnits(
+      double baseUnitMagnitude, TimeUnit unit) {
+    return new Time(unit.fromBaseUnits(baseUnitMagnitude), baseUnitMagnitude, unit);
+  }
+
+  /**
+   * Creates a new measure in the given unit with a magnitude in terms of that
+   * unit.
+   *
+   * @param <U>               the type of the units of measure
+   * @param relativeMagnitude the magnitude of the measure
+   * @param unit              the unit of measure
+   * @return a new measure
+   */
+  public static Time ofRelativeUnits(
+      double relativeMagnitude, TimeUnit unit) {
+    return new Time(relativeMagnitude, unit.toBaseUnits(relativeMagnitude), unit);
+  }
+
+  /**
+   * Checks for <i>object equality</i>. To check if two measures are
+   * <i>equivalent</i>, use {@link
+   * #isEquivalent(Measure) isEquivalent}.
+   */
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof Time other
+        && Objects.equals(m_unit, other.unit())
+        && Math.abs(baseUnitMagnitude() - other.baseUnitMagnitude()) <= EQUIVALENCE_THRESHOLD;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(m_magnitude, m_unit);
+  }
+
+  @Override
+  public String toString() {
+    return toShortString();
+  }
+
+}

--- a/wpiunits/src/main/java/edu/wpi/first/units/time/TimeUnit.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/time/TimeUnit.java
@@ -1,0 +1,347 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.units.time;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.UnaryFunction;
+
+/**
+ * Unit of measurement that defines an Time, such as radians, rotations, or
+ * degrees.
+ *
+ */
+public class TimeUnit {
+
+  public static final TimeUnit Seconds = new TimeUnit();
+
+  public static final TimeUnit Second = Seconds;
+
+  public static final TimeUnit Milliseconds = new TimeUnit(1e-3, "Millisecond", "ms");
+
+  public static final TimeUnit Millisecond = Milliseconds;
+
+  public static final TimeUnit Microseconds = new TimeUnit(1e-6, "Microsecond", "μs");
+
+  public static final TimeUnit Microsecond = Microseconds;
+
+  public static final TimeUnit Minutes = new TimeUnit(60.0, "Minute", "min");
+
+  public static final TimeUnit Minute = Minutes;
+
+
+  private final UnaryFunction m_toBaseConverter;
+  private final UnaryFunction m_fromBaseConverter;
+
+  private final Optional<TimeUnit> m_baseUnit;
+
+  private Time m_zero;
+  private Time m_one;
+
+  private final String m_name;
+  private final String m_symbol;
+
+  /**
+   * Creates a new Time unit defined by its relationship to the S.I. base Time
+   * unit (i.e. Radians).
+   *
+   * @param toBaseConverter   a function for converting units of this type to
+   *                          Radians.
+   * @param fromBaseConverter a function for converting units of the other unit to
+   *                          Radians.
+   * @param name              the name of the Time unit. This should be a
+   *                          singular noun
+   *                          (so "Degree", not "Degrees")
+   * @param symbol            the short symbol for the unit, such as "rad" for
+   *                          Radians or "rev" for Revolutions.
+   */
+  public TimeUnit(
+      UnaryFunction toBaseConverter,
+      UnaryFunction fromBaseConverter,
+      String name,
+      String symbol) {
+    m_baseUnit = Optional.of(Seconds);
+    m_toBaseConverter = Objects.requireNonNull(toBaseConverter);
+    m_fromBaseConverter = Objects.requireNonNull(fromBaseConverter);
+    m_name = Objects.requireNonNull(name);
+    m_symbol = Objects.requireNonNull(symbol);
+  }
+
+  /**
+   * Creates a new unit with the given name and multiplier to the S.I. base Time
+   * unit (i.e. Radians).
+   *
+   * @param baseUnitEquivalent the multiplier to convert this unit to the other
+   *                           unit of this type.
+   *                           For example, meters has a multiplier of 1, mm has a
+   *                           multiplier of 1e3, and km has
+   *                           multiplier of 1e-3.
+   * @param name               the name of the Time unit. This should be a
+   *                           singular noun
+   *                           (so "Degree", not "Degrees")
+   * @param symbol             the short symbol for the unit, such as "rad" for
+   *                           Radians or "rev" for Revolutions.
+   */
+  public TimeUnit(
+      double baseUnitEquivalent,
+      String name,
+      String symbol) {
+    this(
+        x -> x * baseUnitEquivalent,
+        x -> x / baseUnitEquivalent,
+        name,
+        symbol);
+  }
+
+  /**
+   * Creates a new unit that is identical to other, but with a different name and
+   * symbol.
+   *
+   * @param other  the other Time that this one is identical to.
+   * @param name   the name of the Time unit. This should be a
+   *               singular noun
+   *               (so "Degree", not "Degrees")
+   * @param symbol the short symbol for the unit, such as "rad" for
+   *               Radians or "rev" for Revolutions.
+   */
+  public TimeUnit(
+      TimeUnit other,
+      String name,
+      String symbol) {
+    this(
+        other.m_toBaseConverter,
+        other.m_fromBaseConverter,
+        name,
+        symbol);
+  }
+
+  /**
+   * Instantiates the base unit for Times (i.e. Radians). Only used once by the
+   * static field Radians.
+   */
+  private TimeUnit() {
+    m_baseUnit = Optional.empty();
+    m_fromBaseConverter = x -> x;
+    m_toBaseConverter = x -> x;
+    m_name = "Second";
+    m_symbol = "s";
+  }
+
+  /**
+   * Gets the base unit of measurement that this unit is derived from. If the unit
+   * is the base unit,
+   * the unit will be returned.
+   *
+   * <pre>
+   * <code>
+   *   Unit baseUnit = new Unit(null, ...);
+   *   baseUnit.getBaseUnit(); // returns baseUnit
+   *
+   *   Unit derivedUnit = new Unit(baseUnit, ...);
+   *   derivedUnit.getBaseUnit(); // returns baseUnit
+   * </code>
+   * </pre>
+   *
+   * @return the base unit
+   */
+  public Optional<TimeUnit> getBaseUnit() {
+    return m_baseUnit;
+  }
+
+  /**
+   * Checks if this unit is the base unit for its own system of measurement.
+   *
+   * @return true if this is the base unit, false if not
+   */
+  public boolean isBaseUnit() {
+    return this.equals(getBaseUnit().get());
+  }
+
+  /**
+   * Checks if this unit is equivalent to another one. Equivalence is determined
+   * by both units
+   * having the same base type and treat the same base unit magnitude as the same
+   * magnitude in their
+   * own units, to within {@link Measure#EQUIVALENCE_THRESHOLD}.
+   *
+   * @param other the unit to compare to.
+   * @return true if both units are equivalent, false if not
+   */
+  public boolean equivalent(TimeUnit other) {
+
+    double arbitrary = 16_777.214; // 2^24 / 1e3
+
+    return Math.abs(
+        this.m_fromBaseConverter.apply(arbitrary)
+            - other.m_fromBaseConverter.apply(arbitrary)) <= Time.EQUIVALENCE_THRESHOLD
+        && Math.abs(
+            this.m_toBaseConverter.apply(arbitrary)
+                - other.m_toBaseConverter.apply(arbitrary)) <= Time.EQUIVALENCE_THRESHOLD;
+  }
+
+  /**
+   * Converts a value in terms of base units to a value in terms of this unit.
+   *
+   * @param valueInBaseUnits the value in base units to convert
+   * @return the equivalent value in terms of this unit
+   */
+  public double fromBaseUnits(double valueInBaseUnits) {
+    return m_fromBaseConverter.apply(valueInBaseUnits);
+  }
+
+  /**
+   * Converts a value in terms of this unit to a value in terms of the base unit.
+   *
+   * @param valueInNativeUnits the value in terms of this unit to convert
+   * @return the equivalent value in terms of the base unit
+   */
+  public double toBaseUnits(double valueInNativeUnits) {
+    return m_toBaseConverter.apply(valueInNativeUnits);
+  }
+
+  /**
+   * Converts a magnitude in terms of another unit of the same dimension to a
+   * magnitude in terms of
+   * this unit.
+   *
+   * <pre>
+   *   Inches.convertFrom(12, Feet) // 144.0
+   *   Kilograms.convertFrom(2.2, Pounds) // 0.9979024
+   * </pre>
+   *
+   * @param magnitude a magnitude measured in another unit
+   * @param otherUnit the unit to convert the magnitude to
+   * @return the corresponding value in terms of this unit.
+   */
+  public double convertFrom(double magnitude, TimeUnit otherUnit) {
+    if (this.equivalent(otherUnit.getBaseUnit().get())) {
+      // same unit, don't bother converting
+      return magnitude;
+    }
+    return this.fromBaseUnits(otherUnit.toBaseUnits(magnitude));
+  }
+
+  /**
+   * Gets the conversion function used to convert values to base unit terms. This
+   * generally
+   * shouldn't need to be used directly; prefer {@link #toBaseUnits(double)}
+   * instead.
+   *
+   * @return the conversion function
+   */
+  public UnaryFunction getConverterToBase() {
+    return m_toBaseConverter;
+  }
+
+  /**
+   * Gets the conversion function used to convert values to terms of this unit.
+   * This generally
+   * shouldn't need to be used directly; prefer {@link #fromBaseUnits(double)}
+   * instead.
+   *
+   * @return the conversion function
+   */
+  public UnaryFunction getConverterFromBase() {
+    return m_fromBaseConverter;
+  }
+
+  /**
+   * Creates a new measure of this unit with the given value. The resulting
+   * measure is
+   * <i>immutable</i> and cannot have its value modified.
+   *
+   * @param magnitude the magnitude of the measure to create
+   * @return the measure
+   */
+  public Time of(double magnitude) {
+    if (magnitude == 0) {
+      // reuse static object
+      return zero();
+    }
+    if (magnitude == 1) {
+      // reuse static object
+      return one();
+    }
+    return Time.ofRelativeUnits(magnitude, this);
+  }
+
+  /**
+   * Creates a new measure with a magnitude equal to the given base unit
+   * magnitude, converted to be
+   * in terms of this unit.
+   *
+   * @param baseUnitMagnitude the magnitude of the measure in terms of the base
+   *                          unit
+   * @return the measure
+   */
+  public Time ofBaseUnits(double baseUnitMagnitude) {
+    return Time.ofBaseUnits(baseUnitMagnitude, this);
+  }
+
+  /**
+   * Gets a measure with a magnitude of 0 in terms of this unit.
+   *
+   * @return the zero-valued measure
+   */
+  public Time zero() {
+    // lazy init because 'this' is null in object initialization
+    if (m_zero == null) {
+      m_zero = Time.ofRelativeUnits(0, this);
+    }
+    return m_zero;
+  }
+
+  /**
+   * Gets a measure with a magnitude of 1 in terms of this unit.
+   *
+   * @return the 1-valued measure
+   */
+  public Time one() {
+    // lazy init because 'this' is null in object initialization
+    if (m_one == null) {
+      m_one = Time.ofRelativeUnits(1, this);
+    }
+    return m_one;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return this == o
+        || o instanceof TimeUnit that
+            && m_name.equals(that.m_name)
+            && m_symbol.equals(that.m_symbol)
+            && this.equivalent(that);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(m_toBaseConverter, m_fromBaseConverter, m_name, m_symbol);
+  }
+
+  /**
+   * Gets the name of this unit.
+   *
+   * @return the unit's name
+   */
+  public String name() {
+    return m_name;
+  }
+
+  /**
+   * Gets the symbol of this unit.
+   *
+   * @return the unit's symbol
+   */
+  public String symbol() {
+    return m_symbol;
+  }
+
+  @Override
+  public String toString() {
+    return name();
+  }
+}


### PR DESCRIPTION
So this PR is based on feedback and discussion from PR #6710, #6696, #6684, #6676

I know some of those are mine.  I will consider those dead and will leave them only for references to the feedback and notes. 

I'm going to start with taking the existing units API and breaking it down into separate measurement type packages, angle, time, dimensionless, angularvelocity, etc. 

Each will have an a class equivalent to the old Measure interface and ImmutableMeasure class which will handle immutable measures. (i.e. Angle)

Each will have a class that will handle the units of that type (i.e. AngleUnit)

Each class that handles Immutable measures will have a child class that handles mutable ones (i.e. MutableAngle).

At first (and probably at the end) many of the packages will be near duplicates of each other except for minor variations to handle  division, multiplication, etc.

For the most part no generics will be used.  They might come back in a limited form as this is further optimized, but no guarantees.    

Every unit of a certain measurement type will have all of its derived units go back to the S.I. standard unit.  As an example feet will be based on meters and inches will be based on meters.  New units will not be based off of other ones unless that other one is the S.I. base (or derived as in the case of m/s).  I've found it confusing when seeing the word base in the old API and not knowing if S.I. base or a unit that a new one is based on is used.  

Units that are derived from the standard S.I. base units will be done so here as well much like the way AngularVelocity is done.  

I'll not be focusing on UnitBuilder at this time.  I'll effectively deprecate it.  Though custom units of a type can still be created through the constructors and static methods of that type.  

Of course feeback is welcome.  I'll leave this in draft form until I've effectively replaced all of the existing units with the new setup.  
