### PR TITLE
[upstream_utils] Fix LLVM's AlignedCharArrayUnion for C++23

### DIFF
--- a/upstream_utils/llvm_patches/0001-Remove-StringRef-ArrayRef-and-Optional.patch
+++ b/upstream_utils/llvm_patches/0001-Remove-StringRef-ArrayRef-and-Optional.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:09:18 -0400
-Subject: [PATCH 01/36] Remove StringRef, ArrayRef, and Optional
+Subject: [PATCH 01/37] Remove StringRef, ArrayRef, and Optional
 
 ---
  llvm/include/llvm/ADT/PointerUnion.h          |   1 -

--- a/upstream_utils/llvm_patches/0002-Wrap-std-min-max-calls-in-parens-for-Windows-warning.patch
+++ b/upstream_utils/llvm_patches/0002-Wrap-std-min-max-calls-in-parens-for-Windows-warning.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:12:41 -0400
-Subject: [PATCH 02/36] Wrap std::min/max calls in parens, for Windows warnings
+Subject: [PATCH 02/37] Wrap std::min/max calls in parens, for Windows warnings
 
 ---
  llvm/include/llvm/ADT/DenseMap.h       |  4 ++--

--- a/upstream_utils/llvm_patches/0003-Change-unique_function-storage-size.patch
+++ b/upstream_utils/llvm_patches/0003-Change-unique_function-storage-size.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:13:55 -0400
-Subject: [PATCH 03/36] Change unique_function storage size
+Subject: [PATCH 03/37] Change unique_function storage size
 
 ---
  llvm/include/llvm/ADT/FunctionExtras.h | 4 ++--

--- a/upstream_utils/llvm_patches/0004-Threading-updates.patch
+++ b/upstream_utils/llvm_patches/0004-Threading-updates.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:17:19 -0400
-Subject: [PATCH 04/36] Threading updates
+Subject: [PATCH 04/37] Threading updates
 
 - Remove guards for threads and exception
 - Prefer scope gaurd over lock gaurd

--- a/upstream_utils/llvm_patches/0005-ifdef-guard-safety.patch
+++ b/upstream_utils/llvm_patches/0005-ifdef-guard-safety.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:28:13 -0400
-Subject: [PATCH 05/36] \#ifdef guard safety
+Subject: [PATCH 05/37] \#ifdef guard safety
 
 Prevents redefinition if someone is pulling in real LLVM, since the macros are in global namespace
 ---

--- a/upstream_utils/llvm_patches/0006-Explicitly-use-std.patch
+++ b/upstream_utils/llvm_patches/0006-Explicitly-use-std.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:37:34 -0400
-Subject: [PATCH 06/36] Explicitly use std::
+Subject: [PATCH 06/37] Explicitly use std::
 
 ---
  llvm/include/llvm/ADT/SmallSet.h       |  2 +-

--- a/upstream_utils/llvm_patches/0007-Remove-format_provider.patch
+++ b/upstream_utils/llvm_patches/0007-Remove-format_provider.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:53:50 -0400
-Subject: [PATCH 07/36] Remove format_provider
+Subject: [PATCH 07/37] Remove format_provider
 
 ---
  llvm/include/llvm/Support/Chrono.h      | 114 ------------------------

--- a/upstream_utils/llvm_patches/0008-Add-compiler-warning-pragmas.patch
+++ b/upstream_utils/llvm_patches/0008-Add-compiler-warning-pragmas.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 13:34:07 -0400
-Subject: [PATCH 08/36] Add compiler warning pragmas
+Subject: [PATCH 08/37] Add compiler warning pragmas
 
 ---
  llvm/include/llvm/ADT/FunctionExtras.h | 11 +++++++++++

--- a/upstream_utils/llvm_patches/0009-Remove-unused-functions.patch
+++ b/upstream_utils/llvm_patches/0009-Remove-unused-functions.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 13:43:50 -0400
-Subject: [PATCH 09/36] Remove unused functions
+Subject: [PATCH 09/37] Remove unused functions
 
 ---
  llvm/include/llvm/ADT/SmallString.h      |  79 ------

