### PR TITLE
disable check run and comments for robotbuilder ci

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -74,6 +74,7 @@ jobs:
         with:
           files: |
             build/test-results/test/TEST*.xml
+          check_run: false
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -75,6 +75,7 @@ jobs:
           files: |
             build/test-results/test/TEST*.xml
           check_run: false
+          comment_mode: off
       - uses: actions/upload-artifact@v4
         if: always()
         with:


### PR DESCRIPTION
It won't add them to PRs anyway because it doesn't have permissions, but the check run gets added to a random workflow in non-pr builds