### PR TITLE
[examples] Add ProfiledPID command to RapidReactCommandBot

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Drive.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Drive.cpp
@@ -24,6 +24,14 @@ Drive::Drive() {
   // Sets the distance per pulse for the encoders
   m_leftEncoder.SetDistancePerPulse(DriveConstants::kEncoderDistancePerPulse);
   m_rightEncoder.SetDistancePerPulse(DriveConstants::kEncoderDistancePerPulse);
+
+  // Set the controller to be continuous (because it is an angle controller)
+  m_controller.EnableContinuousInput(-180_deg, 180_deg);
+  // Set the controller tolerance - the delta tolerance ensures the robot is
+  // stationary at the setpoint before it is considered as having reached the
+  // reference
+  m_controller.SetTolerance(DriveConstants::kTurnTolerance,
+                            DriveConstants::kTurnRateTolerance);
 }
 
 frc2::CommandPtr Drive::ArcadeDriveCommand(std::function<double()> fwd,
@@ -54,10 +62,10 @@ frc2::CommandPtr Drive::DriveDistanceCommand(units::meter_t distance,
 
 frc2::CommandPtr Drive::TurnToAngleCommand(units::degree_t angle) {
   return StartRun(
-             [this] { m_controller.Reset(m_gyro.GetRotation2d().Radians()); },
+             [this] { m_controller.Reset(m_gyro.GetRotation2d().Degrees()); },
              [this, angle] {
                m_drive.ArcadeDrive(
-                   0, m_controller.Calculate(m_gyro.GetRotation2d().Radians(),
+                   0, m_controller.Calculate(m_gyro.GetRotation2d().Degrees(),
                                              angle) +
                           // Divide feedforward voltage by battery voltage to
                           // normalize it to [-1, 1]

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Drive.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Drive.cpp
@@ -50,3 +50,15 @@ frc2::CommandPtr Drive::DriveDistanceCommand(units::meter_t distance,
       // Stop the drive when the command ends
       .FinallyDo([this](bool interrupted) { m_drive.StopMotor(); });
 }
+
+frc2::CommandPtr Drive::TurnToAngleCommand(units::degree_t angle) {
+  return StartRun(
+             [this] { m_controller.Reset(m_gyro.GetRotation2d().Radians()); },
+             [this, angle] {
+               m_drive.ArcadeDrive(
+                   0, m_controller.Calculate(m_gyro.GetRotation2d().Radians(),
+                                             angle));
+             })
+      .Until([this] { return m_controller.AtGoal(); })
+      .FinallyDo([this] { m_drive.ArcadeDrive(0, 0); });
+}

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Drive.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Drive.cpp
@@ -6,6 +6,7 @@
 
 #include <utility>
 
+#include <frc/RobotController.h>
 #include <frc2/command/Commands.h>
 
 Drive::Drive() {
@@ -57,7 +58,12 @@ frc2::CommandPtr Drive::TurnToAngleCommand(units::degree_t angle) {
              [this, angle] {
                m_drive.ArcadeDrive(
                    0, m_controller.Calculate(m_gyro.GetRotation2d().Radians(),
-                                             angle));
+                                             angle) +
+                          // Divide feedforward voltage by battery voltage to
+                          // normalize it to [-1, 1]
+                          m_feedforward.Calculate(
+                              m_controller.GetSetpoint().velocity) /
+                              frc::RobotController::GetBatteryVoltage());
              })
       .Until([this] { return m_controller.AtGoal(); })
       .FinallyDo([this] { m_drive.ArcadeDrive(0, 0); });

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/Constants.h
@@ -29,6 +29,15 @@ inline constexpr double kEncoderDistancePerPulse =
     // Assumes the encoders are directly mounted on the wheel shafts
     ((kWheelDiameter * std::numbers::pi) / kEncoderCPR).value();
 
+inline constexpr double kTurnP = 1;
+inline constexpr double kTurnI = 0;
+inline constexpr double kTurnD = 0;
+
+inline constexpr auto kTurnTolerance = 5_deg;
+inline constexpr auto kTurnRateTolerance = 10_deg_per_s;
+
+inline constexpr auto kMaxTurnRate = 100_deg_per_s;
+inline constexpr auto kMaxTurnAcceleration = 300_deg_per_s / 1_s;
 }  // namespace DriveConstants
 
 namespace IntakeConstants {

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/Constants.h
@@ -38,6 +38,14 @@ inline constexpr auto kTurnRateTolerance = 10_deg_per_s;
 
 inline constexpr auto kMaxTurnRate = 100_deg_per_s;
 inline constexpr auto kMaxTurnAcceleration = 300_deg_per_s / 1_s;
+
+// These are example values only - DO NOT USE THESE FOR YOUR OWN ROBOT!
+// These characterization values MUST be determined either experimentally or
+// theoretically for *your* robot's drive. The SysId tool provides a convenient
+// method for obtaining these values for your robot.
+inline constexpr auto ks = 1_V;
+inline constexpr auto kv = 0.8_V * 1_s / 1_rad;
+inline constexpr auto ka = 0.15_V * 1_s * 1_s / 1_rad;
 }  // namespace DriveConstants
 
 namespace IntakeConstants {

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/Constants.h
@@ -44,8 +44,8 @@ inline constexpr auto kMaxTurnAcceleration = 300_deg_per_s / 1_s;
 // theoretically for *your* robot's drive. The SysId tool provides a convenient
 // method for obtaining these values for your robot.
 inline constexpr auto ks = 1_V;
-inline constexpr auto kv = 0.8_V * 1_s / 1_rad;
-inline constexpr auto ka = 0.15_V * 1_s * 1_s / 1_rad;
+inline constexpr auto kv = 0.8_V * 1_s / 1_deg;
+inline constexpr auto ka = 0.15_V * 1_s * 1_s / 1_deg;
 }  // namespace DriveConstants
 
 namespace IntakeConstants {

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/Constants.h
@@ -29,6 +29,10 @@ inline constexpr double kEncoderDistancePerPulse =
     // Assumes the encoders are directly mounted on the wheel shafts
     ((kWheelDiameter * std::numbers::pi) / kEncoderCPR).value();
 
+// These are example values only - DO NOT USE THESE FOR YOUR OWN ROBOT!
+// These values MUST be determined either experimentally or theoretically for
+// *your* robot's drive. The SysId tool provides a convenient method for
+// obtaining feedback and feedforward values for your robot.
 inline constexpr double kTurnP = 1;
 inline constexpr double kTurnI = 0;
 inline constexpr double kTurnD = 0;
@@ -39,10 +43,6 @@ inline constexpr auto kTurnRateTolerance = 10_deg_per_s;
 inline constexpr auto kMaxTurnRate = 100_deg_per_s;
 inline constexpr auto kMaxTurnAcceleration = 300_deg_per_s / 1_s;
 
-// These are example values only - DO NOT USE THESE FOR YOUR OWN ROBOT!
-// These characterization values MUST be determined either experimentally or
-// theoretically for *your* robot's drive. The SysId tool provides a convenient
-// method for obtaining these values for your robot.
 inline constexpr auto ks = 1_V;
 inline constexpr auto kv = 0.8_V * 1_s / 1_deg;
 inline constexpr auto ka = 0.15_V * 1_s * 1_s / 1_deg;

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Drive.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Drive.h
@@ -6,7 +6,9 @@
 
 #include <functional>
 
+#include <frc/ADXRS450_Gyro.h>
 #include <frc/Encoder.h>
+#include <frc/controller/ProfiledPIDController.h>
 #include <frc/drive/DifferentialDrive.h>
 #include <frc/motorcontrol/PWMSparkMax.h>
 #include <frc2/command/CommandPtr.h>
@@ -38,6 +40,15 @@ class Drive : public frc2::SubsystemBase {
   [[nodiscard]]
   frc2::CommandPtr DriveDistanceCommand(units::meter_t distance, double speed);
 
+  /**
+   * Returns a command that turns to robot to the specified angle using a motion
+   * profile and PID controller.
+   *
+   * @param angle The angle to turn to
+   */
+  [[nodiscard]]
+  frc2::CommandPtr TurnToAngleCommand(units::degree_t angle);
+
  private:
   frc::PWMSparkMax m_leftLeader{DriveConstants::kLeftMotor1Port};
   frc::PWMSparkMax m_leftFollower{DriveConstants::kLeftMotor2Port};
@@ -54,4 +65,12 @@ class Drive : public frc2::SubsystemBase {
   frc::Encoder m_rightEncoder{DriveConstants::kRightEncoderPorts[0],
                               DriveConstants::kRightEncoderPorts[1],
                               DriveConstants::kRightEncoderReversed};
+
+  frc::ADXRS450_Gyro m_gyro;
+
+  frc::ProfiledPIDController<units::radians> m_controller{
+      DriveConstants::kTurnP,
+      DriveConstants::kTurnI,
+      DriveConstants::kTurnD,
+      {DriveConstants::kMaxTurnRate, DriveConstants::kMaxTurnAcceleration}};
 };

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Drive.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Drive.h
@@ -70,11 +70,11 @@ class Drive : public frc2::SubsystemBase {
 
   frc::ADXRS450_Gyro m_gyro;
 
-  frc::ProfiledPIDController<units::radians> m_controller{
+  frc::ProfiledPIDController<units::degrees> m_controller{
       DriveConstants::kTurnP,
       DriveConstants::kTurnI,
       DriveConstants::kTurnD,
       {DriveConstants::kMaxTurnRate, DriveConstants::kMaxTurnAcceleration}};
-  frc::SimpleMotorFeedforward<units::radians> m_feedforward{
+  frc::SimpleMotorFeedforward<units::degrees> m_feedforward{
       DriveConstants::ks, DriveConstants::kv, DriveConstants::ka};
 };

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Drive.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Drive.h
@@ -9,10 +9,12 @@
 #include <frc/ADXRS450_Gyro.h>
 #include <frc/Encoder.h>
 #include <frc/controller/ProfiledPIDController.h>
+#include <frc/controller/SimpleMotorFeedforward.h>
 #include <frc/drive/DifferentialDrive.h>
 #include <frc/motorcontrol/PWMSparkMax.h>
 #include <frc2/command/CommandPtr.h>
 #include <frc2/command/SubsystemBase.h>
+#include <units/angle.h>
 #include <units/length.h>
 
 #include "Constants.h"
@@ -73,4 +75,6 @@ class Drive : public frc2::SubsystemBase {
       DriveConstants::kTurnI,
       DriveConstants::kTurnD,
       {DriveConstants::kMaxTurnRate, DriveConstants::kMaxTurnAcceleration}};
+  frc::SimpleMotorFeedforward<units::radians> m_feedforward{
+      DriveConstants::ks, DriveConstants::kv, DriveConstants::ka};
 };

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Drive.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Drive.h
@@ -70,11 +70,11 @@ class Drive : public frc2::SubsystemBase {
 
   frc::ADXRS450_Gyro m_gyro;
 
-  frc::ProfiledPIDController<units::degrees> m_controller{
+  frc::ProfiledPIDController<units::radians> m_controller{
       DriveConstants::kTurnP,
       DriveConstants::kTurnI,
       DriveConstants::kTurnD,
       {DriveConstants::kMaxTurnRate, DriveConstants::kMaxTurnAcceleration}};
-  frc::SimpleMotorFeedforward<units::degrees> m_feedforward{
+  frc::SimpleMotorFeedforward<units::radians> m_feedforward{
       DriveConstants::ks, DriveConstants::kv, DriveConstants::ka};
 };

--- a/wpilibcExamples/src/main/cpp/examples/examples.json
+++ b/wpilibcExamples/src/main/cpp/examples/examples.json
@@ -394,6 +394,7 @@
       "Pneumatics",
       "Digital Input",
       "PID",
+      "Gyro",
       "Profiled PID",
       "XboxController"
     ],

--- a/wpilibcExamples/src/main/cpp/examples/examples.json
+++ b/wpilibcExamples/src/main/cpp/examples/examples.json
@@ -394,6 +394,7 @@
       "Pneumatics",
       "Digital Input",
       "PID",
+      "Profiled PID",
       "XboxController"
     ],
     "foldername": "RapidReactCommandBot",

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/examples.json
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/examples.json
@@ -388,6 +388,7 @@
       "Pneumatics",
       "Digital Input",
       "PID",
+      "Gyro",
       "Profiled PID",
       "XboxController"
     ],

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/examples.json
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/examples.json
@@ -388,6 +388,7 @@
       "Pneumatics",
       "Digital Input",
       "PID",
+      "Profiled PID",
       "XboxController"
     ],
     "foldername": "rapidreactcommandbot",

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/Constants.java
@@ -32,6 +32,10 @@ public final class Constants {
         // Assumes the encoders are directly mounted on the wheel shafts
         (kWheelDiameterMeters * Math.PI) / kEncoderCPR;
 
+    // These are example values only - DO NOT USE THESE FOR YOUR OWN ROBOT!
+    // These values MUST be determined either experimentally or theoretically for *your* robot's
+    // drive. The SysId tool provides a convenient method for obtaining feedback and feedforward
+    // values for your robot.
     public static final double kTurnP = 1;
     public static final double kTurnI = 0;
     public static final double kTurnD = 0;
@@ -42,10 +46,6 @@ public final class Constants {
     public static final double kMaxTurnRateDegPerS = 100;
     public static final double kMaxTurnAccelerationDegPerSSquared = 300;
 
-    // These are example values only - DO NOT USE THESE FOR YOUR OWN ROBOT!
-    // These characterization values MUST be determined either experimentally or theoretically
-    // for *your* robot's drive.
-    // The SysId tool provides a convenient method for obtaining these values for your robot.
     public static final double ksVolts = 1;
     public static final double kvVoltSecondsPerDegree = 0.8;
     public static final double kaVoltSecondsSquaredPerDegree = 0.15;

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/Constants.java
@@ -41,6 +41,14 @@ public final class Constants {
 
     public static final double kMaxTurnRateDegPerS = 100;
     public static final double kMaxTurnAccelerationDegPerSSquared = 300;
+
+    // These are example values only - DO NOT USE THESE FOR YOUR OWN ROBOT!
+    // These characterization values MUST be determined either experimentally or theoretically
+    // for *your* robot's drive.
+    // The SysId tool provides a convenient method for obtaining these values for your robot.
+    public static final double ksVolts = 1;
+    public static final double kvVoltSecondsPerDegree = 0.8;
+    public static final double kaVoltSecondsSquaredPerDegree = 0.15;
   }
 
   public static final class ShooterConstants {

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/Constants.java
@@ -31,6 +31,16 @@ public final class Constants {
     public static final double kEncoderDistancePerPulse =
         // Assumes the encoders are directly mounted on the wheel shafts
         (kWheelDiameterMeters * Math.PI) / kEncoderCPR;
+
+    public static final double kTurnP = 1;
+    public static final double kTurnI = 0;
+    public static final double kTurnD = 0;
+
+    public static final double kTurnToleranceDeg = 5;
+    public static final double kTurnRateToleranceDegPerS = 10; // degrees per second
+
+    public static final double kMaxTurnRateDegPerS = 100;
+    public static final double kMaxTurnAccelerationDegPerSSquared = 300;
   }
 
   public static final class ShooterConstants {

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Drive.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Drive.java
@@ -4,7 +4,7 @@
 
 package edu.wpi.first.wpilibj.examples.rapidreactcommandbot.subsystems;
 
-import static edu.wpi.first.units.Units.RadiansPerSecond;
+import static edu.wpi.first.units.Units.DegreesPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.epilogue.Logged;
@@ -144,7 +144,7 @@ public class Drive extends SubsystemBase {
                     m_controller.calculate(m_gyro.getRotation2d().getDegrees(), angleDeg)
                         // Divide feedforward voltage by battery voltage to normalize it to [-1, 1]
                         + m_feedforward
-                                .calculate(RadiansPerSecond.of(m_controller.getSetpoint().velocity))
+                                .calculate(DegreesPerSecond.of(m_controller.getSetpoint().velocity))
                                 .in(Volts)
                             / RobotController.getBatteryVoltage()))
         .until(m_controller::atGoal)

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Drive.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/subsystems/Drive.java
@@ -6,7 +6,10 @@ package edu.wpi.first.wpilibj.examples.rapidreactcommandbot.subsystems;
 
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.NotLogged;
+import edu.wpi.first.math.controller.ProfiledPIDController;
+import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.util.sendable.SendableRegistry;
+import edu.wpi.first.wpilibj.ADXRS450_Gyro;
 import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.examples.rapidreactcommandbot.Constants.DriveConstants;
@@ -44,6 +47,16 @@ public class Drive extends SubsystemBase {
           DriveConstants.kRightEncoderPorts[1],
           DriveConstants.kRightEncoderReversed);
 
+  private final ADXRS450_Gyro m_gyro = new ADXRS450_Gyro();
+  private final ProfiledPIDController m_controller =
+      new ProfiledPIDController(
+          DriveConstants.kTurnP,
+          DriveConstants.kTurnI,
+          DriveConstants.kTurnD,
+          new TrapezoidProfile.Constraints(
+              DriveConstants.kMaxTurnRateDegPerS,
+              DriveConstants.kMaxTurnAccelerationDegPerSSquared));
+
   /** Creates a new Drive subsystem. */
   public Drive() {
     SendableRegistry.addChild(m_drive, m_leftLeader);
@@ -60,6 +73,13 @@ public class Drive extends SubsystemBase {
     // Sets the distance per pulse for the encoders
     m_leftEncoder.setDistancePerPulse(DriveConstants.kEncoderDistancePerPulse);
     m_rightEncoder.setDistancePerPulse(DriveConstants.kEncoderDistancePerPulse);
+
+    // Set the controller to be continuous (because it is an angle controller)
+    m_controller.enableContinuousInput(-180, 180);
+    // Set the controller tolerance - the delta tolerance ensures the robot is stationary at the
+    // setpoint before it is considered as having reached the reference
+    m_controller.setTolerance(
+        DriveConstants.kTurnToleranceDeg, DriveConstants.kTurnRateToleranceDegPerS);
   }
 
   /**
@@ -97,5 +117,21 @@ public class Drive extends SubsystemBase {
                     >= distanceMeters)
         // Stop the drive when the command ends
         .finallyDo(interrupted -> m_drive.stopMotor());
+  }
+
+  /**
+   * Returns a command that turns to robot to the specified angle using a motion profile and PID
+   * controller.
+   *
+   * @param angleDeg The angle to turn to
+   */
+  public Command turnToAngleCommand(double angleDeg) {
+    return startRun(
+            () -> m_controller.reset(m_gyro.getRotation2d().getDegrees()),
+            () ->
+                m_drive.arcadeDrive(
+                    0, m_controller.calculate(m_gyro.getRotation2d().getDegrees(), angleDeg)))
+        .until(m_controller::atGoal)
+        .finallyDo(() -> m_drive.arcadeDrive(0, 0));
   }
 }


### PR DESCRIPTION
Replaces the GyroDriveCommands example. Closes #3114.