--- a/upstream_utils/llvm_patches/0010-Detemplatize-SmallVectorBase.patch
+++ b/upstream_utils/llvm_patches/0010-Detemplatize-SmallVectorBase.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Thu, 5 May 2022 23:18:34 -0400
-Subject: [PATCH 10/36] Detemplatize SmallVectorBase
+Subject: [PATCH 10/37] Detemplatize SmallVectorBase
 
 ---
  llvm/include/llvm/ADT/SmallVector.h | 35 ++++++++++-----------------

--- a/upstream_utils/llvm_patches/0011-Add-vectors-to-raw_ostream.patch
+++ b/upstream_utils/llvm_patches/0011-Add-vectors-to-raw_ostream.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 13:48:59 -0400
-Subject: [PATCH 11/36] Add vectors to raw_ostream
+Subject: [PATCH 11/37] Add vectors to raw_ostream
 
 ---
  llvm/include/llvm/Support/raw_ostream.h | 115 ++++++++++++++++++++++++

--- a/upstream_utils/llvm_patches/0012-Extra-collections-features.patch
+++ b/upstream_utils/llvm_patches/0012-Extra-collections-features.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 3 May 2022 22:16:10 -0400
-Subject: [PATCH 12/36] Extra collections features
+Subject: [PATCH 12/37] Extra collections features
 
 ---
  llvm/include/llvm/ADT/StringMap.h | 103 +++++++++++++++++++++++++++++-

--- a/upstream_utils/llvm_patches/0013-EpochTracker-ABI-macro.patch
+++ b/upstream_utils/llvm_patches/0013-EpochTracker-ABI-macro.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Wed, 4 May 2022 00:01:00 -0400
-Subject: [PATCH 13/36] EpochTracker ABI macro
+Subject: [PATCH 13/37] EpochTracker ABI macro
 
 ---
  llvm/include/llvm/ADT/EpochTracker.h | 2 +-

--- a/upstream_utils/llvm_patches/0014-Delete-numbers-from-MathExtras.patch
+++ b/upstream_utils/llvm_patches/0014-Delete-numbers-from-MathExtras.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Thu, 5 May 2022 18:09:45 -0400
-Subject: [PATCH 14/36] Delete numbers from MathExtras
+Subject: [PATCH 14/37] Delete numbers from MathExtras
 
 ---
  llvm/include/llvm/Support/MathExtras.h | 36 --------------------------

--- a/upstream_utils/llvm_patches/0015-Add-lerp-and-sgn.patch
+++ b/upstream_utils/llvm_patches/0015-Add-lerp-and-sgn.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 3 May 2022 22:50:24 -0400
-Subject: [PATCH 15/36] Add lerp and sgn
+Subject: [PATCH 15/37] Add lerp and sgn
 
 ---
  llvm/include/llvm/Support/MathExtras.h | 20 ++++++++++++++++++++

--- a/upstream_utils/llvm_patches/0016-Fixup-includes.patch
+++ b/upstream_utils/llvm_patches/0016-Fixup-includes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:38:11 -0400
-Subject: [PATCH 16/36] Fixup includes
+Subject: [PATCH 16/37] Fixup includes
 
 ---
  llvm/include/llvm/ADT/StringMap.h                 |  4 ++++

--- a/upstream_utils/llvm_patches/0017-Use-std-is_trivially_copy_constructible.patch
+++ b/upstream_utils/llvm_patches/0017-Use-std-is_trivially_copy_constructible.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:42:09 -0400
-Subject: [PATCH 17/36] Use std::is_trivially_copy_constructible
+Subject: [PATCH 17/37] Use std::is_trivially_copy_constructible
 
 ---
  llvm/include/llvm/Support/type_traits.h | 16 ----------------

--- a/upstream_utils/llvm_patches/0018-Windows-support.patch
+++ b/upstream_utils/llvm_patches/0018-Windows-support.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 3 May 2022 20:22:38 -0400
-Subject: [PATCH 18/36] Windows support
+Subject: [PATCH 18/37] Windows support
 
 ---
  .../llvm/Support/Windows/WindowsSupport.h     | 45 +++++----

--- a/upstream_utils/llvm_patches/0019-Prefer-fmtlib.patch
+++ b/upstream_utils/llvm_patches/0019-Prefer-fmtlib.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:46:20 -0400
-Subject: [PATCH 19/36] Prefer fmtlib
+Subject: [PATCH 19/37] Prefer fmtlib
 
 ---
  llvm/lib/Support/ErrorHandling.cpp | 20 ++++++--------------

