### PR TITLE
[wpilibc] Add missing includes to LEDPattern.cpp

### DIFF
--- a/wpilibc/src/main/native/cpp/LEDPattern.cpp
+++ b/wpilibc/src/main/native/cpp/LEDPattern.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <cmath>
 #include <numbers>
+#include <unordered_map>
+#include <vector>
 
 #include <wpi/MathExtras.h>
 #include <wpi/timestamp.h>


### PR DESCRIPTION
I'm guessing that on most systems, those header files would get included transitively anyways, but on mine (and maybe some others) they wouldn't.