### PR TITLE
[build] CMake: simplify source JAR creation and install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
     message(STATUS "Platform version: ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
 endif()
 
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.21)
 project(allwpilib)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 

--- a/apriltag/CMakeLists.txt
+++ b/apriltag/CMakeLists.txt
@@ -87,22 +87,16 @@ endif()
 
 if(WITH_JAVA_SOURCE)
     include(UseJava)
-    file(GLOB APRILTAG_SOURCES src/main/java/edu/wpi/first/apriltag/*.java)
-    add_jar(
+    include(CreateSourceJar)
+    add_source_jar(
         apriltag_src_jar
-        RESOURCES
-        NAMESPACE "edu/wpi/first/apriltag" ${APRILTAG_SOURCES}
-        NAMESPACE
-            "edu/wpi/first/apriltag/jni"
-            src/main/java/edu/wpi/first/apriltag/jni/AprilTagJNI.java
+        BASE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
         OUTPUT_NAME apriltag-sources
         OUTPUT_DIR ${WPILIB_BINARY_DIR}/${java_lib_dest}
     )
-
-    get_property(APRILTAG_SRC_JAR_FILE TARGET apriltag_src_jar PROPERTY JAR_FILE)
-    install(FILES ${APRILTAG_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
-
     set_property(TARGET apriltag_src_jar PROPERTY FOLDER "java")
+
+    install_jar(apriltag_src_jar DESTINATION ${java_lib_dest})
 endif()
 
 generate_resources(

--- a/cameraserver/CMakeLists.txt
+++ b/cameraserver/CMakeLists.txt
@@ -42,21 +42,16 @@ endif()
 
 if(WITH_JAVA_SOURCE)
     include(UseJava)
-    file(GLOB CAMERASERVER_SOURCES src/main/java/edu/wpi/first/cameraserver/*.java)
-    file(GLOB VISION_SOURCES src/main/java/edu/wpi/first/vision/*.java)
-    add_jar(
+    include(CreateSourceJar)
+    add_source_jar(
         cameraserver_src_jar
-        RESOURCES
-        NAMESPACE "edu/wpi/first/cameraserver" ${CAMERASERVER_SOURCES}
-        NAMESPACE "edu/wpi/first/vision" ${VISION_SOURCES}
+        BASE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
         OUTPUT_NAME cameraserver-sources
         OUTPUT_DIR ${WPILIB_BINARY_DIR}/${java_lib_dest}
     )
-
-    get_property(CAMERASERVER_SRC_JAR_FILE TARGET cameraserver_src_jar PROPERTY JAR_FILE)
-    install(FILES ${CAMERASERVER_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
-
     set_property(TARGET cameraserver_src_jar PROPERTY FOLDER "java")
+
+    install_jar(cameraserver_src_jar DESTINATION ${java_lib_dest})
 endif()
 
 file(GLOB_RECURSE cameraserver_native_src src/main/native/cpp/*.cpp)

--- a/cmake/modules/CreateSourceJar.cmake
+++ b/cmake/modules/CreateSourceJar.cmake
@@ -1,0 +1,34 @@
+macro(add_source_jar target)
+    set(oneValueArgs OUTPUT_NAME OUTPUT_DIR)
+    cmake_parse_arguments(SOURCE_JAR "" "${oneValueArgs}" "BASE_DIRECTORIES" ${ARGN})
+    foreach(base_package_dir ${SOURCE_JAR_BASE_DIRECTORIES})
+        file(GLOB_RECURSE directories LIST_DIRECTORIES true ${base_package_dir}/*.directoriesonly)
+        # Find all packages
+        foreach(directory ${directories})
+            cmake_path(
+                RELATIVE_PATH
+                directory
+                BASE_DIRECTORY ${base_package_dir}
+                OUTPUT_VARIABLE package_name
+            )
+            file(GLOB package_sources ${directory}/*.java)
+            if(package_sources STREQUAL "")
+                continue()
+            endif()
+            # If package sources are scattered across different places, consolidate them under one package
+            list(FIND packages ${package_name} index)
+            if(index EQUAL -1)
+                list(APPEND packages ${package_name})
+            endif()
+            list(APPEND ${package_name} ${package_sources})
+        endforeach()
+    endforeach()
+    set(resources "")
+    foreach(package ${packages})
+        string(APPEND resources "NAMESPACE \"${package}\" ${${package}} ")
+    endforeach()
+    cmake_language(
+        EVAL CODE
+            "add_jar(${target} RESOURCES ${resources} OUTPUT_NAME ${SOURCE_JAR_OUTPUT_NAME} OUTPUT_DIR ${SOURCE_JAR_OUTPUT_DIR})"
+    )
+endmacro()

--- a/cscore/CMakeLists.txt
+++ b/cscore/CMakeLists.txt
@@ -129,21 +129,16 @@ endif()
 
 if(WITH_JAVA_SOURCE)
     include(UseJava)
-    file(GLOB CSCORE_SOURCES src/main/java/edu/wpi/first/cscore/*.java)
-    file(GLOB CSCORE_RAW_SOURCES src/main/java/edu/wpi/first/cscore/raw/*.java)
-    add_jar(
+    include(CreateSourceJar)
+    add_source_jar(
         cscore_src_jar
-        RESOURCES
-        NAMESPACE "edu/wpi/first/cscore" ${CSCORE_SOURCES}
-        NAMESPACE "edu/wpi/first/cscore/raw" ${CSCORE_RAW_SOURCES}
+        BASE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
         OUTPUT_NAME cscore-sources
         OUTPUT_DIR ${WPILIB_BINARY_DIR}/${java_lib_dest}
     )
-
-    get_property(CSCORE_SRC_JAR_FILE TARGET cscore_src_jar PROPERTY JAR_FILE)
-    install(FILES ${CSCORE_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
-
     set_property(TARGET cscore_src_jar PROPERTY FOLDER "java")
+
+    install_jar(cscore_src_jar DESTINATION ${java_lib_dest})
 endif()
 
 if(WITH_TESTS)

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -80,28 +80,18 @@ endif()
 
 if(WITH_JAVA_SOURCE)
     include(UseJava)
-    file(GLOB HAL_SOURCES src/main/java/edu/wpi/first/hal/*.java src/generated/main/java/*.java)
-    file(GLOB HAL_CAN_SOURCES src/main/java/edu/wpi/first/hal/can/*.java)
-    file(GLOB HAL_SIMULATION_SOURCES src/main/java/edu/wpi/first/hal/simulation/*.java)
-    file(GLOB HAL_UTIL_SOURCES src/main/java/edu/wpi/first/hal/util/*.java)
-    add_jar(
+    include(CreateSourceJar)
+    add_source_jar(
         hal_src_jar
-        RESOURCES
-        NAMESPACE "edu/wpi/first/hal" ${HAL_SOURCES}
-        NAMESPACE "edu/wpi/first/hal/can" ${HAL_CAN_SOURCES}
-        NAMESPACE
-            "edu/wpi/first/hal/communication"
-            src/main/java/edu/wpi/first/hal/communication/NIRioStatus.java
-        NAMESPACE "edu/wpi/first/hal/simulation" ${HAL_SIMULATION_SOURCES}
-        NAMESPACE "edu/wpi/first/hal/util" ${HAL_UTIL_SOURCES}
+        BASE_DIRECTORIES
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/generated/main/java
         OUTPUT_NAME wpiHal-sources
         OUTPUT_DIR ${WPILIB_BINARY_DIR}/${java_lib_dest}
     )
-
-    get_property(HAL_SRC_JAR_FILE TARGET hal_src_jar PROPERTY JAR_FILE)
-    install(FILES ${HAL_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
-
     set_property(TARGET hal_src_jar PROPERTY FOLDER "java")
+
+    install_jar(hal_src_jar DESTINATION ${java_lib_dest})
 endif()
 
 if(WITH_TESTS)

--- a/ntcore/CMakeLists.txt
+++ b/ntcore/CMakeLists.txt
@@ -76,23 +76,18 @@ endif()
 
 if(WITH_JAVA_SOURCE)
     include(UseJava)
-    file(
-        GLOB NTCORE_SOURCES
-        src/main/java/edu/wpi/first/networktables/*.java
-        src/generated/main/java/*.java
-    )
-    add_jar(
+    include(CreateSourceJar)
+    add_source_jar(
         ntcore_src_jar
-        RESOURCES
-        NAMESPACE "edu/wpi/first/networktables" ${NTCORE_SOURCES}
+        BASE_DIRECTORIES
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/generated/main/java
         OUTPUT_NAME ntcore-sources
         OUTPUT_DIR ${WPILIB_BINARY_DIR}/${java_lib_dest}
     )
-
-    get_property(NTCORE_SRC_JAR_FILE TARGET ntcore_src_jar PROPERTY JAR_FILE)
-    install(FILES ${NTCORE_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
-
     set_property(TARGET ntcore_src_jar PROPERTY FOLDER "java")
+
+    install_jar(ntcore_src_jar DESTINATION ${java_lib_dest})
 endif()
 
 add_executable(ntcoredev src/dev/native/cpp/main.cpp)

--- a/romiVendordep/CMakeLists.txt
+++ b/romiVendordep/CMakeLists.txt
@@ -35,19 +35,16 @@ endif()
 
 if(WITH_JAVA_SOURCE)
     include(UseJava)
-    file(GLOB_RECURSE ROMIVENDORDEP_SOURCES src/main/java/*.java)
-    add_jar(
+    include(CreateSourceJar)
+    add_source_jar(
         romiVendordep_src_jar
-        RESOURCES
-        NAMESPACE "edu/wpi/first/wpilibj/romi" ${ROMIVENDORDEP_SOURCES}
+        BASE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
         OUTPUT_NAME romiVendordep-sources
         OUTPUT_DIR ${WPILIB_BINARY_DIR}/${java_lib_dest}
     )
-
-    get_property(ROMIVENDORDEP_SRC_JAR_FILE TARGET romiVendordep_src_jar PROPERTY JAR_FILE)
-    install(FILES ${ROMIVENDORDEP_JAR_FILE} DESTINATION "${java_lib_dest}")
-
     set_property(TARGET romiVendordep_src_jar PROPERTY FOLDER "java")
+
+    install_jar(romiVendordep_src_jar DESTINATION ${java_lib_dest})
 endif()
 
 file(GLOB_RECURSE romiVendordep_native_src src/main/native/cpp/*.cpp)

--- a/wpilibNewCommands/CMakeLists.txt
+++ b/wpilibNewCommands/CMakeLists.txt
@@ -37,25 +37,18 @@ endif()
 
 if(WITH_JAVA_SOURCE)
     include(UseJava)
-    file(GLOB WPILIBNEWCOMMANDS_SOURCES src/main/java/edu/wpi/first/wpilibj2/command/*.java)
-    file(
-        GLOB WPILIBNEWCOMMANDS_BUTTON_SOURCES
-        src/main/java/edu/wpi/first/wpilibj2/command/button/*.java
-        src/generated/main/java/edu/wpi/first/wpilibj2/command/button/*.java
-    )
-    add_jar(
+    include(CreateSourceJar)
+    add_source_jar(
         wpilibNewCommands_src_jar
-        RESOURCES
-        NAMESPACE "edu/wpi/first/wpilibj2/command" ${WPILIBNEWCOMMANDS_SOURCES}
-        NAMESPACE "edu/wpi/first/wpilibj2/command/button" ${WPILIBNEWCOMMANDS_BUTTON_SOURCES}
+        BASE_DIRECTORIES
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/generated/main/java
         OUTPUT_NAME wpilibNewCommands-sources
         OUTPUT_DIR ${WPILIB_BINARY_DIR}/${java_lib_dest}
     )
-
-    get_property(WPILIBNEWCOMMANDS_SRC_JAR_FILE TARGET wpilibNewCommands_src_jar PROPERTY JAR_FILE)
-    install(FILES ${WPILIBNEWCOMMANDS_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
-
     set_property(TARGET wpilibNewCommands_src_jar PROPERTY FOLDER "java")
+
+    install_jar(wpilibNewCommands_src_jar DESTINATION ${java_lib_dest})
 endif()
 
 file(

--- a/wpilibj/CMakeLists.txt
+++ b/wpilibj/CMakeLists.txt
@@ -17,7 +17,10 @@ if(WITH_JAVA)
         NO_DEFAULT_PATH
     )
 
-    configure_file(src/generate/WPILibVersion.java.in WPILibVersion.java)
+    configure_file(
+        src/generate/WPILibVersion.java.in
+        generated/main/java/edu/wpi/first/wpilibj/WPILibVersion.java
+    )
 
     file(GLOB_RECURSE JAVA_SOURCES src/main/java/*.java src/generated/main/java/*.java)
     file(GLOB EJML_JARS "${WPILIB_BINARY_DIR}/wpimath/thirdparty/ejml/*.jar")
@@ -26,7 +29,7 @@ if(WITH_JAVA)
     add_jar(
         wpilibj_jar
         ${JAVA_SOURCES}
-        ${CMAKE_CURRENT_BINARY_DIR}/WPILibVersion.java
+        ${CMAKE_CURRENT_BINARY_DIR}/generated/main/java/edu/wpi/first/wpilibj/WPILibVersion.java
         INCLUDE_JARS
             hal_jar
             ntcore_jar
@@ -51,53 +54,24 @@ endif()
 
 if(WITH_JAVA_SOURCE)
     include(UseJava)
-    file(
-        GLOB WPILIBJ_SOURCES
-        src/main/java/edu/wpi/first/wpilibj/*.java
-        src/generated/main/java/edu/wpi/first/wpilibj/*.java
-    )
-    file(GLOB WPILIBJ_COUNTER_SOURCES src/main/java/edu/wpi/first/wpilibj/counter/*.java)
-    file(GLOB WPILIBJ_DRIVE_SOURCES src/main/java/edu/wpi/first/wpilibj/drive/*.java)
-    file(GLOB WPILIBJ_EVENT_SOURCES src/main/java/edu/wpi/first/wpilibj/event/*.java)
-    file(GLOB WPILIBJ_INTERFACES_SOURCES src/main/java/edu/wpi/first/wpilibj/interfaces/*.java)
-    file(GLOB WPILIBJ_MOTORCONTROL_SOURCES src/main/java/edu/wpi/first/wpilibj/motorcontrol*.java)
-    file(GLOB WPILIBJ_SHUFFLEBOARD_SOURCES src/main/java/edu/wpi/first/wpilibj/shuffleboard*.java)
-    file(
-        GLOB WPILIBJ_SIMULATION_SOURCES
-        src/main/java/edu/wpi/first/wpilibj/simulation/*.java
-        src/generated/main/java/edu/wpi/first/wpilibj/simulation/*.java
-    )
-    file(GLOB WPILIBJ_SMARTDASHBOARD_SOURCES src/main/java/edu/wpi/first/wpilibj/*.java)
-    file(
-        GLOB WPILIBJ_UTIL_SOURCES
-        src/main/java/edu/wpi/first/wpilibj/*.java
-        ${CMAKE_CURRENT_BINARY_DIR}/WPILibVersion.java
-    )
-    add_jar(
+    include(CreateSourceJar)
+    # Generate version file if it wasn't generated already
+    if(NOT WITH_JAVA)
+        configure_file(
+            src/generate/WPILi1bVersion.java.in
+            generated/main/java/edu/wpi/first/wpilibj/WPILibVersion.java
+        )
+    endif()
+    add_source_jar(
         wpilibj_src_jar
-        RESOURCES
-        NAMESPACE "edu/wpi/first/wpilibj" ${WPILIBJ_SOURCES}
-        NAMESPACE "edu/wpi/first/wpilibj/counter" ${WPILIBJ_COUNTER_SOURCES}
-        NAMESPACE "edu/wpi/first/wpilibj/drive" ${WPILIBJ_DRIVE_SOURCES}
-        NAMESPACE "edu/wpi/first/wpilibj/event" ${WPILIBJ_EVENT_SOURCES}
-        NAMESPACE "edu/wpi/first/wpilibj/interfaces" ${WPILIBJ_INTERFACES_SOURCES}
-        NAMESPACE
-            "edu/wpi/first/wpilibj/internal"
-            src/main/java/edu/wpi/first/wpilibj/internal/DriverStationModeThread.java
-        NAMESPACE
-            "edu/wpi/first/wpilibj/livewindow"
-            src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
-        NAMESPACE "edu/wpi/first/wpilibj/motorcontrol" ${WPILIBJ_MOTORCONTROL_SOURCES}
-        NAMESPACE "edu/wpi/first/wpilibj/shuffleboard" ${WPILIBJ_SHUFFLEBOARD_SOURCES}
-        NAMESPACE "edu/wpi/first/wpilibj/simulation" ${WPILIBJ_SIMULATION_SOURCES}
-        NAMESPACE "edu/wpi/first/wpilibj/smartdashboard" ${WPILIBJ_SMARTDASHBOARD_SOURCES}
-        NAMESPACE "edu/wpi/first/wpilibj/util" ${WPILIBJ_UTIL_SOURCES}
+        BASE_DIRECTORIES
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/generated/main/java
+            ${CMAKE_CURRENT_BINARY_DIR}/generated/main/java
         OUTPUT_NAME wpilibj-sources
         OUTPUT_DIR ${WPILIB_BINARY_DIR}/${java_lib_dest}
     )
-
-    get_property(WPILIBJ_SRC_JAR_FILE TARGET wpilibj_src_jar PROPERTY JAR_FILE)
-    install(FILES ${WPILIBJ_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
-
     set_property(TARGET wpilibj_src_jar PROPERTY FOLDER "java")
+
+    install_jar(wpilibj_src_jar DESTINATION ${java_lib_dest})
 endif()

--- a/wpimath/CMakeLists.txt
+++ b/wpimath/CMakeLists.txt
@@ -107,52 +107,18 @@ endif()
 
 if(WITH_JAVA_SOURCE)
     include(UseJava)
-    file(
-        GLOB WPIMATH_SOURCES
-        src/main/java/edu/wpi/first/math/*.java
-        src/generated/main/java/edu/wpi/first/math/Nat.java
-    )
-    file(GLOB WPIMATH_CONTROLLER_SOURCES src/main/java/edu/wpi/first/math/controller/*.java)
-    file(GLOB WPIMATH_ESTIMATOR_SOURCES src/main/java/edu/wpi/first/math/estimator/*.java)
-    file(GLOB WPIMATH_FILTER_SOURCES src/main/java/edu/wpi/first/math/filter/*.java)
-    file(GLOB WPIMATH_GEOMETRY_SOURCES src/main/java/edu/wpi/first/math/geometry/*.java)
-    file(GLOB WPIMATH_INTERPOLATION_SOURCES src/main/java/edu/wpi/first/math/interpolation/*.java)
-    file(GLOB WPIMATH_KINEMATICS_SOURCES src/main/java/edu/wpi/first/math/kinematics/*.java)
-    file(GLOB WPIMATH_NUMBERS_SOURCES src/generated/main/java/edu/wpi/first/math/numbers/*.java)
-    file(GLOB WPIMATH_SPLINE_SOURCES src/main/java/edu/wpi/first/math/spline/*.java)
-    file(GLOB WPIMATH_SYSTEM_SOURCES src/main/java/edu/wpi/first/math/system/*.java)
-    file(GLOB WPIMATH_SYSTEM_PLANT_SOURCES src/main/java/edu/wpi/first/math/system/plant/*.java)
-    file(GLOB WPIMATH_TRAJECTORY_SOURCES src/main/java/edu/wpi/first/math/trajectory/*.java)
-    file(
-        GLOB WPIMATH_TRAJECTORY_CONSTRAINT_SOURCES
-        src/main/java/edu/wpi/first/math/trajectory/constraint/*.java
-    )
-    add_jar(
+    include(CreateSourceJar)
+    add_source_jar(
         wpimath_src_jar
-        RESOURCES
-        NAMESPACE "edu/wpi/first/math" ${WPIMATH_SOURCES}
-        NAMESPACE "edu/wpi/first/math/controller" ${WPIMATH_CONTROLLER_SOURCES}
-        NAMESPACE "edu/wpi/first/math/estimator" ${WPIMATH_ESTIMATOR_SOURCES}
-        NAMESPACE "edu/wpi/first/math/filter" ${WPIMATH_FILTER_SOURCES}
-        NAMESPACE "edu/wpi/first/math/geometry" ${WPIMATH_GEOMETRY_SOURCES}
-        NAMESPACE "edu/wpi/first/math/interpolation" ${WPIMATH_INTERPOLATION_SOURCES}
-        NAMESPACE "edu/wpi/first/math/kinematics" ${WPIMATH_KINEMATICS_SOURCES}
-        NAMESPACE "edu/wpi/first/math/spline" ${WPIMATH_SPLINE_SOURCES}
-        NAMESPACE "edu/wpi/first/math/system" ${WPIMATH_SYSTEM_SOURCES}
-        NAMESPACE "edu/wpi/first/math/system/plant" ${WPIMATH_SYSTEM_PLANT_SOURCES}
-        NAMESPACE "edu/wpi/first/math/trajectory" ${WPIMATH_TRAJECTORY_SOURCES}
-        NAMESPACE
-            "edu/wpi/first/math/trajectory/constraint"
-            ${WPIMATH_TRAJECTORY_CONSTRAINT_SOURCES}
-        NAMESPACE "edu/wpi/first/math/util" src/main/java/edu/wpi/first/math/util/Units.java
+        BASE_DIRECTORIES
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/generated/main/java
         OUTPUT_NAME wpimath-sources
         OUTPUT_DIR ${WPILIB_BINARY_DIR}/${java_lib_dest}
     )
-
-    get_property(WPIMATH_SRC_JAR_FILE TARGET wpimath_src_jar PROPERTY JAR_FILE)
-    install(FILES ${WPIMATH_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
-
     set_property(TARGET wpimath_src_jar PROPERTY FOLDER "java")
+
+    install_jar(wpimath_src_jar DESTINATION ${java_lib_dest})
 endif()
 
 file(

--- a/wpinet/CMakeLists.txt
+++ b/wpinet/CMakeLists.txt
@@ -43,19 +43,16 @@ endif()
 
 if(WITH_JAVA_SOURCE)
     include(UseJava)
-    file(GLOB WPINET_SOURCES src/main/java/edu/wpi/first/net/*.java)
-    add_jar(
+    include(CreateSourceJar)
+    add_source_jar(
         wpinet_src_jar
-        RESOURCES
-        NAMESPACE "edu/wpi/first/net" ${WPINET_SOURCES}
+        BASE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
         OUTPUT_NAME wpinet-sources
         OUTPUT_DIR ${WPILIB_BINARY_DIR}/${java_lib_dest}
     )
-
-    get_property(WPINET_SRC_JAR_FILE TARGET wpinet_src_jar PROPERTY JAR_FILE)
-    install(FILES ${WPINET_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
-
     set_property(TARGET wpinet_src_jar PROPERTY FOLDER "java")
+
+    install_jar(wpinet_src_jar DESTINATION ${java_lib_dest})
 endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/wpiunits/CMakeLists.txt
+++ b/wpiunits/CMakeLists.txt
@@ -18,3 +18,16 @@ if(WITH_JAVA)
     install_jar_exports(TARGETS wpiunits_jar FILE wpiunits.cmake DESTINATION share/wpiunits)
     install(FILES wpiunits-config.cmake DESTINATION share/wpiunits)
 endif()
+
+if(WITH_JAVA_SOURCE)
+    include(UseJava)
+    include(CreateSourceJar)
+    add_source_jar(
+        wpiunits_src_jar
+        BASE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
+        OUTPUT_NAME wpiunits-sources
+    )
+    set_property(TARGET wpiunits_src_jar PROPERTY FOLDER "java")
+
+    install_jar(wpiunits_src_jar DESTINATION ${java_lib_dest})
+endif()

--- a/wpiutil/CMakeLists.txt
+++ b/wpiutil/CMakeLists.txt
@@ -87,29 +87,16 @@ endif()
 
 if(WITH_JAVA_SOURCE)
     include(UseJava)
-    file(GLOB WPIUTIL_SOURCES src/main/java/edu/wpi/first/util/*.java)
-    file(GLOB WPIUTIL_CLEANUP_SOURCES src/main/java/edu/wpi/first/util/cleanup/*.java)
-    file(GLOB WPIUTIL_CONCURRENT_SOURCES src/main/java/edu/wpi/first/util/concurrent/*.java)
-    file(GLOB WPIUTIL_DATALOG_SOURCES src/main/java/edu/wpi/first/util/datalog/*.java)
-    file(GLOB WPIUTIL_FUNCTION_SOURCES src/main/java/edu/wpi/first/util/function/*.java)
-    file(GLOB WPIUTIL_SENDABLE_SOURCES src/main/java/edu/wpi/first/util/sendable/*.java)
-    add_jar(
+    include(CreateSourceJar)
+    add_source_jar(
         wpiutil_src_jar
-        RESOURCES
-        NAMESPACE "edu/wpi/first/util" ${WPIUTIL_SOURCES}
-        NAMESPACE "edu/wpi/first/util/cleanup" ${WPIUTIL_CLEANUP_SOURCES}
-        NAMESPACE "edu/wpi/first/util/concurrent" ${WPIUTIL_CONCURRENT_SOURCES}
-        NAMESPACE "edu/wpi/first/util/datalog" ${WPIUTIL_DATALOG_SOURCES}
-        NAMESPACE "edu/wpi/first/util/function" ${WPIUTIL_FUNCTION_SOURCES}
-        NAMESPACE "edu/wpi/first/util/sendable" ${WPIUTIL_SENDABLE_SOURCES}
+        BASE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
         OUTPUT_NAME wpiutil-sources
         OUTPUT_DIR ${WPILIB_BINARY_DIR}/${java_lib_dest}
     )
-
-    get_property(WPIUTIL_SRC_JAR_FILE TARGET wpiutil_src_jar PROPERTY JAR_FILE)
-    install(FILES ${WPIUTIL_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
-
     set_property(TARGET wpiutil_src_jar PROPERTY FOLDER "java")
+
+    install_jar(wpiutil_src_jar DESTINATION ${java_lib_dest})
 endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/xrpVendordep/CMakeLists.txt
+++ b/xrpVendordep/CMakeLists.txt
@@ -35,19 +35,16 @@ endif()
 
 if(WITH_JAVA_SOURCE)
     include(UseJava)
-    file(GLOB XRPVENDORDEP_SOURCES src/main/java/edu/wpi/first/wpilibj/xrp/*.java)
-    add_jar(
+    include(CreateSourceJar)
+    add_source_jar(
         xrpVendordep_src_jar
-        RESOURCES
-        NAMESPACE "edu/wpi/first/wpilibj/xrp" ${XRPVENDORDEP_SOURCES}
+        BASE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
         OUTPUT_NAME xrpVendordep-sources
         OUTPUT_DIR ${WPILIB_BINARY_DIR}/${java_lib_dest}
     )
-
-    get_property(xrpVendordep_src_JAR_FILE TARGET xrpVendordep_src_jar PROPERTY JAR_FILE)
-    install(FILES ${xrpVendordep_src_JAR_FILE} DESTINATION "${java_lib_dest}")
-
     set_property(TARGET xrpVendordep_src_jar PROPERTY FOLDER "java")
+
+    install_jar(xrpVendordep_src_jar DESTINATION ${java_lib_dest})
 endif()
 
 file(GLOB_RECURSE xrpVendordep_native_src src/main/native/cpp/*.cpp)


### PR DESCRIPTION
An `add_source_jar` macro has been added to simplify maintaining source JARs. The old approach has many bugs, and is easily prone to falling out-of-date when new packages are introduced. Instead, the root directories where Java packages are located are given to the macro, and the macro will handle finding all the source files and assigning the right package to them. In addition, the minimum CMake version has been bumped to 3.21 to ensure the `RESOURCES` parameter is available.