### PR TITLE
[hal] Fix potential race in CANAPI

### DIFF
--- a/hal/src/main/native/athena/CANAPI.cpp
+++ b/hal/src/main/native/athena/CANAPI.cpp
@@ -112,10 +112,6 @@ void HAL_WriteCANPacket(HAL_CANHandle handle, const uint8_t* data,
 
   std::scoped_lock lock(can->periodicSendsMutex);
   HAL_CAN_SendMessage(id, data, length, HAL_CAN_SEND_PERIOD_NO_REPEAT, status);
-
-  if (*status != 0) {
-    return;
-  }
   can->periodicSends[apiId] = -1;
 }
 
@@ -131,10 +127,6 @@ void HAL_WriteCANPacketRepeating(HAL_CANHandle handle, const uint8_t* data,
 
   std::scoped_lock lock(can->periodicSendsMutex);
   HAL_CAN_SendMessage(id, data, length, repeatMs, status);
-
-  if (*status != 0) {
-    return;
-  }
   can->periodicSends[apiId] = repeatMs;
 }
 
@@ -152,10 +144,6 @@ void HAL_WriteCANRTRFrame(HAL_CANHandle handle, int32_t length, int32_t apiId,
 
   std::scoped_lock lock(can->periodicSendsMutex);
   HAL_CAN_SendMessage(id, data, length, HAL_CAN_SEND_PERIOD_NO_REPEAT, status);
-
-  if (*status != 0) {
-    return;
-  }
   can->periodicSends[apiId] = -1;
 }
 
@@ -171,10 +159,6 @@ void HAL_StopCANPacketRepeating(HAL_CANHandle handle, int32_t apiId,
   std::scoped_lock lock(can->periodicSendsMutex);
   HAL_CAN_SendMessage(id, nullptr, 0, HAL_CAN_SEND_PERIOD_STOP_REPEATING,
                       status);
-
-  if (*status != 0) {
-    return;
-  }
   can->periodicSends[apiId] = -1;
 }
 

--- a/hal/src/main/native/athena/CANAPI.cpp
+++ b/hal/src/main/native/athena/CANAPI.cpp
@@ -7,6 +7,7 @@
 #include <ctime>
 
 #include <wpi/DenseMap.h>
+#include <wpi/mutex.h>
 
 #include "HALInitializer.h"
 #include "hal/CAN.h"

--- a/hal/src/main/native/athena/CANAPI.cpp
+++ b/hal/src/main/native/athena/CANAPI.cpp
@@ -26,8 +26,9 @@ struct CANStorage {
   HAL_CANManufacturer manufacturer;
   HAL_CANDeviceType deviceType;
   uint8_t deviceId;
-  wpi::mutex mapMutex;
+  wpi::mutex periodicSendsMutex;
   wpi::SmallDenseMap<int32_t, int32_t> periodicSends;
+  wpi::mutex receivesMutex;
   wpi::SmallDenseMap<int32_t, Receives> receives;
 };
 }  // namespace
@@ -89,7 +90,7 @@ void HAL_CleanCAN(HAL_CANHandle handle) {
     return;
   }
 
-  std::scoped_lock lock(data->mapMutex);
+  std::scoped_lock lock(data->periodicSendsMutex);
 
   for (auto&& i : data->periodicSends) {
     int32_t s = 0;
@@ -108,12 +109,12 @@ void HAL_WriteCANPacket(HAL_CANHandle handle, const uint8_t* data,
   }
   auto id = CreateCANId(can.get(), apiId);
 
+  std::scoped_lock lock(can->periodicSendsMutex);
   HAL_CAN_SendMessage(id, data, length, HAL_CAN_SEND_PERIOD_NO_REPEAT, status);
 
   if (*status != 0) {
     return;
   }
-  std::scoped_lock lock(can->mapMutex);
   can->periodicSends[apiId] = -1;
 }
 
@@ -127,12 +128,12 @@ void HAL_WriteCANPacketRepeating(HAL_CANHandle handle, const uint8_t* data,
   }
   auto id = CreateCANId(can.get(), apiId);
 
+  std::scoped_lock lock(can->periodicSendsMutex);
   HAL_CAN_SendMessage(id, data, length, repeatMs, status);
 
   if (*status != 0) {
     return;
   }