--- a/upstream_utils/llvm_patches/0020-Prefer-wpi-s-fs.h.patch
+++ b/upstream_utils/llvm_patches/0020-Prefer-wpi-s-fs.h.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:49:36 -0400
-Subject: [PATCH 20/36] Prefer wpi's fs.h
+Subject: [PATCH 20/37] Prefer wpi's fs.h
 
 ---
  llvm/include/llvm/Support/raw_ostream.h | 7 ++-----

--- a/upstream_utils/llvm_patches/0021-Remove-unused-functions.patch
+++ b/upstream_utils/llvm_patches/0021-Remove-unused-functions.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 19:16:51 -0400
-Subject: [PATCH 21/36] Remove unused functions
+Subject: [PATCH 21/37] Remove unused functions
 
 ---
  llvm/include/llvm/Support/raw_ostream.h |  5 +-

--- a/upstream_utils/llvm_patches/0022-OS-specific-changes.patch
+++ b/upstream_utils/llvm_patches/0022-OS-specific-changes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 19:30:43 -0400
-Subject: [PATCH 22/36] OS-specific changes
+Subject: [PATCH 22/37] OS-specific changes
 
 ---
  llvm/lib/Support/ErrorHandling.cpp | 16 +++++++---------

--- a/upstream_utils/llvm_patches/0023-Use-SmallVector-for-UTF-conversion.patch
+++ b/upstream_utils/llvm_patches/0023-Use-SmallVector-for-UTF-conversion.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Mon, 9 May 2022 00:04:30 -0400
-Subject: [PATCH 23/36] Use SmallVector for UTF conversion
+Subject: [PATCH 23/37] Use SmallVector for UTF conversion
 
 ---
  llvm/include/llvm/Support/ConvertUTF.h    |  6 +++---

--- a/upstream_utils/llvm_patches/0024-Prefer-to-use-static-pointers-in-raw_ostream.patch
+++ b/upstream_utils/llvm_patches/0024-Prefer-to-use-static-pointers-in-raw_ostream.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Thu, 19 May 2022 00:58:36 -0400
-Subject: [PATCH 24/36] Prefer to use static pointers in raw_ostream
+Subject: [PATCH 24/37] Prefer to use static pointers in raw_ostream
 
 See #1401
 ---

--- a/upstream_utils/llvm_patches/0025-constexpr-endian-byte-swap.patch
+++ b/upstream_utils/llvm_patches/0025-constexpr-endian-byte-swap.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Fri, 1 Mar 2024 11:56:17 -0800
-Subject: [PATCH 25/36] constexpr endian byte swap
+Subject: [PATCH 25/37] constexpr endian byte swap
 
 ---
  llvm/include/llvm/Support/Endian.h | 4 +++-

--- a/upstream_utils/llvm_patches/0026-Copy-type-traits-from-STLExtras.h-into-PointerUnion..patch
+++ b/upstream_utils/llvm_patches/0026-Copy-type-traits-from-STLExtras.h-into-PointerUnion..patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Wed, 10 Aug 2022 17:07:52 -0700
-Subject: [PATCH 26/36] Copy type traits from STLExtras.h into PointerUnion.h
+Subject: [PATCH 26/37] Copy type traits from STLExtras.h into PointerUnion.h
 
 ---
  llvm/include/llvm/ADT/PointerUnion.h | 46 ++++++++++++++++++++++++++++

--- a/upstream_utils/llvm_patches/0027-Remove-StringMap-test-for-llvm-sort.patch
+++ b/upstream_utils/llvm_patches/0027-Remove-StringMap-test-for-llvm-sort.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Wed, 10 Aug 2022 22:35:00 -0700
-Subject: [PATCH 27/36] Remove StringMap test for llvm::sort()
+Subject: [PATCH 27/37] Remove StringMap test for llvm::sort()
 
 ---
  llvm/unittests/ADT/StringMapTest.cpp | 14 --------------

--- a/upstream_utils/llvm_patches/0028-Unused-variable-in-release-mode.patch
+++ b/upstream_utils/llvm_patches/0028-Unused-variable-in-release-mode.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Leander Schulten <Leander.Schulten@rwth-aachen.de>
 Date: Mon, 10 Jul 2023 00:53:43 +0200
