### PR TITLE
[upstream_utils] use os path separator when matching path

### DIFF
--- a/upstream_utils/apriltag.py
+++ b/upstream_utils/apriltag.py
@@ -38,7 +38,7 @@ def copy_upstream_src(wpilib_root):
     # Copy apriltag source files into allwpilib
     src_files = walk_cwd_and_copy_if(
         lambda dp, f: (f.endswith(".c") or f.endswith(".cpp"))
-        and not dp.startswith(os.path.join(".","example"))
+        and not dp.startswith(os.path.join(".", "example"))
         and not f.endswith("getopt.c")
         and not "py" in f
         and not remove_tag(f),

--- a/upstream_utils/apriltag.py
+++ b/upstream_utils/apriltag.py
@@ -38,7 +38,7 @@ def copy_upstream_src(wpilib_root):
     # Copy apriltag source files into allwpilib
     src_files = walk_cwd_and_copy_if(
         lambda dp, f: (f.endswith(".c") or f.endswith(".cpp"))
-        and not dp.startswith("./example")
+        and not dp.startswith(os.path.join(".","example"))
         and not f.endswith("getopt.c")
         and not "py" in f
         and not remove_tag(f),

--- a/upstream_utils/eigen.py
+++ b/upstream_utils/eigen.py
@@ -19,7 +19,7 @@ def eigen_inclusions(dp, f):
     dp -- directory path
     f -- filename
     """
-    if not dp.startswith("./Eigen"):
+    if not dp.startswith(os.path.join(".", "Eigen")):
         return False
 
     abspath = os.path.join(dp, f)
@@ -79,7 +79,7 @@ def unsupported_inclusions(dp, f):
     dp -- directory path
     f -- filename
     """
-    if not dp.startswith("./unsupported"):
+    if not dp.startswith(os.path.join(".", "unsupported")):
         return False
 
     abspath = os.path.join(dp, f)

--- a/upstream_utils/fmt.py
+++ b/upstream_utils/fmt.py
@@ -21,13 +21,13 @@ def copy_upstream_src(wpilib_root):
 
     # Copy fmt source files into allwpilib
     walk_cwd_and_copy_if(
-        lambda dp, f: dp.startswith("./src") and f.endswith(".cc") and f != "fmt.cc",
+        lambda dp, f: dp.startswith(os.path.join(".","src")) and f.endswith(".cc") and f != "fmt.cc",
         os.path.join(wpiutil, "src/main/native/thirdparty/fmtlib"),
     )
 
     # Copy fmt header files into allwpilib
     walk_cwd_and_copy_if(
-        lambda dp, f: dp.startswith("./include/fmt"),
+        lambda dp, f: dp.startswith(os.path.join(".", "include", "fmt")),
         os.path.join(wpiutil, "src/main/native/thirdparty/fmtlib"),
     )
 

--- a/upstream_utils/fmt.py
+++ b/upstream_utils/fmt.py
@@ -21,7 +21,9 @@ def copy_upstream_src(wpilib_root):
 
     # Copy fmt source files into allwpilib
     walk_cwd_and_copy_if(
-        lambda dp, f: dp.startswith(os.path.join(".","src")) and f.endswith(".cc") and f != "fmt.cc",
+        lambda dp, f: dp.startswith(os.path.join(".", "src"))
+        and f.endswith(".cc")
+        and f != "fmt.cc",
         os.path.join(wpiutil, "src/main/native/thirdparty/fmtlib"),
     )
 

--- a/upstream_utils/gcem.py
+++ b/upstream_utils/gcem.py
@@ -20,7 +20,7 @@ def copy_upstream_src(wpilib_root):
 
     # Copy gcem include files into allwpilib
     walk_cwd_and_copy_if(
-        lambda dp, f: dp.startswith("./include"),
+        lambda dp, f: dp.startswith(os.path.join(".", "include")),
         os.path.join(wpimath, "src/main/native/thirdparty/gcem"),
     )
 

--- a/upstream_utils/glfw.py
+++ b/upstream_utils/glfw.py
@@ -39,7 +39,7 @@ def copy_upstream_src(wpilib_root):
         if f.endswith("CMakeLists.txt"):
             return False
 
-        if dp.startswith("./src"):
+        if dp.startswith(os.path.join(".", "src")):
             return True
 
         return False
@@ -50,7 +50,7 @@ def copy_upstream_src(wpilib_root):
     )
 
     def cmake_filter(dp, f):
-        if dp.startswith("./CMake"):
+        if dp.startswith(os.path.join(".", "CMake")):
             return True
 
         path = os.path.join(dp, f)

--- a/upstream_utils/libuv.py
+++ b/upstream_utils/libuv.py
@@ -24,7 +24,8 @@ def copy_upstream_src(wpilib_root):
     ]
 
     walk_cwd_and_copy_if(
-        lambda dp, f: dp.startswith(os.path.join(".", "include")) and f not in include_ignorelist,
+        lambda dp, f: dp.startswith(os.path.join(".", "include"))
+        and f not in include_ignorelist,
         os.path.join(wpinet, "src/main/native/thirdparty/libuv"),
     )
 
@@ -45,7 +46,8 @@ def copy_upstream_src(wpilib_root):
         "sysinfo-memory.c",
     ]
     walk_cwd_and_copy_if(
-        lambda dp, f: dp.startswith(os.path.join(".", "src")) and f not in src_ignorelist,
+        lambda dp, f: dp.startswith(os.path.join(".", "src"))
+        and f not in src_ignorelist,
         os.path.join(wpinet, "src/main/native/thirdparty/libuv"),
         rename_c_to_cpp=True,
     )

--- a/upstream_utils/libuv.py
+++ b/upstream_utils/libuv.py
@@ -24,7 +24,7 @@ def copy_upstream_src(wpilib_root):
     ]
 
     walk_cwd_and_copy_if(
-        lambda dp, f: dp.startswith("./include") and f not in include_ignorelist,
+        lambda dp, f: dp.startswith(os.path.join(".", "include")) and f not in include_ignorelist,
         os.path.join(wpinet, "src/main/native/thirdparty/libuv"),
     )
 
@@ -45,7 +45,7 @@ def copy_upstream_src(wpilib_root):
         "sysinfo-memory.c",
     ]
     walk_cwd_and_copy_if(
-        lambda dp, f: dp.startswith("./src") and f not in src_ignorelist,
+        lambda dp, f: dp.startswith(os.path.join(".", "src")) and f not in src_ignorelist,
         os.path.join(wpinet, "src/main/native/thirdparty/libuv"),
         rename_c_to_cpp=True,
     )

--- a/upstream_utils/protobuf.py
+++ b/upstream_utils/protobuf.py
@@ -245,7 +245,7 @@ use_include_files = (
 
 
 def matches(dp, f, files):
-    if not dp.startswith("./src/"):
+    if not dp.startswith(os.path.join(".", "src")):
         return False
     p = dp[6:] + "/" + f
     return p in files


### PR DESCRIPTION
On windows those paths would be `.\foobar` and wouldn't match