### PR TITLE
Change wpilibmath Javadocs to use "reference" instead of "setpoint"

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/controller/ArmFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/ArmFeedforward.java
@@ -70,13 +70,14 @@ public class ArmFeedforward implements ProtobufSerializable, StructSerializable 
   }
 
   /**
-   * Calculates the feedforward from the gains and setpoints.
+   * Calculates the feedforward from the gains and references.
    *
-   * @param positionRadians The position (angle) setpoint. This angle should be measured from the
-   *     horizontal (i.e. if the provided angle is 0, the arm should be parallel with the floor). If
-   *     your encoder does not follow this convention, an offset should be added.
-   * @param velocityRadPerSec The velocity setpoint.
-   * @param accelRadPerSecSquared The acceleration setpoint.
+   * @param positionRadians The position reference as an angle. This defines the "target position" the 
+   *     controller will aim for. This angle should be measured from the horizontal (i.e. if the provided 
+   *     angle is 0, the arm should be parallel with the floor). If your encoder does not follow this
+   *     convention, an offset should be added.
+   * @param velocityRadPerSec The velocity reference.
+   * @param accelRadPerSecSquared The acceleration reference.
    * @return The computed feedforward.
    */
   public double calculate(
@@ -88,13 +89,14 @@ public class ArmFeedforward implements ProtobufSerializable, StructSerializable 
   }
 
   /**
-   * Calculates the feedforward from the gains and velocity setpoint (acceleration is assumed to be
+   * Calculates the feedforward from the gains and velocity reference (acceleration is assumed to be
    * zero).
    *
-   * @param positionRadians The position (angle) setpoint. This angle should be measured from the
-   *     horizontal (i.e. if the provided angle is 0, the arm should be parallel with the floor). If
-   *     your encoder does not follow this convention, an offset should be added.
-   * @param velocity The velocity setpoint.
+   * @param positionRadians The position reference as an angle. This defines the "target position" the 
+   *     controller will aim for. This angle should be measured from the horizontal (i.e. if the provided 
+   *     angle is 0, the arm should be parallel with the floor). If your encoder does not follow this
+   *     convention, an offset should be added.
+   * @param velocity The velocity reference.
    * @return The computed feedforward.
    */
   public double calculate(double positionRadians, double velocity) {
@@ -102,14 +104,14 @@ public class ArmFeedforward implements ProtobufSerializable, StructSerializable 
   }
 
   /**
-   * Calculates the feedforward from the gains and setpoints.
+   * Calculates the feedforward from the gains and references.
    *
    * @param currentAngle The current angle in radians. This angle should be measured from the
    *     horizontal (i.e. if the provided angle is 0, the arm should be parallel to the floor). If
    *     your encoder does not follow this convention, an offset should be added.
-   * @param currentVelocity The current velocity setpoint in radians per second.
-   * @param nextVelocity The next velocity setpoint in radians per second.
-   * @param dt Time between velocity setpoints in seconds.
+   * @param currentVelocity The current velocity reference in radians per second.
+   * @param nextVelocity The next velocity reference in radians per second.
+   * @param dt Time between velocity references in seconds.
    * @return The computed feedforward in volts.
    */
   public double calculate(

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/DifferentialDriveFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/DifferentialDriveFeedforward.java
@@ -44,7 +44,8 @@ public class DifferentialDriveFeedforward {
   }
 
   /**
-   * Calculates the differential drive feedforward inputs given velocity setpoints.
+   * Calculates the differential drive feedforward inputs given velocity setpoints, known formally 
+   * as references.
    *
    * @param currentLeftVelocity The current left velocity of the differential drive in
    *     meters/second.

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/ElevatorFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/ElevatorFeedforward.java
@@ -72,10 +72,10 @@ public class ElevatorFeedforward implements ProtobufSerializable, StructSerializ
   }
 
   /**
-   * Calculates the feedforward from the gains and setpoints.
+   * Calculates the feedforward from the gains and references.
    *
-   * @param velocity The velocity setpoint.
-   * @param acceleration The acceleration setpoint.
+   * @param velocity The velocity reference.
+   * @param acceleration The acceleration reference.
    * @return The computed feedforward.
    */
   public double calculate(double velocity, double acceleration) {
@@ -83,13 +83,13 @@ public class ElevatorFeedforward implements ProtobufSerializable, StructSerializ
   }
 
   /**
-   * Calculates the feedforward from the gains and setpoints.
+   * Calculates the feedforward from the gains and references.
    *
    * <p>Note this method is inaccurate when the velocity crosses 0.
    *
-   * @param currentVelocity The current velocity setpoint.
-   * @param nextVelocity The next velocity setpoint.
-   * @param dtSeconds Time between velocity setpoints in seconds.
+   * @param currentVelocity The current velocity reference.
+   * @param nextVelocity The next velocity reference.
+   * @param dtSeconds Time between velocity references in seconds.
    * @return The computed feedforward.
    */
   public double calculate(double currentVelocity, double nextVelocity, double dtSeconds) {
@@ -125,10 +125,10 @@ public class ElevatorFeedforward implements ProtobufSerializable, StructSerializ
   }
 
   /**
-   * Calculates the feedforward from the gains and velocity setpoint (acceleration is assumed to be
+   * Calculates the feedforward from the gains and velocity reference (acceleration is assumed to be
    * zero).
    *
-   * @param velocity The velocity setpoint.
+   * @param velocity The velocity reference.
    * @return The computed feedforward.
    */
   public double calculate(double velocity) {

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -242,7 +242,7 @@ public class PIDController implements Sendable, AutoCloseable {
   }
 
   /**
-   * Sets the setpoint for the PIDController.
+   * Sets the setpoint, known formally as the reference, for the PIDController.
    *
    * @param setpoint The desired setpoint.
    */


### PR DESCRIPTION
(#6749)

The WPILibMath module uses the setpoint terminology instead of reference in the implementation and public APIs as well as the documentation. Before this gets merged we should discuss if it makes sense to fragment our terminology between javadocs and API. I only changed the javadocs where it seemed uncontroversial. 