-Subject: [PATCH 28/36] Unused variable in release mode
+Subject: [PATCH 28/37] Unused variable in release mode
 
 ---
  llvm/include/llvm/ADT/DenseMap.h | 2 +-

--- a/upstream_utils/llvm_patches/0029-Use-C-20-bit-header.patch
+++ b/upstream_utils/llvm_patches/0029-Use-C-20-bit-header.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Tue, 11 Jul 2023 22:56:09 -0700
-Subject: [PATCH 29/36] Use C++20 <bit> header
+Subject: [PATCH 29/37] Use C++20 <bit> header
 
 ---
  llvm/include/llvm/ADT/DenseMap.h       |   3 +-

--- a/upstream_utils/llvm_patches/0030-Remove-DenseMap-GTest-printer-test.patch
+++ b/upstream_utils/llvm_patches/0030-Remove-DenseMap-GTest-printer-test.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Sun, 30 Jul 2023 14:17:37 -0700
-Subject: [PATCH 30/36] Remove DenseMap GTest printer test
+Subject: [PATCH 30/37] Remove DenseMap GTest printer test
 
 LLVM modifies internal GTest headers to support it, which we can't do.
 ---

--- a/upstream_utils/llvm_patches/0031-Replace-deprecated-std-aligned_storage_t.patch
+++ b/upstream_utils/llvm_patches/0031-Replace-deprecated-std-aligned_storage_t.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Fri, 15 Sep 2023 18:26:50 -0700
-Subject: [PATCH 31/36] Replace deprecated std::aligned_storage_t
+Subject: [PATCH 31/37] Replace deprecated std::aligned_storage_t
 
 ---
  llvm/include/llvm/ADT/FunctionExtras.h | 4 ++--

--- a/upstream_utils/llvm_patches/0032-raw_ostream-Add-SetNumBytesInBuffer.patch
+++ b/upstream_utils/llvm_patches/0032-raw_ostream-Add-SetNumBytesInBuffer.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sun, 29 Oct 2023 23:00:08 -0700
-Subject: [PATCH 32/36] raw_ostream: Add SetNumBytesInBuffer
+Subject: [PATCH 32/37] raw_ostream: Add SetNumBytesInBuffer
 
 ---
  llvm/include/llvm/Support/raw_ostream.h | 5 +++++

--- a/upstream_utils/llvm_patches/0033-type_traits.h-Add-is_constexpr.patch
+++ b/upstream_utils/llvm_patches/0033-type_traits.h-Add-is_constexpr.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 2 Dec 2023 15:21:32 -0800
-Subject: [PATCH 33/36] type_traits.h: Add is_constexpr()
+Subject: [PATCH 33/37] type_traits.h: Add is_constexpr()
 
 ---
  llvm/include/llvm/Support/type_traits.h | 5 +++++

--- a/upstream_utils/llvm_patches/0034-Add-back-removed-raw_string_ostream-write_impl.patch
+++ b/upstream_utils/llvm_patches/0034-Add-back-removed-raw_string_ostream-write_impl.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Fri, 1 Mar 2024 11:37:36 -0800
-Subject: [PATCH 34/36] Add back removed raw_string_ostream::write_impl()
+Subject: [PATCH 34/37] Add back removed raw_string_ostream::write_impl()
 
 ---
  llvm/lib/Support/raw_ostream.cpp | 8 ++++++++

--- a/upstream_utils/llvm_patches/0035-Remove-auto-conversion-from-raw_ostream.patch
+++ b/upstream_utils/llvm_patches/0035-Remove-auto-conversion-from-raw_ostream.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Sun, 17 Mar 2024 14:51:11 -0700
-Subject: [PATCH 35/36] Remove auto-conversion from raw_ostream
+Subject: [PATCH 35/37] Remove auto-conversion from raw_ostream
 
 ---
  llvm/lib/Support/raw_ostream.cpp | 9 ---------

--- a/upstream_utils/llvm_patches/0036-Add-SmallVector-erase_if.patch
+++ b/upstream_utils/llvm_patches/0036-Add-SmallVector-erase_if.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Tue, 18 Jun 2024 09:07:33 -0700
-Subject: [PATCH 36/36] Add SmallVector erase_if()
+Subject: [PATCH 36/37] Add SmallVector erase_if()
 
 ---
  llvm/include/llvm/ADT/SmallVector.h | 8 ++++++++

