### PR TITLE
[upstream_utils] Determine patch list from patch files

### DIFF
--- a/upstream_utils/README.md
+++ b/upstream_utils/README.md
@@ -71,12 +71,12 @@ Navigate back to `upstream_utils`.
 cd allwpilib/upstream_utils
 ```
 
-Update the `upstream_utils` patch files.
+Update the `upstream_utils` patch files and the patch list in the script.
 ```bash
 ./<lib>.py format-patch
 ```
 
-Update the list of patch files in `<lib>.py`, then rerun `<lib>.py` to reimport the thirdparty files.
+Rerun `<lib>.py` to reimport the thirdparty files.
 ```bash
 ./<lib>.py copy-upstream-to-thirdparty
 ```

--- a/upstream_utils/README.md
+++ b/upstream_utils/README.md
@@ -71,7 +71,7 @@ Navigate back to `upstream_utils`.
 cd allwpilib/upstream_utils
 ```
 
-Update the `upstream_utils` patch files and the patch list in the script.
+Update the `upstream_utils` patch files.
 ```bash
 ./<lib>.py format-patch
 ```

--- a/upstream_utils/apriltag.py
+++ b/upstream_utils/apriltag.py
@@ -71,22 +71,11 @@ def main():
     url = "https://github.com/AprilRobotics/apriltag.git"
     tag = "ebdb2017e04b8e36f7d8a12ce60060416a905e12"
 
-    patch_list = [
-        "0001-apriltag_pose.c-Set-NULL-when-second-solution-could-.patch",
-        "0002-zmaxheapify-Avoid-return-of-void-expression.patch",
-        "0003-Avoid-unused-variable-warnings-in-release-builds.patch",
-        "0004-Make-orthogonal_iteration-exit-early-upon-convergenc.patch",
-        "0005-Fix-signed-left-shift-warning.patch",
-        "0006-Avoid-incompatible-pointer-warning.patch",
-        "0007-Fix-GCC-14-calloc-warning.patch",
-        "0008-Remove-calls-to-postscript_image.patch",
-        "0009-Fix-clang-16-warnings.patch",
-    ]
     patch_options = {
         "ignore_whitespace": True,
     }
 
-    apriltag = Lib(name, url, tag, patch_list, copy_upstream_src, patch_options)
+    apriltag = Lib(name, url, tag, copy_upstream_src, patch_options)
     apriltag.main()
 
 

--- a/upstream_utils/eigen.py
+++ b/upstream_utils/eigen.py
@@ -131,13 +131,7 @@ def main():
     url = "https://gitlab.com/libeigen/eigen.git"
     tag = "c4d84dfddc9f9edef0fdbe7cf9966d2f4a303198"
 
-    patch_list = [
-        "0001-Disable-warnings.patch",
-        "0002-Intellisense-fix.patch",
-        "0003-Suppress-has_denorm-and-has_denorm_loss-deprecation-.patch",
-    ]
-
-    eigen = Lib(name, url, tag, patch_list, copy_upstream_src)
+    eigen = Lib(name, url, tag, copy_upstream_src)
     eigen.main()
 
 

--- a/upstream_utils/expected.py
+++ b/upstream_utils/expected.py
@@ -31,7 +31,9 @@ def main():
     # master on 2024-01-25
     tag = "3f0ca7b19253129700a073abfa6d8638d9f7c80c"
 
-    expected = Lib(name, url, tag, [], copy_upstream_src)
+    patch_list = []
+
+    expected = Lib(name, url, tag, patch_list, copy_upstream_src)
     expected.main()
 
 

--- a/upstream_utils/expected.py
+++ b/upstream_utils/expected.py
@@ -31,9 +31,7 @@ def main():
     # master on 2024-01-25
     tag = "3f0ca7b19253129700a073abfa6d8638d9f7c80c"
 
-    patch_list = []
-
-    expected = Lib(name, url, tag, patch_list, copy_upstream_src)
+    expected = Lib(name, url, tag, copy_upstream_src)
     expected.main()
 
 

--- a/upstream_utils/fmt.py
+++ b/upstream_utils/fmt.py
@@ -37,9 +37,7 @@ def main():
     url = "https://github.com/fmtlib/fmt"
     tag = "11.0.1"
 
