### PR TITLE
[hal] Check for invalid handle before closing handles

### DIFF
--- a/crossConnIntegrationTests/src/main/native/include/LifetimeWrappers.h
+++ b/crossConnIntegrationTests/src/main/native/include/LifetimeWrappers.h
@@ -13,48 +13,42 @@ namespace hlt {
 struct InterruptHandle : hal::Handle<HAL_InterruptHandle, HAL_CleanInterrupts> {
  public:
   explicit InterruptHandle(int32_t* status)
-      : hal::Handle<HAL_InterruptHandle, HAL_CleanInterrupts>{
-            HAL_InitializeInterrupts(status)} {}
+      : Handle{HAL_InitializeInterrupts(status)} {}
 };
 
 struct DMAHandle : hal::Handle<HAL_DMAHandle, HAL_FreeDMA> {
  public:
-  explicit DMAHandle(int32_t* status)
-      : hal::Handle<HAL_DMAHandle, HAL_FreeDMA>{HAL_InitializeDMA(status)} {}
+  explicit DMAHandle(int32_t* status) : Handle{HAL_InitializeDMA(status)} {}
 };
 
 struct AnalogInputHandle
     : hal::Handle<HAL_AnalogInputHandle, HAL_FreeAnalogInputPort> {
  public:
   AnalogInputHandle(int32_t port, int32_t* status)
-      : hal::Handle<HAL_AnalogInputHandle, HAL_FreeAnalogInputPort>{
-            HAL_InitializeAnalogInputPort(HAL_GetPort(port), nullptr,
-                                          status)} {}
+      : Handle{HAL_InitializeAnalogInputPort(HAL_GetPort(port), nullptr,
+                                             status)} {}
 };
 
 struct AnalogOutputHandle
     : hal::Handle<HAL_AnalogOutputHandle, HAL_FreeAnalogOutputPort> {
  public:
   AnalogOutputHandle(int32_t port, int32_t* status)
-      : hal::Handle<HAL_AnalogOutputHandle, HAL_FreeAnalogOutputPort>{
-            HAL_InitializeAnalogOutputPort(HAL_GetPort(port), nullptr,
-                                           status)} {}
+      : Handle{HAL_InitializeAnalogOutputPort(HAL_GetPort(port), nullptr,
+                                              status)} {}
 };
 
 struct AnalogTriggerHandle
     : hal::Handle<HAL_AnalogTriggerHandle, HAL_CleanAnalogTrigger> {
  public:
   explicit AnalogTriggerHandle(HAL_AnalogInputHandle port, int32_t* status)
-      : hal::Handle<HAL_AnalogTriggerHandle, HAL_CleanAnalogTrigger>{
-            HAL_InitializeAnalogTrigger(port, status)} {}
+      : Handle{HAL_InitializeAnalogTrigger(port, status)} {}
 };
 
 struct DutyCycleHandle : hal::Handle<HAL_DutyCycleHandle, HAL_FreeDutyCycle> {
  public:
   DutyCycleHandle(HAL_DigitalHandle port, int32_t* status)
-      : hal::Handle<HAL_DutyCycleHandle, HAL_FreeDutyCycle>{
-            HAL_InitializeDutyCycle(
-                port, HAL_AnalogTriggerType::HAL_Trigger_kInWindow, status)} {}
+      : Handle{HAL_InitializeDutyCycle(
+            port, HAL_AnalogTriggerType::HAL_Trigger_kInWindow, status)} {}
 };
 
 struct DIOHandle : hal::Handle<HAL_DigitalHandle, HAL_FreeDIOPort> {
@@ -62,7 +56,7 @@ struct DIOHandle : hal::Handle<HAL_DigitalHandle, HAL_FreeDIOPort> {
   DIOHandle() {}
 
   DIOHandle(int32_t port, HAL_Bool input, int32_t* status)
-      : hal::Handle<HAL_DigitalHandle, HAL_FreeDIOPort>{
+      : Handle{
             HAL_InitializeDIOPort(HAL_GetPort(port), input, nullptr, status)} {}
 };
 
@@ -71,14 +65,13 @@ struct PWMHandle : hal::Handle<HAL_DigitalHandle, HAL_FreePWMPort> {
   PWMHandle() {}
 
   PWMHandle(int32_t port, int32_t* status)
-      : hal::Handle<HAL_DigitalHandle, HAL_FreePWMPort>{
-            HAL_InitializePWMPort(HAL_GetPort(port), nullptr, status)} {}
+      : Handle{HAL_InitializePWMPort(HAL_GetPort(port), nullptr, status)} {}
 };
 
 struct RelayHandle : hal::Handle<HAL_RelayHandle, HAL_FreeRelayPort> {
  public:
   RelayHandle(int32_t port, HAL_Bool fwd, int32_t* status)
-      : hal::Handle<HAL_RelayHandle, HAL_FreeRelayPort>{
+      : Handle{
             HAL_InitializeRelayPort(HAL_GetPort(port), fwd, nullptr, status)} {}
 };
 

--- a/crossConnIntegrationTests/src/main/native/include/LifetimeWrappers.h
+++ b/crossConnIntegrationTests/src/main/native/include/LifetimeWrappers.h
@@ -95,10 +95,7 @@ struct AnalogTriggerHandle {
   AnalogTriggerHandle(AnalogTriggerHandle&&) = default;
   AnalogTriggerHandle& operator=(AnalogTriggerHandle&&) = default;
 
-  ~AnalogTriggerHandle() {
-    int32_t status = 0;
-    HAL_CleanAnalogTrigger(handle, &status);
-  }
+  ~AnalogTriggerHandle() { HAL_CleanAnalogTrigger(handle); }
 
   operator HAL_AnalogTriggerHandle() const { return handle; }
 
@@ -160,10 +157,7 @@ struct PWMHandle {
     handle = HAL_InitializePWMPort(HAL_GetPort(port), nullptr, status);
   }
 
-  ~PWMHandle() {
-    int32_t status = 0;
-    HAL_FreePWMPort(handle, &status);
-  }
+  ~PWMHandle() { HAL_FreePWMPort(handle); }
 
   operator HAL_DigitalHandle() const { return handle; }
 

--- a/crossConnIntegrationTests/src/main/native/include/LifetimeWrappers.h
+++ b/crossConnIntegrationTests/src/main/native/include/LifetimeWrappers.h
@@ -10,178 +10,76 @@
 
 namespace hlt {
 
-struct InterruptHandle {
+struct InterruptHandle : hal::Handle<HAL_InterruptHandle, HAL_CleanInterrupts> {
  public:
-  explicit InterruptHandle(int32_t* status) {
-    handle = HAL_InitializeInterrupts(status);
-  }
-  InterruptHandle(const InterruptHandle&) = delete;
-  InterruptHandle operator=(const InterruptHandle&) = delete;
-
-  InterruptHandle(InterruptHandle&&) = default;
-  InterruptHandle& operator=(InterruptHandle&&) = default;
-
-  ~InterruptHandle() { HAL_CleanInterrupts(handle); }
-
-  operator HAL_InterruptHandle() const { return handle; }
-
- private:
-  HAL_InterruptHandle handle = 0;
+  explicit InterruptHandle(int32_t* status)
+      : hal::Handle<HAL_InterruptHandle, HAL_CleanInterrupts>{
+            HAL_InitializeInterrupts(status)} {}
 };
 
-struct DMAHandle {
+struct DMAHandle : hal::Handle<HAL_DMAHandle, HAL_FreeDMA> {
  public:
-  explicit DMAHandle(int32_t* status) { handle = HAL_InitializeDMA(status); }
-  DMAHandle(const DMAHandle&) = delete;
-  DMAHandle operator=(const DMAHandle&) = delete;
-
-  DMAHandle(DMAHandle&&) = default;
-  DMAHandle& operator=(DMAHandle&&) = default;
-
-  ~DMAHandle() { HAL_FreeDMA(handle); }
-
-  operator HAL_DMAHandle() const { return handle; }
-
- private:
-  HAL_DMAHandle handle = 0;
+  explicit DMAHandle(int32_t* status)
+      : hal::Handle<HAL_DMAHandle, HAL_FreeDMA>{HAL_InitializeDMA(status)} {}
 };
 
-struct AnalogInputHandle {
+struct AnalogInputHandle
+    : hal::Handle<HAL_AnalogInputHandle, HAL_FreeAnalogInputPort> {
  public:
-  AnalogInputHandle(int32_t port, int32_t* status) {
-    handle = HAL_InitializeAnalogInputPort(HAL_GetPort(port), nullptr, status);
-  }
-  AnalogInputHandle(const AnalogInputHandle&) = delete;
-  AnalogInputHandle operator=(const AnalogInputHandle&) = delete;
-
-  AnalogInputHandle(AnalogInputHandle&&) = default;
-  AnalogInputHandle& operator=(AnalogInputHandle&&) = default;
-
-  ~AnalogInputHandle() { HAL_FreeAnalogInputPort(handle); }
-
-  operator HAL_AnalogInputHandle() const { return handle; }
-
- private:
-  HAL_AnalogInputHandle handle = 0;
+  AnalogInputHandle(int32_t port, int32_t* status)
+      : hal::Handle<HAL_AnalogInputHandle, HAL_FreeAnalogInputPort>{
+            HAL_InitializeAnalogInputPort(HAL_GetPort(port), nullptr,
+                                          status)} {}
 };
 
-struct AnalogOutputHandle {
+struct AnalogOutputHandle
+    : hal::Handle<HAL_AnalogOutputHandle, HAL_FreeAnalogOutputPort> {
  public:
-  AnalogOutputHandle(int32_t port, int32_t* status) {
-    handle = HAL_InitializeAnalogOutputPort(HAL_GetPort(port), nullptr, status);
-  }
-  AnalogOutputHandle(const AnalogOutputHandle&) = delete;
-  AnalogOutputHandle operator=(const AnalogOutputHandle&) = delete;
-
-  AnalogOutputHandle(AnalogOutputHandle&&) = default;
-  AnalogOutputHandle& operator=(AnalogOutputHandle&&) = default;
-
-  ~AnalogOutputHandle() { HAL_FreeAnalogOutputPort(handle); }
-
-  operator HAL_AnalogOutputHandle() const { return handle; }
-
- private:
-  HAL_AnalogOutputHandle handle = 0;
+  AnalogOutputHandle(int32_t port, int32_t* status)
+      : hal::Handle<HAL_AnalogOutputHandle, HAL_FreeAnalogOutputPort>{
+            HAL_InitializeAnalogOutputPort(HAL_GetPort(port), nullptr,
+                                           status)} {}
 };
 
-struct AnalogTriggerHandle {
+struct AnalogTriggerHandle
+    : hal::Handle<HAL_AnalogTriggerHandle, HAL_CleanAnalogTrigger> {
  public:
-  explicit AnalogTriggerHandle(HAL_AnalogInputHandle port, int32_t* status) {
-    handle = HAL_InitializeAnalogTrigger(port, status);
-  }
-  AnalogTriggerHandle(const AnalogTriggerHandle&) = delete;
-  AnalogTriggerHandle operator=(const AnalogTriggerHandle&) = delete;
-
-  AnalogTriggerHandle(AnalogTriggerHandle&&) = default;
-  AnalogTriggerHandle& operator=(AnalogTriggerHandle&&) = default;
-
-  ~AnalogTriggerHandle() { HAL_CleanAnalogTrigger(handle); }
-
-  operator HAL_AnalogTriggerHandle() const { return handle; }
-
- private:
-  HAL_AnalogTriggerHandle handle = 0;
+  explicit AnalogTriggerHandle(HAL_AnalogInputHandle port, int32_t* status)
+      : hal::Handle<HAL_AnalogTriggerHandle, HAL_CleanAnalogTrigger>{
+            HAL_InitializeAnalogTrigger(port, status)} {}
 };
 
-struct DutyCycleHandle {
+struct DutyCycleHandle : hal::Handle<HAL_DutyCycleHandle, HAL_FreeDutyCycle> {
  public:
-  DutyCycleHandle(HAL_DigitalHandle port, int32_t* status) {
-    handle = HAL_InitializeDutyCycle(
-        port, HAL_AnalogTriggerType::HAL_Trigger_kInWindow, status);
-  }
-  DutyCycleHandle(const DutyCycleHandle&) = delete;
-  DutyCycleHandle operator=(const DutyCycleHandle&) = delete;
-
-  DutyCycleHandle(DutyCycleHandle&&) = default;
-  DutyCycleHandle& operator=(DutyCycleHandle&&) = default;
-
-  ~DutyCycleHandle() { HAL_FreeDutyCycle(handle); }
-
-  operator HAL_DutyCycleHandle() const { return handle; }
-
- private:
-  HAL_DutyCycleHandle handle = 0;
+  DutyCycleHandle(HAL_DigitalHandle port, int32_t* status)
+      : hal::Handle<HAL_DutyCycleHandle, HAL_FreeDutyCycle>{
+            HAL_InitializeDutyCycle(
+                port, HAL_AnalogTriggerType::HAL_Trigger_kInWindow, status)} {}
 };
 
-struct DIOHandle {
+struct DIOHandle : hal::Handle<HAL_DigitalHandle, HAL_FreeDIOPort> {
  public:
   DIOHandle() {}
-  DIOHandle(const DIOHandle&) = delete;
-  DIOHandle operator=(const DIOHandle&) = delete;
 
-  DIOHandle(DIOHandle&&) = default;
-  DIOHandle& operator=(DIOHandle&&) = default;
-
-  DIOHandle(int32_t port, HAL_Bool input, int32_t* status) {
-    handle = HAL_InitializeDIOPort(HAL_GetPort(port), input, nullptr, status);
-  }
-
-  ~DIOHandle() { HAL_FreeDIOPort(handle); }
-
-  operator HAL_DigitalHandle() const { return handle; }
-
- private:
-  HAL_DigitalHandle handle = 0;
+  DIOHandle(int32_t port, HAL_Bool input, int32_t* status)
+      : hal::Handle<HAL_DigitalHandle, HAL_FreeDIOPort>{
+            HAL_InitializeDIOPort(HAL_GetPort(port), input, nullptr, status)} {}
 };
 
-struct PWMHandle {
+struct PWMHandle : hal::Handle<HAL_DigitalHandle, HAL_FreePWMPort> {
  public:
   PWMHandle() {}
-  PWMHandle(const PWMHandle&) = delete;
-  PWMHandle operator=(const PWMHandle&) = delete;
 
-  PWMHandle(PWMHandle&&) = default;
-  PWMHandle& operator=(PWMHandle&&) = default;
-
-  PWMHandle(int32_t port, int32_t* status) {
-    handle = HAL_InitializePWMPort(HAL_GetPort(port), nullptr, status);
-  }
-
-  ~PWMHandle() { HAL_FreePWMPort(handle); }
-
-  operator HAL_DigitalHandle() const { return handle; }
-
- private:
-  HAL_DigitalHandle handle = 0;
+  PWMHandle(int32_t port, int32_t* status)
+      : hal::Handle<HAL_DigitalHandle, HAL_FreePWMPort>{
+            HAL_InitializePWMPort(HAL_GetPort(port), nullptr, status)} {}
 };
 
-struct RelayHandle {
+struct RelayHandle : hal::Handle<HAL_RelayHandle, HAL_FreeRelayPort> {
  public:
-  RelayHandle(int32_t port, HAL_Bool fwd, int32_t* status) {
-    handle = HAL_InitializeRelayPort(HAL_GetPort(port), fwd, nullptr, status);
-  }
-  RelayHandle(const RelayHandle&) = delete;
-  RelayHandle operator=(const RelayHandle&) = delete;
-
-  RelayHandle(RelayHandle&&) = default;
-  RelayHandle& operator=(RelayHandle&&) = default;
-
-  ~RelayHandle() { HAL_FreeRelayPort(handle); }
-
-  operator HAL_RelayHandle() const { return handle; }
-
- private:
-  HAL_RelayHandle handle = 0;
+  RelayHandle(int32_t port, HAL_Bool fwd, int32_t* status)
+      : hal::Handle<HAL_RelayHandle, HAL_FreeRelayPort>{
+            HAL_InitializeRelayPort(HAL_GetPort(port), fwd, nullptr, status)} {}
 };
 
 #define ASSERT_LAST_ERROR_STATUS(status, x)                          \

--- a/hal/src/main/native/athena/AnalogTrigger.cpp
+++ b/hal/src/main/native/athena/AnalogTrigger.cpp
@@ -99,8 +99,7 @@ HAL_AnalogTriggerHandle HAL_InitializeAnalogTriggerDutyCycle(
   return handle;
 }
 
-void HAL_CleanAnalogTrigger(HAL_AnalogTriggerHandle analogTriggerHandle,
-                            int32_t* status) {
+void HAL_CleanAnalogTrigger(HAL_AnalogTriggerHandle analogTriggerHandle) {
   analogTriggerHandles->Free(analogTriggerHandle);
   // caller owns the input handle.
 }

--- a/hal/src/main/native/athena/Counter.cpp
+++ b/hal/src/main/native/athena/Counter.cpp
@@ -63,7 +63,7 @@ HAL_CounterHandle HAL_InitializeCounter(HAL_Counter_Mode mode, int32_t* index,
   return handle;
 }
 
-void HAL_FreeCounter(HAL_CounterHandle counterHandle, int32_t* status) {
+void HAL_FreeCounter(HAL_CounterHandle counterHandle) {
   counterHandles->Free(counterHandle);
 }
 

--- a/hal/src/main/native/athena/DIO.cpp
+++ b/hal/src/main/native/athena/DIO.cpp
@@ -188,7 +188,7 @@ HAL_DigitalPWMHandle HAL_AllocateDigitalPWM(int32_t* status) {
   return handle;
 }
 
-void HAL_FreeDigitalPWM(HAL_DigitalPWMHandle pwmGenerator, int32_t* status) {
+void HAL_FreeDigitalPWM(HAL_DigitalPWMHandle pwmGenerator) {
   digitalPWMHandles->Free(pwmGenerator);
 }
 

--- a/hal/src/main/native/athena/Encoder.cpp
+++ b/hal/src/main/native/athena/Encoder.cpp
@@ -94,11 +94,9 @@ void Encoder::SetupCounter(HAL_Handle digitalSourceHandleA,
 
 Encoder::~Encoder() {
   if (m_counter != HAL_kInvalidHandle) {
-    int32_t status = 0;
-    HAL_FreeCounter(m_counter, &status);
+    HAL_FreeCounter(m_counter);
   } else {
-    int32_t status = 0;
-    HAL_FreeFPGAEncoder(m_encoder, &status);
+    HAL_FreeFPGAEncoder(m_encoder);
   }
 }
 
@@ -285,7 +283,7 @@ HAL_EncoderHandle HAL_InitializeEncoder(
   return handle;
 }
 
-void HAL_FreeEncoder(HAL_EncoderHandle encoderHandle, int32_t* status) {
+void HAL_FreeEncoder(HAL_EncoderHandle encoderHandle) {
   encoderHandles->Free(encoderHandle);
 }
 

--- a/hal/src/main/native/athena/FPGAEncoder.cpp
+++ b/hal/src/main/native/athena/FPGAEncoder.cpp
@@ -96,8 +96,7 @@ HAL_FPGAEncoderHandle HAL_InitializeFPGAEncoder(
   return handle;
 }
 
-void HAL_FreeFPGAEncoder(HAL_FPGAEncoderHandle fpgaEncoderHandle,
-                         int32_t* status) {
+void HAL_FreeFPGAEncoder(HAL_FPGAEncoderHandle fpgaEncoderHandle) {
   fpgaEncoderHandles->Free(fpgaEncoderHandle);
 }
 

--- a/hal/src/main/native/athena/FPGAEncoder.h
+++ b/hal/src/main/native/athena/FPGAEncoder.h
@@ -15,8 +15,7 @@ HAL_FPGAEncoderHandle HAL_InitializeFPGAEncoder(
     HAL_Handle digitalSourceHandleA, HAL_AnalogTriggerType analogTriggerTypeA,
     HAL_Handle digitalSourceHandleB, HAL_AnalogTriggerType analogTriggerTypeB,
     HAL_Bool reverseDirection, int32_t* index, int32_t* status);
-void HAL_FreeFPGAEncoder(HAL_FPGAEncoderHandle fpgaEncoderHandle,
-                         int32_t* status);
+void HAL_FreeFPGAEncoder(HAL_FPGAEncoderHandle fpgaEncoderHandle);
 
 /**
  * Reset the Encoder distance to zero.

--- a/hal/src/main/native/athena/Notifier.cpp
+++ b/hal/src/main/native/athena/Notifier.cpp
@@ -216,7 +216,7 @@ void HAL_StopNotifier(HAL_NotifierHandle notifierHandle, int32_t* status) {
   notifier->cond.notify_all();  // wake up any waiting threads
 }
 
-void HAL_CleanNotifier(HAL_NotifierHandle notifierHandle, int32_t* status) {
+void HAL_CleanNotifier(HAL_NotifierHandle notifierHandle) {
   auto notifier = notifierHandles->Free(notifierHandle);
   if (!notifier) {
     return;
@@ -236,9 +236,9 @@ void HAL_CleanNotifier(HAL_NotifierHandle notifierHandle, int32_t* status) {
     // the notifier can call back into our callback, so don't hold the lock
     // here (the atomic fetch_sub will prevent multiple parallel entries
     // into this function)
-
+    int32_t status = 0;
     if (notifierAlarm) {
-      notifierAlarm->writeEnable(false, status);
+      notifierAlarm->writeEnable(false, &status);
     }
     notifierRunning = false;
     hal::ReleaseFPGAInterrupt(kTimerInterruptNumber);

--- a/hal/src/main/native/athena/SerialPort.cpp
+++ b/hal/src/main/native/athena/SerialPort.cpp
@@ -141,7 +141,7 @@ HAL_SerialPortHandle HAL_InitializeSerialPortDirect(HAL_SerialPort port,
   return handle;
 }
 
-void HAL_CloseSerial(HAL_SerialPortHandle handle, int32_t* status) {
+void HAL_CloseSerial(HAL_SerialPortHandle handle) {
   auto port = serialPortHandles->Get(handle);
   serialPortHandles->Free(handle);
 

--- a/hal/src/main/native/cpp/jni/AddressableLEDJNI.cpp
+++ b/hal/src/main/native/cpp/jni/AddressableLEDJNI.cpp
@@ -41,7 +41,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_AddressableLEDJNI_free
   (JNIEnv* env, jclass, jint handle)
 {
-  HAL_FreeAddressableLED(static_cast<HAL_AddressableLEDHandle>(handle));
+  if (handle != HAL_kInvalidHandle) {
+    HAL_FreeAddressableLED(static_cast<HAL_AddressableLEDHandle>(handle));
+  }
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/AnalogGyroJNI.cpp
+++ b/hal/src/main/native/cpp/jni/AnalogGyroJNI.cpp
@@ -57,7 +57,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_AnalogGyroJNI_freeAnalogGyro
   (JNIEnv* env, jclass, jint id)
 {
-  HAL_FreeAnalogGyro((HAL_GyroHandle)id);
+  if (id != HAL_kInvalidHandle) {
+    HAL_FreeAnalogGyro((HAL_GyroHandle)id);
+  }
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/AnalogJNI.cpp
+++ b/hal/src/main/native/cpp/jni/AnalogJNI.cpp
@@ -540,9 +540,7 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_AnalogJNI_cleanAnalogTrigger
   (JNIEnv* env, jclass, jint id)
 {
-  int32_t status = 0;
-  HAL_CleanAnalogTrigger((HAL_AnalogTriggerHandle)id, &status);
-  CheckStatus(env, status);
+  HAL_CleanAnalogTrigger((HAL_AnalogTriggerHandle)id);
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/AnalogJNI.cpp
+++ b/hal/src/main/native/cpp/jni/AnalogJNI.cpp
@@ -47,7 +47,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_AnalogJNI_freeAnalogInputPort
   (JNIEnv* env, jclass, jint id)
 {
-  HAL_FreeAnalogInputPort((HAL_AnalogInputHandle)id);
+  if (id != HAL_kInvalidHandle) {
+    HAL_FreeAnalogInputPort((HAL_AnalogInputHandle)id);
+  }
 }
 
 /*
@@ -76,7 +78,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_AnalogJNI_freeAnalogOutputPort
   (JNIEnv* env, jclass, jint id)
 {
-  HAL_FreeAnalogOutputPort((HAL_AnalogOutputHandle)id);
+  if (id != HAL_kInvalidHandle) {
+    HAL_FreeAnalogOutputPort((HAL_AnalogOutputHandle)id);
+  }
 }
 
 /*
@@ -540,7 +544,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_AnalogJNI_cleanAnalogTrigger
   (JNIEnv* env, jclass, jint id)
 {
-  HAL_CleanAnalogTrigger((HAL_AnalogTriggerHandle)id);
+  if (id != HAL_kInvalidHandle) {
+    HAL_CleanAnalogTrigger((HAL_AnalogTriggerHandle)id);
+  }
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/CANAPIJNI.cpp
+++ b/hal/src/main/native/cpp/jni/CANAPIJNI.cpp
@@ -58,7 +58,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_CANAPIJNI_cleanCAN
   (JNIEnv* env, jclass, jint handle)
 {
-  HAL_CleanCAN(static_cast<HAL_CANHandle>(handle));
+  if (handle != HAL_kInvalidHandle) {
+    HAL_CleanCAN(static_cast<HAL_CANHandle>(handle));
+  }
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/CTREPCMJNI.cpp
+++ b/hal/src/main/native/cpp/jni/CTREPCMJNI.cpp
@@ -41,7 +41,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_CTREPCMJNI_free
   (JNIEnv* env, jclass, jint handle)
 {
-  HAL_FreeCTREPCM(handle);
+  if (handle != HAL_kInvalidHandle) {
+    HAL_FreeCTREPCM(handle);
+  }
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/CounterJNI.cpp
+++ b/hal/src/main/native/cpp/jni/CounterJNI.cpp
@@ -53,9 +53,7 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_CounterJNI_freeCounter
   (JNIEnv* env, jclass, jint id)
 {
-  int32_t status = 0;
-  HAL_FreeCounter((HAL_CounterHandle)id, &status);
-  CheckStatus(env, status);
+  HAL_FreeCounter((HAL_CounterHandle)id);
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/CounterJNI.cpp
+++ b/hal/src/main/native/cpp/jni/CounterJNI.cpp
@@ -53,7 +53,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_CounterJNI_freeCounter
   (JNIEnv* env, jclass, jint id)
 {
-  HAL_FreeCounter((HAL_CounterHandle)id);
+  if (id != HAL_kInvalidHandle) {
+    HAL_FreeCounter((HAL_CounterHandle)id);
+  }
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/DIOJNI.cpp
+++ b/hal/src/main/native/cpp/jni/DIOJNI.cpp
@@ -57,7 +57,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_DIOJNI_freeDIOPort
   (JNIEnv* env, jclass, jint id)
 {
-  HAL_FreeDIOPort((HAL_DigitalHandle)id);
+  if (id != HAL_kInvalidHandle) {
+    HAL_FreeDIOPort((HAL_DigitalHandle)id);
+  }
 }
 
 /*
@@ -227,7 +229,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_DIOJNI_freeDigitalPWM
   (JNIEnv* env, jclass, jint id)
 {
-  HAL_FreeDigitalPWM((HAL_DigitalPWMHandle)id);
+  if (id != HAL_kInvalidHandle) {
+    HAL_FreeDigitalPWM((HAL_DigitalPWMHandle)id);
+  }
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/DIOJNI.cpp
+++ b/hal/src/main/native/cpp/jni/DIOJNI.cpp
@@ -227,9 +227,7 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_DIOJNI_freeDigitalPWM
   (JNIEnv* env, jclass, jint id)
 {
-  int32_t status = 0;
-  HAL_FreeDigitalPWM((HAL_DigitalPWMHandle)id, &status);
-  CheckStatus(env, status);
+  HAL_FreeDigitalPWM((HAL_DigitalPWMHandle)id);
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/DMAJNI.cpp
+++ b/hal/src/main/native/cpp/jni/DMAJNI.cpp
@@ -46,7 +46,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_DMAJNI_free
   (JNIEnv* env, jclass, jint handle)
 {
-  HAL_FreeDMA(handle);
+  if (handle != HAL_kInvalidHandle) {
+    HAL_FreeDMA(handle);
+  }
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/DutyCycleJNI.cpp
+++ b/hal/src/main/native/cpp/jni/DutyCycleJNI.cpp
@@ -37,7 +37,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_DutyCycleJNI_free
   (JNIEnv*, jclass, jint handle)
 {
-  HAL_FreeDutyCycle(static_cast<HAL_DutyCycleHandle>(handle));
+  if (handle != HAL_kInvalidHandle) {
+    HAL_FreeDutyCycle(static_cast<HAL_DutyCycleHandle>(handle));
+  }
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/EncoderJNI.cpp
+++ b/hal/src/main/native/cpp/jni/EncoderJNI.cpp
@@ -46,9 +46,7 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_EncoderJNI_freeEncoder
   (JNIEnv* env, jclass, jint id)
 {
-  int32_t status = 0;
-  HAL_FreeEncoder((HAL_EncoderHandle)id, &status);
-  CheckStatus(env, status);
+  HAL_FreeEncoder((HAL_EncoderHandle)id);
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/EncoderJNI.cpp
+++ b/hal/src/main/native/cpp/jni/EncoderJNI.cpp
@@ -46,7 +46,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_EncoderJNI_freeEncoder
   (JNIEnv* env, jclass, jint id)
 {
-  HAL_FreeEncoder((HAL_EncoderHandle)id);
+  if (id != HAL_kInvalidHandle) {
+    HAL_FreeEncoder((HAL_EncoderHandle)id);
+  }
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/I2CJNI.cpp
+++ b/hal/src/main/native/cpp/jni/I2CJNI.cpp
@@ -175,9 +175,7 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_I2CJNI_i2CClose
   (JNIEnv*, jclass, jint port)
 {
-  if (port != HAL_kInvalidHandle) {
-    HAL_CloseI2C(static_cast<HAL_I2CPort>(port));
-  }
+  HAL_CloseI2C(static_cast<HAL_I2CPort>(port));
 }
 
 }  // extern "C"

--- a/hal/src/main/native/cpp/jni/I2CJNI.cpp
+++ b/hal/src/main/native/cpp/jni/I2CJNI.cpp
@@ -175,7 +175,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_I2CJNI_i2CClose
   (JNIEnv*, jclass, jint port)
 {
-  HAL_CloseI2C(static_cast<HAL_I2CPort>(port));
+  if (port != HAL_kInvalidHandle) {
+    HAL_CloseI2C(static_cast<HAL_I2CPort>(port));
+  }
 }
 
 }  // extern "C"

--- a/hal/src/main/native/cpp/jni/InterruptJNI.cpp
+++ b/hal/src/main/native/cpp/jni/InterruptJNI.cpp
@@ -44,7 +44,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_InterruptJNI_cleanInterrupts
   (JNIEnv* env, jclass, jint interruptHandle)
 {
-  HAL_CleanInterrupts((HAL_InterruptHandle)interruptHandle);
+  if (interruptHandle != HAL_kInvalidHandle) {
+    HAL_CleanInterrupts((HAL_InterruptHandle)interruptHandle);
+  }
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/NotifierJNI.cpp
+++ b/hal/src/main/native/cpp/jni/NotifierJNI.cpp
@@ -88,7 +88,9 @@ Java_edu_wpi_first_hal_NotifierJNI_cleanNotifier
   (JNIEnv* env, jclass, jint notifierHandle)
 {
   int32_t status = 0;
-  HAL_CleanNotifier((HAL_NotifierHandle)notifierHandle);
+  if (notifierHandle != HAL_kInvalidHandle) {
+    HAL_CleanNotifier((HAL_NotifierHandle)notifierHandle);
+  }
   CheckStatus(env, status);
 }
 

--- a/hal/src/main/native/cpp/jni/NotifierJNI.cpp
+++ b/hal/src/main/native/cpp/jni/NotifierJNI.cpp
@@ -88,7 +88,7 @@ Java_edu_wpi_first_hal_NotifierJNI_cleanNotifier
   (JNIEnv* env, jclass, jint notifierHandle)
 {
   int32_t status = 0;
-  HAL_CleanNotifier((HAL_NotifierHandle)notifierHandle, &status);
+  HAL_CleanNotifier((HAL_NotifierHandle)notifierHandle);
   CheckStatus(env, status);
 }
 

--- a/hal/src/main/native/cpp/jni/NotifierJNI.cpp
+++ b/hal/src/main/native/cpp/jni/NotifierJNI.cpp
@@ -87,11 +87,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_NotifierJNI_cleanNotifier
   (JNIEnv* env, jclass, jint notifierHandle)
 {
-  int32_t status = 0;
   if (notifierHandle != HAL_kInvalidHandle) {
     HAL_CleanNotifier((HAL_NotifierHandle)notifierHandle);
   }
-  CheckStatus(env, status);
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/PWMJNI.cpp
+++ b/hal/src/main/native/cpp/jni/PWMJNI.cpp
@@ -56,9 +56,7 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_PWMJNI_freePWMPort
   (JNIEnv* env, jclass, jint id)
 {
-  int32_t status = 0;
-  HAL_FreePWMPort((HAL_DigitalHandle)id, &status);
-  CheckStatus(env, status);
+  HAL_FreePWMPort((HAL_DigitalHandle)id);
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/PWMJNI.cpp
+++ b/hal/src/main/native/cpp/jni/PWMJNI.cpp
@@ -56,7 +56,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_PWMJNI_freePWMPort
   (JNIEnv* env, jclass, jint id)
 {
-  HAL_FreePWMPort((HAL_DigitalHandle)id);
+  if (id != HAL_kInvalidHandle) {
+    HAL_FreePWMPort((HAL_DigitalHandle)id);
+  }
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/PowerDistributionJNI.cpp
+++ b/hal/src/main/native/cpp/jni/PowerDistributionJNI.cpp
@@ -51,7 +51,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_PowerDistributionJNI_free
   (JNIEnv*, jclass, jint handle)
 {
-  HAL_CleanPowerDistribution(handle);
+  if (handle != HAL_kInvalidHandle) {
+    HAL_CleanPowerDistribution(handle);
+  }
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/RelayJNI.cpp
+++ b/hal/src/main/native/cpp/jni/RelayJNI.cpp
@@ -44,7 +44,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_RelayJNI_freeRelayPort
   (JNIEnv* env, jclass, jint id)
 {
-  HAL_FreeRelayPort((HAL_RelayHandle)id);
+  if (id != HAL_kInvalidHandle) {
+    HAL_FreeRelayPort((HAL_RelayHandle)id);
+  }
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/SPIJNI.cpp
+++ b/hal/src/main/native/cpp/jni/SPIJNI.cpp
@@ -206,7 +206,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_SPIJNI_spiClose
   (JNIEnv*, jclass, jint port)
 {
-  HAL_CloseSPI(static_cast<HAL_SPIPort>(port));
+  if (port != HAL_kInvalidHandle) {
+    HAL_CloseSPI(static_cast<HAL_SPIPort>(port));
+  }
 }
 
 /*
@@ -298,7 +300,9 @@ Java_edu_wpi_first_hal_SPIJNI_spiFreeAuto
   (JNIEnv* env, jclass, jint port)
 {
   int32_t status = 0;
-  HAL_FreeSPIAuto(static_cast<HAL_SPIPort>(port), &status);
+  if (port != HAL_kInvalidHandle) {
+    HAL_FreeSPIAuto(static_cast<HAL_SPIPort>(port), &status);
+  }
   CheckStatus(env, status);
 }
 

--- a/hal/src/main/native/cpp/jni/SPIJNI.cpp
+++ b/hal/src/main/native/cpp/jni/SPIJNI.cpp
@@ -206,9 +206,7 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_SPIJNI_spiClose
   (JNIEnv*, jclass, jint port)
 {
-  if (port != HAL_kInvalidHandle) {
-    HAL_CloseSPI(static_cast<HAL_SPIPort>(port));
-  }
+  HAL_CloseSPI(static_cast<HAL_SPIPort>(port));
 }
 
 /*

--- a/hal/src/main/native/cpp/jni/SerialPortJNI.cpp
+++ b/hal/src/main/native/cpp/jni/SerialPortJNI.cpp
@@ -306,7 +306,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_SerialPortJNI_serialClose
   (JNIEnv* env, jclass, jint handle)
 {
-  HAL_CloseSerial(static_cast<HAL_SerialPortHandle>(handle));
+  if (handle != HAL_kInvalidHandle) {
+    HAL_CloseSerial(static_cast<HAL_SerialPortHandle>(handle));
+  }
 }
 
 }  // extern "C"

--- a/hal/src/main/native/cpp/jni/SerialPortJNI.cpp
+++ b/hal/src/main/native/cpp/jni/SerialPortJNI.cpp
@@ -306,9 +306,7 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_SerialPortJNI_serialClose
   (JNIEnv* env, jclass, jint handle)
 {
-  int32_t status = 0;
-  HAL_CloseSerial(static_cast<HAL_SerialPortHandle>(handle), &status);
-  CheckStatus(env, status);
+  HAL_CloseSerial(static_cast<HAL_SerialPortHandle>(handle));
 }
 
 }  // extern "C"

--- a/hal/src/main/native/cpp/jni/SimDeviceJNI.cpp
+++ b/hal/src/main/native/cpp/jni/SimDeviceJNI.cpp
@@ -60,7 +60,9 @@ JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_SimDeviceJNI_freeSimDevice
   (JNIEnv*, jclass, jint handle)
 {
-  HAL_FreeSimDevice(handle);
+  if (handle != HAL_kInvalidHandle) {
+    HAL_FreeSimDevice(handle);
+  }
 }
 
 /*

--- a/hal/src/main/native/include/hal/AnalogTrigger.h
+++ b/hal/src/main/native/include/hal/AnalogTrigger.h
@@ -52,10 +52,8 @@ HAL_AnalogTriggerHandle HAL_InitializeAnalogTriggerDutyCycle(
  * Frees an analog trigger.
  *
  * @param[in] analogTriggerHandle the trigger handle
- * @param[out] status Error status variable. 0 on success.
  */
-void HAL_CleanAnalogTrigger(HAL_AnalogTriggerHandle analogTriggerHandle,
-                            int32_t* status);
+void HAL_CleanAnalogTrigger(HAL_AnalogTriggerHandle analogTriggerHandle);
 
 /**
  * Sets the raw ADC upper and lower limits of the analog trigger.

--- a/hal/src/main/native/include/hal/Counter.h
+++ b/hal/src/main/native/include/hal/Counter.h
@@ -48,9 +48,8 @@ HAL_CounterHandle HAL_InitializeCounter(HAL_Counter_Mode mode, int32_t* index,
  * Frees a counter.
  *
  * @param[in] counterHandle the counter handle
- * @param[out] status       Error status variable. 0 on success.
  */
-void HAL_FreeCounter(HAL_CounterHandle counterHandle, int32_t* status);
+void HAL_FreeCounter(HAL_CounterHandle counterHandle);
 
 /**
  * Sets the average sample size of a counter.

--- a/hal/src/main/native/include/hal/DIO.h
+++ b/hal/src/main/native/include/hal/DIO.h
@@ -68,9 +68,8 @@ HAL_DigitalPWMHandle HAL_AllocateDigitalPWM(int32_t* status);
  * Frees the resource associated with a DO PWM generator.
  *
  * @param[in] pwmGenerator the digital PWM handle
- * @param[out] status Error status variable. 0 on success.
  */
-void HAL_FreeDigitalPWM(HAL_DigitalPWMHandle pwmGenerator, int32_t* status);
+void HAL_FreeDigitalPWM(HAL_DigitalPWMHandle pwmGenerator);
 
 /**
  * Changes the frequency of the DO PWM generator.

--- a/hal/src/main/native/include/hal/Encoder.h
+++ b/hal/src/main/native/include/hal/Encoder.h
@@ -65,9 +65,8 @@ HAL_EncoderHandle HAL_InitializeEncoder(
  * Frees an encoder.
  *
  * @param[in] encoderHandle the encoder handle
- * @param[out] status Error status variable. 0 on success.
  */
-void HAL_FreeEncoder(HAL_EncoderHandle encoderHandle, int32_t* status);
+void HAL_FreeEncoder(HAL_EncoderHandle encoderHandle);
 
 /**
  * Indicates the encoder is used by a simulated device.

--- a/hal/src/main/native/include/hal/I2CTypes.h
+++ b/hal/src/main/native/include/hal/I2CTypes.h
@@ -27,7 +27,7 @@ namespace hal {
  * A move-only C++ wrapper around HAL_I2CPort.
  * Does not ensure destruction.
  */
-using I2CPort = Handle<HAL_I2CPort, HAL_I2C_kInvalid>;
+using I2CPort = Handle<HAL_I2CPort, nullptr, HAL_I2C_kInvalid>;
 
 }  // namespace hal
 #endif

--- a/hal/src/main/native/include/hal/Notifier.h
+++ b/hal/src/main/native/include/hal/Notifier.h
@@ -77,9 +77,8 @@ void HAL_StopNotifier(HAL_NotifierHandle notifierHandle, int32_t* status);
  * Note this also stops a notifier if it is already running.
  *
  * @param[in] notifierHandle the notifier handle
- * @param[out] status Error status variable. 0 on success.
  */
-void HAL_CleanNotifier(HAL_NotifierHandle notifierHandle, int32_t* status);
+void HAL_CleanNotifier(HAL_NotifierHandle notifierHandle);
 
 /**
  * Updates the trigger time for a notifier.

--- a/hal/src/main/native/include/hal/PWM.h
+++ b/hal/src/main/native/include/hal/PWM.h
@@ -35,9 +35,8 @@ HAL_DigitalHandle HAL_InitializePWMPort(HAL_PortHandle portHandle,
  * Frees a PWM port.
  *
  * @param[in] pwmPortHandle the pwm handle
- * @param[out] status       Error status variable. 0 on success.
  */
-void HAL_FreePWMPort(HAL_DigitalHandle pwmPortHandle, int32_t* status);
+void HAL_FreePWMPort(HAL_DigitalHandle pwmPortHandle);
 
 /**
  * Checks if a pwm channel is valid.

--- a/hal/src/main/native/include/hal/SPITypes.h
+++ b/hal/src/main/native/include/hal/SPITypes.h
@@ -49,7 +49,7 @@ namespace hal {
  * A move-only C++ wrapper around HAL_SPIPort.
  * Does not ensure destruction.
  */
-using SPIPort = Handle<HAL_SPIPort, HAL_SPI_kInvalid>;
+using SPIPort = Handle<HAL_SPIPort, nullptr, HAL_SPI_kInvalid>;
 
 }  // namespace hal
 #endif

--- a/hal/src/main/native/include/hal/SerialPort.h
+++ b/hal/src/main/native/include/hal/SerialPort.h
@@ -255,9 +255,8 @@ void HAL_ClearSerial(HAL_SerialPortHandle handle, int32_t* status);
  * Closes a serial port.
  *
  * @param[in] handle  the serial port handle to close
- * @param[out] status the error code, or 0 for success
  */
-void HAL_CloseSerial(HAL_SerialPortHandle handle, int32_t* status);
+void HAL_CloseSerial(HAL_SerialPortHandle handle);
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/hal/src/main/native/include/hal/Types.h
+++ b/hal/src/main/native/include/hal/Types.h
@@ -110,6 +110,11 @@ class Handle {
   }
 
   ~Handle() {
+// FIXME: GCC gives the false positive "the address of <GetDefault> will never
+// be NULL" because it doesn't realize the default template parameter can make
+// GetDefault nullptr. Fixed in GCC 13.
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94554
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105885
 #if __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Waddress"

--- a/hal/src/main/native/include/hal/Types.h
+++ b/hal/src/main/native/include/hal/Types.h
@@ -87,12 +87,12 @@ typedef int32_t HAL_Bool;
 
 #ifdef __cplusplus
 namespace hal {
-
 /**
  * A move-only C++ wrapper around a HAL handle.
- * Does not ensure destruction.
+ * Will free the handle if FreeFunction is provided
  */
-template <typename CType, int32_t CInvalid = HAL_kInvalidHandle>
+template <typename CType, void (*FreeFunction)(CType) = nullptr,
+          int32_t CInvalid = HAL_kInvalidHandle>
 class Handle {
  public:
   Handle() = default;
@@ -107,6 +107,21 @@ class Handle {
     m_handle = rhs.m_handle;
     rhs.m_handle = CInvalid;
     return *this;
+  }
+
+  ~Handle() {
+#if __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress"
+#endif  // __GNUC__
+    if constexpr (FreeFunction != nullptr) {
+#if __GNUC__
+#pragma GCC diagnostic pop
+#endif  // __GNUC__
+      if (m_handle != CInvalid) {
+        FreeFunction(m_handle);
+      }
+    }
   }
 
   operator CType() const { return m_handle; }  // NOLINT

--- a/hal/src/main/native/sim/AnalogTrigger.cpp
+++ b/hal/src/main/native/sim/AnalogTrigger.cpp
@@ -93,8 +93,7 @@ HAL_AnalogTriggerHandle HAL_InitializeAnalogTriggerDutyCycle(
   return HAL_kInvalidHandle;
 }
 
-void HAL_CleanAnalogTrigger(HAL_AnalogTriggerHandle analogTriggerHandle,
-                            int32_t* status) {
+void HAL_CleanAnalogTrigger(HAL_AnalogTriggerHandle analogTriggerHandle) {
   auto trigger = analogTriggerHandles->Get(analogTriggerHandle);
   analogTriggerHandles->Free(analogTriggerHandle);
   if (trigger == nullptr) {

--- a/hal/src/main/native/sim/Counter.cpp
+++ b/hal/src/main/native/sim/Counter.cpp
@@ -31,7 +31,7 @@ HAL_CounterHandle HAL_InitializeCounter(HAL_Counter_Mode mode, int32_t* index,
   hal::init::CheckInit();
   return 0;
 }
-void HAL_FreeCounter(HAL_CounterHandle counterHandle, int32_t* status) {}
+void HAL_FreeCounter(HAL_CounterHandle counterHandle) {}
 void HAL_SetCounterAverageSize(HAL_CounterHandle counterHandle, int32_t size,
                                int32_t* status) {}
 void HAL_SetCounterUpSource(HAL_CounterHandle counterHandle,

--- a/hal/src/main/native/sim/DIO.cpp
+++ b/hal/src/main/native/sim/DIO.cpp
@@ -113,7 +113,7 @@ HAL_DigitalPWMHandle HAL_AllocateDigitalPWM(int32_t* status) {
   return handle;
 }
 
-void HAL_FreeDigitalPWM(HAL_DigitalPWMHandle pwmGenerator, int32_t* status) {
+void HAL_FreeDigitalPWM(HAL_DigitalPWMHandle pwmGenerator) {
   auto port = digitalPWMHandles->Get(pwmGenerator);
   digitalPWMHandles->Free(pwmGenerator);
   if (port == nullptr) {

--- a/hal/src/main/native/sim/Encoder.cpp
+++ b/hal/src/main/native/sim/Encoder.cpp
@@ -113,7 +113,7 @@ HAL_EncoderHandle HAL_InitializeEncoder(
   return handle;
 }
 
-void HAL_FreeEncoder(HAL_EncoderHandle encoderHandle, int32_t* status) {
+void HAL_FreeEncoder(HAL_EncoderHandle encoderHandle) {
   auto encoder = encoderHandles->Get(encoderHandle);
   encoderHandles->Free(encoderHandle);
   if (encoder == nullptr) {

--- a/hal/src/main/native/sim/Notifier.cpp
+++ b/hal/src/main/native/sim/Notifier.cpp
@@ -204,7 +204,7 @@ void HAL_StopNotifier(HAL_NotifierHandle notifierHandle, int32_t* status) {
   notifier->cond.notify_all();
 }
 
-void HAL_CleanNotifier(HAL_NotifierHandle notifierHandle, int32_t* status) {
+void HAL_CleanNotifier(HAL_NotifierHandle notifierHandle) {
   auto notifier = notifierHandles->Free(notifierHandle);
   if (!notifier) {
     return;

--- a/hal/src/main/native/sim/PWM.cpp
+++ b/hal/src/main/native/sim/PWM.cpp
@@ -111,10 +111,9 @@ HAL_DigitalHandle HAL_InitializePWMPort(HAL_PortHandle portHandle,
 
   return handle;
 }
-void HAL_FreePWMPort(HAL_DigitalHandle pwmPortHandle, int32_t* status) {
+void HAL_FreePWMPort(HAL_DigitalHandle pwmPortHandle) {
   auto port = digitalChannelHandles->Get(pwmPortHandle, HAL_HandleEnum::PWM);
   if (port == nullptr) {
-    *status = HAL_HANDLE_ERROR;
     return;
   }
 

--- a/hal/src/main/native/sim/SerialPort.cpp
+++ b/hal/src/main/native/sim/SerialPort.cpp
@@ -80,5 +80,5 @@ void HAL_FlushSerial(HAL_SerialPortHandle handle, int32_t* status) {}
 
 void HAL_ClearSerial(HAL_SerialPortHandle handle, int32_t* status) {}
 
-void HAL_CloseSerial(HAL_SerialPortHandle handle, int32_t* status) {}
+void HAL_CloseSerial(HAL_SerialPortHandle handle) {}
 }  // extern "C"

--- a/wpilibc/src/main/native/cpp/AddressableLED.cpp
+++ b/wpilibc/src/main/native/cpp/AddressableLED.cpp
@@ -35,11 +35,6 @@ AddressableLED::AddressableLED(int port) : m_port{port} {
   HAL_Report(HALUsageReporting::kResourceType_AddressableLEDs, port + 1);
 }
 
-AddressableLED::~AddressableLED() {
-  HAL_FreeAddressableLED(m_handle);
-  HAL_FreePWMPort(m_pwmHandle);
-}
-
 void AddressableLED::SetLength(int length) {
   int32_t status = 0;
   HAL_SetAddressableLEDLength(m_handle, length, &status);

--- a/wpilibc/src/main/native/cpp/AddressableLED.cpp
+++ b/wpilibc/src/main/native/cpp/AddressableLED.cpp
@@ -29,7 +29,7 @@ AddressableLED::AddressableLED(int port) : m_port{port} {
   m_handle = HAL_InitializeAddressableLED(m_pwmHandle, &status);
   FRC_CheckErrorStatus(status, "Port {}", port);
   if (m_handle == HAL_kInvalidHandle) {
-    HAL_FreePWMPort(m_pwmHandle, &status);
+    HAL_FreePWMPort(m_pwmHandle);
   }
 
   HAL_Report(HALUsageReporting::kResourceType_AddressableLEDs, port + 1);
@@ -37,9 +37,7 @@ AddressableLED::AddressableLED(int port) : m_port{port} {
 
 AddressableLED::~AddressableLED() {
   HAL_FreeAddressableLED(m_handle);
-  int32_t status = 0;
-  HAL_FreePWMPort(m_pwmHandle, &status);
-  FRC_ReportError(status, "Port {}", m_port);
+  HAL_FreePWMPort(m_pwmHandle);
 }
 
 void AddressableLED::SetLength(int length) {

--- a/wpilibc/src/main/native/cpp/AnalogGyro.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogGyro.cpp
@@ -58,10 +58,6 @@ AnalogGyro::AnalogGyro(std::shared_ptr<AnalogInput> channel, int center,
   Reset();
 }
 
-AnalogGyro::~AnalogGyro() {
-  HAL_FreeAnalogGyro(m_gyroHandle);
-}
-
 double AnalogGyro::GetAngle() const {
   int32_t status = 0;
   double value = HAL_GetAnalogGyroAngle(m_gyroHandle, &status);

--- a/wpilibc/src/main/native/cpp/AnalogInput.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogInput.cpp
@@ -37,10 +37,6 @@ AnalogInput::AnalogInput(int channel) {
   wpi::SendableRegistry::AddLW(this, "AnalogInput", channel);
 }
 
-AnalogInput::~AnalogInput() {
-  HAL_FreeAnalogInputPort(m_port);
-}
-
 int AnalogInput::GetValue() const {
   int32_t status = 0;
   int value = HAL_GetAnalogValue(m_port, &status);

--- a/wpilibc/src/main/native/cpp/AnalogOutput.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogOutput.cpp
@@ -37,10 +37,6 @@ AnalogOutput::AnalogOutput(int channel) {
   wpi::SendableRegistry::AddLW(this, "AnalogOutput", m_channel);
 }
 
-AnalogOutput::~AnalogOutput() {
-  HAL_FreeAnalogOutputPort(m_port);
-}
-
 void AnalogOutput::SetVoltage(double voltage) {
   int32_t status = 0;
   HAL_SetAnalogOutput(m_port, voltage, &status);

--- a/wpilibc/src/main/native/cpp/AnalogTrigger.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogTrigger.cpp
@@ -58,9 +58,7 @@ AnalogTrigger::AnalogTrigger(std::shared_ptr<DutyCycle> input)
 }
 
 AnalogTrigger::~AnalogTrigger() {
-  int32_t status = 0;
-  HAL_CleanAnalogTrigger(m_trigger, &status);
-  FRC_ReportError(status, "Channel {}", GetSourceChannel());
+  HAL_CleanAnalogTrigger(m_trigger);
 }
 
 void AnalogTrigger::SetLimitsVoltage(double lower, double upper) {

--- a/wpilibc/src/main/native/cpp/AnalogTrigger.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogTrigger.cpp
@@ -57,10 +57,6 @@ AnalogTrigger::AnalogTrigger(std::shared_ptr<DutyCycle> input)
   wpi::SendableRegistry::AddLW(this, "AnalogTrigger", index);
 }
 
-AnalogTrigger::~AnalogTrigger() {
-  HAL_CleanAnalogTrigger(m_trigger);
-}
-
 void AnalogTrigger::SetLimitsVoltage(double lower, double upper) {
   int32_t status = 0;
   HAL_SetAnalogTriggerLimitsVoltage(m_trigger, lower, upper, &status);

--- a/wpilibc/src/main/native/cpp/CAN.cpp
+++ b/wpilibc/src/main/native/cpp/CAN.cpp
@@ -35,13 +35,6 @@ CAN::CAN(int deviceId, int deviceManufacturer, int deviceType) {
   HAL_Report(HALUsageReporting::kResourceType_CAN, deviceId + 1);
 }
 
-CAN::~CAN() {
-  if (m_handle != HAL_kInvalidHandle) {
-    HAL_CleanCAN(m_handle);
-    m_handle = HAL_kInvalidHandle;
-  }
-}
-
 void CAN::WritePacket(const uint8_t* data, int length, int apiId) {
   int32_t status = 0;
   HAL_WriteCANPacket(m_handle, data, length, apiId, &status);

--- a/wpilibc/src/main/native/cpp/Counter.cpp
+++ b/wpilibc/src/main/native/cpp/Counter.cpp
@@ -89,8 +89,6 @@ Counter::~Counter() {
   } catch (const RuntimeError& e) {
     e.Report();
   }
-
-  HAL_FreeCounter(m_counter);
 }
 
 void Counter::SetUpSource(int channel) {

--- a/wpilibc/src/main/native/cpp/Counter.cpp
+++ b/wpilibc/src/main/native/cpp/Counter.cpp
@@ -90,9 +90,7 @@ Counter::~Counter() {
     e.Report();
   }
 
-  int32_t status = 0;
-  HAL_FreeCounter(m_counter, &status);
-  FRC_ReportError(status, "Counter destructor");
+  HAL_FreeCounter(m_counter);
 }
 
 void Counter::SetUpSource(int channel) {

--- a/wpilibc/src/main/native/cpp/DMA.cpp
+++ b/wpilibc/src/main/native/cpp/DMA.cpp
@@ -30,10 +30,6 @@ DMA::DMA() {
   FRC_CheckErrorStatus(status, "InitializeDMA");
 }
 
-DMA::~DMA() {
-  HAL_FreeDMA(dmaHandle);
-}
-
 void DMA::SetPause(bool pause) {
   int32_t status = 0;
   HAL_SetDMAPause(dmaHandle, pause, &status);

--- a/wpilibc/src/main/native/cpp/DigitalInput.cpp
+++ b/wpilibc/src/main/native/cpp/DigitalInput.cpp
@@ -35,10 +35,6 @@ DigitalInput::DigitalInput(int channel) {
   wpi::SendableRegistry::AddLW(this, "DigitalInput", channel);
 }
 
-DigitalInput::~DigitalInput() {
-  HAL_FreeDIOPort(m_handle);
-}
-
 bool DigitalInput::Get() const {
   int32_t status = 0;
   bool value = HAL_GetDIO(m_handle, &status);

--- a/wpilibc/src/main/native/cpp/DigitalOutput.cpp
+++ b/wpilibc/src/main/native/cpp/DigitalOutput.cpp
@@ -43,8 +43,6 @@ DigitalOutput::~DigitalOutput() {
   } catch (const RuntimeError& e) {
     e.Report();
   }
-
-  HAL_FreeDIOPort(m_handle);
 }
 
 void DigitalOutput::Set(bool value) {

--- a/wpilibc/src/main/native/cpp/DigitalOutput.cpp
+++ b/wpilibc/src/main/native/cpp/DigitalOutput.cpp
@@ -141,8 +141,7 @@ void DigitalOutput::DisablePWM() {
                                  &status);
   FRC_CheckErrorStatus(status, "Channel {}", m_channel);
 
-  HAL_FreeDigitalPWM(m_pwmGenerator, &status);
-  FRC_CheckErrorStatus(status, "Channel {}", m_channel);
+  HAL_FreeDigitalPWM(m_pwmGenerator);
 
   m_pwmGenerator = HAL_kInvalidHandle;
 }

--- a/wpilibc/src/main/native/cpp/DutyCycle.cpp
+++ b/wpilibc/src/main/native/cpp/DutyCycle.cpp
@@ -35,10 +35,6 @@ DutyCycle::DutyCycle(std::shared_ptr<DigitalSource> source)
   InitDutyCycle();
 }
 
-DutyCycle::~DutyCycle() {
-  HAL_FreeDutyCycle(m_handle);
-}
-
 void DutyCycle::InitDutyCycle() {
   int32_t status = 0;
   m_handle =

--- a/wpilibc/src/main/native/cpp/Encoder.cpp
+++ b/wpilibc/src/main/native/cpp/Encoder.cpp
@@ -60,9 +60,7 @@ Encoder::Encoder(std::shared_ptr<DigitalSource> aSource,
 }
 
 Encoder::~Encoder() {
-  int32_t status = 0;
-  HAL_FreeEncoder(m_encoder, &status);
-  FRC_ReportError(status, "FreeEncoder");
+  HAL_FreeEncoder(m_encoder);
 }
 
 int Encoder::Get() const {

--- a/wpilibc/src/main/native/cpp/Encoder.cpp
+++ b/wpilibc/src/main/native/cpp/Encoder.cpp
@@ -59,10 +59,6 @@ Encoder::Encoder(std::shared_ptr<DigitalSource> aSource,
   InitEncoder(reverseDirection, encodingType);
 }
 
-Encoder::~Encoder() {
-  HAL_FreeEncoder(m_encoder);
-}
-
 int Encoder::Get() const {
   int32_t status = 0;
   int value = HAL_GetEncoder(m_encoder, &status);

--- a/wpilibc/src/main/native/cpp/I2C.cpp
+++ b/wpilibc/src/main/native/cpp/I2C.cpp
@@ -31,10 +31,6 @@ I2C::I2C(Port port, int deviceAddress)
   HAL_Report(HALUsageReporting::kResourceType_I2C, deviceAddress);
 }
 
-I2C::~I2C() {
-  HAL_CloseI2C(m_port);
-}
-
 I2C::Port I2C::GetPort() const {
   return static_cast<Port>(static_cast<int>(m_port));
 }

--- a/wpilibc/src/main/native/cpp/Notifier.cpp
+++ b/wpilibc/src/main/native/cpp/Notifier.cpp
@@ -128,7 +128,7 @@ Notifier::~Notifier() {
     m_thread.join();
   }
 
-  HAL_CleanNotifier(handle, &status);
+  HAL_CleanNotifier(handle);
 }
 
 Notifier::Notifier(Notifier&& rhs)

--- a/wpilibc/src/main/native/cpp/PWM.cpp
+++ b/wpilibc/src/main/native/cpp/PWM.cpp
@@ -50,8 +50,7 @@ PWM::~PWM() {
   HAL_SetPWMDisabled(m_handle, &status);
   FRC_ReportError(status, "Channel {}", m_channel);
 
-  HAL_FreePWMPort(m_handle, &status);
-  FRC_ReportError(status, "Channel {}", m_channel);
+  HAL_FreePWMPort(m_handle);
 }
 
 void PWM::SetPulseTime(units::microsecond_t time) {

--- a/wpilibc/src/main/native/cpp/PWM.cpp
+++ b/wpilibc/src/main/native/cpp/PWM.cpp
@@ -46,11 +46,8 @@ PWM::PWM(int channel, bool registerSendable) {
 
 PWM::~PWM() {
   int32_t status = 0;
-
   HAL_SetPWMDisabled(m_handle, &status);
   FRC_ReportError(status, "Channel {}", m_channel);
-
-  HAL_FreePWMPort(m_handle);
 }
 
 void PWM::SetPulseTime(units::microsecond_t time) {

--- a/wpilibc/src/main/native/cpp/PowerDistribution.cpp
+++ b/wpilibc/src/main/native/cpp/PowerDistribution.cpp
@@ -57,13 +57,6 @@ PowerDistribution::PowerDistribution(int module, ModuleType moduleType) {
   wpi::SendableRegistry::AddLW(this, "PowerDistribution", m_module);
 }
 
-PowerDistribution::~PowerDistribution() {
-  if (m_handle != HAL_kInvalidHandle) {
-    HAL_CleanPowerDistribution(m_handle);
-    m_handle = HAL_kInvalidHandle;
-  }
-}
-
 int PowerDistribution::GetNumChannels() const {
   int32_t status = 0;
   int32_t size = HAL_GetPowerDistributionNumChannels(m_handle, &status);

--- a/wpilibc/src/main/native/cpp/Relay.cpp
+++ b/wpilibc/src/main/native/cpp/Relay.cpp
@@ -63,13 +63,6 @@ Relay::~Relay() {
   int32_t status = 0;
   HAL_SetRelay(m_forwardHandle, false, &status);
   HAL_SetRelay(m_reverseHandle, false, &status);
-  // ignore errors, as we want to make sure a free happens.
-  if (m_forwardHandle != HAL_kInvalidHandle) {
-    HAL_FreeRelayPort(m_forwardHandle);
-  }
-  if (m_reverseHandle != HAL_kInvalidHandle) {
-    HAL_FreeRelayPort(m_reverseHandle);
-  }
 }
 
 void Relay::Set(Relay::Value value) {

--- a/wpilibc/src/main/native/cpp/SPI.cpp
+++ b/wpilibc/src/main/native/cpp/SPI.cpp
@@ -165,9 +165,7 @@ SPI::SPI(Port port) : m_port(static_cast<HAL_SPIPort>(port)) {
              static_cast<uint8_t>(port) + 1);
 }
 
-SPI::~SPI() {
-  HAL_CloseSPI(m_port);
-}
+SPI::~SPI() = default;
 
 SPI::Port SPI::GetPort() const {
   return static_cast<Port>(static_cast<int>(m_port));

--- a/wpilibc/src/main/native/cpp/SerialPort.cpp
+++ b/wpilibc/src/main/native/cpp/SerialPort.cpp
@@ -74,10 +74,6 @@ SerialPort::SerialPort(int baudRate, std::string_view portName, Port port,
              static_cast<uint8_t>(port) + 1);
 }
 
-SerialPort::~SerialPort() {
-  HAL_CloseSerial(m_portHandle);
-}
-
 void SerialPort::SetFlowControl(SerialPort::FlowControl flowControl) {
   int32_t status = 0;
   HAL_SetSerialFlowControl(m_portHandle, flowControl, &status);

--- a/wpilibc/src/main/native/cpp/SerialPort.cpp
+++ b/wpilibc/src/main/native/cpp/SerialPort.cpp
@@ -75,9 +75,7 @@ SerialPort::SerialPort(int baudRate, std::string_view portName, Port port,
 }
 
 SerialPort::~SerialPort() {
-  int32_t status = 0;
-  HAL_CloseSerial(m_portHandle, &status);
-  FRC_ReportError(status, "CloseSerial");
+  HAL_CloseSerial(m_portHandle);
 }
 
 void SerialPort::SetFlowControl(SerialPort::FlowControl flowControl) {

--- a/wpilibc/src/main/native/cpp/SynchronousInterrupt.cpp
+++ b/wpilibc/src/main/native/cpp/SynchronousInterrupt.cpp
@@ -49,10 +49,6 @@ void SynchronousInterrupt::InitSynchronousInterrupt() {
   FRC_CheckErrorStatus(status, "Interrupt setting up source edge failed");
 }
 
-SynchronousInterrupt::~SynchronousInterrupt() {
-  HAL_CleanInterrupts(m_handle);
-}
-
 inline SynchronousInterrupt::WaitResult operator|(
     SynchronousInterrupt::WaitResult lhs,
     SynchronousInterrupt::WaitResult rhs) {

--- a/wpilibc/src/main/native/cpp/TimedRobot.cpp
+++ b/wpilibc/src/main/native/cpp/TimedRobot.cpp
@@ -95,7 +95,7 @@ TimedRobot::~TimedRobot() {
   HAL_StopNotifier(m_notifier, &status);
   FRC_ReportError(status, "StopNotifier");
 
-  HAL_CleanNotifier(m_notifier, &status);
+  HAL_CleanNotifier(m_notifier);
 }
 
 void TimedRobot::AddPeriodic(std::function<void()> callback,

--- a/wpilibc/src/main/native/cpp/TimedRobot.cpp
+++ b/wpilibc/src/main/native/cpp/TimedRobot.cpp
@@ -94,8 +94,6 @@ TimedRobot::~TimedRobot() {
 
   HAL_StopNotifier(m_notifier, &status);
   FRC_ReportError(status, "StopNotifier");
-
-  HAL_CleanNotifier(m_notifier);
 }
 
 void TimedRobot::AddPeriodic(std::function<void()> callback,

--- a/wpilibc/src/main/native/cpp/Watchdog.cpp
+++ b/wpilibc/src/main/native/cpp/Watchdog.cpp
@@ -65,7 +65,7 @@ Watchdog::Impl::~Impl() {
     m_thread.join();
   }
 
-  HAL_CleanNotifier(handle, &status);
+  HAL_CleanNotifier(handle);
 }
 
 void Watchdog::Impl::UpdateAlarm() {

--- a/wpilibc/src/main/native/cpp/counter/ExternalDirectionCounter.cpp
+++ b/wpilibc/src/main/native/cpp/counter/ExternalDirectionCounter.cpp
@@ -62,8 +62,7 @@ ExternalDirectionCounter::ExternalDirectionCounter(
 }
 
 ExternalDirectionCounter::~ExternalDirectionCounter() {
-  int32_t status = 0;
-  HAL_FreeCounter(m_handle, &status);
+  HAL_FreeCounter(m_handle);
 }
 
 int ExternalDirectionCounter::GetCount() const {

--- a/wpilibc/src/main/native/cpp/counter/ExternalDirectionCounter.cpp
+++ b/wpilibc/src/main/native/cpp/counter/ExternalDirectionCounter.cpp
@@ -61,10 +61,6 @@ ExternalDirectionCounter::ExternalDirectionCounter(
   wpi::SendableRegistry::AddLW(this, "External Direction Counter", m_index);
 }
 
-ExternalDirectionCounter::~ExternalDirectionCounter() {
-  HAL_FreeCounter(m_handle);
-}
-
 int ExternalDirectionCounter::GetCount() const {
   int32_t status = 0;
   int val = HAL_GetCounter(m_handle, &status);

--- a/wpilibc/src/main/native/cpp/counter/Tachometer.cpp
+++ b/wpilibc/src/main/native/cpp/counter/Tachometer.cpp
@@ -37,10 +37,6 @@ Tachometer::Tachometer(std::shared_ptr<DigitalSource> source) {
   wpi::SendableRegistry::AddLW(this, "Tachometer", m_index);
 }
 
-Tachometer::~Tachometer() {
-  HAL_FreeCounter(m_handle);
-}
-
 units::hertz_t Tachometer::GetFrequency() const {
   auto period = GetPeriod();
   if (period.value() == 0) {

--- a/wpilibc/src/main/native/cpp/counter/Tachometer.cpp
+++ b/wpilibc/src/main/native/cpp/counter/Tachometer.cpp
@@ -38,8 +38,7 @@ Tachometer::Tachometer(std::shared_ptr<DigitalSource> source) {
 }
 
 Tachometer::~Tachometer() {
-  int32_t status = 0;
-  HAL_FreeCounter(m_handle, &status);
+  HAL_FreeCounter(m_handle);
 }
 
 units::hertz_t Tachometer::GetFrequency() const {

--- a/wpilibc/src/main/native/cpp/counter/UpDownCounter.cpp
+++ b/wpilibc/src/main/native/cpp/counter/UpDownCounter.cpp
@@ -55,10 +55,6 @@ UpDownCounter::UpDownCounter(std::shared_ptr<DigitalSource> upSource,
   wpi::SendableRegistry::AddLW(this, "UpDown Counter", m_index);
 }
 
-UpDownCounter::~UpDownCounter() {
-  HAL_FreeCounter(m_handle);
-}
-
 int UpDownCounter::GetCount() const {
   int32_t status = 0;
   int val = HAL_GetCounter(m_handle, &status);

--- a/wpilibc/src/main/native/cpp/counter/UpDownCounter.cpp
+++ b/wpilibc/src/main/native/cpp/counter/UpDownCounter.cpp
@@ -56,8 +56,7 @@ UpDownCounter::UpDownCounter(std::shared_ptr<DigitalSource> upSource,
 }
 
 UpDownCounter::~UpDownCounter() {
-  int32_t status = 0;
-  HAL_FreeCounter(m_handle, &status);
+  HAL_FreeCounter(m_handle);
 }
 
 int UpDownCounter::GetCount() const {

--- a/wpilibc/src/main/native/include/frc/AddressableLED.h
+++ b/wpilibc/src/main/native/include/frc/AddressableLED.h
@@ -7,7 +7,9 @@
 #include <initializer_list>
 #include <span>
 
+#include <hal/AddressableLED.h>
 #include <hal/AddressableLEDTypes.h>
+#include <hal/PWM.h>
 #include <hal/Types.h>
 #include <units/time.h>
 
@@ -93,8 +95,6 @@ class AddressableLED {
   AddressableLED(AddressableLED&&) = default;
   AddressableLED& operator=(AddressableLED&&) = default;
 
-  ~AddressableLED();
-
   /**
    * Sets the length of the LED strip.
    *
@@ -165,8 +165,8 @@ class AddressableLED {
   void Stop();
 
  private:
-  hal::Handle<HAL_DigitalHandle> m_pwmHandle;
-  hal::Handle<HAL_AddressableLEDHandle> m_handle;
+  hal::Handle<HAL_DigitalHandle, HAL_FreePWMPort> m_pwmHandle;
+  hal::Handle<HAL_AddressableLEDHandle, HAL_FreeAddressableLED> m_handle;
   int m_port;
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/AnalogGyro.h
+++ b/wpilibc/src/main/native/include/frc/AnalogGyro.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include <hal/AnalogGyro.h>
 #include <hal/Types.h>
 #include <wpi/sendable/Sendable.h>
 #include <wpi/sendable/SendableHelper.h>
@@ -100,10 +101,10 @@ class AnalogGyro : public wpi::Sendable,
    */
   AnalogGyro(std::shared_ptr<AnalogInput> channel, int center, double offset);
 
-  ~AnalogGyro() override;
-
   AnalogGyro(AnalogGyro&& rhs) = default;
   AnalogGyro& operator=(AnalogGyro&& rhs) = default;
+
+  ~AnalogGyro() override = default;
 
   /**
    * Return the actual angle in degrees that the robot is currently facing.
@@ -220,7 +221,7 @@ class AnalogGyro : public wpi::Sendable,
 
  private:
   std::shared_ptr<AnalogInput> m_analog;
-  hal::Handle<HAL_GyroHandle> m_gyroHandle;
+  hal::Handle<HAL_GyroHandle, HAL_FreeAnalogGyro> m_gyroHandle;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/AnalogInput.h
+++ b/wpilibc/src/main/native/include/frc/AnalogInput.h
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 
+#include <hal/AnalogInput.h>
 #include <hal/Types.h>
 #include <wpi/sendable/Sendable.h>
 #include <wpi/sendable/SendableHelper.h>
@@ -47,10 +48,10 @@ class AnalogInput : public wpi::Sendable,
    */
   explicit AnalogInput(int channel);
 
-  ~AnalogInput() override;
-
   AnalogInput(AnalogInput&&) = default;
   AnalogInput& operator=(AnalogInput&&) = default;
+
+  ~AnalogInput() override = default;
 
   /**
    * Get a sample straight from this channel.
@@ -284,7 +285,7 @@ class AnalogInput : public wpi::Sendable,
 
  private:
   int m_channel;
-  hal::Handle<HAL_AnalogInputHandle> m_port;
+  hal::Handle<HAL_AnalogInputHandle, HAL_FreeAnalogInputPort> m_port;
   int64_t m_accumulatorOffset;
 };
 

--- a/wpilibc/src/main/native/include/frc/AnalogOutput.h
+++ b/wpilibc/src/main/native/include/frc/AnalogOutput.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <hal/AnalogOutput.h>
 #include <hal/Types.h>
 #include <wpi/sendable/Sendable.h>
 #include <wpi/sendable/SendableHelper.h>
@@ -25,10 +26,10 @@ class AnalogOutput : public wpi::Sendable,
    */
   explicit AnalogOutput(int channel);
 
-  ~AnalogOutput() override;
-
   AnalogOutput(AnalogOutput&&) = default;
   AnalogOutput& operator=(AnalogOutput&&) = default;
+
+  ~AnalogOutput() override = default;
 
   /**
    * Set the value of the analog output.
@@ -53,7 +54,7 @@ class AnalogOutput : public wpi::Sendable,
 
  protected:
   int m_channel;
-  hal::Handle<HAL_AnalogOutputHandle> m_port;
+  hal::Handle<HAL_AnalogOutputHandle, HAL_FreeAnalogOutputPort> m_port;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/AnalogTrigger.h
+++ b/wpilibc/src/main/native/include/frc/AnalogTrigger.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include <hal/AnalogTrigger.h>
 #include <hal/Types.h>
 #include <wpi/sendable/Sendable.h>
 #include <wpi/sendable/SendableHelper.h>
@@ -84,7 +85,7 @@ class AnalogTrigger : public wpi::Sendable,
   AnalogTrigger(AnalogTrigger&&) = default;
   AnalogTrigger& operator=(AnalogTrigger&&) = default;
 
-  ~AnalogTrigger() override;
+  ~AnalogTrigger() override = default;
 
   /**
    * Set the upper and lower limits of the analog trigger.
@@ -186,7 +187,7 @@ class AnalogTrigger : public wpi::Sendable,
 
   std::shared_ptr<AnalogInput> m_analogInput;
   std::shared_ptr<DutyCycle> m_dutyCycle;
-  hal::Handle<HAL_AnalogTriggerHandle> m_trigger;
+  hal::Handle<HAL_AnalogTriggerHandle, HAL_CleanAnalogTrigger> m_trigger;
   bool m_ownsAnalog = false;
 };
 

--- a/wpilibc/src/main/native/include/frc/CAN.h
+++ b/wpilibc/src/main/native/include/frc/CAN.h
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 
-#include <hal/CANAPITypes.h>
+#include <hal/CANAPI.h>
 
 namespace frc {
 struct CANData {
@@ -49,11 +49,6 @@ class CAN {
    * @param deviceType         The device type
    */
   CAN(int deviceId, int deviceManufacturer, int deviceType);
-
-  /**
-   * Closes the CAN communication.
-   */
-  ~CAN();
 
   CAN(CAN&&) = default;
   CAN& operator=(CAN&&) = default;
@@ -178,6 +173,6 @@ class CAN {
       HAL_CAN_Dev_kMiscellaneous;
 
  private:
-  hal::Handle<HAL_CANHandle> m_handle;
+  hal::Handle<HAL_CANHandle, HAL_CleanCAN> m_handle;
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/Counter.h
+++ b/wpilibc/src/main/native/include/frc/Counter.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include <hal/Counter.h>
 #include <hal/Types.h>
 #include <units/time.h>
 #include <wpi/sendable/Sendable.h>
@@ -142,10 +143,10 @@ class Counter : public CounterBase,
   Counter(EncodingType encodingType, std::shared_ptr<DigitalSource> upSource,
           std::shared_ptr<DigitalSource> downSource, bool inverted);
 
-  ~Counter() override;
-
   Counter(Counter&&) = default;
   Counter& operator=(Counter&&) = default;
+
+  ~Counter() override;
 
   /**
    * Set the up source for the counter as a digital input channel.
@@ -458,7 +459,7 @@ class Counter : public CounterBase,
   std::shared_ptr<DigitalSource> m_downSource;
 
   /// The FPGA counter object
-  hal::Handle<HAL_CounterHandle> m_counter;
+  hal::Handle<HAL_CounterHandle, HAL_FreeCounter> m_counter;
 
  private:
   /// The index of this counter.

--- a/wpilibc/src/main/native/include/frc/DMA.h
+++ b/wpilibc/src/main/native/include/frc/DMA.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <hal/Types.h>
+#include <hal/DMA.h>
 #include <units/time.h>
 
 namespace frc {
@@ -25,7 +25,6 @@ class DMA {
 
  public:
   DMA();
-  ~DMA();
 
   DMA& operator=(DMA&& other) = default;
   DMA(DMA&& other) = default;
@@ -189,6 +188,6 @@ class DMA {
   void Stop();
 
  private:
-  hal::Handle<HAL_DMAHandle> dmaHandle;
+  hal::Handle<HAL_DMAHandle, HAL_FreeDMA> dmaHandle;
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/DigitalInput.h
+++ b/wpilibc/src/main/native/include/frc/DigitalInput.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <hal/DIO.h>
 #include <wpi/sendable/Sendable.h>
 #include <wpi/sendable/SendableHelper.h>
 
@@ -35,10 +36,10 @@ class DigitalInput : public DigitalSource,
    */
   explicit DigitalInput(int channel);
 
-  ~DigitalInput() override;
-
   DigitalInput(DigitalInput&&) = default;
   DigitalInput& operator=(DigitalInput&&) = default;
+
+  ~DigitalInput() override = default;
 
   /**
    * Get the value from a digital input channel.
@@ -79,7 +80,7 @@ class DigitalInput : public DigitalSource,
 
  private:
   int m_channel;
-  hal::Handle<HAL_DigitalHandle> m_handle;
+  hal::Handle<HAL_DigitalHandle, HAL_FreeDIOPort> m_handle;
 
   friend class DigitalGlitchFilter;
 };

--- a/wpilibc/src/main/native/include/frc/DigitalOutput.h
+++ b/wpilibc/src/main/native/include/frc/DigitalOutput.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <hal/DIO.h>
 #include <hal/Types.h>
 #include <units/time.h>
 #include <wpi/sendable/Sendable.h>
@@ -34,10 +35,10 @@ class DigitalOutput : public DigitalSource,
    */
   explicit DigitalOutput(int channel);
 
-  ~DigitalOutput() override;
-
   DigitalOutput(DigitalOutput&&) = default;
   DigitalOutput& operator=(DigitalOutput&&) = default;
+
+  ~DigitalOutput() override;
 
   /**
    * Set the value of a digital output.
@@ -161,7 +162,7 @@ class DigitalOutput : public DigitalSource,
 
  private:
   int m_channel;
-  hal::Handle<HAL_DigitalHandle> m_handle;
+  hal::Handle<HAL_DigitalHandle, HAL_FreeDIOPort> m_handle;
   hal::Handle<HAL_DigitalPWMHandle> m_pwmGenerator;
 };
 

--- a/wpilibc/src/main/native/include/frc/DutyCycle.h
+++ b/wpilibc/src/main/native/include/frc/DutyCycle.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include <hal/DutyCycle.h>
 #include <hal/Types.h>
 #include <units/time.h>
 #include <wpi/sendable/Sendable.h>
@@ -59,13 +60,13 @@ class DutyCycle : public wpi::Sendable, public wpi::SendableHelper<DutyCycle> {
    */
   explicit DutyCycle(std::shared_ptr<DigitalSource> source);
 
+  DutyCycle(DutyCycle&&) = default;
+  DutyCycle& operator=(DutyCycle&&) = default;
+
   /**
    * Close the DutyCycle and free all resources.
    */
-  ~DutyCycle() override;
-
-  DutyCycle(DutyCycle&&) = default;
-  DutyCycle& operator=(DutyCycle&&) = default;
+  ~DutyCycle() override = default;
 
   /**
    * Get the frequency of the duty cycle signal.
@@ -121,6 +122,6 @@ class DutyCycle : public wpi::Sendable, public wpi::SendableHelper<DutyCycle> {
  private:
   void InitDutyCycle();
   std::shared_ptr<DigitalSource> m_source;
-  hal::Handle<HAL_DutyCycleHandle> m_handle;
+  hal::Handle<HAL_DutyCycleHandle, HAL_FreeDutyCycle> m_handle;
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/Encoder.h
+++ b/wpilibc/src/main/native/include/frc/Encoder.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include <hal/Encoder.h>
 #include <hal/Types.h>
 #include <wpi/sendable/Sendable.h>
 #include <wpi/sendable/SendableHelper.h>
@@ -138,10 +139,10 @@ class Encoder : public CounterBase,
           std::shared_ptr<DigitalSource> bSource, bool reverseDirection = false,
           EncodingType encodingType = k4X);
 
-  ~Encoder() override;
-
   Encoder(Encoder&&) = default;
   Encoder& operator=(Encoder&&) = default;
+
+  ~Encoder() override = default;
 
   // CounterBase interface
   /**
@@ -378,7 +379,7 @@ class Encoder : public CounterBase,
   std::shared_ptr<DigitalSource> m_aSource;  // The A phase of the quad encoder
   std::shared_ptr<DigitalSource> m_bSource;  // The B phase of the quad encoder
   std::shared_ptr<DigitalSource> m_indexSource = nullptr;
-  hal::Handle<HAL_EncoderHandle> m_encoder;
+  hal::Handle<HAL_EncoderHandle, HAL_FreeEncoder> m_encoder;
 
   friend class DigitalGlitchFilter;
 };

--- a/wpilibc/src/main/native/include/frc/I2C.h
+++ b/wpilibc/src/main/native/include/frc/I2C.h
@@ -40,8 +40,6 @@ class I2C {
    */
   I2C(Port port, int deviceAddress);
 
-  ~I2C();
-
   I2C(I2C&&) = default;
   I2C& operator=(I2C&&) = default;
 

--- a/wpilibc/src/main/native/include/frc/PWM.h
+++ b/wpilibc/src/main/native/include/frc/PWM.h
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 
+#include <hal/PWM.h>
 #include <hal/Types.h>
 #include <units/time.h>
 #include <wpi/sendable/Sendable.h>
@@ -59,15 +60,15 @@ class PWM : public wpi::Sendable, public wpi::SendableHelper<PWM> {
    */
   explicit PWM(int channel, bool registerSendable = true);
 
+  PWM(PWM&&) = default;
+  PWM& operator=(PWM&&) = default;
+
   /**
    * Free the PWM channel.
    *
    * Free the resource associated with the PWM channel and set the value to 0.
    */
   ~PWM() override;
-
-  PWM(PWM&&) = default;
-  PWM& operator=(PWM&&) = default;
 
   /**
    * Set the PWM pulse time directly to the hardware.
@@ -206,7 +207,7 @@ class PWM : public wpi::Sendable, public wpi::SendableHelper<PWM> {
 
  private:
   int m_channel;
-  hal::Handle<HAL_DigitalHandle> m_handle;
+  hal::Handle<HAL_DigitalHandle, HAL_FreePWMPort> m_handle;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/PowerDistribution.h
+++ b/wpilibc/src/main/native/include/frc/PowerDistribution.h
@@ -6,6 +6,7 @@
 
 #include <vector>
 
+#include <hal/PowerDistribution.h>
 #include <hal/Types.h>
 #include <wpi/sendable/Sendable.h>
 #include <wpi/sendable/SendableHelper.h>
@@ -48,9 +49,10 @@ class PowerDistribution : public wpi::Sendable,
    */
   PowerDistribution(int module, ModuleType moduleType);
 
-  ~PowerDistribution() override;
   PowerDistribution(PowerDistribution&&) = default;
   PowerDistribution& operator=(PowerDistribution&&) = default;
+
+  ~PowerDistribution() override = default;
 
   /**
    * Gets the number of channels for this power distribution object.
@@ -341,7 +343,7 @@ class PowerDistribution : public wpi::Sendable,
   void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
-  hal::Handle<HAL_PowerDistributionHandle> m_handle;
+  hal::Handle<HAL_PowerDistributionHandle, HAL_CleanPowerDistribution> m_handle;
   int m_module;
 };
 

--- a/wpilibc/src/main/native/include/frc/Relay.h
+++ b/wpilibc/src/main/native/include/frc/Relay.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 
+#include <hal/Relay.h>
 #include <hal/Types.h>
 #include <wpi/sendable/Sendable.h>
 #include <wpi/sendable/SendableHelper.h>
@@ -68,15 +69,15 @@ class Relay : public MotorSafety,
    */
   explicit Relay(int channel, Direction direction = kBothDirections);
 
+  Relay(Relay&&) = default;
+  Relay& operator=(Relay&&) = default;
+
   /**
    * Free the resource associated with a relay.
    *
    * The relay channels are set to free and the relay output is turned off.
    */
   ~Relay() override;
-
-  Relay(Relay&&) = default;
-  Relay& operator=(Relay&&) = default;
 
   /**
    * Set the relay state.
@@ -120,8 +121,8 @@ class Relay : public MotorSafety,
   int m_channel;
   Direction m_direction;
 
-  hal::Handle<HAL_RelayHandle> m_forwardHandle;
-  hal::Handle<HAL_RelayHandle> m_reverseHandle;
+  hal::Handle<HAL_RelayHandle, HAL_FreeRelayPort> m_forwardHandle;
+  hal::Handle<HAL_RelayHandle, HAL_FreeRelayPort> m_reverseHandle;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/SPI.h
+++ b/wpilibc/src/main/native/include/frc/SPI.h
@@ -62,10 +62,10 @@ class SPI {
    */
   explicit SPI(Port port);
 
-  ~SPI();
-
   SPI(SPI&&) = default;
   SPI& operator=(SPI&&) = default;
+
+  ~SPI();
 
   /**
    * Returns the SPI port.

--- a/wpilibc/src/main/native/include/frc/SerialPort.h
+++ b/wpilibc/src/main/native/include/frc/SerialPort.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <string_view>
 
+#include <hal/SerialPort.h>
 #include <hal/Types.h>
 #include <units/time.h>
 
@@ -127,8 +128,6 @@ class SerialPort {
   SerialPort(int baudRate, std::string_view portName, Port port = kOnboard,
              int dataBits = 8, Parity parity = kParity_None,
              StopBits stopBits = kStopBits_One);
-
-  ~SerialPort();
 
   SerialPort(SerialPort&& rhs) = default;
   SerialPort& operator=(SerialPort&& rhs) = default;
@@ -255,7 +254,7 @@ class SerialPort {
   void Reset();
 
  private:
-  hal::Handle<HAL_SerialPortHandle> m_portHandle;
+  hal::Handle<HAL_SerialPortHandle, HAL_CloseSerial> m_portHandle;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/SynchronousInterrupt.h
+++ b/wpilibc/src/main/native/include/frc/SynchronousInterrupt.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include <hal/Interrupts.h>
 #include <hal/Types.h>
 #include <units/time.h>
 
@@ -55,8 +56,6 @@ class SynchronousInterrupt {
    * @param source the DigitalSource the interrupts are triggered from
    */
   explicit SynchronousInterrupt(std::shared_ptr<DigitalSource> source);
-
-  ~SynchronousInterrupt();
 
   SynchronousInterrupt(SynchronousInterrupt&&) = default;
   SynchronousInterrupt& operator=(SynchronousInterrupt&&) = default;
@@ -108,6 +107,6 @@ class SynchronousInterrupt {
  private:
   void InitSynchronousInterrupt();
   std::shared_ptr<DigitalSource> m_source;
-  hal::Handle<HAL_InterruptHandle> m_handle;
+  hal::Handle<HAL_InterruptHandle, HAL_CleanInterrupts> m_handle;
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/TimedRobot.h
+++ b/wpilibc/src/main/native/include/frc/TimedRobot.h
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include <hal/Notifier.h>
 #include <hal/Types.h>
 #include <units/math.h>
 #include <units/time.h>
@@ -50,10 +51,10 @@ class TimedRobot : public IterativeRobotBase {
    */
   explicit TimedRobot(units::second_t period = kDefaultPeriod);
 
-  ~TimedRobot() override;
-
   TimedRobot(TimedRobot&&) = default;
   TimedRobot& operator=(TimedRobot&&) = default;
+
+  ~TimedRobot() override;
 
   /**
    * Add a callback to run at a specific period with a starting time offset.
@@ -100,7 +101,7 @@ class TimedRobot : public IterativeRobotBase {
     }
   };
 
-  hal::Handle<HAL_NotifierHandle> m_notifier;
+  hal::Handle<HAL_NotifierHandle, HAL_CleanNotifier> m_notifier;
   std::chrono::microseconds m_startTime;
 
   wpi::priority_queue<Callback, std::vector<Callback>, std::greater<Callback>>

--- a/wpilibc/src/main/native/include/frc/counter/ExternalDirectionCounter.h
+++ b/wpilibc/src/main/native/include/frc/counter/ExternalDirectionCounter.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include <hal/Counter.h>
 #include <hal/Types.h>
 #include <wpi/sendable/Sendable.h>
 #include <wpi/sendable/SendableHelper.h>
@@ -43,10 +44,10 @@ class ExternalDirectionCounter
   ExternalDirectionCounter(std::shared_ptr<DigitalSource> countSource,
                            std::shared_ptr<DigitalSource> directionSource);
 
-  ~ExternalDirectionCounter() override;
-
   ExternalDirectionCounter(ExternalDirectionCounter&&) = default;
   ExternalDirectionCounter& operator=(ExternalDirectionCounter&&) = default;
+
+  ~ExternalDirectionCounter() override = default;
 
   /**
    * Gets the current count.
@@ -78,7 +79,7 @@ class ExternalDirectionCounter
  private:
   std::shared_ptr<DigitalSource> m_countSource;
   std::shared_ptr<DigitalSource> m_directionSource;
-  hal::Handle<HAL_CounterHandle> m_handle;
+  hal::Handle<HAL_CounterHandle, HAL_FreeCounter> m_handle;
   int32_t m_index = 0;
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/counter/Tachometer.h
+++ b/wpilibc/src/main/native/include/frc/counter/Tachometer.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include <hal/Counter.h>
 #include <hal/Types.h>
 #include <units/angular_velocity.h>
 #include <units/frequency.h>
@@ -42,10 +43,10 @@ class Tachometer : public wpi::Sendable,
    */
   explicit Tachometer(std::shared_ptr<DigitalSource> source);
 
-  ~Tachometer() override;
-
   Tachometer(Tachometer&&) = default;
   Tachometer& operator=(Tachometer&&) = default;
+
+  ~Tachometer() override = default;
 
   /**
    * Gets the tachometer frequency.
@@ -133,7 +134,7 @@ class Tachometer : public wpi::Sendable,
 
  private:
   std::shared_ptr<DigitalSource> m_source;
-  hal::Handle<HAL_CounterHandle> m_handle;
+  hal::Handle<HAL_CounterHandle, HAL_FreeCounter> m_handle;
   int m_edgesPerRevolution;
   int32_t m_index;
 };

--- a/wpilibc/src/main/native/include/frc/counter/UpDownCounter.h
+++ b/wpilibc/src/main/native/include/frc/counter/UpDownCounter.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include <hal/Counter.h>
 #include <hal/Types.h>
 #include <wpi/sendable/Sendable.h>
 #include <wpi/sendable/SendableHelper.h>
@@ -41,10 +42,10 @@ class UpDownCounter : public wpi::Sendable,
   UpDownCounter(std::shared_ptr<DigitalSource> upSource,
                 std::shared_ptr<DigitalSource> downSource);
 
-  ~UpDownCounter() override;
-
   UpDownCounter(UpDownCounter&&) = default;
   UpDownCounter& operator=(UpDownCounter&&) = default;
+
+  ~UpDownCounter() override = default;
 
   /**
    * Gets the current count.
@@ -84,7 +85,7 @@ class UpDownCounter : public wpi::Sendable,
   void InitUpDownCounter();
   std::shared_ptr<DigitalSource> m_upSource;
   std::shared_ptr<DigitalSource> m_downSource;
-  hal::Handle<HAL_CounterHandle> m_handle;
+  hal::Handle<HAL_CounterHandle, HAL_FreeCounter> m_handle;
   int32_t m_index = 0;
 };
 }  // namespace frc

--- a/wpilibcExamples/src/main/cpp/examples/HAL/c/Robot.c
+++ b/wpilibcExamples/src/main/cpp/examples/HAL/c/Robot.c
@@ -82,8 +82,7 @@ int main(void) {
   if (status != 0) {
     const char* message = HAL_GetLastError(&status);
     printf("%s\n", message);
-    status = 0;
-    HAL_FreePWMPort(pwmPort, &status);
+    HAL_FreePWMPort(pwmPort);
     return 1;
   }
 
@@ -128,5 +127,5 @@ int main(void) {
 
   status = 0;
   HAL_FreeDIOPort(dio);
-  HAL_FreePWMPort(pwmPort, &status);
+  HAL_FreePWMPort(pwmPort);
 }


### PR DESCRIPTION
Closes #6991 

Adds a close function pointer template parameter to `hal::Handle`- this allowed default destructors in many places. 
The status parameter has been removed from close functions- in most places it was not used. Where it was, an error is printed in stead.
JNI functions also check for invalid handle- though now that i'm thining about it, I'm not sure this is really necessary. It's easy enough to remove.
