### PR TITLE
[build] Disable std::mutex constexpr constructor on Windows (again)

### DIFF
--- a/cmake/modules/CompileWarnings.cmake
+++ b/cmake/modules/CompileWarnings.cmake
@@ -53,4 +53,9 @@ macro(wpilib_target_warnings target)
     )
         target_compile_options(${target} PRIVATE -gz=zlib)
     endif()
+
+    # Disable std::mutex constexpr constructor on MSVC
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+    endif()
 endmacro()

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -41,6 +41,11 @@ nativeUtils.platformConfigs.each {
   }
 }
 
+// Disable std::mutex constexpr constructor on MSVC
+nativeUtils.platformConfigs.named(nativeUtils.wpi.platforms.windowsx64).configure {
+    it.cppCompiler.args.add("/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR")
+}
+
 nativeUtils.platformConfigs.linuxathena.linker.args.add("-Wl,--fatal-warnings")
 
 model {


### PR DESCRIPTION
Currently, artifacts are broken on a number of non-wpilib windows JVMs due to the JVM using an older redistributable.