-    patch_list = ["0001-Suppress-warnings-we-can-t-fix.patch"]
-
-    fmt = Lib(name, url, tag, patch_list, copy_upstream_src)
+    fmt = Lib(name, url, tag, copy_upstream_src)
     fmt.main()
 
 

--- a/upstream_utils/gcem.py
+++ b/upstream_utils/gcem.py
@@ -30,12 +30,7 @@ def main():
     url = "https://github.com/kthohr/gcem.git"
     tag = "v1.18.0"
 
-    patch_list = [
-        "0001-Call-std-functions-if-not-constant-evaluated.patch",
-        "0002-Add-hypot-x-y-z.patch",
-    ]
-
-    gcem = Lib(name, url, tag, patch_list, copy_upstream_src)
+    gcem = Lib(name, url, tag, copy_upstream_src)
     gcem.main()
 
 

--- a/upstream_utils/gl3w.py
+++ b/upstream_utils/gl3w.py
@@ -22,9 +22,7 @@ def main():
     url = "https://github.com/skaslev/gl3w"
     tag = "5f8d7fd191ba22ff2b60c1106d7135bb9a335533"
 
-    patch_list = []
-
-    gl3w = Lib(name, url, tag, patch_list, copy_upstream_src)
+    gl3w = Lib(name, url, tag, copy_upstream_src)
     gl3w.main()
 
 

--- a/upstream_utils/glfw.py
+++ b/upstream_utils/glfw.py
@@ -71,12 +71,7 @@ def main():
     url = "https://github.com/glfw/glfw.git"
     tag = "6b57e08bb0078c9834889eab871bac2368198c15"
 
-    patch_list = [
-        "0001-Suppress-Compiler-Warnings.patch",
-        "0002-Disable-docs-build-by-default.patch",
-    ]
-
-    glfw = Lib(name, url, tag, patch_list, copy_upstream_src)
+    glfw = Lib(name, url, tag, copy_upstream_src)
     glfw.main()
 
 

--- a/upstream_utils/googletest.py
+++ b/upstream_utils/googletest.py
@@ -69,9 +69,7 @@ def main():
     url = "https://github.com/google/googletest.git"
     tag = "v1.14.0"
 
-    patch_list = []
-
-    googletest = Lib(name, url, tag, patch_list, copy_upstream_src)
+    googletest = Lib(name, url, tag, copy_upstream_src)
     googletest.main()
 
 

--- a/upstream_utils/googletest.py
+++ b/upstream_utils/googletest.py
@@ -69,7 +69,9 @@ def main():
     url = "https://github.com/google/googletest.git"
     tag = "v1.14.0"
 
-    googletest = Lib(name, url, tag, [], copy_upstream_src)
+    patch_list = []
+
+    googletest = Lib(name, url, tag, patch_list, copy_upstream_src)
     googletest.main()
 
 

--- a/upstream_utils/imgui.py
+++ b/upstream_utils/imgui.py
@@ -66,9 +66,7 @@ def main():
     url = "https://github.com/ocornut/imgui.git"
     tag = "64b1e448d20c9be9275af731c34b4c7bf14a8e95"
 
-    patch_list = []
-
-    imgui = Lib(name, url, tag, patch_list, copy_upstream_src)
+    imgui = Lib(name, url, tag, copy_upstream_src)
     imgui.main()
 
 

--- a/upstream_utils/implot.py
+++ b/upstream_utils/implot.py
@@ -43,9 +43,7 @@ def main():
     url = "https://github.com/epezent/implot.git"
     tag = "18c72431f8265e2b0b5378a3a73d8a883b2175ff"
 
-    patch_list = ["0001-Supress-compiler-warnings.patch"]
-
-    implot = Lib(name, url, tag, patch_list, copy_upstream_src)
+    implot = Lib(name, url, tag, copy_upstream_src)
     implot.main()
 
 

--- a/upstream_utils/json.py
+++ b/upstream_utils/json.py
@@ -60,17 +60,11 @@ def main():
     url = "https://github.com/nlohmann/json"
     tag = "v3.11.3"
 
