### PR TITLE
Fix CMake builds of GUI tools

### DIFF
--- a/glass/CMakeLists.txt
+++ b/glass/CMakeLists.txt
@@ -9,8 +9,12 @@ include(LinkMacOSGUI)
 #
 file(GLOB_RECURSE libglass_src src/lib/native/cpp/*.cpp)
 
-add_library(libglass ${libglass_src})
-set_target_properties(libglass PROPERTIES DEBUG_POSTFIX "d" OUTPUT_NAME "glass")
+add_library(libglass STATIC ${libglass_src})
+set_target_properties(libglass PROPERTIES DEBUG_POSTFIX "d")
+# Library name can't be glass on Windows or else it will overwrite the Glass app PDB file
+if(NOT MSVC)
+    set_target_properties(libglass PROPERTIES OUTPUT_NAME "glass")
+endif()
 set_property(TARGET libglass PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 set_property(TARGET libglass PROPERTY FOLDER "libraries")
@@ -34,8 +38,11 @@ install(DIRECTORY src/lib/native/include/ DESTINATION "${include_dest}/glass")
 #
 file(GLOB_RECURSE libglassnt_src src/libnt/native/cpp/*.cpp)
 
-add_library(libglassnt ${libglassnt_src})
-set_target_properties(libglassnt PROPERTIES DEBUG_POSTFIX "d" OUTPUT_NAME "glassnt")
+add_library(libglassnt STATIC ${libglassnt_src})
+set_target_properties(libglassnt PROPERTIES DEBUG_POSTFIX "d")
+if(NOT MSVC)
+    set_target_properties(libglassnt PROPERTIES OUTPUT_NAME "glassnt")
+endif()
 set_property(TARGET libglassnt PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 set_property(TARGET libglassnt PROPERTY FOLDER "libraries")

--- a/wpigui/CMakeLists.txt
+++ b/wpigui/CMakeLists.txt
@@ -8,11 +8,7 @@ file(GLOB wpigui_windows_src src/main/native/directx11/*.cpp)
 file(GLOB wpigui_mac_src src/main/native/metal/*.mm)
 file(GLOB wpigui_unix_src src/main/native/opengl3/*.cpp)
 
-if(MSVC)
-    add_library(wpigui STATIC ${wpigui_src})
-else()
-    add_library(wpigui ${wpigui_src})
-endif()
+add_library(wpigui STATIC ${wpigui_src})
 set_target_properties(wpigui PROPERTIES DEBUG_POSTFIX "d")
 set_property(TARGET wpigui PROPERTY POSITION_INDEPENDENT_CODE ON)
 


### PR DESCRIPTION
GUI libraries are now always built statically to match Gradle builds. The output name of the Glass libs are now only renamed on non-Windows platforms because libglass would produce a glass.pdb file while Glass would also produce a glass.pdb file, causing one of the PDB files to be overwritten.