### PR TITLE
[hal] remove dangling periodic packet function from sim CANAPI (NFC)

### DIFF
--- a/hal/src/main/native/sim/CANAPI.cpp
+++ b/hal/src/main/native/sim/CANAPI.cpp
@@ -63,7 +63,7 @@ static int32_t CreateCANId(CANStorage* storage, int32_t apiId) {
   createdId |= (storage->deviceId & 0x3F);
   return createdId;
 }
-
+extern "C" {
 uint32_t HAL_GetCANPacketBaseTime() {
   int status = 0;
   auto basetime = HAL_GetFPGATime(&status);
@@ -289,65 +289,4 @@ void HAL_ReadCANPacketTimeout(HAL_CANHandle handle, int32_t apiId,
     }
   }
 }
-
-void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
-                               uint8_t* data, int32_t* length,
-                               uint64_t* receivedTimestamp, int32_t timeoutMs,
-                               int32_t periodMs, int32_t* status) {
-  auto can = canHandles->Get(handle);
-  if (!can) {
-    *status = HAL_HANDLE_ERROR;
-    return;
-  }
-
-  uint32_t messageId = CreateCANId(can.get(), apiId);
-
-  {
-    std::scoped_lock lock(can->mapMutex);
-    auto i = can->receives.find(messageId);
-    if (i != can->receives.end()) {
-      // Found, check if new enough
-      uint32_t now = HAL_GetCANPacketBaseTime();
-      if (now - i->second.lastTimeStamp < static_cast<uint32_t>(periodMs)) {
-        *status = 0;
-        // Read the data from the stored message into the output
-        std::memcpy(data, i->second.data, i->second.length);
-        *length = i->second.length;
-        *receivedTimestamp = i->second.lastTimeStamp;
-        return;
-      }
-    }
-  }
-
-  uint8_t dataSize = 0;
-  uint32_t ts = 0;
-  HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
-
-  std::scoped_lock lock(can->mapMutex);
-  if (*status == 0) {
-    // fresh update
-    auto& msg = can->receives[messageId];
-    msg.length = dataSize;
-    *length = dataSize;
-    msg.lastTimeStamp = ts;
-    *receivedTimestamp = ts;
-    // The NetComm call placed in data, copy into the msg
-    std::memcpy(msg.data, data, dataSize);
-  } else {
-    auto i = can->receives.find(messageId);
-    if (i != can->receives.end()) {
-      // Found, check if new enough
-      uint32_t now = HAL_GetCANPacketBaseTime();
-      if (now - i->second.lastTimeStamp > static_cast<uint32_t>(timeoutMs)) {
-        // Timeout, return bad status
-        *status = HAL_CAN_TIMEOUT;
-        return;
-      }
-      // Read the data from the stored message into the output
-      std::memcpy(data, i->second.data, i->second.length);
-      *length = i->second.length;
-      *receivedTimestamp = i->second.lastTimeStamp;
-      *status = 0;
-    }
-  }
-}
+} // extern "C"

--- a/hal/src/main/native/sim/CANAPI.cpp
+++ b/hal/src/main/native/sim/CANAPI.cpp
@@ -64,7 +64,7 @@ static int32_t CreateCANId(CANStorage* storage, int32_t apiId) {
   return createdId;
 }
 extern "C" {
-uint32_t HAL_GetCANPacketBaseTime() {
+uint32_t HAL_GetCANPacketBaseTime(void) {
   int status = 0;
   auto basetime = HAL_GetFPGATime(&status);
   // us to ms
@@ -289,4 +289,4 @@ void HAL_ReadCANPacketTimeout(HAL_CANHandle handle, int32_t apiId,
     }
   }
 }
-} // extern "C"
+}  // extern "C"


### PR DESCRIPTION
Removed from API in #1868, sim definition was left dangling

Also adds `extern "C"` to the sim file