### PR TITLE
[hal] Windows sim: enable HighQoS and honor timer resolution requests

### DIFF
--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -372,12 +372,13 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
 #ifdef _WIN32
   // https://stackoverflow.com/questions/3141556/how-to-setup-timer-resolution-to-0-5-ms
   ULONG min, max, current;
-  if (NtQueryTimerResolution(&min, &max, &current) == STATUS_SUCCESS) {
-    static ULONG currentRes;
-    if (NtSetTimerResolution(max, TRUE, &currentRes) == STATUS_SUCCESS) {
+  if (NtQueryTimerResolution(&min, &max, &current) == 0) {
+    static ULONG desired = max;
+    ULONG currentRes;
+    if (NtSetTimerResolution(desired, TRUE, &currentRes) == 0) {
       std::atexit([]() {
-        ULONG ignore;
-        NtSetTimerResolution(currentRes, TRUE, &ignore);
+        ULONG currentRes;
+        NtSetTimerResolution(desired, FALSE, &currentRes);
       });
     }
   }

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -13,6 +13,11 @@
 
 #ifdef _WIN32
 #include <Windows.h>
+extern "C" NTSYSAPI NTSTATUS NTAPI NtSetTimerResolution(
+    ULONG DesiredResolution, BOOLEAN SetResolution, PULONG CurrentResolution);
+extern "C" NTSYSAPI NTSTATUS NTAPI
+NtQueryTimerResolution(PULONG MinimumResolution, PULONG MaximumResolution,
+                       PULONG CurrentResolution);
 #endif  // _WIN32
 
 #include "ErrorsInternal.h"
@@ -25,14 +30,6 @@
 #include "hal/simulation/DriverStationData.h"
 #include "hal/simulation/SimCallbackRegistry.h"
 #include "mockdata/RoboRioDataInternal.h"
-
-#ifdef _WIN32
-extern "C" NTSYSAPI NTSTATUS NTAPI NtSetTimerResolution(
-    ULONG DesiredResolution, BOOLEAN SetResolution, PULONG CurrentResolution);
-extern "C" NTSYSAPI NTSTATUS NTAPI
-NtQueryTimerResolution(PULONG MinimumResolution, PULONG MaximumResolution,
-                       PULONG CurrentResolution);
-#endif  // _WIN32
 
 using namespace hal;
 

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -373,11 +373,11 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
   // https://stackoverflow.com/questions/3141556/how-to-setup-timer-resolution-to-0-5-ms
   ULONG min, max, current;
   if (NtQueryTimerResolution(&min, &max, &current) == 0) {
-    static ULONG desired = max;
-    static ULONG currentRes;
+    ULONG currentRes;
     if (NtSetTimerResolution(desired, TRUE, &currentRes) == 0) {
       std::atexit([]() {
-        NtSetTimerResolution(desired, FALSE, &currentRes);
+        ULONG currentRes;
+        NtSetTimerResolution(0, FALSE, &currentRes);
       });
     }
   }

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -374,10 +374,9 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
   ULONG min, max, current;
   if (NtQueryTimerResolution(&min, &max, &current) == 0) {
     static ULONG desired = max;
-    ULONG currentRes;
+    static ULONG currentRes;
     if (NtSetTimerResolution(desired, TRUE, &currentRes) == 0) {
       std::atexit([]() {
-        ULONG currentRes;
         NtSetTimerResolution(desired, FALSE, &currentRes);
       });
     }

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -379,7 +379,7 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
 
   static ULONG currentRes;
   NtSetTimerResolution(max, TRUE, &currentRes);
-  std::atext([]() {
+  std::atexit([]() {
     ULONG ignore;
     NtSetTimerResolution(currentRes, TRUE, &ignore);
   });

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -13,6 +13,7 @@
 
 #ifdef _WIN32
 #include <Windows.h>
+#pragma comment(lib, "ntdll.lib")
 extern "C" NTSYSAPI NTSTATUS NTAPI NtSetTimerResolution(
     ULONG DesiredResolution, BOOLEAN SetResolution, PULONG CurrentResolution);
 extern "C" NTSYSAPI NTSTATUS NTAPI

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -374,7 +374,7 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
   ULONG min, max, current;
   if (NtQueryTimerResolution(&min, &max, &current) == 0) {
     ULONG currentRes;
-    if (NtSetTimerResolution(desired, TRUE, &currentRes) == 0) {
+    if (NtSetTimerResolution(max, TRUE, &currentRes) == 0) {
       std::atexit([]() {
         ULONG currentRes;
         NtSetTimerResolution(0, FALSE, &currentRes);

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -375,14 +375,15 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
 #ifdef _WIN32
   // https://stackoverflow.com/questions/3141556/how-to-setup-timer-resolution-to-0-5-ms
   ULONG min, max, current;
-  NtQueryTimerResolution(&min, &max, &current);
-
-  static ULONG currentRes;
-  NtSetTimerResolution(max, TRUE, &currentRes);
-  std::atexit([]() {
-    ULONG ignore;
-    NtSetTimerResolution(currentRes, TRUE, &ignore);
-  });
+  if (NtQueryTimerResolution(&min, &max, &current) == STATUS_SUCCESS) {
+    static ULONG currentRes;
+    if (NtSetTimerResolution(max, TRUE, &currentRes) == STATUS_SUCCESS) {
+      std::atexit([]() {
+        ULONG ignore;
+        NtSetTimerResolution(currentRes, TRUE, &ignore);
+      });
+    }
+  }
 
   // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setprocessinformation
   // Enable HighQoS to achieve maximum performance, and turn off power saving.

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -13,7 +13,6 @@
 
 #ifdef _WIN32
 #include <Windows.h>
-#pragma comment(lib, "Winmm.lib")
 #endif  // _WIN32
 
 #include "ErrorsInternal.h"
@@ -26,6 +25,14 @@
 #include "hal/simulation/DriverStationData.h"
 #include "hal/simulation/SimCallbackRegistry.h"
 #include "mockdata/RoboRioDataInternal.h"
+
+#ifdef _WIN32
+extern "C" NTSYSAPI NTSTATUS NTAPI NtSetTimerResolution(
+    ULONG DesiredResolution, BOOLEAN SetResolution, PULONG CurrentResolution);
+extern "C" NTSYSAPI NTSTATUS NTAPI
+NtQueryTimerResolution(PULONG MinimumResolution, PULONG MaximumResolution,
+                       PULONG CurrentResolution);
+#endif  // _WIN32
 
 using namespace hal;
 
@@ -364,19 +371,50 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
 
   initialized = true;
 
-// Set Timer Precision to 1ms on Windows
+// Set Timer Precision to 0.5ms on Windows
 #ifdef _WIN32
-  TIMECAPS tc;
-  if (timeGetDevCaps(&tc, sizeof(tc)) == TIMERR_NOERROR) {
-    UINT target = (std::min)(static_cast<UINT>(1), tc.wPeriodMin);
-    timeBeginPeriod(target);
-    std::atexit([]() {
-      TIMECAPS tc;
-      if (timeGetDevCaps(&tc, sizeof(tc)) == TIMERR_NOERROR) {
-        UINT target = (std::min)(static_cast<UINT>(1), tc.wPeriodMin);
-        timeEndPeriod(target);
-      }
-    });
+  // https://stackoverflow.com/questions/3141556/how-to-setup-timer-resolution-to-0-5-ms
+  ULONG min, max, current;
+  NtQueryTimerResolution(&min, &max, &current);
+
+  static ULONG currentRes;
+  NtSetTimerResolution(max, TRUE, &currentRes);
+  std::atext([]() {
+    ULONG ignore;
+    NtSetTimerResolution(currentRes, TRUE, &ignore);
+  });
+
+  // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setprocessinformation
+  // Enable HighQoS to achieve maximum performance, and turn off power saving.
+  {
+    PROCESS_POWER_THROTTLING_STATE PowerThrottling{};
+    PowerThrottling.Version = PROCESS_POWER_THROTTLING_CURRENT_VERSION;
+    PowerThrottling.ControlMask = PROCESS_POWER_THROTTLING_EXECUTION_SPEED;
+    PowerThrottling.StateMask = 0;
+
+    SetProcessInformation(GetCurrentProcess(), ProcessPowerThrottling,
+                          &PowerThrottling, sizeof(PowerThrottling));
+  }
+
+  // https://forums.oculusvr.com/t5/General/SteamVR-has-fixed-the-problems-with-Windows-11/td-p/956413
+  // Always honor Timer Resolution Requests. This is to ensure that the timer
+  // resolution set-up above sticks through transitions of the main window (eg:
+  // minimization).
+  {
+    // This setting was introduced in Windows 11 and the definition is not
+    // available in older headers.
+#ifndef PROCESS_POWER_THROTTLING_IGNORE_TIMER_RESOLUTION
+    const auto PROCESS_POWER_THROTTLING_IGNORE_TIMER_RESOLUTION = 0x4U;
+#endif
+
+    PROCESS_POWER_THROTTLING_STATE PowerThrottling{};
+    PowerThrottling.Version = PROCESS_POWER_THROTTLING_CURRENT_VERSION;
+    PowerThrottling.ControlMask =
+        PROCESS_POWER_THROTTLING_IGNORE_TIMER_RESOLUTION;
+    PowerThrottling.StateMask = 0;
+
+    SetProcessInformation(GetCurrentProcess(), ProcessPowerThrottling,
+                          &PowerThrottling, sizeof(PowerThrottling));
   }
 #endif  // _WIN32
 


### PR DESCRIPTION
By default on Windows 11, power throttling will increase timer resolution if a window is occluded.  Disable that behavior.  Also enable high QOS to achieve maximum performance and turn off power saving.

Also use internal APIs to set timer precision to 500 us if available.