### PR TITLE
[build] CMake: consolidate and clean up include dirs

### DIFF
--- a/apriltag/CMakeLists.txt
+++ b/apriltag/CMakeLists.txt
@@ -128,13 +128,12 @@ target_link_libraries(apriltag wpimath)
 target_include_directories(
     apriltag
     PUBLIC
-        $<BUILD_INTERFACE:${apriltaglib_SOURCE_DIR}>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/include>
         $<INSTALL_INTERFACE:${include_dest}/apriltag>
 )
 
 install(
-    DIRECTORY src/main/native/thirdparty/apriltag/include/
+    DIRECTORY src/main/native/include/ src/main/native/thirdparty/apriltag/include/
     DESTINATION "${include_dest}/apriltag"
 )
 target_include_directories(
@@ -143,12 +142,10 @@ target_include_directories(
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/apriltag/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/apriltag/include/common>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/apriltag/src>
 )
 
 install(TARGETS apriltag EXPORT apriltag)
 export(TARGETS apriltag FILE apriltag.cmake NAMESPACE apriltag::)
-install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/apriltag")
 
 configure_file(apriltag-config.cmake.in ${WPILIB_BINARY_DIR}/apriltag-config.cmake)
 install(FILES ${WPILIB_BINARY_DIR}/apriltag-config.cmake DESTINATION share/apriltag)

--- a/apriltag/build.gradle
+++ b/apriltag/build.gradle
@@ -32,8 +32,7 @@ ext {
                 }
                 exportedHeaders {
                     srcDirs 'src/main/native/thirdparty/apriltag/include',
-                            'src/main/native/thirdparty/apriltag/include/common',
-                            'src/main/native/thirdparty/apriltag/src'
+                            'src/main/native/thirdparty/apriltag/include/common'
                 }
             }
         }

--- a/cscore/CMakeLists.txt
+++ b/cscore/CMakeLists.txt
@@ -36,8 +36,8 @@ target_include_directories(
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/include>
         $<INSTALL_INTERFACE:${include_dest}/cscore>
+    PRIVATE src/main/native/cpp
 )
-target_include_directories(cscore PRIVATE src/main/native/cpp)
 wpilib_target_warnings(cscore)
 target_link_libraries(cscore PUBLIC wpinet wpiutil ${OpenCV_LIBS})
 

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -19,12 +19,6 @@ target_include_directories(
     hal
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/include>
-        $<INSTALL_INTERFACE:${include_dest}/hal>
-)
-
-target_include_directories(
-    hal
-    PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/generated/main/native/include>
         $<INSTALL_INTERFACE:${include_dest}/hal>
 )

--- a/wpimath/CMakeLists.txt
+++ b/wpimath/CMakeLists.txt
@@ -157,7 +157,6 @@ if(NOT USE_SYSTEM_EIGEN)
         SYSTEM
         PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/eigen/include>
-            $<INSTALL_INTERFACE:${include_dest}/wpimath>
     )
 else()
     find_package(Eigen3 CONFIG REQUIRED)
@@ -165,22 +164,16 @@ else()
 endif()
 
 install(
-    DIRECTORY src/main/native/thirdparty/sleipnir/include/
+    DIRECTORY src/main/native/thirdparty/gcem/include/ src/main/native/thirdparty/sleipnir/include/
     DESTINATION "${include_dest}/wpimath"
 )
 target_include_directories(
     wpimath
     SYSTEM
     PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/gcem/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/sleipnir/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/sleipnir/src>
-)
-
-install(DIRECTORY src/main/native/thirdparty/gcem/include/ DESTINATION "${include_dest}/wpimath")
-target_include_directories(
-    wpimath
-    SYSTEM
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/gcem/include>
 )
 
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/wpimath")

--- a/wpinet/CMakeLists.txt
+++ b/wpinet/CMakeLists.txt
@@ -173,20 +173,14 @@ else()
 endif()
 
 install(
-    DIRECTORY src/main/native/thirdparty/tcpsockets/include/
+    DIRECTORY src/main/native/include/ src/main/native/thirdparty/tcpsockets/include/
     DESTINATION "${include_dest}/wpinet"
 )
 target_include_directories(
     wpinet
     PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/tcpsockets/include>
-)
-
-install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/wpinet")
-target_include_directories(
-    wpinet
-    PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/tcpsockets/include>
         $<INSTALL_INTERFACE:${include_dest}/wpinet>
 )
 

--- a/wpiutil/CMakeLists.txt
+++ b/wpiutil/CMakeLists.txt
@@ -184,49 +184,26 @@ else()
 endif()
 
 install(
-    DIRECTORY src/main/native/thirdparty/expected/include/
+    DIRECTORY
+        src/main/native/include/
+        src/main/native/thirdparty/expected/include/
+        src/main/native/thirdparty/json/include/
+        src/main/native/thirdparty/llvm/include/
+        src/main/native/thirdparty/memory/include/
+        src/main/native/thirdparty/mpack/include/
+        src/main/native/thirdparty/sigslot/include/
     DESTINATION "${include_dest}/wpiutil"
 )
 target_include_directories(
     wpiutil
     PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/expected/include>
-)
-install(DIRECTORY src/main/native/thirdparty/memory/include/ DESTINATION "${include_dest}/wpiutil")
-target_include_directories(
-    wpiutil
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/memory/include>
-)
-
-install(DIRECTORY src/main/native/thirdparty/json/include/ DESTINATION "${include_dest}/wpiutil")
-target_include_directories(
-    wpiutil
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/json/include>
-)
-
-install(DIRECTORY src/main/native/thirdparty/llvm/include/ DESTINATION "${include_dest}/wpiutil")
-target_include_directories(
-    wpiutil
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/llvm/include>
-)
-
-install(DIRECTORY src/main/native/thirdparty/mpack/include/ DESTINATION "${include_dest}/wpiutil")
-target_include_directories(
-    wpiutil
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/mpack/include>
-)
-
-install(DIRECTORY src/main/native/thirdparty/sigslot/include/ DESTINATION "${include_dest}/wpiutil")
-target_include_directories(
-    wpiutil
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/sigslot/include>
-)
-
-install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/wpiutil")
-target_include_directories(
-    wpiutil
-    PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/expected/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/json/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/llvm/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/memory/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/mpack/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/sigslot/include>
         $<INSTALL_INTERFACE:${include_dest}/wpiutil>
 )
 


### PR DESCRIPTION
Also removes the thirdparty AprilTag source directory from both CMake and Gradle's header setup.