### PR TITLE
[wpilib] Deprecate setNetworkTablesFlushEnabled

### DIFF
--- a/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
+++ b/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
@@ -207,7 +207,9 @@ class IterativeRobotBase : public RobotBase {
    * By default, this is enabled.
    *
    * @param enabled True to enable, false to disable
+   * @deprecated Deprecated without replacement.
    */
+  [[deprecated("Deprecated without replacement.")]]
   void SetNetworkTablesFlushEnabled(bool enabled);
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -253,7 +253,9 @@ public abstract class IterativeRobotBase extends RobotBase {
    * Enables or disables flushing NetworkTables every loop iteration. By default, this is enabled.
    *
    * @param enabled True to enable, false to disable
+   * @deprecated Deprecated without replacement.
    */
+  @Deprecated(forRemoval = true, since = "2025")
   public void setNetworkTablesFlushEnabled(boolean enabled) {
     m_ntFlushEnabled = enabled;
   }


### PR DESCRIPTION
The function no longer flushes to network like it did originally, and users generally would not want to disable flushing locally.