-    patch_list = [
-        "0001-Remove-version-from-namespace.patch",
-        "0002-Make-serializer-public.patch",
-        "0003-Make-dump_escaped-take-std-string_view.patch",
-        "0004-Add-llvm-stream-support.patch",
-    ]
     patch_options = {
         "use_threeway": True,
     }
 
-    json = Lib(name, url, tag, patch_list, copy_upstream_src, patch_options)
+    json = Lib(name, url, tag, copy_upstream_src, patch_options)
     json.main()
 
 

--- a/upstream_utils/libuv.py
+++ b/upstream_utils/libuv.py
@@ -56,20 +56,7 @@ def main():
     url = "https://github.com/libuv/libuv"
     tag = "v1.48.0"
 
-    patch_list = [
-        "0001-Revert-win-process-write-minidumps-when-sending-SIGQ.patch",
-        "0002-Fix-missing-casts.patch",
-        "0003-Fix-warnings.patch",
-        "0004-Preprocessor-cleanup.patch",
-        "0005-Cleanup-problematic-language.patch",
-        "0006-Fix-Win32-warning-suppression-pragma.patch",
-        "0007-Use-C-atomics.patch",
-        "0008-Remove-static-from-array-indices.patch",
-        "0009-Add-pragmas-for-missing-libraries-and-set-_WIN32_WIN.patch",
-        "0010-Remove-swearing.patch",
-    ]
-
-    libuv = Lib(name, url, tag, patch_list, copy_upstream_src)
+    libuv = Lib(name, url, tag, copy_upstream_src)
     libuv.main()
 
 

--- a/upstream_utils/llvm.py
+++ b/upstream_utils/llvm.py
@@ -177,50 +177,11 @@ def main():
     url = "https://github.com/llvm/llvm-project"
     tag = "llvmorg-18.1.8"
 
-    patch_list = [
-        "0001-Remove-StringRef-ArrayRef-and-Optional.patch",
-        "0002-Wrap-std-min-max-calls-in-parens-for-Windows-warning.patch",
-        "0003-Change-unique_function-storage-size.patch",
-        "0004-Threading-updates.patch",
-        "0005-ifdef-guard-safety.patch",
-        "0006-Explicitly-use-std.patch",
-        "0007-Remove-format_provider.patch",
-        "0008-Add-compiler-warning-pragmas.patch",
-        "0009-Remove-unused-functions.patch",
-        "0010-Detemplatize-SmallVectorBase.patch",
-        "0011-Add-vectors-to-raw_ostream.patch",
-        "0012-Extra-collections-features.patch",
-        "0013-EpochTracker-ABI-macro.patch",
-        "0014-Delete-numbers-from-MathExtras.patch",
-        "0015-Add-lerp-and-sgn.patch",
-        "0016-Fixup-includes.patch",
-        "0017-Use-std-is_trivially_copy_constructible.patch",
-        "0018-Windows-support.patch",
-        "0019-Prefer-fmtlib.patch",
-        "0020-Prefer-wpi-s-fs.h.patch",
-        "0021-Remove-unused-functions.patch",
-        "0022-OS-specific-changes.patch",
-        "0023-Use-SmallVector-for-UTF-conversion.patch",
-        "0024-Prefer-to-use-static-pointers-in-raw_ostream.patch",
-        "0025-constexpr-endian-byte-swap.patch",
-        "0026-Copy-type-traits-from-STLExtras.h-into-PointerUnion..patch",
-        "0027-Remove-StringMap-test-for-llvm-sort.patch",
-        "0028-Unused-variable-in-release-mode.patch",
-        "0029-Use-C-20-bit-header.patch",
-        "0030-Remove-DenseMap-GTest-printer-test.patch",
-        "0031-Replace-deprecated-std-aligned_storage_t.patch",
-        "0032-raw_ostream-Add-SetNumBytesInBuffer.patch",
-        "0033-type_traits.h-Add-is_constexpr.patch",
-        "0034-Add-back-removed-raw_string_ostream-write_impl.patch",
-        "0035-Remove-auto-conversion-from-raw_ostream.patch",
-        "0036-Add-SmallVector-erase_if.patch",
-        "0037-Fix-AlignedCharArrayUnion-for-C-23.patch",
-    ]
     patch_options = {
         "use_threeway": True,
     }
 
