### PR TITLE
[wpilib] Wait 0.5s after enabling interrupts in tests

### DIFF
--- a/wpilibc/src/test/native/cpp/InterruptTest.cpp
+++ b/wpilibc/src/test/native/cpp/InterruptTest.cpp
@@ -57,9 +57,8 @@ TEST(InterruptTest, RisingEdge) {
   interrupt.SetInterruptEdges(true, true);
   DIOSim digitalSim{di};
   digitalSim.SetValue(false);
-  frc::Wait(0.5_s);
   interrupt.Enable();
-  frc::Wait(20_ms);
+  frc::Wait(0.5_s);
   digitalSim.SetValue(true);
   frc::Wait(20_ms);
 
@@ -87,9 +86,8 @@ TEST(InterruptTest, FallingEdge) {
   interrupt.SetInterruptEdges(true, true);
   DIOSim digitalSim{di};
   digitalSim.SetValue(true);
-  frc::Wait(0.5_s);
   interrupt.Enable();
-  frc::Wait(20_ms);
+  frc::Wait(0.5_s);
   digitalSim.SetValue(false);
   frc::Wait(20_ms);
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/InterruptTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/InterruptTest.java
@@ -62,9 +62,8 @@ class InterruptTest {
       interrupt.setInterruptEdges(true, true);
       DIOSim digitalSim = new DIOSim(di);
       digitalSim.setValue(false);
-      Timer.delay(0.5);
       interrupt.enable();
-      Timer.delay(0.02);
+      Timer.delay(0.5);
       digitalSim.setValue(true);
       Timer.delay(0.02);
 
@@ -99,9 +98,8 @@ class InterruptTest {
       interrupt.setInterruptEdges(true, true);
       DIOSim digitalSim = new DIOSim(di);
       digitalSim.setValue(true);
-      Timer.delay(0.5);
       interrupt.enable();
-      Timer.delay(0.02);
+      Timer.delay(0.5);
       digitalSim.setValue(false);
       Timer.delay(0.02);
 


### PR DESCRIPTION
If the interrupt edge tests are running while under heavy CPU load (like building wpilib,) they are prone to failure since the interrupt thread doesn't have enough time to set up callbacks. The interrupt edge tests now behave like the original AsynchronousInterrupt test, which has a 0.5s delay after the interrupt is enabled. Running the new interrupt tests while building allwpilib causes almost no failures compared to the old tests.