### PR TITLE
[upstream_utils] Shorten file copy command

### DIFF
--- a/.github/workflows/upstream-utils.yml
+++ b/.github/workflows/upstream-utils.yml
@@ -34,92 +34,92 @@ jobs:
         run: |
           cd upstream_utils
           ./apriltag.py clone
-          ./apriltag.py copy-upstream-to-thirdparty
+          ./apriltag.py copy-src
       - name: Run eigen.py
         run: |
           cd upstream_utils
           ./eigen.py clone
-          ./eigen.py copy-upstream-to-thirdparty
+          ./eigen.py copy-src
       - name: Run fmt.py
         run: |
           cd upstream_utils
           ./fmt.py clone
-          ./fmt.py copy-upstream-to-thirdparty
+          ./fmt.py copy-src
       - name: Run gcem.py
         run: |
           cd upstream_utils
           ./gcem.py clone
-          ./gcem.py copy-upstream-to-thirdparty
+          ./gcem.py copy-src
       - name: Run gl3w.py
         run: |
           cd upstream_utils
           ./gl3w.py clone
-          ./gl3w.py copy-upstream-to-thirdparty
+          ./gl3w.py copy-src
       - name: Run glfw.py
         run: |
           cd upstream_utils
           ./glfw.py clone
-          ./glfw.py copy-upstream-to-thirdparty
+          ./glfw.py copy-src
       - name: Run googletest.py
         run: |
           cd upstream_utils
           ./googletest.py clone
-          ./googletest.py copy-upstream-to-thirdparty
+          ./googletest.py copy-src
       - name: Run imgui.py
         run: |
           cd upstream_utils
           ./imgui.py clone
-          ./imgui.py copy-upstream-to-thirdparty
+          ./imgui.py copy-src
       - name: Run implot.py
         run: |
           cd upstream_utils
           ./implot.py clone
-          ./implot.py copy-upstream-to-thirdparty
+          ./implot.py copy-src
       - name: Run json.py
         run: |
           cd upstream_utils
           ./json.py clone
-          ./json.py copy-upstream-to-thirdparty
+          ./json.py copy-src
       - name: Run libuv.py
         run: |
           cd upstream_utils
           ./libuv.py clone
-          ./libuv.py copy-upstream-to-thirdparty
+          ./libuv.py copy-src
       - name: Run llvm.py
         run: |
           cd upstream_utils
           ./llvm.py clone
-          ./llvm.py copy-upstream-to-thirdparty
+          ./llvm.py copy-src
       - name: Run mpack.py
         run: |
           cd upstream_utils
           ./mpack.py clone
-          ./mpack.py copy-upstream-to-thirdparty
+          ./mpack.py copy-src
       - name: Run stack_walker.py
         run: |
           cd upstream_utils
           ./stack_walker.py clone
-          ./stack_walker.py copy-upstream-to-thirdparty
+          ./stack_walker.py copy-src
       - name: Run memory.py
         run: |
           cd upstream_utils
           ./memory.py clone
-          ./memory.py copy-upstream-to-thirdparty
+          ./memory.py copy-src
       - name: Run protobuf.py
         run: |
           cd upstream_utils
           ./protobuf.py clone
-          ./protobuf.py copy-upstream-to-thirdparty
+          ./protobuf.py copy-src
       - name: Run sleipnir.py
         run: |
           cd upstream_utils
           ./sleipnir.py clone
-          ./sleipnir.py copy-upstream-to-thirdparty
+          ./sleipnir.py copy-src
       - name: Run stb.py
         run: |
           cd upstream_utils
           ./stb.py clone
-          ./stb.py copy-upstream-to-thirdparty
+          ./stb.py copy-src
       - name: Add untracked files to index so they count as changes
         run: git add -A
       - name: Check output

--- a/upstream_utils/README.md
+++ b/upstream_utils/README.md
@@ -37,7 +37,7 @@ Update the `upstream_utils` patch files and the tag in the script.
 
 Copy the updated upstream files into the thirdparty files within allwpilib.
 ```bash
-./<lib>.py copy-upstream-to-thirdparty
+./<lib>.py copy-src
 ```
 
 ## Adding patch to thirdparty library
@@ -78,5 +78,5 @@ Update the `upstream_utils` patch files.
 
 Rerun `<lib>.py` to reimport the thirdparty files.
 ```bash
-./<lib>.py copy-upstream-to-thirdparty
+./<lib>.py copy-src
 ```

--- a/upstream_utils/upstream_utils.py
+++ b/upstream_utils/upstream_utils.py
@@ -564,7 +564,7 @@ class Lib:
         )
 
         subparsers.add_parser(
-            "copy-upstream-to-thirdparty",
+            "copy-src",
             help="Copies files from the upstream repository into the thirdparty directory in allwpilib",
         )
 
@@ -581,5 +581,5 @@ class Lib:
             self.rebase(args.new_tag)
         elif args.subcommand == "format-patch":
             self.format_patch()
-        elif args.subcommand == "copy-upstream-to-thirdparty":
+        elif args.subcommand == "copy-src":
             self.copy_upstream_to_thirdparty()


### PR DESCRIPTION
The new upstream_utils command-line API has been nice, but the copy-upstream-to-thirdparty command has been annoying to type. Since it already has documentation, we can shorten it to make it easier to remember and type.