-    llvm = Lib(name, url, tag, patch_list, copy_upstream_src, patch_options)
+    llvm = Lib(name, url, tag, copy_upstream_src, patch_options)
     llvm.main()
 
 

--- a/upstream_utils/memory.py
+++ b/upstream_utils/memory.py
@@ -100,9 +100,7 @@ def main():
     url = "https://github.com/foonathan/memory"
     tag = "v0.7-3"
 
-    patch_list = []
-
-    memory = Lib(name, url, tag, patch_list, copy_upstream_src)
+    memory = Lib(name, url, tag, copy_upstream_src)
     memory.main()
 
 

--- a/upstream_utils/memory.py
+++ b/upstream_utils/memory.py
@@ -100,7 +100,9 @@ def main():
     url = "https://github.com/foonathan/memory"
     tag = "v0.7-3"
 
-    memory = Lib(name, url, tag, [], copy_upstream_src)
+    patch_list = []
+
+    memory = Lib(name, url, tag, patch_list, copy_upstream_src)
     memory.main()
 
 

--- a/upstream_utils/mpack.py
+++ b/upstream_utils/mpack.py
@@ -45,14 +45,7 @@ def main():
     url = "https://github.com/ludocode/mpack"
     tag = "v1.1.1"
 
-    patch_list = [
-        "0001-Don-t-emit-inline-defs.patch",
-        "0002-Update-amalgamation-script.patch",
-        "0003-Use-namespace-for-C.patch",
-        "0004-Group-doxygen-into-MPack-module.patch",
-    ]
-
-    mpack = Lib(name, url, tag, patch_list, copy_upstream_src)
+    mpack = Lib(name, url, tag, copy_upstream_src)
     mpack.main()
 
 

--- a/upstream_utils/protobuf.py
+++ b/upstream_utils/protobuf.py
@@ -284,22 +284,7 @@ def main():
     url = "https://github.com/protocolbuffers/protobuf"
     tag = "v3.21.12"
 
-    patch_list = [
-        "0001-Fix-sign-compare-warnings.patch",
-        "0002-Remove-redundant-move.patch",
-        "0003-Fix-maybe-uninitialized-warnings.patch",
-        "0004-Fix-coded_stream-WriteRaw.patch",
-        "0005-Suppress-enum-enum-conversion-warning.patch",
-        "0006-Fix-noreturn-function-returning.patch",
-        "0007-Work-around-GCC-12-restrict-warning-compiler-bug.patch",
-        "0008-Disable-MSVC-switch-warning.patch",
-        "0009-Disable-unused-function-warning.patch",
-        "0010-Disable-pedantic-warning.patch",
-        "0011-Avoid-use-of-sprintf.patch",
-        "0012-Suppress-stringop-overflow-warning-false-positives.patch",
-    ]
-
-    protobuf = Lib(name, url, tag, patch_list, copy_upstream_src)
+    protobuf = Lib(name, url, tag, copy_upstream_src)
     protobuf.main()
 
 

--- a/upstream_utils/sleipnir.py
+++ b/upstream_utils/sleipnir.py
@@ -54,15 +54,7 @@ def main():
     # main on 2024-07-09
     tag = "b6ffa2d4fdb99cab1bf79491f715a6a9a86633b5"
 
-    patch_list = [
-        "0001-Remove-using-enum-declarations.patch",
-        "0002-Use-fmtlib.patch",
-        "0003-Remove-unsupported-constexpr.patch",
-        "0004-Use-wpi-SmallVector.patch",
-        "0005-Suppress-clang-tidy-false-positives.patch",
-    ]
-
-    sleipnir = Lib(name, url, tag, patch_list, copy_upstream_src)
+    sleipnir = Lib(name, url, tag, copy_upstream_src)
     sleipnir.main()
 
 

--- a/upstream_utils/stack_walker.py
+++ b/upstream_utils/stack_walker.py
@@ -45,9 +45,6 @@ def main():
     url = "https://github.com/JochenKalmbach/StackWalker"
     tag = "5b0df7a4db8896f6b6dc45d36e383c52577e3c6b"
 
-    patch_list = [
-        "0001-Add-advapi-pragma.patch",
-    ]
     patch_options = {
         "ignore_whitespace": True,
     }
