### PR TITLE
[build] Remove redundant `_M_` prefix from artifact file name

### DIFF
--- a/datalogtool/publish.gradle
+++ b/datalogtool/publish.gradle
@@ -34,7 +34,7 @@ model {
                             description("Copies the DataLogTool executable to the outputs directory.")
                             destinationDirectory = outputsFolder
 
-                            archiveBaseName = '_M_' + zipBaseName
+                            archiveBaseName = zipBaseName
                             duplicatesStrategy = 'exclude'
                             archiveClassifier = nativeUtils.getPublishClassifier(binary)
 

--- a/glass/publish.gradle
+++ b/glass/publish.gradle
@@ -89,7 +89,7 @@ model {
                             description("Copies the Glass executable to the outputs directory.")
                             destinationDirectory = outputsFolder
 
-                            archiveBaseName = '_M_' + zipBaseName
+                            archiveBaseName = zipBaseName
                             duplicatesStrategy = 'exclude'
                             archiveClassifier = nativeUtils.getPublishClassifier(binary)
 

--- a/outlineviewer/publish.gradle
+++ b/outlineviewer/publish.gradle
@@ -34,7 +34,7 @@ model {
                             description("Copies the OutlineViewer executable to the outputs directory.")
                             destinationDirectory = outputsFolder
 
-                            archiveBaseName = '_M_' + zipBaseName
+                            archiveBaseName = zipBaseName
                             duplicatesStrategy = 'exclude'
                             archiveClassifier = nativeUtils.getPublishClassifier(binary)
 

--- a/processstarter/publish.gradle
+++ b/processstarter/publish.gradle
@@ -33,7 +33,7 @@ model {
                             description("Copies the processstarter executable to the outputs directory.")
                             destinationDirectory = outputsFolder
 
-                            archiveBaseName = '_M_' + zipBaseName
+                            archiveBaseName = zipBaseName
                             duplicatesStrategy = 'exclude'
                             archiveClassifier = nativeUtils.getPublishClassifier(binary)
 

--- a/roborioteamnumbersetter/publish.gradle
+++ b/roborioteamnumbersetter/publish.gradle
@@ -34,7 +34,7 @@ model {
                             description("Copies the roboRIOTeamNumberSetter executable to the outputs directory.")
                             destinationDirectory = outputsFolder
 
-                            archiveBaseName = '_M_' + zipBaseName
+                            archiveBaseName = zipBaseName
                             duplicatesStrategy = 'exclude'
                             archiveClassifier = nativeUtils.getPublishClassifier(binary)
 

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -131,7 +131,7 @@ ext.createComponentZipTasks = { components, names, base, type, project, func ->
             description = 'Creates component archive for platform ' + key
             destinationDirectory = outputsFolder
             archiveClassifier = key
-            archiveBaseName = '_M_' + base
+            archiveBaseName = base
             duplicatesStrategy = 'exclude'
 
             from(licenseFile) {

--- a/sysid/publish.gradle
+++ b/sysid/publish.gradle
@@ -77,7 +77,7 @@ model {
                             description("Copies the SysId executable to the outputs directory.")
                             destinationDirectory = outputsFolder
 
-                            archiveBaseName = '_M_' + zipBaseName
+                            archiveBaseName = zipBaseName
                             duplicatesStrategy = 'exclude'
                             archiveClassifier = nativeUtils.getPublishClassifier(binary)
 


### PR DESCRIPTION
The prefix has been unused for about 5 years (unused since wpilibsuite/build-tools#74).