### PR TITLE
[wpilib] Increase time between interrupt operations in tests

### DIFF
--- a/wpilibc/src/test/native/cpp/InterruptTest.cpp
+++ b/wpilibc/src/test/native/cpp/InterruptTest.cpp
@@ -30,9 +30,9 @@ TEST(InterruptTest, AsynchronousInterrupt) {
   frc::Wait(0.5_s);
   DIOSim digitalSim{di};
   digitalSim.SetValue(false);
-  frc::Wait(10_ms);
+  frc::Wait(20_ms);
   digitalSim.SetValue(true);
-  frc::Wait(10_ms);
+  frc::Wait(20_ms);
 
   int count = 0;
   while (!hasFired) {
@@ -59,9 +59,9 @@ TEST(InterruptTest, RisingEdge) {
   digitalSim.SetValue(false);
   frc::Wait(0.5_s);
   interrupt.Enable();
-  frc::Wait(10_ms);
+  frc::Wait(20_ms);
   digitalSim.SetValue(true);
-  frc::Wait(10_ms);
+  frc::Wait(20_ms);
 
   int count = 0;
   while (!hasFiredRisingEdge) {
@@ -89,9 +89,9 @@ TEST(InterruptTest, FallingEdge) {
   digitalSim.SetValue(true);
   frc::Wait(0.5_s);
   interrupt.Enable();
-  frc::Wait(10_ms);
+  frc::Wait(20_ms);
   digitalSim.SetValue(false);
-  frc::Wait(10_ms);
+  frc::Wait(20_ms);
 
   int count = 0;
   while (!hasFiredFallingEdge) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/InterruptTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/InterruptTest.java
@@ -32,9 +32,9 @@ class InterruptTest {
       Timer.delay(0.5);
       DIOSim digitalSim = new DIOSim(di);
       digitalSim.setValue(false);
-      Timer.delay(0.01);
+      Timer.delay(0.02);
       digitalSim.setValue(true);
-      Timer.delay(0.01);
+      Timer.delay(0.02);
 
       int count = 0;
       while (!hasFired.get()) {
@@ -64,9 +64,9 @@ class InterruptTest {
       digitalSim.setValue(false);
       Timer.delay(0.5);
       interrupt.enable();
-      Timer.delay(0.01);
+      Timer.delay(0.02);
       digitalSim.setValue(true);
-      Timer.delay(0.01);
+      Timer.delay(0.02);
 
       int count = 0;
       while (!hasFiredRisingEdge.get()) {
@@ -101,9 +101,9 @@ class InterruptTest {
       digitalSim.setValue(true);
       Timer.delay(0.5);
       interrupt.enable();
-      Timer.delay(0.01);
+      Timer.delay(0.02);
       digitalSim.setValue(false);
-      Timer.delay(0.01);
+      Timer.delay(0.02);
 
       int count = 0;
       while (!hasFiredFallingEdge.get()) {


### PR DESCRIPTION
Interrupt tests seem to be failing often only on Gradle Win64Debug, but different tests fail, and sometimes there's no failure. More time has been given to the interrupts to try and allow the state to propagate.