### PR TITLE
Add 4324 to ignored warnings in cmake

### DIFF
--- a/cmake/modules/CompileWarnings.cmake
+++ b/cmake/modules/CompileWarnings.cmake
@@ -21,6 +21,7 @@ macro(wpilib_target_warnings target)
                 /wd4244
                 /wd4251
                 /wd4267
+                /wd4324
                 /WX
                 /D_CRT_SECURE_NO_WARNINGS
                 ${WPILIB_TARGET_WARNINGS}


### PR DESCRIPTION
4324 is issued at /W4 if alignas forces padding. Makes it impossible to use SmallVector from something compiled in /W4. Add it to the warning exclusion list. 