@@ -56,7 +53,6 @@ def main():
         name,
         url,
         tag,
-        patch_list,
         copy_upstream_src,
         patch_options,
         pre_patch_hook=crlf_to_lf,

--- a/upstream_utils/stb.py
+++ b/upstream_utils/stb.py
@@ -44,9 +44,7 @@ def main():
     url = "https://github.com/nothings/stb.git"
     tag = "c9064e317699d2e495f36ba4f9ac037e88ee371a"
 
-    patch_list = []
-
-    stb = Lib(name, url, tag, patch_list, copy_upstream_src)
+    stb = Lib(name, url, tag, copy_upstream_src)
     stb.main()
 
 

--- a/upstream_utils/upstream_utils.py
+++ b/upstream_utils/upstream_utils.py
@@ -262,38 +262,6 @@ class Lib:
         self.pre_patch_commits = pre_patch_commits
         self.wpilib_root = get_repo_root()
 
-    def check_patches(self):
-        """Checks that the patch list supplied to the constructor matches the
-        patches in the patch directory.
-        """
-        patch_directory_patches = set()
-        patch_directory = os.path.join(
-            self.wpilib_root, f"upstream_utils/{self.name}_patches"
-        )
-        if os.path.exists(patch_directory):
-            for f in os.listdir(patch_directory):
-                if f.endswith(".patch"):
-                    patch_directory_patches.add(f)
-        patches = set(self.patch_list)
-        patch_directory_only = sorted(patch_directory_patches - patches)
-        patch_list_only = sorted(patches - patch_directory_patches)
-        common_patches = sorted(patch_directory_patches & patches)
-        warning = False
-        if patch_directory_only:
-            print(
-                f"WARNING: The patch directory has patches {patch_directory_only} not in the patch list"
-            )
-            warning = True
-        if patch_list_only:
-            print(
-                f"WARNING: The patch list has patches {patch_list_only} not in the patch directory"
-            )
-            warning = True
-        if warning and common_patches:
-            print(
-                f"  Note: The patch directory and the patch list both have patches {common_patches}"
-            )
-
     def get_repo_path(self, tempdir=None):
         """Returns the path to the clone of the upstream repository.
 
@@ -654,5 +622,3 @@ class Lib:
             self.format_patch()
         elif args.subcommand == "copy-upstream-to-thirdparty":
             self.copy_upstream_to_thirdparty()
-
-        self.check_patches()

--- a/upstream_utils/upstream_utils.py
+++ b/upstream_utils/upstream_utils.py
@@ -501,12 +501,7 @@ class Lib:
             ]
         )
 
-        if not os.path.exists(self.get_patch_directory()):
-            print(
-                f"WARNING: Patch directory {self.get_patch_directory()} does not exist",
-                file=sys.stderr,
-            )
-        else:
+        if os.path.exists(self.get_patch_directory()):
             shutil.rmtree(self.get_patch_directory())
 
         is_first = True

--- a/upstream_utils/upstream_utils.py
+++ b/upstream_utils/upstream_utils.py
@@ -353,18 +353,25 @@ class Lib:
 
         subprocess.run(["git", "tag", f"upstream_utils_root-{tag}", tag])
 
+    def get_patch_directory(self):
+        """Returns the path to the directory containing the patch files.
+
+        Returns:
+        The absolute path to the directory containing the patch files.
+        """
+        return os.path.join(self.wpilib_root, f"upstream_utils/{self.name}_patches")
+
     def get_patch_list(self):
         """Returns a list of the filenames of the patches to apply.
 
         Returns:
         A list of the filenames of the patches to apply, sorted in lexicographic
         order by the Unicode code points."""
-        patch_directory = os.path.join(
-            self.wpilib_root, f"upstream_utils/{self.name}_patches"
-        )
-        if not os.path.exists(patch_directory):
+        if not os.path.exists(self.get_patch_directory()):
             return []
-        return sorted(f for f in os.listdir(patch_directory) if f.endswith(".patch"))
+        return sorted(
+            f for f in os.listdir(self.get_patch_directory()) if f.endswith(".patch")
+        )
 
     def apply_patches(self):
         """Applies the patches listed in the patch list to the current
