### PR TITLE
Properly unpublish client published values on disconnect

### DIFF
--- a/ntcore/src/main/native/cpp/net/ServerImpl.cpp
+++ b/ntcore/src/main/native/cpp/net/ServerImpl.cpp
@@ -1268,7 +1268,7 @@ void ServerImpl::RemoveClient(int clientId) {
       topic->clients.erase(tcdIt);
     }
 
-    if (!topic->IsPublished()) {
+    if (topic->IsLastPublisher()) {
       toDelete.push_back(topic.get());
     } else {
       if (pubChanged) {

--- a/ntcore/src/main/native/cpp/net/ServerImpl.h
+++ b/ntcore/src/main/native/cpp/net/ServerImpl.h
@@ -110,6 +110,10 @@ class ServerImpl final {
       RefreshProperties();
     }
 
+    bool IsLastPublisher() const {
+      return !persistent && !retained && publisherCount <= 1;
+    }
+
     bool IsPublished() const {
       return persistent || retained || publisherCount != 0;
     }


### PR DESCRIPTION
Currently, client published values don't get unpublished properly when the client disconnects from the server. That leaves a vestigial publisher around. This fixes it to properly remove the publisher.