### PR TITLE
Correct warning suppression and note in SimDataValue.h

### DIFF
--- a/hal/src/main/native/include/hal/simulation/SimDataValue.h
+++ b/hal/src/main/native/include/hal/simulation/SimDataValue.h
@@ -87,21 +87,21 @@ template <typename T, HAL_Value (*MakeValue)(T), const char* (*GetName)(),
           T (*GetDefault)() = nullptr>
 class SimDataValue final : public impl::SimDataValueBase<T, MakeValue> {
  public:
-// FIXME: GCC 12.1 gives the false positive "the address of <GetDefault> will
-// never be NULL" because it doesn't realize the default template parameter can
-// make GetDefault nullptr. In C++20, replace "T (*GetDefault)() = nullptr" with
-// "T (*GetDefault)() = [] { return T(); }" and unconditionally call
-// GetDefault() to fix the warning.
-#if __GNUC__ >= 12
+// FIXME: GCC gives the false positive "the address of <GetDefault> will never
+// be NULL" because it doesn't realize the default template parameter can make
+// GetDefault nullptr. Fixed in GCC 13.
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94554
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105885
+#if __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Waddress"
-#endif  // __GNUC__ >= 12
+#endif  // __GNUC__
   SimDataValue()
       : impl::SimDataValueBase<T, MakeValue>(
             GetDefault != nullptr ? GetDefault() : T()) {}
-#if __GNUC__ >= 12
+#if __GNUC__
 #pragma GCC diagnostic pop
-#endif  // __GNUC__ >= 12
+#endif  // __GNUC__
   explicit SimDataValue(T value)
       : impl::SimDataValueBase<T, MakeValue>(value) {}
 


### PR DESCRIPTION
The issue also occurs in GCC <12 if the provided function is not constexpr. 
The suggested C++20 fix does not work due to another GCC bug, fixed in GCC 14 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70413)