### PR TITLE
[wpimath] Add getAccumulatedError() to PIDController

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -243,7 +243,7 @@ public class PIDController implements Sendable, AutoCloseable {
 
   /**
    * Returns the accumulated error used in the integral calculation of this controller.
-   * 
+   *
    * @return The accumulated error of this controller.
    */
   public double getAccumulatedError() {

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -242,6 +242,15 @@ public class PIDController implements Sendable, AutoCloseable {
   }
 
   /**
+   * Returns the accumulated error used in the integral calculation of this controller.
+   * 
+   * @return The accumulated error of this controller.
+   */
+  public double getAccumulatedError() {
+    return m_totalError;
+  }
+
+  /**
    * Sets the setpoint for the PIDController.
    *
    * @param setpoint The desired setpoint.

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/ProfiledPIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/ProfiledPIDController.java
@@ -188,7 +188,7 @@ public class ProfiledPIDController implements Sendable {
 
   /**
    * Returns the accumulated error used in the integral calculation of this controller.
-   * 
+   *
    * @return The accumulated error of this controller.
    */
   public double getAccumulatedError() {

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/ProfiledPIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/ProfiledPIDController.java
@@ -187,6 +187,15 @@ public class ProfiledPIDController implements Sendable {
   }
 
   /**
+   * Returns the accumulated error used in the integral calculation of this controller.
+   * 
+   * @return The accumulated error of this controller.
+   */
+  public double getAccumulatedError() {
+    return m_controller.getAccumulatedError();
+  }
+
+  /**
    * Sets the goal for the ProfiledPIDController.
    *
    * @param goal The desired goal state.

--- a/wpimath/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpimath/src/main/native/cpp/controller/PIDController.cpp
@@ -110,6 +110,10 @@ double PIDController::GetVelocityTolerance() const {
   return m_velocityTolerance;
 }
 
+double PIDController::GetAccumulatedError() const {
+  return m_totalError;
+}
+
 void PIDController::SetSetpoint(double setpoint) {
   m_setpoint = setpoint;
   m_haveSetpoint = true;

--- a/wpimath/src/main/native/include/frc/controller/PIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/PIDController.h
@@ -136,6 +136,13 @@ class WPILIB_DLLEXPORT PIDController
   double GetVelocityTolerance() const;
 
   /**
+   * Gets the accumulated error used in the integral calculation of this controller.
+   * 
+   * @return The accumulated error of this controller.
+   */
+  double GetAccumulatedError() const;
+
+  /**
    * Sets the setpoint for the PIDController.
    *
    * @param setpoint The desired setpoint.

--- a/wpimath/src/main/native/include/frc/controller/PIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/PIDController.h
@@ -136,7 +136,8 @@ class WPILIB_DLLEXPORT PIDController
   double GetVelocityTolerance() const;
 
   /**
-   * Gets the accumulated error used in the integral calculation of this controller.
+   * Gets the accumulated error used in the integral calculation of this
+   * controller.
    *
    * @return The accumulated error of this controller.
    */

--- a/wpimath/src/main/native/include/frc/controller/PIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/PIDController.h
@@ -137,7 +137,7 @@ class WPILIB_DLLEXPORT PIDController
 
   /**
    * Gets the accumulated error used in the integral calculation of this controller.
-   * 
+   *
    * @return The accumulated error of this controller.
    */
   double GetAccumulatedError() const;

--- a/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -175,6 +175,15 @@ class ProfiledPIDController
   }
 
   /**
+   * Gets the accumulated error used in the integral calculation of this controller.
+   * 
+   * @return The accumulated error of this controller.
+   */
+  double GetAccumulatedError() const {
+    return m_controller.GetAccumulatedError();
+  }
+
+  /**
    * Sets the goal for the ProfiledPIDController.
    *
    * @param goal The desired unprofiled setpoint.

--- a/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -176,7 +176,7 @@ class ProfiledPIDController
 
   /**
    * Gets the accumulated error used in the integral calculation of this controller.
-   * 
+   *
    * @return The accumulated error of this controller.
    */
   double GetAccumulatedError() const {

--- a/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -175,7 +175,8 @@ class ProfiledPIDController
   }
 
   /**
-   * Gets the accumulated error used in the integral calculation of this controller.
+   * Gets the accumulated error used in the integral calculation of this
+   * controller.
    *
    * @return The accumulated error of this controller.
    */


### PR DESCRIPTION
Adds a method `getAccumulatedError()` (`GetAccumulatedError()` in cpp) to get the accumulated value used for the integral gain of the PID controllers. This can be useful in debugging to determine how high the integral accumulates over time.

This has Java and CPP implementations for PIDController and ProfiledPIDController.