### PR TITLE
[build] CMake: remove external HAL option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,10 +70,6 @@ option(WITH_TESTS "Build unit tests (requires internet connection)" ON)
 option(WITH_GUI "Build GUI items" ON)
 option(WITH_SIMULATION_MODULES "Build simulation modules" ON)
 
-# Options for external HAL.
-option(WITH_EXTERNAL_HAL "Use a separately built HAL" OFF)
-set(EXTERNAL_HAL_FILE "" CACHE FILEPATH "Location to look for an external HAL CMake File")
-
 # Options for using a package manager (e.g., vcpkg) for certain dependencies.
 option(USE_SYSTEM_FMTLIB "Use system fmtlib" OFF)
 option(USE_SYSTEM_LIBUV "Use system libuv" OFF)

--- a/README-CMAKE.md
+++ b/README-CMAKE.md
@@ -67,10 +67,6 @@ The following build options are available:
   * This option will build the wpimath library. This option must be on to build wpilib.
 * `WITH_WPIUNITS` (ON Default)
   * This option will build the wpiunits library. This option must be on to build the Java wpimath library and requires `WITH_JAVA` to also be on.
-* `WITH_EXTERNAL_HAL` (OFF Default)
-  * This option will build wpilib with an externally built HAL.
-* `EXTERNAL_HAL_FILE`
-  * Set this option to the CMake File of the externally built HAL. NOTE: set it to the file itself, not the folder the file is located in!
 * `OPENCV_JAVA_INSTALL_DIR`
   * Set this option to the location of the archive of the OpenCV Java bindings (it should be called opencv-xxx.jar, with the x'es being version numbers). NOTE: set it to the LOCATION of the file, not the file itself!
 * `NO_WERROR` (OFF Default)

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -6,15 +6,10 @@ include(AddTest)
 file(
     GLOB hal_shared_native_src
     src/main/native/cpp/*.cpp
-    hal_shared_native_src
     src/main/native/cpp/cpp/*.cpp
-    hal_shared_native_src
     src/main/native/cpp/handles/*.cpp
-    hal_sim_native_src
-    src/main/native/sim/*.cpp
-    hal_sim_native_src
-    src/main/native/sim/mockdata/*.cpp
 )
+file(GLOB_RECURSE hal_sim_native_src src/main/native/sim/*.cpp)
 add_library(hal ${hal_shared_native_src} ${hal_sim_native_src})
 wpilib_target_warnings(hal)
 set_target_properties(hal PROPERTIES DEBUG_POSTFIX "d")

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -15,16 +15,9 @@ file(
     hal_sim_native_src
     src/main/native/sim/mockdata/*.cpp
 )
-add_library(hal ${hal_shared_native_src})
+add_library(hal ${hal_shared_native_src} ${hal_sim_native_src})
 wpilib_target_warnings(hal)
 set_target_properties(hal PROPERTIES DEBUG_POSTFIX "d")
-
-if(USE_EXTERNAL_HAL)
-    include(${EXTERNAL_HAL_FILE})
-else()
-    target_sources(hal PRIVATE ${hal_sim_native_src})
-endif()
-
 set_target_properties(hal PROPERTIES OUTPUT_NAME "wpiHal")
 
 target_include_directories(
@@ -77,11 +70,6 @@ if(WITH_JAVA)
     install_jar_exports(TARGETS hal_jar FILE hal_jar.cmake DESTINATION share/hal)
 
     add_library(haljni ${hal_shared_jni_src})
-
-    if(USE_EXTERNAL_HAL)
-        include(${EXTERNAL_HAL_FILE})
-    endif()
-
     set_target_properties(haljni PROPERTIES OUTPUT_NAME "wpiHaljni")
 
     wpilib_target_warnings(haljni)


### PR DESCRIPTION
It was broken in #2788. I don't see much utility in fixing this compared to just modifying hal/CMakeLists.txt to point to alternative HAL source files, especially because [a vendor](https://github.com/kauailabs/allwpilib/blob/master/hal/CMakeLists.txt) has already done just that.