### PR TITLE
[build] Drop jinjava as a Gradle dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,6 @@ buildscript {
             url = 'https://frcmaven.wpi.edu/artifactory/ex-mvn'
         }
     }
-    dependencies {
-        classpath 'com.hubspot.jinjava:jinjava:2.7.1'
-    }
 }
 
 plugins {

--- a/wpimath/build.gradle
+++ b/wpimath/build.gradle
@@ -1,6 +1,3 @@
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.JinjavaConfig;
-
 ext {
     useJava = true
     useCpp = true


### PR DESCRIPTION
Since we pregen Jinja templates, we don't need jinjava anymore.