-  std::scoped_lock lock(can->mapMutex);
   can->periodicSends[apiId] = repeatMs;
 }
 
@@ -148,12 +149,12 @@ void HAL_WriteCANRTRFrame(HAL_CANHandle handle, int32_t length, int32_t apiId,
   uint8_t data[8];
   std::memset(data, 0, sizeof(data));
 
+  std::scoped_lock lock(can->periodicSendsMutex);
   HAL_CAN_SendMessage(id, data, length, HAL_CAN_SEND_PERIOD_NO_REPEAT, status);
 
   if (*status != 0) {
     return;
   }
-  std::scoped_lock lock(can->mapMutex);
   can->periodicSends[apiId] = -1;
 }
 
@@ -166,13 +167,13 @@ void HAL_StopCANPacketRepeating(HAL_CANHandle handle, int32_t apiId,
   }
   auto id = CreateCANId(can.get(), apiId);
 
+  std::scoped_lock lock(can->periodicSendsMutex);
   HAL_CAN_SendMessage(id, nullptr, 0, HAL_CAN_SEND_PERIOD_STOP_REPEATING,
                       status);
 
   if (*status != 0) {
     return;
   }
-  std::scoped_lock lock(can->mapMutex);
   can->periodicSends[apiId] = -1;
 }
 
