### PR TITLE
[build] Publish source and headers of all generated files

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -66,7 +66,6 @@ doxygen {
             cppIncludeRoots.add(it.absolutePath)
         }
     }
-    cppIncludeRoots << '../ntcore/build/generated/main/native/include/'
 
     if (project.hasProperty('docWarningsAsErrors')) {
         // apriltag

--- a/shared/javacpp/publish.gradle
+++ b/shared/javacpp/publish.gradle
@@ -20,6 +20,9 @@ task cppSourcesZip(type: Zip) {
     from('src/main/native/cpp') {
         into '/'
     }
+    from("$buildDir/generated/cpp") {
+        into '/'
+    }
 }
 
 task cppHeadersZip(type: Zip) {
@@ -32,7 +35,8 @@ task cppHeadersZip(type: Zip) {
     }
 
     ext.includeDirs = [
-        project.file('src/main/native/include')
+        project.file('src/main/native/include'),
+        project.file('src/generated/main/native/include')
     ]
 
     ext.includeDirs.each {


### PR DESCRIPTION
Fixes #6962
Don't specially include ntcore generated files from build directory in doxygen, as they are now pregenerated in source