### PR TITLE
[wpilibj] AnalogEncoder: fix documentation

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogEncoder.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogEncoder.java
@@ -101,10 +101,7 @@ public class AnalogEncoder implements Sendable, AutoCloseable {
   /**
    * Get the encoder value.
    *
-   * <p>By default, this will not count rollovers. If that behavior is necessary, call
-   * configureRolloverCounting(true).
-   *
-   * @return the encoder value
+   * @return the encoder value scaled by the full range input
    */
   public double get() {
     if (m_simPosition != null) {


### PR DESCRIPTION
configureRolloverCounting was added and removed as part of the absolute encoder overhaul, this reference was left dangling