@@ -191,7 +192,7 @@ void HAL_ReadCANPacketNew(HAL_CANHandle handle, int32_t apiId, uint8_t* data,
   HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
 
   if (*status == 0) {
-    std::scoped_lock lock(can->mapMutex);
+    std::scoped_lock lock(can->receivesMutex);
     auto& msg = can->receives[messageId];
     msg.length = dataSize;
     msg.lastTimeStamp = ts;
@@ -216,7 +217,7 @@ void HAL_ReadCANPacketLatest(HAL_CANHandle handle, int32_t apiId, uint8_t* data,
   uint32_t ts = 0;
   HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
 
-  std::scoped_lock lock(can->mapMutex);
+  std::scoped_lock lock(can->receivesMutex);
   if (*status == 0) {
     // fresh update
     auto& msg = can->receives[messageId];
@@ -253,7 +254,7 @@ void HAL_ReadCANPacketTimeout(HAL_CANHandle handle, int32_t apiId,
   uint32_t ts = 0;
   HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
 
-  std::scoped_lock lock(can->mapMutex);
+  std::scoped_lock lock(can->receivesMutex);
   if (*status == 0) {
     // fresh update
     auto& msg = can->receives[messageId];

--- a/hal/src/main/native/sim/CANAPI.cpp
+++ b/hal/src/main/native/sim/CANAPI.cpp
@@ -26,8 +26,9 @@ struct CANStorage {
   HAL_CANManufacturer manufacturer;
   HAL_CANDeviceType deviceType;
   uint8_t deviceId;
-  wpi::mutex mapMutex;
+  wpi::mutex periodicSendsMutex;
   wpi::SmallDenseMap<int32_t, int32_t> periodicSends;
+  wpi::mutex receivesMutex;
   wpi::SmallDenseMap<int32_t, Receives> receives;
 };
 }  // namespace
@@ -97,7 +98,7 @@ void HAL_CleanCAN(HAL_CANHandle handle) {
     return;
   }
 
-  std::scoped_lock lock(data->mapMutex);
+  std::scoped_lock lock(data->periodicSendsMutex);
 
   for (auto&& i : data->periodicSends) {
     int32_t s = 0;
@@ -116,12 +117,8 @@ void HAL_WriteCANPacket(HAL_CANHandle handle, const uint8_t* data,
   }
   auto id = CreateCANId(can.get(), apiId);
 
+  std::scoped_lock lock(can->periodicSendsMutex);
   HAL_CAN_SendMessage(id, data, length, HAL_CAN_SEND_PERIOD_NO_REPEAT, status);
-
-  if (*status != 0) {
-    return;
-  }
-  std::scoped_lock lock(can->mapMutex);
   can->periodicSends[apiId] = -1;
 }
 
@@ -135,12 +132,8 @@ void HAL_WriteCANPacketRepeating(HAL_CANHandle handle, const uint8_t* data,
   }
   auto id = CreateCANId(can.get(), apiId);
 
+  std::scoped_lock lock(can->periodicSendsMutex);
   HAL_CAN_SendMessage(id, data, length, repeatMs, status);
-
-  if (*status != 0) {
-    return;
-  }
-  std::scoped_lock lock(can->mapMutex);
   can->periodicSends[apiId] = repeatMs;
 }
 
@@ -156,12 +149,8 @@ void HAL_WriteCANRTRFrame(HAL_CANHandle handle, int32_t length, int32_t apiId,
   uint8_t data[8];
   std::memset(data, 0, sizeof(data));
 
+  std::scoped_lock lock(can->periodicSendsMutex);
   HAL_CAN_SendMessage(id, data, length, HAL_CAN_SEND_PERIOD_NO_REPEAT, status);
-
-  if (*status != 0) {
-    return;
-  }
-  std::scoped_lock lock(can->mapMutex);
   can->periodicSends[apiId] = -1;
 }
 
@@ -174,13 +163,9 @@ void HAL_StopCANPacketRepeating(HAL_CANHandle handle, int32_t apiId,
   }
   auto id = CreateCANId(can.get(), apiId);
 
+  std::scoped_lock lock(can->periodicSendsMutex);
   HAL_CAN_SendMessage(id, nullptr, 0, HAL_CAN_SEND_PERIOD_STOP_REPEATING,
                       status);
-
-  if (*status != 0) {
-    return;
-  }
-  std::scoped_lock lock(can->mapMutex);
   can->periodicSends[apiId] = -1;
 }
 
@@ -199,7 +184,7 @@ void HAL_ReadCANPacketNew(HAL_CANHandle handle, int32_t apiId, uint8_t* data,
   HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
 
   if (*status == 0) {
-    std::scoped_lock lock(can->mapMutex);
+    std::scoped_lock lock(can->receivesMutex);
     auto& msg = can->receives[messageId];
     msg.length = dataSize;
     msg.lastTimeStamp = ts;
@@ -224,7 +209,7 @@ void HAL_ReadCANPacketLatest(HAL_CANHandle handle, int32_t apiId, uint8_t* data,
   uint32_t ts = 0;
   HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
 
-  std::scoped_lock lock(can->mapMutex);
+  std::scoped_lock lock(can->receivesMutex);
   if (*status == 0) {
     // fresh update
     auto& msg = can->receives[messageId];
@@ -261,7 +246,7 @@ void HAL_ReadCANPacketTimeout(HAL_CANHandle handle, int32_t apiId,
   uint32_t ts = 0;
   HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
 
-  std::scoped_lock lock(can->mapMutex);
+  std::scoped_lock lock(can->receivesMutex);
   if (*status == 0) {
     // fresh update
     auto& msg = can->receives[messageId];


### PR DESCRIPTION
Currently, the call to `HAL_CAN_SendMessage` is not synchronized with updates to `periodicSends` (which represents the internal state of the netcomm sender thread). 

Now, the mutex is locked before `HAL_CAN_SendMessage` is called to ensure the update is atomic.
periodicSends and receives also now have their own mutexes to reduce unnecessary contention between send and receive functions.

Ex:
Thread A calls `HAL_StopCANPacketRepeating` with apiId 0
Thread B calls `HAL_WriteCANPacketRepeating` with apiId 0 and repeatMs 10
Inside `HAL_StopCANPacketRepeating`, Thread A calls `HAL_CAN_SendMessage`, which updates netcomm's state to not repeat the packet
Thread A is paused
Inside `HAL_WriteCANPacketRepeating`, Thread B calls `HAL_CAN_SendMessage`, which updates netcomm's state to repeat the packet
Thread B locks the mutex
Thread B updates the map to indicate the new state (packet is repeating)
Thread B exits `HAL_WriteCANPacketRepeating` and unlocks the mutex
Thread A resumes
Thread A locks the mutex
Thread A updates the map with what it thinks the new state is (packet is not repeating)
Thread A exits `HAL_StopCANPacketRepeating` and unlocks the mutex
Thread A calls `HAL_CleanCAN`, which doesn't stop the repeating packet because the state has diverged.