### PR TITLE
[upstream_utils] Suppress has_denorm deprecation in Eigen

### DIFF
--- a/upstream_utils/eigen_patches/0001-Disable-warnings.patch
+++ b/upstream_utils/eigen_patches/0001-Disable-warnings.patch
@@ -1,14 +1,14 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Wed, 18 May 2022 09:14:24 -0700
-Subject: [PATCH 1/2] Disable warnings
+Subject: [PATCH 1/3] Disable warnings
 
 ---
  Eigen/src/Core/util/DisableStupidWarnings.h | 6 ++++++
  1 file changed, 6 insertions(+)
 
 diff --git a/Eigen/src/Core/util/DisableStupidWarnings.h b/Eigen/src/Core/util/DisableStupidWarnings.h
-index 32a427d852355a51dc4263d81498554ff4c3cbba..9f3e3f5b0f15518377c9a8283fd58081902896f2 100644
+index 32a427d852355a51dc4263d81498554ff4c3cbba..1182198231ab784346f8d80838363e4a0abba2ba 100644
 --- a/Eigen/src/Core/util/DisableStupidWarnings.h
 +++ b/Eigen/src/Core/util/DisableStupidWarnings.h
 @@ -81,6 +81,12 @@

--- a/upstream_utils/eigen_patches/0002-Intellisense-fix.patch
+++ b/upstream_utils/eigen_patches/0002-Intellisense-fix.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Fri, 20 Jan 2023 23:41:56 -0800
-Subject: [PATCH 2/2] Intellisense fix
+Subject: [PATCH 2/3] Intellisense fix
 
 ---
  Eigen/src/Core/util/ConfigureVectorization.h | 7 +++++++

