### PR TITLE
[build] Remove invalid MSVC warning suppression in apriltag

### DIFF
--- a/apriltag/CMakeLists.txt
+++ b/apriltag/CMakeLists.txt
@@ -13,7 +13,7 @@ file(
 if(MSVC)
     set_source_files_properties(
         ${apriltaglib_src}
-        PROPERTIES COMPILE_FLAGS "/wd2220 /wd4005 /wd4018 /wd4244 /wd4267 /wd4996"
+        PROPERTIES COMPILE_FLAGS "/wd4005 /wd4018 /wd4244 /wd4267 /wd4996"
     )
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set_source_files_properties(

--- a/apriltag/build.gradle
+++ b/apriltag/build.gradle
@@ -66,7 +66,6 @@ cppHeadersZip {
 // Suppress sign-compare warnings
 nativeUtils.platformConfigs.each {
     if (it.name.contains('windows')) {
-        it.cCompiler.args.add("/wd2220")
         it.cCompiler.args.add("/wd4005")
         it.cCompiler.args.add("/wd4018")
         it.cCompiler.args.add("/wd4244")


### PR DESCRIPTION
2220 is not a valid warning.