--- a/upstream_utils/llvm_patches/0037-Fix-AlignedCharArrayUnion-for-C-23.patch
+++ b/upstream_utils/llvm_patches/0037-Fix-AlignedCharArrayUnion-for-C-23.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tyler Veness <calcmogul@gmail.com>
+Date: Sat, 13 Jul 2024 15:24:30 -0700
+Subject: [PATCH 37/37] Fix AlignedCharArrayUnion for C++23
+
+---
+ llvm/include/llvm/Support/AlignOf.h | 14 +++++---------
+ 1 file changed, 5 insertions(+), 9 deletions(-)
+
+diff --git a/llvm/include/llvm/Support/AlignOf.h b/llvm/include/llvm/Support/AlignOf.h
+index f586d7f182aab6e56b7fae6ae98a7cd89e63976c..ca98a564733a07a5e16122d31805e970bf76b673 100644
+--- a/llvm/include/llvm/Support/AlignOf.h
++++ b/llvm/include/llvm/Support/AlignOf.h
+@@ -13,20 +13,16 @@
+ #ifndef LLVM_SUPPORT_ALIGNOF_H
+ #define LLVM_SUPPORT_ALIGNOF_H
+ 
+-#include <type_traits>
++#include <algorithm>
++#include <cstddef>
+ 
+ namespace llvm {
+ 
+ /// A suitably aligned and sized character array member which can hold elements
+ /// of any type.
+-///
+-/// This template is equivalent to std::aligned_union_t<1, ...>, but we cannot
+-/// use it due to a bug in the MSVC x86 compiler:
+-/// https://github.com/microsoft/STL/issues/1533
+-/// Using `alignas` here works around the bug.
+-template <typename T, typename... Ts> struct AlignedCharArrayUnion {
+-  using AlignedUnion = std::aligned_union_t<1, T, Ts...>;
+-  alignas(alignof(AlignedUnion)) char buffer[sizeof(AlignedUnion)];
++template <typename... Ts> struct AlignedCharArrayUnion {
++  alignas((std::max)({alignof(Ts)...}))
++      std::byte buffer[(std::max)({static_cast<size_t>(1), sizeof(Ts)...})];
+ };
+ 
+ } // end namespace llvm

--- a/upstream_utils/update_llvm.py
+++ b/upstream_utils/update_llvm.py
@@ -214,6 +214,7 @@ def main():
         "0034-Add-back-removed-raw_string_ostream-write_impl.patch",
         "0035-Remove-auto-conversion-from-raw_ostream.patch",
         "0036-Add-SmallVector-erase_if.patch",
+        "0037-Fix-AlignedCharArrayUnion-for-C-23.patch",
     ]:
         git_am(
             os.path.join(wpilib_root, "upstream_utils/llvm_patches", f),

--- a/wpiutil/src/main/native/thirdparty/llvm/include/wpi/AlignOf.h
+++ b/wpiutil/src/main/native/thirdparty/llvm/include/wpi/AlignOf.h
@@ -13,20 +13,16 @@
 #ifndef WPIUTIL_WPI_ALIGNOF_H
 #define WPIUTIL_WPI_ALIGNOF_H
 
-#include <type_traits>
+#include <algorithm>
+#include <cstddef>
 
 namespace wpi {
 
 /// A suitably aligned and sized character array member which can hold elements
 /// of any type.
-///
-/// This template is equivalent to std::aligned_union_t<1, ...>, but we cannot
-/// use it due to a bug in the MSVC x86 compiler:
-/// https://github.com/microsoft/STL/issues/1533
-/// Using `alignas` here works around the bug.
-template <typename T, typename... Ts> struct AlignedCharArrayUnion {
-  using AlignedUnion = std::aligned_union_t<1, T, Ts...>;
-  alignas(alignof(AlignedUnion)) char buffer[sizeof(AlignedUnion)];
+template <typename... Ts> struct AlignedCharArrayUnion {
+  alignas((std::max)({alignof(Ts)...}))
+      std::byte buffer[(std::max)({static_cast<size_t>(1), sizeof(Ts)...})];
 };
 
 } // end namespace wpi


### PR DESCRIPTION
C++23 deprecated std::aligned_union_t.