--- a/upstream_utils/eigen_patches/0003-Suppress-has_denorm-and-has_denorm_loss-deprecation-.patch
+++ b/upstream_utils/eigen_patches/0003-Suppress-has_denorm-and-has_denorm_loss-deprecation-.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tyler Veness <calcmogul@gmail.com>
+Date: Sat, 13 Jul 2024 18:51:32 -0700
+Subject: [PATCH 3/3] Suppress has_denorm and has_denorm_loss deprecation
+ warnings
+
+MSVC doesn't yet claim C++23 compliance for c++latest, so we have to be
+less specific in the preprocessor check.
+---
+ Eigen/src/Core/arch/Default/BFloat16.h | 8 --------
+ Eigen/src/Core/arch/Default/Half.h     | 8 --------
+ 2 files changed, 16 deletions(-)
+
+diff --git a/Eigen/src/Core/arch/Default/BFloat16.h b/Eigen/src/Core/arch/Default/BFloat16.h
+index 9e79a39a4c81d3c08868e3b70e64d56118a4efe8..14f0524a3b0e4ff836b77092949caafa0949a18c 100644
+--- a/Eigen/src/Core/arch/Default/BFloat16.h
++++ b/Eigen/src/Core/arch/Default/BFloat16.h
+@@ -139,15 +139,11 @@ struct numeric_limits_bfloat16_impl {
+   static EIGEN_CONSTEXPR const bool has_infinity = true;
+   static EIGEN_CONSTEXPR const bool has_quiet_NaN = true;
+   static EIGEN_CONSTEXPR const bool has_signaling_NaN = true;
+-#if __cplusplus >= 202302L
+   EIGEN_DIAGNOSTICS(push)
+   EIGEN_DISABLE_DEPRECATED_WARNING
+-#endif
+   static EIGEN_CONSTEXPR const std::float_denorm_style has_denorm = std::denorm_present;
+   static EIGEN_CONSTEXPR const bool has_denorm_loss = false;
+-#if __cplusplus >= 202302L
+   EIGEN_DIAGNOSTICS(pop)
+-#endif
+   static EIGEN_CONSTEXPR const std::float_round_style round_style = std::numeric_limits<float>::round_style;
+   static EIGEN_CONSTEXPR const bool is_iec559 = true;
+   // The C++ standard defines this as "true if the set of values representable
+@@ -194,17 +190,13 @@ template <typename T>
+ EIGEN_CONSTEXPR const bool numeric_limits_bfloat16_impl<T>::has_quiet_NaN;
+ template <typename T>
+ EIGEN_CONSTEXPR const bool numeric_limits_bfloat16_impl<T>::has_signaling_NaN;
+-#if __cplusplus >= 202302L
+ EIGEN_DIAGNOSTICS(push)
+ EIGEN_DISABLE_DEPRECATED_WARNING
+-#endif
+ template <typename T>
+ EIGEN_CONSTEXPR const std::float_denorm_style numeric_limits_bfloat16_impl<T>::has_denorm;
+ template <typename T>
+ EIGEN_CONSTEXPR const bool numeric_limits_bfloat16_impl<T>::has_denorm_loss;
+-#if __cplusplus >= 202302L
+ EIGEN_DIAGNOSTICS(pop)
+-#endif
+ template <typename T>
+ EIGEN_CONSTEXPR const std::float_round_style numeric_limits_bfloat16_impl<T>::round_style;
+ template <typename T>
+diff --git a/Eigen/src/Core/arch/Default/Half.h b/Eigen/src/Core/arch/Default/Half.h
+index 7754e8f27261f5e10eec8e1125b4869e01e5dde8..90d65c5e3cb099374179223d4b3e50d4991b06cd 100644
+--- a/Eigen/src/Core/arch/Default/Half.h
++++ b/Eigen/src/Core/arch/Default/Half.h
+@@ -208,15 +208,11 @@ struct numeric_limits_half_impl {
+   static EIGEN_CONSTEXPR const bool has_infinity = true;
+   static EIGEN_CONSTEXPR const bool has_quiet_NaN = true;
+   static EIGEN_CONSTEXPR const bool has_signaling_NaN = true;
+-#if __cplusplus >= 202302L
+   EIGEN_DIAGNOSTICS(push)
+   EIGEN_DISABLE_DEPRECATED_WARNING
+-#endif
+   static EIGEN_CONSTEXPR const std::float_denorm_style has_denorm = std::denorm_present;
+   static EIGEN_CONSTEXPR const bool has_denorm_loss = false;
+-#if __cplusplus >= 202302L
+   EIGEN_DIAGNOSTICS(pop)
+-#endif
+   static EIGEN_CONSTEXPR const std::float_round_style round_style = std::round_to_nearest;
+   static EIGEN_CONSTEXPR const bool is_iec559 = true;
+   // The C++ standard defines this as "true if the set of values representable
+@@ -263,17 +259,13 @@ template <typename T>
+ EIGEN_CONSTEXPR const bool numeric_limits_half_impl<T>::has_quiet_NaN;
+ template <typename T>
+ EIGEN_CONSTEXPR const bool numeric_limits_half_impl<T>::has_signaling_NaN;
+-#if __cplusplus >= 202302L
+ EIGEN_DIAGNOSTICS(push)
+ EIGEN_DISABLE_DEPRECATED_WARNING
+-#endif
+ template <typename T>
+ EIGEN_CONSTEXPR const std::float_denorm_style numeric_limits_half_impl<T>::has_denorm;
+ template <typename T>
+ EIGEN_CONSTEXPR const bool numeric_limits_half_impl<T>::has_denorm_loss;
+-#if __cplusplus >= 202302L
+ EIGEN_DIAGNOSTICS(pop)
+-#endif
+ template <typename T>
+ EIGEN_CONSTEXPR const std::float_round_style numeric_limits_half_impl<T>::round_style;
+ template <typename T>

--- a/upstream_utils/update_eigen.py
+++ b/upstream_utils/update_eigen.py
@@ -109,6 +109,7 @@ def main():
     for f in [
         "0001-Disable-warnings.patch",
         "0002-Intellisense-fix.patch",
+        "0003-Suppress-has_denorm-and-has_denorm_loss-deprecation-.patch",
     ]:
         git_am(os.path.join(wpilib_root, "upstream_utils/eigen_patches", f))
 

--- a/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/arch/Default/BFloat16.h
+++ b/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/arch/Default/BFloat16.h
@@ -139,15 +139,11 @@ struct numeric_limits_bfloat16_impl {
   static EIGEN_CONSTEXPR const bool has_infinity = true;
   static EIGEN_CONSTEXPR const bool has_quiet_NaN = true;
   static EIGEN_CONSTEXPR const bool has_signaling_NaN = true;
-#if __cplusplus >= 202302L
   EIGEN_DIAGNOSTICS(push)
   EIGEN_DISABLE_DEPRECATED_WARNING
-#endif
   static EIGEN_CONSTEXPR const std::float_denorm_style has_denorm = std::denorm_present;
   static EIGEN_CONSTEXPR const bool has_denorm_loss = false;
-#if __cplusplus >= 202302L
   EIGEN_DIAGNOSTICS(pop)
-#endif
   static EIGEN_CONSTEXPR const std::float_round_style round_style = std::numeric_limits<float>::round_style;
   static EIGEN_CONSTEXPR const bool is_iec559 = true;
   // The C++ standard defines this as "true if the set of values representable
@@ -194,17 +190,13 @@ template <typename T>
 EIGEN_CONSTEXPR const bool numeric_limits_bfloat16_impl<T>::has_quiet_NaN;
 template <typename T>
 EIGEN_CONSTEXPR const bool numeric_limits_bfloat16_impl<T>::has_signaling_NaN;
-#if __cplusplus >= 202302L
 EIGEN_DIAGNOSTICS(push)
 EIGEN_DISABLE_DEPRECATED_WARNING
-#endif
 template <typename T>
 EIGEN_CONSTEXPR const std::float_denorm_style numeric_limits_bfloat16_impl<T>::has_denorm;
 template <typename T>
 EIGEN_CONSTEXPR const bool numeric_limits_bfloat16_impl<T>::has_denorm_loss;
-#if __cplusplus >= 202302L
 EIGEN_DIAGNOSTICS(pop)
-#endif
 template <typename T>
 EIGEN_CONSTEXPR const std::float_round_style numeric_limits_bfloat16_impl<T>::round_style;
 template <typename T>

--- a/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/arch/Default/Half.h
+++ b/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/arch/Default/Half.h
@@ -208,15 +208,11 @@ struct numeric_limits_half_impl {
   static EIGEN_CONSTEXPR const bool has_infinity = true;
   static EIGEN_CONSTEXPR const bool has_quiet_NaN = true;
   static EIGEN_CONSTEXPR const bool has_signaling_NaN = true;
-#if __cplusplus >= 202302L
   EIGEN_DIAGNOSTICS(push)
   EIGEN_DISABLE_DEPRECATED_WARNING
-#endif
   static EIGEN_CONSTEXPR const std::float_denorm_style has_denorm = std::denorm_present;
   static EIGEN_CONSTEXPR const bool has_denorm_loss = false;
-#if __cplusplus >= 202302L
   EIGEN_DIAGNOSTICS(pop)
-#endif
   static EIGEN_CONSTEXPR const std::float_round_style round_style = std::round_to_nearest;
   static EIGEN_CONSTEXPR const bool is_iec559 = true;
   // The C++ standard defines this as "true if the set of values representable
@@ -263,17 +259,13 @@ template <typename T>
 EIGEN_CONSTEXPR const bool numeric_limits_half_impl<T>::has_quiet_NaN;
 template <typename T>
 EIGEN_CONSTEXPR const bool numeric_limits_half_impl<T>::has_signaling_NaN;
-#if __cplusplus >= 202302L
 EIGEN_DIAGNOSTICS(push)
 EIGEN_DISABLE_DEPRECATED_WARNING
-#endif
 template <typename T>
 EIGEN_CONSTEXPR const std::float_denorm_style numeric_limits_half_impl<T>::has_denorm;
 template <typename T>
 EIGEN_CONSTEXPR const bool numeric_limits_half_impl<T>::has_denorm_loss;
-#if __cplusplus >= 202302L
 EIGEN_DIAGNOSTICS(pop)
-#endif
 template <typename T>
 EIGEN_CONSTEXPR const std::float_round_style numeric_limits_half_impl<T>::round_style;
 template <typename T>


### PR DESCRIPTION
MSVC doesn't yet claim C++23 compliance for c++latest, so we have to be less specific in the preprocessor check.