### PR TITLE
[wpilibc] Add missing deprecated HID sim methods

### DIFF
--- a/wpilibc/src/generate/main/native/cpp/simulation/hidsim.cpp.jinja
+++ b/wpilibc/src/generate/main/native/cpp/simulation/hidsim.cpp.jinja
@@ -39,4 +39,17 @@ void {{ ConsoleName }}ControllerSim::Set{{ capitalize_first(trigger.name) }}Axis
 void {{ ConsoleName }}ControllerSim::Set{{ capitalize_first(button.name) }}Button(bool value) {
   SetRawButton({{ ConsoleName }}Controller::Button::k{{ capitalize_first(button.name) }}, value);
 }
-{% endfor %}
+{% endfor -%}
+{% if ConsoleName == "Xbox" %}
+void {{ ConsoleName }}ControllerSim::SetLeftBumper(bool value) {
+  SetRawButton({{ ConsoleName }}Controller::Button::kLeftBumper, value);
+}
+
+void {{ ConsoleName }}ControllerSim::SetRightBumper(bool value) {
+  SetRawButton({{ ConsoleName }}Controller::Button::kRightBumper, value);
+}
+{% elif ConsoleName == "PS4" or ConsoleName == "PS5" %}
+void {{ ConsoleName }}ControllerSim::SetTouchpad(bool value) {
+  SetRawButton({{ ConsoleName }}Controller::Button::kTouchpad, value);
+}
+{% endif %}

--- a/wpilibc/src/generated/main/native/cpp/simulation/PS4ControllerSim.cpp
+++ b/wpilibc/src/generated/main/native/cpp/simulation/PS4ControllerSim.cpp
@@ -103,3 +103,7 @@ void PS4ControllerSim::SetPSButton(bool value) {
 void PS4ControllerSim::SetTouchpadButton(bool value) {
   SetRawButton(PS4Controller::Button::kTouchpad, value);
 }
+
+void PS4ControllerSim::SetTouchpad(bool value) {
+  SetRawButton(PS4Controller::Button::kTouchpad, value);
+}

--- a/wpilibc/src/generated/main/native/cpp/simulation/PS5ControllerSim.cpp
+++ b/wpilibc/src/generated/main/native/cpp/simulation/PS5ControllerSim.cpp
@@ -103,3 +103,7 @@ void PS5ControllerSim::SetPSButton(bool value) {
 void PS5ControllerSim::SetTouchpadButton(bool value) {
   SetRawButton(PS5Controller::Button::kTouchpad, value);
 }
+
+void PS5ControllerSim::SetTouchpad(bool value) {
+  SetRawButton(PS5Controller::Button::kTouchpad, value);
+}

--- a/wpilibc/src/generated/main/native/cpp/simulation/XboxControllerSim.cpp
+++ b/wpilibc/src/generated/main/native/cpp/simulation/XboxControllerSim.cpp
@@ -87,3 +87,11 @@ void XboxControllerSim::SetLeftStickButton(bool value) {
 void XboxControllerSim::SetRightStickButton(bool value) {
   SetRawButton(XboxController::Button::kRightStick, value);
 }
+
+void XboxControllerSim::SetLeftBumper(bool value) {
+  SetRawButton(XboxController::Button::kLeftBumper, value);
+}
+
+void XboxControllerSim::SetRightBumper(bool value) {
+  SetRawButton(XboxController::Button::kRightBumper, value);
+}


### PR DESCRIPTION
Forgot to add these for C++. Fixes #7004.