### PR TITLE
Read text input streams as UTF-8 in Java

### DIFF
--- a/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFieldLayout.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFieldLayout.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -256,7 +257,7 @@ public class AprilTagFieldLayout {
       // Class.getResourceAsStream() returns null if the resource does not exist.
       throw new IOException("Could not locate resource: " + resourcePath);
     }
-    InputStreamReader reader = new InputStreamReader(stream);
+    InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8);
     try {
       return new ObjectMapper().readerFor(AprilTagFieldLayout.class).readValue(reader);
     } catch (IOException e) {

--- a/fieldImages/src/main/java/edu/wpi/first/fields/FieldConfig.java
+++ b/fieldImages/src/main/java/edu/wpi/first/fields/FieldConfig.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -81,7 +82,7 @@ public class FieldConfig {
    */
   public static FieldConfig loadFromResource(String resourcePath) throws IOException {
     try (InputStream stream = FieldConfig.class.getResourceAsStream(resourcePath);
-        InputStreamReader reader = new InputStreamReader(stream)) {
+        InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
       return new ObjectMapper().readerFor(FieldConfig.class).readValue(reader);
     }
   }

--- a/wpiutil/src/main/java/edu/wpi/first/util/ClassPreloader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/ClassPreloader.java
@@ -95,7 +95,7 @@ public final class ClassPreloader {
    * @return Number of classes loaded.
    */
   public static int preload(InputStream stream) {
-    return preload(new BufferedReader(new InputStreamReader(stream)));
+    return preload(new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8)));
   }
 
   /**


### PR DESCRIPTION
Fixes https://errorprone.info/bugpattern/DefaultCharset for InputStreamReader instances.