### PR TITLE
[examples] Replace usages of SIMULATION macro with constexpr if

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/CloseClaw.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/CloseClaw.cpp
@@ -4,6 +4,8 @@
 
 #include "commands/CloseClaw.h"
 
+#include <frc/RobotBase.h>
+
 #include "Robot.h"
 
 CloseClaw::CloseClaw(Claw& claw) : m_claw(&claw) {
@@ -23,10 +25,10 @@ bool CloseClaw::IsFinished() {
 
 // Called once after isFinished returns true
 void CloseClaw::End(bool) {
-// NOTE: Doesn't stop in simulation due to lower friction causing the can to
-// fall out
-// + there is no need to worry about stalling the motor or crushing the can.
-#ifndef SIMULATION
-  m_claw->Stop();
-#endif
+  // NOTE: Doesn't stop in simulation due to lower friction causing the can to
+  // fall out + there is no need to worry about stalling the motor or crushing
+  // the can.
+  if constexpr (frc::RobotBase::IsSimulation()) {
+    m_claw->Stop();
+  }
 }

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Drivetrain.cpp
@@ -7,6 +7,7 @@
 #include <numbers>
 
 #include <frc/Joystick.h>
+#include <frc/RobotBase.h>
 #include <frc/smartdashboard/SmartDashboard.h>
 #include <units/length.h>
 
@@ -22,21 +23,20 @@ Drivetrain::Drivetrain() {
   // gearbox is constructed, you might have to invert the left side instead.
   m_frontRight.SetInverted(true);
 
-// Encoders may measure differently in the real world and in
-// simulation. In this example the robot moves 0.042 barleycorns
-// per tick in the real world, but the simulated encoders
-// simulate 360 tick encoders. This if statement allows for the
-// real robot to handle this difference in devices.
-#ifndef SIMULATION
-  m_leftEncoder.SetDistancePerPulse(0.042);
-  m_rightEncoder.SetDistancePerPulse(0.042);
-#else
-  // Circumference = diameter * pi. 360 tick simulated encoders.
-  m_leftEncoder.SetDistancePerPulse(units::foot_t{4_in}.value() *
-                                    std::numbers::pi / 360.0);
-  m_rightEncoder.SetDistancePerPulse(units::foot_t{4_in}.value() *
-                                     std::numbers::pi / 360.0);
-#endif
+  // Encoders may measure differently in the real world and in simulation. In
+  // this example the robot moves 0.042 barleycorns per tick in the real world,
+  // but the simulated encoders simulate 360 tick encoders. This if statement
+  // allows for the real robot to handle this difference in devices.
+  if constexpr (frc::RobotBase::IsSimulation()) {
+    m_leftEncoder.SetDistancePerPulse(0.042);
+    m_rightEncoder.SetDistancePerPulse(0.042);
+  } else {
+    // Circumference = diameter * pi. 360 tick simulated encoders.
+    m_leftEncoder.SetDistancePerPulse(units::foot_t{4_in}.value() *
+                                      std::numbers::pi / 360.0);
+    m_rightEncoder.SetDistancePerPulse(units::foot_t{4_in}.value() *
+                                       std::numbers::pi / 360.0);
+  }
   SetName("Drivetrain");
   // Let's show everything on the LiveWindow
   AddChild("Front_Left Motor", &m_frontLeft);

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Elevator.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Elevator.cpp
@@ -4,15 +4,21 @@
 
 #include "subsystems/Elevator.h"
 
+#include <frc/RobotBase.h>
 #include <frc/controller/PIDController.h>
 #include <frc/livewindow/LiveWindow.h>
 #include <frc/smartdashboard/SmartDashboard.h>
 
 Elevator::Elevator()
     : frc2::PIDSubsystem{frc::PIDController{kP_real, kI_real, 0}} {
-#ifdef SIMULATION  // Check for simulation and update PID values
-  GetPIDController()->SetPID(kP_simulation, kI_simulation, 0, 0);
-#endif
+  if constexpr (frc::RobotBase::IsSimulation()) {
+    // Check for simulation and update PID values
+    GetController().SetPID(kP_simulation, kI_simulation, 0);
+    // Conversion value of potentiometer varies between the real world and
+    // simulation
+    m_pot = frc::AnalogPotentiometer{2};  // Defaults to degrees
+  }
+
   m_controller.SetTolerance(0.005);
 
   SetName("Elevator");

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Elevator.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Elevator.cpp
@@ -4,7 +4,6 @@
 
 #include "subsystems/Elevator.h"
 
-#include <frc/RobotBase.h>
 #include <frc/controller/PIDController.h>
 #include <frc/livewindow/LiveWindow.h>
 #include <frc/smartdashboard/SmartDashboard.h>
@@ -14,9 +13,6 @@ Elevator::Elevator()
   if constexpr (frc::RobotBase::IsSimulation()) {
     // Check for simulation and update PID values
     GetController().SetPID(kP_simulation, kI_simulation, 0);
-    // Conversion value of potentiometer varies between the real world and
-    // simulation
-    m_pot = frc::AnalogPotentiometer{2};  // Defaults to degrees
   }
 
   m_controller.SetTolerance(0.005);

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Wrist.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Wrist.cpp
@@ -4,16 +4,10 @@
 
 #include "subsystems/Wrist.h"
 
-#include <frc/RobotBase.h>
 #include <frc/controller/PIDController.h>
 #include <frc/smartdashboard/SmartDashboard.h>
 
 Wrist::Wrist() : frc2::PIDSubsystem{frc::PIDController{kP, 0, 0}} {
-  if constexpr (frc::RobotBase::IsSimulation()) {
-    // Conversion value of potentiometer varies between the real world and
-    // simulation
-    m_pot = frc::AnalogPotentiometer{3};  // Defaults to meters
-  }
   m_controller.SetTolerance(2.5);
 
   SetName("Wrist");

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Wrist.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Wrist.cpp
@@ -4,10 +4,16 @@
 
 #include "subsystems/Wrist.h"
 
+#include <frc/RobotBase.h>
 #include <frc/controller/PIDController.h>
 #include <frc/smartdashboard/SmartDashboard.h>
 
 Wrist::Wrist() : frc2::PIDSubsystem{frc::PIDController{kP, 0, 0}} {
+  if constexpr (frc::RobotBase::IsSimulation()) {
+    // Conversion value of potentiometer varies between the real world and
+    // simulation
+    m_pot = frc::AnalogPotentiometer{3};  // Defaults to meters
+  }
   m_controller.SetTolerance(2.5);
 
   SetName("Wrist");

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Elevator.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Elevator.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <frc/AnalogPotentiometer.h>
+#include <frc/RobotBase.h>
 #include <frc/motorcontrol/PWMSparkMax.h>
 #include <frc2/command/PIDSubsystem.h>
 
@@ -44,8 +45,12 @@ class Elevator : public frc2::PIDSubsystem {
 
  private:
   frc::PWMSparkMax m_motor{5};
-
-  frc::AnalogPotentiometer m_pot{2, -2.0 / 5};
+  // Conversion value of potentiometer varies between the real world and
+  // simulation
+  frc::AnalogPotentiometer m_pot =
+      frc::RobotBase::IsReal()
+          ? frc::AnalogPotentiometer{2, -2.0 / 5}
+          : frc::AnalogPotentiometer{2};  // Defaults to meters
 
   static constexpr double kP_real = 4;
   static constexpr double kI_real = 0.07;

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Elevator.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Elevator.h
@@ -45,13 +45,7 @@ class Elevator : public frc2::PIDSubsystem {
  private:
   frc::PWMSparkMax m_motor{5};
 
-// Conversion value of potentiometer varies between the real world and
-// simulation
-#ifndef SIMULATION
   frc::AnalogPotentiometer m_pot{2, -2.0 / 5};
-#else
-  frc::AnalogPotentiometer m_pot{2};  // Defaults to meters
-#endif
 
   static constexpr double kP_real = 4;
   static constexpr double kI_real = 0.07;

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Wrist.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Wrist.h
@@ -41,14 +41,7 @@ class Wrist : public frc2::PIDSubsystem {
 
  private:
   frc::PWMSparkMax m_motor{6};
-
-// Conversion value of potentiometer varies between the real world and
-// simulation
-#ifndef SIMULATION
   frc::AnalogPotentiometer m_pot{3, -270.0 / 5};
-#else
-  frc::AnalogPotentiometer m_pot{3};  // Defaults to degrees
-#endif
 
   static constexpr double kP = 1;
 };

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Wrist.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Wrist.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <frc/AnalogPotentiometer.h>
+#include <frc/RobotBase.h>
 #include <frc/motorcontrol/PWMSparkMax.h>
 #include <frc2/command/PIDSubsystem.h>
 
@@ -41,7 +42,12 @@ class Wrist : public frc2::PIDSubsystem {
 
  private:
   frc::PWMSparkMax m_motor{6};
-  frc::AnalogPotentiometer m_pot{3, -270.0 / 5};
+  // Conversion value of potentiometer varies between the real world and
+  // simulation
+  frc::AnalogPotentiometer m_pot =
+      frc::RobotBase::IsReal()
+          ? frc::AnalogPotentiometer{3, -270.0 / 5}
+          : frc::AnalogPotentiometer{3};  // Defaults to degrees
 
   static constexpr double kP = 1;
 };


### PR DESCRIPTION
the macro hasn't been used/available in a *long* time, and some usages of it were Broken.