### PR TITLE
[wpimath] Add and use kinematics.copyInto()

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/DifferentialDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/DifferentialDriveKinematics.java
@@ -121,11 +121,10 @@ public class DifferentialDriveKinematics
   }
 
   @Override
-  public DifferentialDriveWheelPositions copyInto(
-      DifferentialDriveWheelPositions positions, DifferentialDriveWheelPositions buffer) {
-    buffer.leftMeters = positions.leftMeters;
-    buffer.rightMeters = positions.rightMeters;
-    return buffer;
+  public void copyInto(
+      DifferentialDriveWheelPositions positions, DifferentialDriveWheelPositions output) {
+    output.leftMeters = positions.leftMeters;
+    output.rightMeters = positions.rightMeters;
   }
 
   @Override

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/DifferentialDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/DifferentialDriveKinematics.java
@@ -121,6 +121,14 @@ public class DifferentialDriveKinematics
   }
 
   @Override
+  public DifferentialDriveWheelPositions copyInto(
+      DifferentialDriveWheelPositions positions, DifferentialDriveWheelPositions buffer) {
+    buffer.leftMeters = positions.leftMeters;
+    buffer.rightMeters = positions.rightMeters;
+    return buffer;
+  }
+
+  @Override
   public DifferentialDriveWheelPositions interpolate(
       DifferentialDriveWheelPositions startValue,
       DifferentialDriveWheelPositions endValue,

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/Kinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/Kinematics.java
@@ -49,8 +49,43 @@ public interface Kinematics<S, P> extends Interpolator<P> {
   /**
    * Returns a copy of the wheel positions object.
    *
+   * <p>Implementation note:
+   *
+   * <ul>
+   *   <li>If {@code P} is (deeply) immutable, this should return {@code positions}.
+   *   <li>Otherwise, a new copy should be created and returned.
+   * </ul>
+   *
    * @param positions The wheel positions object to copy.
    * @return A copy.
    */
   P copy(P positions);
+
+  /**
+   * Returns a copy of the wheel positions object, possibly reusing storage in the buffer.
+   *
+   * <p>This is meant to be used like this:
+   *
+   * <pre>
+   * m_buffer = m_kinematics.copyInto(positions, m_buffer);
+   * </pre>
+   *
+   * <p>Implementation note:
+   *
+   * <ul>
+   *   <li>If {@code P} is (deeply) immutable, then like {@link #copy}, this should return {@code
+   *       positions}.
+   *   <li>If {@code P} is completely mutable, then this should copy into {@code buffer} and return
+   *       it.
+   *   <li>Otherwise (some members are immutable and some are mutable), a new copy should be created
+   *       and returned.
+   * </ul>
+   *
+   * @param positions The wheel positions object to copy. Must not be modified.
+   * @param buffer A buffer available for overwriting. The state after the call is undefined.
+   * @return The copy. Identity is undefined.
+   */
+  default P copyInto(P positions, P buffer) {
+    return copy(positions);
+  }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/Kinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/Kinematics.java
@@ -49,43 +49,17 @@ public interface Kinematics<S, P> extends Interpolator<P> {
   /**
    * Returns a copy of the wheel positions object.
    *
-   * <p>Implementation note:
-   *
-   * <ul>
-   *   <li>If {@code P} is (deeply) immutable, this should return {@code positions}.
-   *   <li>Otherwise, a new copy should be created and returned.
-   * </ul>
-   *
    * @param positions The wheel positions object to copy.
    * @return A copy.
    */
   P copy(P positions);
 
   /**
-   * Returns a copy of the wheel positions object, possibly reusing storage in the buffer.
+   * Copies the value of the wheel positions object into the output.
    *
-   * <p>This is meant to be used like this:
-   *
-   * <pre>
-   * m_buffer = m_kinematics.copyInto(positions, m_buffer);
-   * </pre>
-   *
-   * <p>Implementation note:
-   *
-   * <ul>
-   *   <li>If {@code P} is (deeply) immutable, then like {@link #copy}, this should return {@code
-   *       positions}.
-   *   <li>If {@code P} is completely mutable, then this should copy into {@code buffer} and return
-   *       it.
-   *   <li>Otherwise (some members are immutable and some are mutable), a new copy should be created
-   *       and returned.
-   * </ul>
-   *
-   * @param positions The wheel positions object to copy. Must not be modified.
-   * @param buffer A buffer available for overwriting. The state after the call is undefined.
-   * @return The copy. Identity is undefined.
+   * @param positions The wheel positions object to copy. Will not be modified.
+   * @param output The output variable of the copy operation. Will have the same value as the
+   *     positions object after the call.
    */
-  default P copyInto(P positions, P buffer) {
-    return copy(positions);
-  }
+  void copyInto(P positions, P output);
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/MecanumDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/MecanumDriveKinematics.java
@@ -267,6 +267,16 @@ public class MecanumDriveKinematics
   }
 
   @Override
+  public MecanumDriveWheelPositions copyInto(
+      MecanumDriveWheelPositions positions, MecanumDriveWheelPositions buffer) {
+    buffer.frontLeftMeters = positions.frontLeftMeters;
+    buffer.frontRightMeters = positions.frontRightMeters;
+    buffer.rearLeftMeters = positions.rearLeftMeters;
+    buffer.rearRightMeters = positions.rearRightMeters;
+    return buffer;
+  }
+
+  @Override
   public MecanumDriveWheelPositions interpolate(
       MecanumDriveWheelPositions startValue, MecanumDriveWheelPositions endValue, double t) {
     return new MecanumDriveWheelPositions(

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/MecanumDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/MecanumDriveKinematics.java
@@ -267,13 +267,11 @@ public class MecanumDriveKinematics
   }
 
   @Override
-  public MecanumDriveWheelPositions copyInto(
-      MecanumDriveWheelPositions positions, MecanumDriveWheelPositions buffer) {
-    buffer.frontLeftMeters = positions.frontLeftMeters;
-    buffer.frontRightMeters = positions.frontRightMeters;
-    buffer.rearLeftMeters = positions.rearLeftMeters;
-    buffer.rearRightMeters = positions.rearRightMeters;
-    return buffer;
+  public void copyInto(MecanumDriveWheelPositions positions, MecanumDriveWheelPositions output) {
+    output.frontLeftMeters = positions.frontLeftMeters;
+    output.frontRightMeters = positions.frontRightMeters;
+    output.rearLeftMeters = positions.rearLeftMeters;
+    output.rearRightMeters = positions.rearRightMeters;
   }
 
   @Override

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/Odometry.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/Odometry.java
@@ -60,7 +60,7 @@ public class Odometry<T> {
     m_poseMeters = poseMeters;
     m_previousAngle = m_poseMeters.getRotation();
     m_gyroOffset = m_poseMeters.getRotation().minus(gyroAngle);
-    m_previousWheelPositions = m_kinematics.copy(wheelPositions);
+    m_previousWheelPositions = m_kinematics.copyInto(wheelPositions, m_previousWheelPositions);
   }
 
   /**
@@ -90,7 +90,7 @@ public class Odometry<T> {
 
     var newPose = m_poseMeters.exp(twist);
 
-    m_previousWheelPositions = m_kinematics.copy(wheelPositions);
+    m_previousWheelPositions = m_kinematics.copyInto(wheelPositions, m_previousWheelPositions);
     m_previousAngle = angle;
     m_poseMeters = new Pose2d(newPose.getTranslation(), angle);
 

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/Odometry.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/Odometry.java
@@ -24,7 +24,7 @@ public class Odometry<T> {
 
   private Rotation2d m_gyroOffset;
   private Rotation2d m_previousAngle;
-  private T m_previousWheelPositions;
+  private final T m_previousWheelPositions;
 
   /**
    * Constructs an Odometry object.
@@ -60,7 +60,7 @@ public class Odometry<T> {
     m_poseMeters = poseMeters;
     m_previousAngle = m_poseMeters.getRotation();
     m_gyroOffset = m_poseMeters.getRotation().minus(gyroAngle);
-    m_previousWheelPositions = m_kinematics.copyInto(wheelPositions, m_previousWheelPositions);
+    m_kinematics.copyInto(wheelPositions, m_previousWheelPositions);
   }
 
   /**
@@ -90,7 +90,7 @@ public class Odometry<T> {
 
     var newPose = m_poseMeters.exp(twist);
 
-    m_previousWheelPositions = m_kinematics.copyInto(wheelPositions, m_previousWheelPositions);
+    m_kinematics.copyInto(wheelPositions, m_previousWheelPositions);
     m_previousAngle = angle;
     m_poseMeters = new Pose2d(newPose.getTranslation(), angle);
 

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
@@ -393,16 +393,14 @@ public class SwerveDriveKinematics
   }
 
   @Override
-  public SwerveModulePosition[] copyInto(
-      SwerveModulePosition[] positions, SwerveModulePosition[] buffer) {
-    if (positions.length != buffer.length) {
-      return copy(positions);
+  public void copyInto(SwerveModulePosition[] positions, SwerveModulePosition[] output) {
+    if (positions.length != output.length) {
+      throw new IllegalArgumentException("Inconsistent number of modules!");
     }
     for (int i = 0; i < positions.length; ++i) {
-      buffer[i].distanceMeters = positions[i].distanceMeters;
-      buffer[i].angle = positions[i].angle;
+      output[i].distanceMeters = positions[i].distanceMeters;
+      output[i].angle = positions[i].angle;
     }
-    return buffer;
   }
 
   @Override

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
@@ -393,6 +393,19 @@ public class SwerveDriveKinematics
   }
 
   @Override
+  public SwerveModulePosition[] copyInto(
+      SwerveModulePosition[] positions, SwerveModulePosition[] buffer) {
+    if (positions.length != buffer.length) {
+      return copy(positions);
+    }
+    for (int i = 0; i < positions.length; ++i) {
+      buffer[i].distanceMeters = positions[i].distanceMeters;
+      buffer[i].angle = positions[i].angle;
+    }
+    return buffer;
+  }
+
+  @Override
   public SwerveModulePosition[] interpolate(
       SwerveModulePosition[] startValue, SwerveModulePosition[] endValue, double t) {
     if (endValue.length != startValue.length) {

--- a/wpimath/src/main/native/include/frc/kinematics/Kinematics.h
+++ b/wpimath/src/main/native/include/frc/kinematics/Kinematics.h
@@ -20,7 +20,8 @@ namespace frc {
  * forward kinematics converts wheel speeds into chassis speed.
  */
 template <typename WheelSpeeds, typename WheelPositions>
-  requires std::copy_constructible<WheelPositions>
+  requires std::copy_constructible<WheelPositions> &&
+           std::assignable_from<WheelPositions&, const WheelPositions&>
 class WPILIB_DLLEXPORT Kinematics {
  public:
   /**


### PR DESCRIPTION
This saves on a deep copy of the wheel positions in `Odometry.resetPosition()` and `Odometry.update()`, and by extension `PoseEstimator.resetPosition()` and `PoseEstimator.update()`. Notably, for a 4 module swerve that's 5 object allocations (1 for the array and 1 per module), which given that `update()` is typically called every single robot loop can add up relatively quickly. It also doesn't effect what few custom kinematics implementations there are, since you could use the defaulted implementation.