### PR TITLE
[units] Add default case for UNIT_ADD_IO

### DIFF
--- a/wpimath/src/main/native/include/units/base.h
+++ b/wpimath/src/main/native/include/units/base.h
@@ -175,7 +175,7 @@ namespace units
  * @param		namespaceName namespace in which the new units will be encapsulated.
  * @param		nameSingular singular version of the unit name, e.g. 'meter'
  * @param		abbrev - abbreviated unit name, e.g. 'm'
- * @note		When UNIT_LIB_ENABLE_IOSTREAM isn't defined, the macro does not generate any code
+ * @note		When UNIT_LIB_DISABLE_FMT is defined and UNIT_LIB_ENABLE_IOSTREAM isn't defined, the macro does not generate any code
  */
 #if __has_include(<fmt/format.h>) && !defined(UNIT_LIB_DISABLE_FMT)
 	#define UNIT_ADD_IO(namespaceName, nameSingular, abbrev)\
@@ -203,8 +203,7 @@ namespace units
 			return units::detail::to_string(obj()) + std::string(" "#abbrev);\
 		}\
 	}
-#endif
-#if defined(UNIT_LIB_ENABLE_IOSTREAM)
+#elif defined(UNIT_LIB_ENABLE_IOSTREAM)
 	#define UNIT_ADD_IO(namespaceName, nameSingular, abbrev)\
 	namespace namespaceName\
 	{\
@@ -217,6 +216,8 @@ namespace units
 			return units::detail::to_string(obj()) + std::string(" "#abbrev);\
 		}\
 	}
+#else
+    #define UNIT_ADD_IO(namespaceName, nameSingular, abbrev)
 #endif
 
  /**


### PR DESCRIPTION
If fmt isn't available/is disabled and iostream is not enabled UNIT_ADD_IO won't be defined