@@ -375,9 +382,7 @@ class Lib:
 
         for f in self.get_patch_list():
             git_am(
-                os.path.join(
-                    self.wpilib_root, f"upstream_utils/{self.name}_patches", f
-                ),
+                os.path.join(self.get_patch_directory(), f),
                 **self.patch_options,
             )
 
@@ -496,24 +501,21 @@ class Lib:
             ]
         )
 
-        patch_dest = os.path.join(
-            self.wpilib_root, f"upstream_utils/{self.name}_patches"
-        )
-
-        if not os.path.exists(patch_dest):
+        if not os.path.exists(self.get_patch_directory()):
             print(
-                f"WARNING: Patch directory {patch_dest} does not exist", file=sys.stderr
+                f"WARNING: Patch directory {self.get_patch_directory()} does not exist",
+                file=sys.stderr,
             )
         else:
-            shutil.rmtree(patch_dest)
+            shutil.rmtree(self.get_patch_directory())
 
         is_first = True
         for f in os.listdir():
             if f.endswith(".patch"):
                 if is_first:
-                    os.mkdir(patch_dest)
+                    os.mkdir(self.get_patch_directory())
                     is_first = False
-                shutil.move(f, patch_dest)
+                shutil.move(f, self.get_patch_directory())
 
         self.replace_tag(script_tag)
 

--- a/upstream_utils/upstream_utils.py
+++ b/upstream_utils/upstream_utils.py
@@ -395,48 +395,6 @@ class Lib:
         with open(path, "w") as file:
             file.writelines(lines)
 
-    def replace_patch_list(self, patch_list):
-        """Replaces the patch list in the script.
-
-        Keyword argument:
-        patch_list -- The list of patch file names to replace the script patch list with.
-        """
-        path = os.path.join(self.wpilib_root, f"upstream_utils/{self.name}.py")
-        with open(path, "r") as file:
-            lines = file.readlines()
-
-        for i in range(len(lines) - 1, -1, -1):
-            if "patch_list = " in lines[i]:
-                # Exclusive end of the range of lines defining the list
-                end_i = None
-                for j in range(i, len(lines)):
-                    if "]" in lines[j]:
-                        end_i = j + 1
-                        break
-                if end_i is None:
-                    print(
-                        f'ERROR: Expected "]" after "patch_list = " at line {i}',
-                        file=sys.stderr,
-                    )
-                    exit(1)
-
-                chars_after_indent = len(lines[i].lstrip())
-                indent = lines[i][:-chars_after_indent]
-
-                if patch_list:
-                    replacement_lines = [f"{indent}patch_list = [\n"]
-                    replacement_lines.extend(
-                        f'{indent}    "{patch}",\n' for patch in patch_list
-                    )
-                    replacement_lines.append(f"{indent}]\n")
-                else:
-                    replacement_lines = [f"{indent}patch_list = []\n"]
-
-                lines[i:end_i] = replacement_lines
-
-        with open(path, "w") as file:
-            file.writelines(lines)
-
     def info(self):
         """Prints info about the library to stdout."""
         print(f"Repository name: {self.name}")
@@ -539,7 +497,6 @@ class Lib:
         else:
             shutil.rmtree(patch_dest)
 
-        new_patch_list = []
         is_first = True
         for f in os.listdir():
             if f.endswith(".patch"):
@@ -547,11 +504,8 @@ class Lib:
                     os.mkdir(patch_dest)
                     is_first = False
                 shutil.move(f, patch_dest)
-                new_patch_list.append(f)
 
         self.replace_tag(script_tag)
-
-        self.replace_patch_list(new_patch_list)
 
     def copy_upstream_to_thirdparty(self):
         """Copies files from the upstream repository into the thirdparty


### PR DESCRIPTION
Resolves #6864

To simplify the logic for searching for the patch list, all libraries have a `patch_list` variable, even if there are no patches. (Inlining the list was originally done so that libraries not needing it have less clutter, but patches are pretty likely to be added at some point, so it's fine to make all libraries have an extra line or two for that. It also makes things more consistent, but by far the biggest factor was that otherwise, the logic for the auto replacement would have to be significantly more complex)

The patch list is no longer checked, since it should be up to date unless the contributor makes manual edits outside of the CLI, and there would be false positives when running `format_patch` since the check didn't use the updated list.