### PR TITLE
[build] cmake: Add meta target for examples and example tests

### DIFF
--- a/wpilibcExamples/CMakeLists.txt
+++ b/wpilibcExamples/CMakeLists.txt
@@ -6,6 +6,9 @@ include(SubDirList)
 subdir_list(TEMPLATES ${CMAKE_SOURCE_DIR}/wpilibcExamples/src/main/cpp/templates)
 subdir_list(EXAMPLES ${CMAKE_SOURCE_DIR}/wpilibcExamples/src/main/cpp/examples)
 
+add_custom_target(wpilibcExamples)
+add_custom_target(wpilibcExamples_test)
+
 foreach(example ${EXAMPLES})
     file(
         GLOB_RECURSE sources
@@ -23,19 +26,20 @@ foreach(example ${EXAMPLES})
         romiVendordep
         xrpVendordep
     )
+    add_dependencies(wpilibcExamples ${example})
 
     if(WITH_TESTS AND EXISTS ${CMAKE_SOURCE_DIR}/wpilibcExamples/src/test/cpp/examples/${example})
-        wpilib_add_test(${example} src/test/cpp/examples/${example}/cpp)
-        target_sources(${example}_test PRIVATE ${sources})
+        wpilib_add_test(Example_${example} src/test/cpp/examples/${example}/cpp)
+        target_sources(Example_${example}_test PRIVATE ${sources})
         target_include_directories(
-            ${example}_test
+            Example_${example}_test
             PRIVATE
                 src/main/cpp/examples/${example}/include
                 src/test/cpp/examples/${example}/include
         )
-        target_compile_definitions(${example}_test PUBLIC RUNNING_FRC_TESTS)
+        target_compile_definitions(Example_${example}_test PUBLIC RUNNING_FRC_TESTS)
         target_link_libraries(
-            ${example}_test
+            Example_${example}_test
             apriltag
             wpilibc
             wpilibNewCommands
@@ -43,6 +47,7 @@ foreach(example ${EXAMPLES})
             xrpVendordep
             googletest
         )
+        add_dependencies(wpilibcExamples_test Example_${example}_test)
     endif()
 endforeach()
 
@@ -56,4 +61,5 @@ foreach(template ${TEMPLATES})
     wpilib_target_warnings(${template})
     target_include_directories(${template} PUBLIC src/main/cpp/templates/${template}/include)
     target_link_libraries(${template} wpilibc wpilibNewCommands romiVendordep xrpVendordep)
+    add_dependencies(wpilibcExamples ${template})
 endforeach()


### PR DESCRIPTION
Also prefix example test targets with Example_ to make running tests easier
