### PR TITLE
[wpiutil] Remove Protobuf.getNested()

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/proto/Ellipse2dProto.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/proto/Ellipse2dProto.java
@@ -22,11 +22,6 @@ public class Ellipse2dProto implements Protobuf<Ellipse2d, ProtobufEllipse2d> {
   }
 
   @Override
-  public Protobuf<?, ?>[] getNested() {
-    return new Protobuf<?, ?>[] {Pose2d.proto};
-  }
-
-  @Override
   public ProtobufEllipse2d createMessage() {
     return ProtobufEllipse2d.newInstance();
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/proto/Pose2dProto.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/proto/Pose2dProto.java
@@ -23,11 +23,6 @@ public class Pose2dProto implements Protobuf<Pose2d, ProtobufPose2d> {
   }
 
   @Override
-  public Protobuf<?, ?>[] getNested() {
-    return new Protobuf<?, ?>[] {Translation2d.proto, Rotation2d.proto};
-  }
-
-  @Override
   public ProtobufPose2d createMessage() {
     return ProtobufPose2d.newInstance();
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/proto/Pose3dProto.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/proto/Pose3dProto.java
@@ -23,11 +23,6 @@ public class Pose3dProto implements Protobuf<Pose3d, ProtobufPose3d> {
   }
 
   @Override
-  public Protobuf<?, ?>[] getNested() {
-    return new Protobuf<?, ?>[] {Translation3d.proto, Rotation3d.proto};
-  }
-
-  @Override
   public ProtobufPose3d createMessage() {
     return ProtobufPose3d.newInstance();
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/proto/Rectangle2dProto.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/proto/Rectangle2dProto.java
@@ -22,11 +22,6 @@ public class Rectangle2dProto implements Protobuf<Rectangle2d, ProtobufRectangle
   }
 
   @Override
-  public Protobuf<?, ?>[] getNested() {
-    return new Protobuf<?, ?>[] {Pose2d.proto};
-  }
-
-  @Override
   public ProtobufRectangle2d createMessage() {
     return ProtobufRectangle2d.newInstance();
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/proto/Rotation3dProto.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/proto/Rotation3dProto.java
@@ -22,11 +22,6 @@ public class Rotation3dProto implements Protobuf<Rotation3d, ProtobufRotation3d>
   }
 
   @Override
-  public Protobuf<?, ?>[] getNested() {
-    return new Protobuf<?, ?>[] {Quaternion.proto};
-  }
-
-  @Override
   public ProtobufRotation3d createMessage() {
     return ProtobufRotation3d.newInstance();
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/proto/Transform2dProto.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/proto/Transform2dProto.java
@@ -23,11 +23,6 @@ public class Transform2dProto implements Protobuf<Transform2d, ProtobufTransform
   }
 
   @Override
-  public Protobuf<?, ?>[] getNested() {
-    return new Protobuf<?, ?>[] {Translation2d.proto, Rotation2d.proto};
-  }
-
-  @Override
   public ProtobufTransform2d createMessage() {
     return ProtobufTransform2d.newInstance();
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/proto/Transform3dProto.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/proto/Transform3dProto.java
@@ -23,11 +23,6 @@ public class Transform3dProto implements Protobuf<Transform3d, ProtobufTransform
   }
 
   @Override
-  public Protobuf<?, ?>[] getNested() {
-    return new Protobuf<?, ?>[] {Translation3d.proto, Rotation3d.proto};
-  }
-
-  @Override
   public ProtobufTransform3d createMessage() {
     return ProtobufTransform3d.newInstance();
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/proto/MecanumDriveKinematicsProto.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/proto/MecanumDriveKinematicsProto.java
@@ -23,11 +23,6 @@ public class MecanumDriveKinematicsProto
   }
 
   @Override
-  public Protobuf<?, ?>[] getNested() {
-    return new Protobuf<?, ?>[] {Translation2d.proto};
-  }
-
-  @Override
   public ProtobufMecanumDriveKinematics createMessage() {
     return ProtobufMecanumDriveKinematics.newInstance();
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/proto/SwerveModulePositionProto.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/proto/SwerveModulePositionProto.java
@@ -23,11 +23,6 @@ public class SwerveModulePositionProto
   }
 
   @Override
-  public Protobuf<?, ?>[] getNested() {
-    return new Protobuf<?, ?>[] {Rotation2d.proto};
-  }
-
-  @Override
   public ProtobufSwerveModulePosition createMessage() {
     return ProtobufSwerveModulePosition.newInstance();
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/proto/SwerveModuleStateProto.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/proto/SwerveModuleStateProto.java
@@ -23,11 +23,6 @@ public class SwerveModuleStateProto
   }
 
   @Override
-  public Protobuf<?, ?>[] getNested() {
-    return new Protobuf<?, ?>[] {Rotation2d.proto};
-  }
-
-  @Override
   public ProtobufSwerveModuleState createMessage() {
     return ProtobufSwerveModuleState.newInstance();
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/proto/TrajectoryProto.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/proto/TrajectoryProto.java
@@ -23,11 +23,6 @@ public class TrajectoryProto implements Protobuf<Trajectory, ProtobufTrajectory>
   }
 
   @Override
-  public Protobuf<?, ?>[] getNested() {
-    return new Protobuf<?, ?>[] {Trajectory.State.proto};
-  }
-
-  @Override
   public ProtobufTrajectory createMessage() {
     return ProtobufTrajectory.newInstance();
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/proto/TrajectoryStateProto.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/proto/TrajectoryStateProto.java
@@ -22,11 +22,6 @@ public class TrajectoryStateProto implements Protobuf<Trajectory.State, Protobuf
   }
 
   @Override
-  public Protobuf<?, ?>[] getNested() {
-    return new Protobuf<?, ?>[] {Pose2d.proto};
-  }
-
-  @Override
   public ProtobufTrajectoryState createMessage() {
     return ProtobufTrajectoryState.newInstance();
   }

--- a/wpiutil/src/main/java/edu/wpi/first/util/protobuf/Protobuf.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/protobuf/Protobuf.java
@@ -49,15 +49,6 @@ public interface Protobuf<T, MessageType extends ProtoMessage<?>> {
   Descriptor getDescriptor();
 
   /**
-   * Gets the list of protobuf types referenced by this protobuf.
-   *
-   * @return list of protobuf types
-   */
-  default Protobuf<?, ?>[] getNested() {
-    return new Protobuf<?, ?>[] {};
-  }
-
-  /**
    * Creates protobuf message.
    *
    * @return protobuf message


### PR DESCRIPTION
It was superseded by using `FileDescriptor.getDependencies()`.