### PR TITLE
Allow use of expected with JSON

### DIFF
--- a/upstream_utils/expected_patches/0001-Remove-C-11-to-C-17-shims.patch
+++ b/upstream_utils/expected_patches/0001-Remove-C-11-to-C-17-shims.patch
@@ -1,0 +1,1236 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Joseph Eng <s-engjo@bsd405.org>
+Date: Sat, 7 Sep 2024 13:30:36 -0700
+Subject: [PATCH] Remove C++11 to C++17 shims
+
+---
+ include/tl/expected.hpp | 620 +++++++++++++++-------------------------
+ 1 file changed, 227 insertions(+), 393 deletions(-)
+
+diff --git a/include/tl/expected.hpp b/include/tl/expected.hpp
+index afee404d43ee50f772fc962befbfeac0794b2aea..1ec179a11be84486df113e157e130540ecae6edb 100644
+--- a/include/tl/expected.hpp
++++ b/include/tl/expected.hpp
+@@ -222,187 +222,21 @@ template <typename E>
+ #endif
+ }
+ 
+-#ifndef TL_TRAITS_MUTEX
+-#define TL_TRAITS_MUTEX
+-// C++14-style aliases for brevity
+-template <class T> using remove_const_t = typename std::remove_const<T>::type;
+-template <class T>
+-using remove_reference_t = typename std::remove_reference<T>::type;
+-template <class T> using decay_t = typename std::decay<T>::type;
+-template <bool E, class T = void>
+-using enable_if_t = typename std::enable_if<E, T>::type;
+-template <bool B, class T, class F>
+-using conditional_t = typename std::conditional<B, T, F>::type;
+-
+-// std::conjunction from C++17
+-template <class...> struct conjunction : std::true_type {};
+-template <class B> struct conjunction<B> : B {};
+-template <class B, class... Bs>
+-struct conjunction<B, Bs...>
+-    : std::conditional<bool(B::value), conjunction<Bs...>, B>::type {};
+-
+-#if defined(_LIBCPP_VERSION) && __cplusplus == 201103L
+-#define TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
+-#endif
+-
+-// In C++11 mode, there's an issue in libc++'s std::mem_fn
+-// which results in a hard-error when using it in a noexcept expression
+-// in some cases. This is a check to workaround the common failing case.
+-#ifdef TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
+-template <class T>
+-struct is_pointer_to_non_const_member_func : std::false_type {};
+-template <class T, class Ret, class... Args>
+-struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...)>
+-    : std::true_type {};
+-template <class T, class Ret, class... Args>
+-struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) &>
+-    : std::true_type {};
+-template <class T, class Ret, class... Args>
+-struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) &&>
+-    : std::true_type {};
+-template <class T, class Ret, class... Args>
+-struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) volatile>
+-    : std::true_type {};
+-template <class T, class Ret, class... Args>
+-struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) volatile &>
+-    : std::true_type {};
+-template <class T, class Ret, class... Args>
+-struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) volatile &&>
+-    : std::true_type {};
+-
+-template <class T> struct is_const_or_const_ref : std::false_type {};
+-template <class T> struct is_const_or_const_ref<T const &> : std::true_type {};
+-template <class T> struct is_const_or_const_ref<T const> : std::true_type {};
+-#endif
+-
+-// std::invoke from C++17
+-// https://stackoverflow.com/questions/38288042/c11-14-invoke-workaround
+-template <
+-    typename Fn, typename... Args,
+-#ifdef TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
+-    typename = enable_if_t<!(is_pointer_to_non_const_member_func<Fn>::value &&
+-                             is_const_or_const_ref<Args...>::value)>,
+-#endif
+-    typename = enable_if_t<std::is_member_pointer<decay_t<Fn>>::value>, int = 0>
+-constexpr auto invoke(Fn &&f, Args &&...args) noexcept(
+-    noexcept(std::mem_fn(f)(std::forward<Args>(args)...)))
+-    -> decltype(std::mem_fn(f)(std::forward<Args>(args)...)) {
+-  return std::mem_fn(f)(std::forward<Args>(args)...);
+-}
+-
+-template <typename Fn, typename... Args,
+-          typename = enable_if_t<!std::is_member_pointer<decay_t<Fn>>::value>>
+-constexpr auto invoke(Fn &&f, Args &&...args) noexcept(
+-    noexcept(std::forward<Fn>(f)(std::forward<Args>(args)...)))
+-    -> decltype(std::forward<Fn>(f)(std::forward<Args>(args)...)) {
+-  return std::forward<Fn>(f)(std::forward<Args>(args)...);
+-}
+-
+-// std::invoke_result from C++17
+-template <class F, class, class... Us> struct invoke_result_impl;
+-
+-template <class F, class... Us>
+-struct invoke_result_impl<
+-    F,
+-    decltype(detail::invoke(std::declval<F>(), std::declval<Us>()...), void()),
+-    Us...> {
+-  using type =
+-      decltype(detail::invoke(std::declval<F>(), std::declval<Us>()...));
+-};
+-
+-template <class F, class... Us>
+-using invoke_result = invoke_result_impl<F, void, Us...>;
+-
+-template <class F, class... Us>
+-using invoke_result_t = typename invoke_result<F, Us...>::type;
+-
+-#if defined(_MSC_VER) && _MSC_VER <= 1900
+-// TODO make a version which works with MSVC 2015
+-template <class T, class U = T> struct is_swappable : std::true_type {};
+-
+-template <class T, class U = T> struct is_nothrow_swappable : std::true_type {};
+-#else
+-// https://stackoverflow.com/questions/26744589/what-is-a-proper-way-to-implement-is-swappable-to-test-for-the-swappable-concept
+-namespace swap_adl_tests {
+-// if swap ADL finds this then it would call std::swap otherwise (same
+-// signature)
+-struct tag {};
+-
+-template <class T> tag swap(T &, T &);
+-template <class T, std::size_t N> tag swap(T (&a)[N], T (&b)[N]);
+-
+-// helper functions to test if an unqualified swap is possible, and if it
+-// becomes std::swap
+-template <class, class> std::false_type can_swap(...) noexcept(false);
+-template <class T, class U,
+-          class = decltype(swap(std::declval<T &>(), std::declval<U &>()))>
+-std::true_type can_swap(int) noexcept(noexcept(swap(std::declval<T &>(),
+-                                                    std::declval<U &>())));
+-
+-template <class, class> std::false_type uses_std(...);
+-template <class T, class U>
+-std::is_same<decltype(swap(std::declval<T &>(), std::declval<U &>())), tag>
+-uses_std(int);
+-
+-template <class T>
+-struct is_std_swap_noexcept
+-    : std::integral_constant<bool,
+-                             std::is_nothrow_move_constructible<T>::value &&
+-                                 std::is_nothrow_move_assignable<T>::value> {};
+-
+-template <class T, std::size_t N>
+-struct is_std_swap_noexcept<T[N]> : is_std_swap_noexcept<T> {};
+-
+-template <class T, class U>
+-struct is_adl_swap_noexcept
+-    : std::integral_constant<bool, noexcept(can_swap<T, U>(0))> {};
+-} // namespace swap_adl_tests
+-
+-template <class T, class U = T>
+-struct is_swappable
+-    : std::integral_constant<
+-          bool,
+-          decltype(detail::swap_adl_tests::can_swap<T, U>(0))::value &&
+-              (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value ||
+-               (std::is_move_assignable<T>::value &&
+-                std::is_move_constructible<T>::value))> {};
+-
+-template <class T, std::size_t N>
+-struct is_swappable<T[N], T[N]>
+-    : std::integral_constant<
+-          bool,
+-          decltype(detail::swap_adl_tests::can_swap<T[N], T[N]>(0))::value &&
+-              (!decltype(detail::swap_adl_tests::uses_std<T[N], T[N]>(
+-                   0))::value ||
+-               is_swappable<T, T>::value)> {};
+-
+-template <class T, class U = T>
+-struct is_nothrow_swappable
+-    : std::integral_constant<
+-          bool,
+-          is_swappable<T, U>::value &&
+-              ((decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value &&
+-                detail::swap_adl_tests::is_std_swap_noexcept<T>::value) ||
+-               (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value &&
+-                detail::swap_adl_tests::is_adl_swap_noexcept<T, U>::value))> {};
+-#endif
+-#endif
+-
+ // Trait for checking if a type is a tl::expected
+ template <class T> struct is_expected_impl : std::false_type {};
+ template <class T, class E>
+ struct is_expected_impl<expected<T, E>> : std::true_type {};
+-template <class T> using is_expected = is_expected_impl<decay_t<T>>;
++template <class T> using is_expected = is_expected_impl<std::decay_t<T>>;
+ 
+ template <class T, class E, class U>
+-using expected_enable_forward_value = detail::enable_if_t<
++using expected_enable_forward_value = std::enable_if_t<
+     std::is_constructible<T, U &&>::value &&
+-    !std::is_same<detail::decay_t<U>, in_place_t>::value &&
+-    !std::is_same<expected<T, E>, detail::decay_t<U>>::value &&
+-    !std::is_same<unexpected<E>, detail::decay_t<U>>::value>;
++    !std::is_same<std::decay_t<U>, in_place_t>::value &&
++    !std::is_same<expected<T, E>, std::decay_t<U>>::value &&
++    !std::is_same<unexpected<E>, std::decay_t<U>>::value>;
+ 
+ template <class T, class E, class U, class G, class UR, class GR>
+-using expected_enable_from_other = detail::enable_if_t<
++using expected_enable_from_other = std::enable_if_t<
+     std::is_constructible<T, UR>::value &&
+     std::is_constructible<E, GR>::value &&
+     !std::is_constructible<T, expected<U, G> &>::value &&
+@@ -415,7 +249,7 @@ using expected_enable_from_other = detail::enable_if_t<
+     !std::is_convertible<const expected<U, G> &&, T>::value>;
+ 
+ template <class T, class U>
+-using is_void_or = conditional_t<std::is_void<T>::value, std::true_type, U>;
++using is_void_or = std::conditional_t<std::is_void<T>::value, std::true_type, U>;
+ 
+ template <class T>
+ using is_copy_constructible_or_void =
+@@ -450,25 +284,25 @@ struct expected_storage_base {
+   constexpr expected_storage_base(no_init_t) : m_no_init(), m_has_val(false) {}
+ 
+   template <class... Args,
+-            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
++            std::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+                 nullptr>
+   constexpr expected_storage_base(in_place_t, Args &&...args)
+       : m_val(std::forward<Args>(args)...), m_has_val(true) {}
+ 
+   template <class U, class... Args,
+-            detail::enable_if_t<std::is_constructible<
++            std::enable_if_t<std::is_constructible<
+                 T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+   constexpr expected_storage_base(in_place_t, std::initializer_list<U> il,
+                                   Args &&...args)
+       : m_val(il, std::forward<Args>(args)...), m_has_val(true) {}
+   template <class... Args,
+-            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
++            std::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+                 nullptr>
+   constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
+       : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
+ 
+   template <class U, class... Args,
+-            detail::enable_if_t<std::is_constructible<
++            std::enable_if_t<std::is_constructible<
+                 E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+   constexpr explicit expected_storage_base(unexpect_t,
+                                            std::initializer_list<U> il,
+@@ -497,25 +331,25 @@ template <class T, class E> struct expected_storage_base<T, E, true, true> {
+   constexpr expected_storage_base(no_init_t) : m_no_init(), m_has_val(false) {}
+ 
+   template <class... Args,
+-            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
++            std::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+                 nullptr>
+   constexpr expected_storage_base(in_place_t, Args &&...args)
+       : m_val(std::forward<Args>(args)...), m_has_val(true) {}
+ 
+   template <class U, class... Args,
+-            detail::enable_if_t<std::is_constructible<
++            std::enable_if_t<std::is_constructible<
+                 T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+   constexpr expected_storage_base(in_place_t, std::initializer_list<U> il,
+                                   Args &&...args)
+       : m_val(il, std::forward<Args>(args)...), m_has_val(true) {}
+   template <class... Args,
+-            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
++            std::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+                 nullptr>
+   constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
+       : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
+ 
+   template <class U, class... Args,
+-            detail::enable_if_t<std::is_constructible<
++            std::enable_if_t<std::is_constructible<
+                 E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+   constexpr explicit expected_storage_base(unexpect_t,
+                                            std::initializer_list<U> il,
+@@ -538,25 +372,25 @@ template <class T, class E> struct expected_storage_base<T, E, true, false> {
+       : m_no_init(), m_has_val(false) {}
+ 
+   template <class... Args,
+-            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
++            std::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+                 nullptr>
+   constexpr expected_storage_base(in_place_t, Args &&...args)
+       : m_val(std::forward<Args>(args)...), m_has_val(true) {}
+ 
+   template <class U, class... Args,
+-            detail::enable_if_t<std::is_constructible<
++            std::enable_if_t<std::is_constructible<
+                 T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+   constexpr expected_storage_base(in_place_t, std::initializer_list<U> il,
+                                   Args &&...args)
+       : m_val(il, std::forward<Args>(args)...), m_has_val(true) {}
+   template <class... Args,
+-            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
++            std::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+                 nullptr>
+   constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
+       : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
+ 
+   template <class U, class... Args,
+-            detail::enable_if_t<std::is_constructible<
++            std::enable_if_t<std::is_constructible<
+                 E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+   constexpr explicit expected_storage_base(unexpect_t,
+                                            std::initializer_list<U> il,
+@@ -583,25 +417,25 @@ template <class T, class E> struct expected_storage_base<T, E, false, true> {
+   constexpr expected_storage_base(no_init_t) : m_no_init(), m_has_val(false) {}
+ 
+   template <class... Args,
+-            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
++            std::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+                 nullptr>
+   constexpr expected_storage_base(in_place_t, Args &&...args)
+       : m_val(std::forward<Args>(args)...), m_has_val(true) {}
+ 
+   template <class U, class... Args,
+-            detail::enable_if_t<std::is_constructible<
++            std::enable_if_t<std::is_constructible<
+                 T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+   constexpr expected_storage_base(in_place_t, std::initializer_list<U> il,
+                                   Args &&...args)
+       : m_val(il, std::forward<Args>(args)...), m_has_val(true) {}
+   template <class... Args,
+-            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
++            std::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+                 nullptr>
+   constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
+       : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
+ 
+   template <class U, class... Args,
+-            detail::enable_if_t<std::is_constructible<
++            std::enable_if_t<std::is_constructible<
+                 E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+   constexpr explicit expected_storage_base(unexpect_t,
+                                            std::initializer_list<U> il,
+@@ -635,13 +469,13 @@ template <class E> struct expected_storage_base<void, E, false, true> {
+   constexpr expected_storage_base(in_place_t) : m_has_val(true) {}
+ 
+   template <class... Args,
+-            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
++            std::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+                 nullptr>
+   constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
+       : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
+ 
+   template <class U, class... Args,
+-            detail::enable_if_t<std::is_constructible<
++            std::enable_if_t<std::is_constructible<
+                 E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+   constexpr explicit expected_storage_base(unexpect_t,
+                                            std::initializer_list<U> il,
+@@ -665,13 +499,13 @@ template <class E> struct expected_storage_base<void, E, false, false> {
+   constexpr expected_storage_base(in_place_t) : m_dummy(), m_has_val(true) {}
+ 
+   template <class... Args,
+-            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
++            std::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+                 nullptr>
+   constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
+       : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
+ 
+   template <class U, class... Args,
+-            detail::enable_if_t<std::is_constructible<
++            std::enable_if_t<std::is_constructible<
+                 E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+   constexpr explicit expected_storage_base(unexpect_t,
+                                            std::initializer_list<U> il,
+@@ -722,7 +556,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
+   // This overload handles the case where we can just copy-construct `T`
+   // directly into place without throwing.
+   template <class U = T,
+-            detail::enable_if_t<std::is_nothrow_copy_constructible<U>::value>
++            std::enable_if_t<std::is_nothrow_copy_constructible<U>::value>
+                 * = nullptr>
+   void assign(const expected_operations_base &rhs) noexcept {
+     if (!this->m_has_val && rhs.m_has_val) {
+@@ -736,7 +570,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
+   // This overload handles the case where we can attempt to create a copy of
+   // `T`, then no-throw move it into place if the copy was successful.
+   template <class U = T,
+-            detail::enable_if_t<!std::is_nothrow_copy_constructible<U>::value &&
++            std::enable_if_t<!std::is_nothrow_copy_constructible<U>::value &&
+                                 std::is_nothrow_move_constructible<U>::value>
+                 * = nullptr>
+   void assign(const expected_operations_base &rhs) noexcept {
+@@ -755,7 +589,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
+   // then we move the old unexpected value back into place before rethrowing the
+   // exception.
+   template <class U = T,
+-            detail::enable_if_t<!std::is_nothrow_copy_constructible<U>::value &&
++            std::enable_if_t<!std::is_nothrow_copy_constructible<U>::value &&
+                                 !std::is_nothrow_move_constructible<U>::value>
+                 * = nullptr>
+   void assign(const expected_operations_base &rhs) {
+@@ -780,7 +614,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
+ 
+   // These overloads do the same as above, but for rvalues
+   template <class U = T,
+-            detail::enable_if_t<std::is_nothrow_move_constructible<U>::value>
++            std::enable_if_t<std::is_nothrow_move_constructible<U>::value>
+                 * = nullptr>
+   void assign(expected_operations_base &&rhs) noexcept {
+     if (!this->m_has_val && rhs.m_has_val) {
+@@ -792,7 +626,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
+   }
+ 
+   template <class U = T,
+-            detail::enable_if_t<!std::is_nothrow_move_constructible<U>::value>
++            std::enable_if_t<!std::is_nothrow_move_constructible<U>::value>
+                 * = nullptr>
+   void assign(expected_operations_base &&rhs) {
+     if (!this->m_has_val && rhs.m_has_val) {
+@@ -999,9 +833,9 @@ struct expected_move_base<T, E, false> : expected_copy_base<T, E> {
+ // This class manages conditionally having a trivial copy assignment operator
+ template <class T, class E,
+           bool = is_void_or<
+-              T, conjunction<TL_EXPECTED_IS_TRIVIALLY_COPY_ASSIGNABLE(T),
+-                             TL_EXPECTED_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T),
+-                             TL_EXPECTED_IS_TRIVIALLY_DESTRUCTIBLE(T)>>::value
++              T, std::conjunction<TL_EXPECTED_IS_TRIVIALLY_COPY_ASSIGNABLE(T),
++                                  TL_EXPECTED_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T),
++                                  TL_EXPECTED_IS_TRIVIALLY_DESTRUCTIBLE(T)>>::value
+               &&TL_EXPECTED_IS_TRIVIALLY_COPY_ASSIGNABLE(E)::value
+                   &&TL_EXPECTED_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(E)::value
+                       &&TL_EXPECTED_IS_TRIVIALLY_DESTRUCTIBLE(E)::value>
+@@ -1033,7 +867,7 @@ struct expected_copy_assign_base<T, E, false> : expected_move_base<T, E> {
+ #ifndef TL_EXPECTED_GCC49
+ template <class T, class E,
+           bool =
+-              is_void_or<T, conjunction<std::is_trivially_destructible<T>,
++              is_void_or<T, std::conjunction<std::is_trivially_destructible<T>,
+                                         std::is_trivially_move_constructible<T>,
+                                         std::is_trivially_move_assignable<T>>>::
+                   value &&std::is_trivially_destructible<E>::value
+@@ -1266,14 +1100,14 @@ class expected : private detail::expected_move_assign_base<T, E>,
+   }
+ 
+   template <class U = T,
+-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
++            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
+   TL_EXPECTED_11_CONSTEXPR U &val() {
+     return this->m_val;
+   }
+   TL_EXPECTED_11_CONSTEXPR unexpected<E> &err() { return this->m_unexpect; }
+ 
+   template <class U = T,
+-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
++            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
+   constexpr const U &val() const {
+     return this->m_val;
+   }
+@@ -1531,23 +1365,23 @@ public:
+   expected &operator=(expected &&rhs) = default;
+ 
+   template <class... Args,
+-            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
++            std::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+                 nullptr>
+   constexpr expected(in_place_t, Args &&...args)
+       : impl_base(in_place, std::forward<Args>(args)...),
+         ctor_base(detail::default_constructor_tag{}) {}
+ 
+   template <class U, class... Args,
+-            detail::enable_if_t<std::is_constructible<
++            std::enable_if_t<std::is_constructible<
+                 T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+   constexpr expected(in_place_t, std::initializer_list<U> il, Args &&...args)
+       : impl_base(in_place, il, std::forward<Args>(args)...),
+         ctor_base(detail::default_constructor_tag{}) {}
+ 
+   template <class G = E,
+-            detail::enable_if_t<std::is_constructible<E, const G &>::value> * =
++            std::enable_if_t<std::is_constructible<E, const G &>::value> * =
+                 nullptr,
+-            detail::enable_if_t<!std::is_convertible<const G &, E>::value> * =
++            std::enable_if_t<!std::is_convertible<const G &, E>::value> * =
+                 nullptr>
+   explicit constexpr expected(const unexpected<G> &e)
+       : impl_base(unexpect, e.value()),
+@@ -1555,17 +1389,17 @@ public:
+ 
+   template <
+       class G = E,
+-      detail::enable_if_t<std::is_constructible<E, const G &>::value> * =
++      std::enable_if_t<std::is_constructible<E, const G &>::value> * =
+           nullptr,
+-      detail::enable_if_t<std::is_convertible<const G &, E>::value> * = nullptr>
++      std::enable_if_t<std::is_convertible<const G &, E>::value> * = nullptr>
+   constexpr expected(unexpected<G> const &e)
+       : impl_base(unexpect, e.value()),
+         ctor_base(detail::default_constructor_tag{}) {}
+ 
+   template <
+       class G = E,
+-      detail::enable_if_t<std::is_constructible<E, G &&>::value> * = nullptr,
+-      detail::enable_if_t<!std::is_convertible<G &&, E>::value> * = nullptr>
++      std::enable_if_t<std::is_constructible<E, G &&>::value> * = nullptr,
++      std::enable_if_t<!std::is_convertible<G &&, E>::value> * = nullptr>
+   explicit constexpr expected(unexpected<G> &&e) noexcept(
+       std::is_nothrow_constructible<E, G &&>::value)
+       : impl_base(unexpect, std::move(e.value())),
+@@ -1573,22 +1407,22 @@ public:
+ 
+   template <
+       class G = E,
+-      detail::enable_if_t<std::is_constructible<E, G &&>::value> * = nullptr,
+-      detail::enable_if_t<std::is_convertible<G &&, E>::value> * = nullptr>
++      std::enable_if_t<std::is_constructible<E, G &&>::value> * = nullptr,
++      std::enable_if_t<std::is_convertible<G &&, E>::value> * = nullptr>
+   constexpr expected(unexpected<G> &&e) noexcept(
+       std::is_nothrow_constructible<E, G &&>::value)
+       : impl_base(unexpect, std::move(e.value())),
+         ctor_base(detail::default_constructor_tag{}) {}
+ 
+   template <class... Args,
+-            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
++            std::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+                 nullptr>
+   constexpr explicit expected(unexpect_t, Args &&...args)
+       : impl_base(unexpect, std::forward<Args>(args)...),
+         ctor_base(detail::default_constructor_tag{}) {}
+ 
+   template <class U, class... Args,
+-            detail::enable_if_t<std::is_constructible<
++            std::enable_if_t<std::is_constructible<
+                 E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+   constexpr explicit expected(unexpect_t, std::initializer_list<U> il,
+                               Args &&...args)
+@@ -1596,7 +1430,7 @@ public:
+         ctor_base(detail::default_constructor_tag{}) {}
+ 
+   template <class U, class G,
+-            detail::enable_if_t<!(std::is_convertible<U const &, T>::value &&
++            std::enable_if_t<!(std::is_convertible<U const &, T>::value &&
+                                   std::is_convertible<G const &, E>::value)> * =
+                 nullptr,
+             detail::expected_enable_from_other<T, E, U, G, const U &, const G &>
+@@ -1611,7 +1445,7 @@ public:
+   }
+ 
+   template <class U, class G,
+-            detail::enable_if_t<(std::is_convertible<U const &, T>::value &&
++            std::enable_if_t<(std::is_convertible<U const &, T>::value &&
+                                  std::is_convertible<G const &, E>::value)> * =
+                 nullptr,
+             detail::expected_enable_from_other<T, E, U, G, const U &, const G &>
+@@ -1627,7 +1461,7 @@ public:
+ 
+   template <
+       class U, class G,
+-      detail::enable_if_t<!(std::is_convertible<U &&, T>::value &&
++      std::enable_if_t<!(std::is_convertible<U &&, T>::value &&
+                             std::is_convertible<G &&, E>::value)> * = nullptr,
+       detail::expected_enable_from_other<T, E, U, G, U &&, G &&> * = nullptr>
+   explicit TL_EXPECTED_11_CONSTEXPR expected(expected<U, G> &&rhs)
+@@ -1641,7 +1475,7 @@ public:
+ 
+   template <
+       class U, class G,
+-      detail::enable_if_t<(std::is_convertible<U &&, T>::value &&
++      std::enable_if_t<(std::is_convertible<U &&, T>::value &&
+                            std::is_convertible<G &&, E>::value)> * = nullptr,
+       detail::expected_enable_from_other<T, E, U, G, U &&, G &&> * = nullptr>
+   TL_EXPECTED_11_CONSTEXPR expected(expected<U, G> &&rhs)
+@@ -1655,27 +1489,27 @@ public:
+ 
+   template <
+       class U = T,
+-      detail::enable_if_t<!std::is_convertible<U &&, T>::value> * = nullptr,
++      std::enable_if_t<!std::is_convertible<U &&, T>::value> * = nullptr,
+       detail::expected_enable_forward_value<T, E, U> * = nullptr>
+   explicit TL_EXPECTED_MSVC2015_CONSTEXPR expected(U &&v)
+       : expected(in_place, std::forward<U>(v)) {}
+ 
+   template <
+       class U = T,
+-      detail::enable_if_t<std::is_convertible<U &&, T>::value> * = nullptr,
++      std::enable_if_t<std::is_convertible<U &&, T>::value> * = nullptr,
+       detail::expected_enable_forward_value<T, E, U> * = nullptr>
+   TL_EXPECTED_MSVC2015_CONSTEXPR expected(U &&v)
+       : expected(in_place, std::forward<U>(v)) {}
+ 
+   template <
+       class U = T, class G = T,
+-      detail::enable_if_t<std::is_nothrow_constructible<T, U &&>::value> * =
++      std::enable_if_t<std::is_nothrow_constructible<T, U &&>::value> * =
+           nullptr,
+-      detail::enable_if_t<!std::is_void<G>::value> * = nullptr,
+-      detail::enable_if_t<
+-          (!std::is_same<expected<T, E>, detail::decay_t<U>>::value &&
+-           !detail::conjunction<std::is_scalar<T>,
+-                                std::is_same<T, detail::decay_t<U>>>::value &&
++      std::enable_if_t<!std::is_void<G>::value> * = nullptr,
++      std::enable_if_t<
++          (!std::is_same<expected<T, E>, std::decay_t<U>>::value &&
++           !std::conjunction<std::is_scalar<T>,
++                             std::is_same<T, std::decay_t<U>>>::value &&
+            std::is_constructible<T, U>::value &&
+            std::is_assignable<G &, U>::value &&
+            std::is_nothrow_move_constructible<E>::value)> * = nullptr>
+@@ -1693,13 +1527,13 @@ public:
+ 
+   template <
+       class U = T, class G = T,
+-      detail::enable_if_t<!std::is_nothrow_constructible<T, U &&>::value> * =
++      std::enable_if_t<!std::is_nothrow_constructible<T, U &&>::value> * =
+           nullptr,
+-      detail::enable_if_t<!std::is_void<U>::value> * = nullptr,
+-      detail::enable_if_t<
+-          (!std::is_same<expected<T, E>, detail::decay_t<U>>::value &&
+-           !detail::conjunction<std::is_scalar<T>,
+-                                std::is_same<T, detail::decay_t<U>>>::value &&
++      std::enable_if_t<!std::is_void<U>::value> * = nullptr,
++      std::enable_if_t<
++          (!std::is_same<expected<T, E>, std::decay_t<U>>::value &&
++           !std::conjunction<std::is_scalar<T>,
++                             std::is_same<T, std::decay_t<U>>>::value &&
+            std::is_constructible<T, U>::value &&
+            std::is_assignable<G &, U>::value &&
+            std::is_nothrow_move_constructible<E>::value)> * = nullptr>
+@@ -1728,8 +1562,8 @@ public:
+   }
+ 
+   template <class G = E,
+-            detail::enable_if_t<std::is_nothrow_copy_constructible<G>::value &&
+-                                std::is_assignable<G &, G>::value> * = nullptr>
++            std::enable_if_t<std::is_nothrow_copy_constructible<G>::value &&
++                             std::is_assignable<G &, G>::value> * = nullptr>
+   expected &operator=(const unexpected<G> &rhs) {
+     if (!has_value()) {
+       err() = rhs;
+@@ -1743,8 +1577,8 @@ public:
+   }
+ 
+   template <class G = E,
+-            detail::enable_if_t<std::is_nothrow_move_constructible<G>::value &&
+-                                std::is_move_assignable<G>::value> * = nullptr>
++            std::enable_if_t<std::is_nothrow_move_constructible<G>::value &&
++                             std::is_move_assignable<G>::value> * = nullptr>
+   expected &operator=(unexpected<G> &&rhs) noexcept {
+     if (!has_value()) {
+       err() = std::move(rhs);
+@@ -1757,7 +1591,7 @@ public:
+     return *this;
+   }
+ 
+-  template <class... Args, detail::enable_if_t<std::is_nothrow_constructible<
++  template <class... Args, std::enable_if_t<std::is_nothrow_constructible<
+                                T, Args &&...>::value> * = nullptr>
+   void emplace(Args &&...args) {
+     if (has_value()) {
+@@ -1769,7 +1603,7 @@ public:
+     ::new (valptr()) T(std::forward<Args>(args)...);
+   }
+ 
+-  template <class... Args, detail::enable_if_t<!std::is_nothrow_constructible<
++  template <class... Args, std::enable_if_t<!std::is_nothrow_constructible<
+                                T, Args &&...>::value> * = nullptr>
+   void emplace(Args &&...args) {
+     if (has_value()) {
+@@ -1795,7 +1629,7 @@ public:
+   }
+ 
+   template <class U, class... Args,
+-            detail::enable_if_t<std::is_nothrow_constructible<
++            std::enable_if_t<std::is_nothrow_constructible<
+                 T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+   void emplace(std::initializer_list<U> il, Args &&...args) {
+     if (has_value()) {
+@@ -1809,7 +1643,7 @@ public:
+   }
+ 
+   template <class U, class... Args,
+-            detail::enable_if_t<!std::is_nothrow_constructible<
++            std::enable_if_t<!std::is_nothrow_constructible<
+                 T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+   void emplace(std::initializer_list<U> il, Args &&...args) {
+     if (has_value()) {
+@@ -1923,15 +1757,15 @@ private:
+ 
+ public:
+   template <class OT = T, class OE = E>
+-  detail::enable_if_t<detail::is_swappable<OT>::value &&
+-                      detail::is_swappable<OE>::value &&
+-                      (std::is_nothrow_move_constructible<OT>::value ||
+-                       std::is_nothrow_move_constructible<OE>::value)>
++  std::enable_if_t<std::is_swappable<OT>::value &&
++                   std::is_swappable<OE>::value &&
++                   (std::is_nothrow_move_constructible<OT>::value ||
++                    std::is_nothrow_move_constructible<OE>::value)>
+   swap(expected &rhs) noexcept(
+       std::is_nothrow_move_constructible<T>::value
+-          &&detail::is_nothrow_swappable<T>::value
++          &&std::is_nothrow_swappable<T>::value
+               &&std::is_nothrow_move_constructible<E>::value
+-                  &&detail::is_nothrow_swappable<E>::value) {
++                  &&std::is_nothrow_swappable<E>::value) {
+     if (has_value() && rhs.has_value()) {
+       swap_where_both_have_value(rhs, typename std::is_void<T>::type{});
+     } else if (!has_value() && rhs.has_value()) {
+@@ -1954,25 +1788,25 @@ public:
+   }
+ 
+   template <class U = T,
+-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
++            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
+   constexpr const U &operator*() const & {
+     TL_ASSERT(has_value());
+     return val();
+   }
+   template <class U = T,
+-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
++            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
+   TL_EXPECTED_11_CONSTEXPR U &operator*() & {
+     TL_ASSERT(has_value());
+     return val();
+   }
+   template <class U = T,
+-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
++            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
+   constexpr const U &&operator*() const && {
+     TL_ASSERT(has_value());
+     return std::move(val());
+   }
+   template <class U = T,
+-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
++            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
+   TL_EXPECTED_11_CONSTEXPR U &&operator*() && {
+     TL_ASSERT(has_value());
+     return std::move(val());
+@@ -1982,28 +1816,28 @@ public:
+   constexpr explicit operator bool() const noexcept { return this->m_has_val; }
+ 
+   template <class U = T,
+-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
++            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
+   TL_EXPECTED_11_CONSTEXPR const U &value() const & {
+     if (!has_value())
+       detail::throw_exception(bad_expected_access<E>(err().value()));
+     return val();
+   }
+   template <class U = T,
+-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
++            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
+   TL_EXPECTED_11_CONSTEXPR U &value() & {
+     if (!has_value())
+       detail::throw_exception(bad_expected_access<E>(err().value()));
+     return val();
+   }
+   template <class U = T,
+-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
++            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
+   TL_EXPECTED_11_CONSTEXPR const U &&value() const && {
+     if (!has_value())
+       detail::throw_exception(bad_expected_access<E>(std::move(err()).value()));
+     return std::move(val());
+   }
+   template <class U = T,
+-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
++            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
+   TL_EXPECTED_11_CONSTEXPR U &&value() && {
+     if (!has_value())
+       detail::throw_exception(bad_expected_access<E>(std::move(err()).value()));
+@@ -2042,79 +1876,79 @@ public:
+ };
+ 
+ namespace detail {
+-template <class Exp> using exp_t = typename detail::decay_t<Exp>::value_type;
+-template <class Exp> using err_t = typename detail::decay_t<Exp>::error_type;
++template <class Exp> using exp_t = typename std::decay_t<Exp>::value_type;
++template <class Exp> using err_t = typename std::decay_t<Exp>::error_type;
+ template <class Exp, class Ret> using ret_t = expected<Ret, err_t<Exp>>;
+ 
+ #ifdef TL_EXPECTED_CXX14
+ template <class Exp, class F,
+-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              *std::declval<Exp>()))>
++          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           *std::declval<Exp>()))>
+ constexpr auto and_then_impl(Exp &&exp, F &&f) {
+   static_assert(detail::is_expected<Ret>::value, "F must return an expected");
+ 
+   return exp.has_value()
+-             ? detail::invoke(std::forward<F>(f), *std::forward<Exp>(exp))
++             ? std::invoke(std::forward<F>(f), *std::forward<Exp>(exp))
+              : Ret(unexpect, std::forward<Exp>(exp).error());
+ }
+ 
+ template <class Exp, class F,
+-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>()))>
++          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>()))>
+ constexpr auto and_then_impl(Exp &&exp, F &&f) {
+   static_assert(detail::is_expected<Ret>::value, "F must return an expected");
+ 
+-  return exp.has_value() ? detail::invoke(std::forward<F>(f))
++  return exp.has_value() ? std::invoke(std::forward<F>(f))
+                          : Ret(unexpect, std::forward<Exp>(exp).error());
+ }
+ #else
+ template <class> struct TC;
+ template <class Exp, class F,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              *std::declval<Exp>())),
+-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr>
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           *std::declval<Exp>())),
++          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr>
+ auto and_then_impl(Exp &&exp, F &&f) -> Ret {
+   static_assert(detail::is_expected<Ret>::value, "F must return an expected");
+ 
+   return exp.has_value()
+-             ? detail::invoke(std::forward<F>(f), *std::forward<Exp>(exp))
++             ? std::invoke(std::forward<F>(f), *std::forward<Exp>(exp))
+              : Ret(unexpect, std::forward<Exp>(exp).error());
+ }
+ 
+ template <class Exp, class F,
+-          class Ret = decltype(detail::invoke(std::declval<F>())),
+-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr>
++          class Ret = decltype(std::invoke(std::declval<F>())),
++          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr>
+ constexpr auto and_then_impl(Exp &&exp, F &&f) -> Ret {
+   static_assert(detail::is_expected<Ret>::value, "F must return an expected");
+ 
+-  return exp.has_value() ? detail::invoke(std::forward<F>(f))
++  return exp.has_value() ? std::invoke(std::forward<F>(f))
+                          : Ret(unexpect, std::forward<Exp>(exp).error());
+ }
+ #endif
+ 
+ #ifdef TL_EXPECTED_CXX14
+ template <class Exp, class F,
+-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              *std::declval<Exp>())),
+-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           *std::declval<Exp>())),
++          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+ constexpr auto expected_map_impl(Exp &&exp, F &&f) {
+-  using result = ret_t<Exp, detail::decay_t<Ret>>;
+-  return exp.has_value() ? result(detail::invoke(std::forward<F>(f),
+-                                                 *std::forward<Exp>(exp)))
++  using result = ret_t<Exp, std::decay_t<Ret>>;
++  return exp.has_value() ? result(std::invoke(std::forward<F>(f),
++                                              *std::forward<Exp>(exp)))
+                          : result(unexpect, std::forward<Exp>(exp).error());
+ }
+ 
+ template <class Exp, class F,
+-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              *std::declval<Exp>())),
+-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           *std::declval<Exp>())),
++          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+ auto expected_map_impl(Exp &&exp, F &&f) {
+   using result = expected<void, err_t<Exp>>;
+   if (exp.has_value()) {
+-    detail::invoke(std::forward<F>(f), *std::forward<Exp>(exp));
++    std::invoke(std::forward<F>(f), *std::forward<Exp>(exp));
+     return result();
+   }
+ 
+@@ -2122,23 +1956,23 @@ auto expected_map_impl(Exp &&exp, F &&f) {
+ }
+ 
+ template <class Exp, class F,
+-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>())),
+-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>())),
++          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+ constexpr auto expected_map_impl(Exp &&exp, F &&f) {
+-  using result = ret_t<Exp, detail::decay_t<Ret>>;
+-  return exp.has_value() ? result(detail::invoke(std::forward<F>(f)))
++  using result = ret_t<Exp, std::decay_t<Ret>>;
++  return exp.has_value() ? result(std::invoke(std::forward<F>(f)))
+                          : result(unexpect, std::forward<Exp>(exp).error());
+ }
+ 
+ template <class Exp, class F,
+-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>())),
+-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>())),
++          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+ auto expected_map_impl(Exp &&exp, F &&f) {
+   using result = expected<void, err_t<Exp>>;
+   if (exp.has_value()) {
+-    detail::invoke(std::forward<F>(f));
++    std::invoke(std::forward<F>(f));
+     return result();
+   }
+ 
+@@ -2146,29 +1980,29 @@ auto expected_map_impl(Exp &&exp, F &&f) {
+ }
+ #else
+ template <class Exp, class F,
+-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              *std::declval<Exp>())),
+-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           *std::declval<Exp>())),
++          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+ 
+ constexpr auto expected_map_impl(Exp &&exp, F &&f)
+-    -> ret_t<Exp, detail::decay_t<Ret>> {
+-  using result = ret_t<Exp, detail::decay_t<Ret>>;
++    -> ret_t<Exp, std::decay_t<Ret>> {
++  using result = ret_t<Exp, std::decay_t<Ret>>;
+ 
+-  return exp.has_value() ? result(detail::invoke(std::forward<F>(f),
+-                                                 *std::forward<Exp>(exp)))
++  return exp.has_value() ? result(std::invoke(std::forward<F>(f),
++                                              *std::forward<Exp>(exp)))
+                          : result(unexpect, std::forward<Exp>(exp).error());
+ }
+ 
+ template <class Exp, class F,
+-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              *std::declval<Exp>())),
+-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           *std::declval<Exp>())),
++          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+ 
+ auto expected_map_impl(Exp &&exp, F &&f) -> expected<void, err_t<Exp>> {
+   if (exp.has_value()) {
+-    detail::invoke(std::forward<F>(f), *std::forward<Exp>(exp));
++    std::invoke(std::forward<F>(f), *std::forward<Exp>(exp));
+     return {};
+   }
+ 
+@@ -2176,26 +2010,26 @@ auto expected_map_impl(Exp &&exp, F &&f) -> expected<void, err_t<Exp>> {
+ }
+ 
+ template <class Exp, class F,
+-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>())),
+-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>())),
++          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+ 
+ constexpr auto expected_map_impl(Exp &&exp, F &&f)
+-    -> ret_t<Exp, detail::decay_t<Ret>> {
+-  using result = ret_t<Exp, detail::decay_t<Ret>>;
++    -> ret_t<Exp, std::decay_t<Ret>> {
++  using result = ret_t<Exp, std::decay_t<Ret>>;
+ 
+-  return exp.has_value() ? result(detail::invoke(std::forward<F>(f)))
++  return exp.has_value() ? result(std::invoke(std::forward<F>(f)))
+                          : result(unexpect, std::forward<Exp>(exp).error());
+ }
+ 
+ template <class Exp, class F,
+-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>())),
+-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>())),
++          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+ 
+ auto expected_map_impl(Exp &&exp, F &&f) -> expected<void, err_t<Exp>> {
+   if (exp.has_value()) {
+-    detail::invoke(std::forward<F>(f));
++    std::invoke(std::forward<F>(f));
+     return {};
+   }
+ 
+@@ -2206,161 +2040,161 @@ auto expected_map_impl(Exp &&exp, F &&f) -> expected<void, err_t<Exp>> {
+ #if defined(TL_EXPECTED_CXX14) && !defined(TL_EXPECTED_GCC49) &&               \
+     !defined(TL_EXPECTED_GCC54) && !defined(TL_EXPECTED_GCC55)
+ template <class Exp, class F,
+-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              std::declval<Exp>().error())),
+-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           std::declval<Exp>().error())),
++          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+ constexpr auto map_error_impl(Exp &&exp, F &&f) {
+-  using result = expected<exp_t<Exp>, detail::decay_t<Ret>>;
++  using result = expected<exp_t<Exp>, std::decay_t<Ret>>;
+   return exp.has_value()
+              ? result(*std::forward<Exp>(exp))
+-             : result(unexpect, detail::invoke(std::forward<F>(f),
+-                                               std::forward<Exp>(exp).error()));
++             : result(unexpect, std::invoke(std::forward<F>(f),
++                                            std::forward<Exp>(exp).error()));
+ }
+ template <class Exp, class F,
+-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              std::declval<Exp>().error())),
+-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           std::declval<Exp>().error())),
++          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+ auto map_error_impl(Exp &&exp, F &&f) {
+   using result = expected<exp_t<Exp>, monostate>;
+   if (exp.has_value()) {
+     return result(*std::forward<Exp>(exp));
+   }
+ 
+-  detail::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
++  std::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
+   return result(unexpect, monostate{});
+ }
+ template <class Exp, class F,
+-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              std::declval<Exp>().error())),
+-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           std::declval<Exp>().error())),
++          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+ constexpr auto map_error_impl(Exp &&exp, F &&f) {
+-  using result = expected<exp_t<Exp>, detail::decay_t<Ret>>;
++  using result = expected<exp_t<Exp>, std::decay_t<Ret>>;
+   return exp.has_value()
+              ? result()
+-             : result(unexpect, detail::invoke(std::forward<F>(f),
+-                                               std::forward<Exp>(exp).error()));
++             : result(unexpect, std::invoke(std::forward<F>(f),
++                                            std::forward<Exp>(exp).error()));
+ }
+ template <class Exp, class F,
+-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              std::declval<Exp>().error())),
+-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           std::declval<Exp>().error())),
++          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+ auto map_error_impl(Exp &&exp, F &&f) {
+   using result = expected<exp_t<Exp>, monostate>;
+   if (exp.has_value()) {
+     return result();
+   }
+ 
+-  detail::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
++  std::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
+   return result(unexpect, monostate{});
+ }
+ #else
+ template <class Exp, class F,
+-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              std::declval<Exp>().error())),
+-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           std::declval<Exp>().error())),
++          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+ constexpr auto map_error_impl(Exp &&exp, F &&f)
+-    -> expected<exp_t<Exp>, detail::decay_t<Ret>> {
+-  using result = expected<exp_t<Exp>, detail::decay_t<Ret>>;
++    -> expected<exp_t<Exp>, std::decay_t<Ret>> {
++  using result = expected<exp_t<Exp>, std::decay_t<Ret>>;
+ 
+   return exp.has_value()
+              ? result(*std::forward<Exp>(exp))
+-             : result(unexpect, detail::invoke(std::forward<F>(f),
+-                                               std::forward<Exp>(exp).error()));
++             : result(unexpect, std::invoke(std::forward<F>(f),
++                                            std::forward<Exp>(exp).error()));
+ }
+ 
+ template <class Exp, class F,
+-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              std::declval<Exp>().error())),
+-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           std::declval<Exp>().error())),
++          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+ auto map_error_impl(Exp &&exp, F &&f) -> expected<exp_t<Exp>, monostate> {
+   using result = expected<exp_t<Exp>, monostate>;
+   if (exp.has_value()) {
+     return result(*std::forward<Exp>(exp));
+   }
+ 
+-  detail::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
++  std::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
+   return result(unexpect, monostate{});
+ }
+ 
+ template <class Exp, class F,
+-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              std::declval<Exp>().error())),
+-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           std::declval<Exp>().error())),
++          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+ constexpr auto map_error_impl(Exp &&exp, F &&f)
+-    -> expected<exp_t<Exp>, detail::decay_t<Ret>> {
+-  using result = expected<exp_t<Exp>, detail::decay_t<Ret>>;
++    -> expected<exp_t<Exp>, std::decay_t<Ret>> {
++  using result = expected<exp_t<Exp>, std::decay_t<Ret>>;
+ 
+   return exp.has_value()
+              ? result()
+-             : result(unexpect, detail::invoke(std::forward<F>(f),
+-                                               std::forward<Exp>(exp).error()));
++             : result(unexpect, std::invoke(std::forward<F>(f),
++                                            std::forward<Exp>(exp).error()));
+ }
+ 
+ template <class Exp, class F,
+-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              std::declval<Exp>().error())),
+-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
++          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           std::declval<Exp>().error())),
++          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+ auto map_error_impl(Exp &&exp, F &&f) -> expected<exp_t<Exp>, monostate> {
+   using result = expected<exp_t<Exp>, monostate>;
+   if (exp.has_value()) {
+     return result();
+   }
+ 
+-  detail::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
++  std::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
+   return result(unexpect, monostate{});
+ }
+ #endif
+ 
+ #ifdef TL_EXPECTED_CXX14
+ template <class Exp, class F,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              std::declval<Exp>().error())),
+-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           std::declval<Exp>().error())),
++          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+ constexpr auto or_else_impl(Exp &&exp, F &&f) {
+   static_assert(detail::is_expected<Ret>::value, "F must return an expected");
+   return exp.has_value() ? std::forward<Exp>(exp)
+-                         : detail::invoke(std::forward<F>(f),
+-                                          std::forward<Exp>(exp).error());
++                         : std::invoke(std::forward<F>(f),
++                                       std::forward<Exp>(exp).error());
+ }
+ 
+ template <class Exp, class F,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              std::declval<Exp>().error())),
+-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+-detail::decay_t<Exp> or_else_impl(Exp &&exp, F &&f) {
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           std::declval<Exp>().error())),
++          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
++std::decay_t<Exp> or_else_impl(Exp &&exp, F &&f) {
+   return exp.has_value() ? std::forward<Exp>(exp)
+-                         : (detail::invoke(std::forward<F>(f),
+-                                           std::forward<Exp>(exp).error()),
++                         : (std::invoke(std::forward<F>(f),
++                                        std::forward<Exp>(exp).error()),
+                             std::forward<Exp>(exp));
+ }
+ #else
+ template <class Exp, class F,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              std::declval<Exp>().error())),
+-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           std::declval<Exp>().error())),
++          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+ auto or_else_impl(Exp &&exp, F &&f) -> Ret {
+   static_assert(detail::is_expected<Ret>::value, "F must return an expected");
+   return exp.has_value() ? std::forward<Exp>(exp)
+-                         : detail::invoke(std::forward<F>(f),
+-                                          std::forward<Exp>(exp).error());
++                         : std::invoke(std::forward<F>(f),
++                                       std::forward<Exp>(exp).error());
+ }
+ 
+ template <class Exp, class F,
+-          class Ret = decltype(detail::invoke(std::declval<F>(),
+-                                              std::declval<Exp>().error())),
+-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+-detail::decay_t<Exp> or_else_impl(Exp &&exp, F &&f) {
++          class Ret = decltype(std::invoke(std::declval<F>(),
++                                           std::declval<Exp>().error())),
++          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
++std::decay_t<Exp> or_else_impl(Exp &&exp, F &&f) {
+   return exp.has_value() ? std::forward<Exp>(exp)
+-                         : (detail::invoke(std::forward<F>(f),
+-                                           std::forward<Exp>(exp).error()),
++                         : (std::invoke(std::forward<F>(f),
++                                        std::forward<Exp>(exp).error()),
+                             std::forward<Exp>(exp));
+ }
+ #endif
+@@ -2430,11 +2264,11 @@ constexpr bool operator!=(const unexpected<E> &e, const expected<T, E> &x) {
+ }
+ 
+ template <class T, class E,
+-          detail::enable_if_t<(std::is_void<T>::value ||
+-                               std::is_move_constructible<T>::value) &&
+-                              detail::is_swappable<T>::value &&
+-                              std::is_move_constructible<E>::value &&
+-                              detail::is_swappable<E>::value> * = nullptr>
++          std::enable_if_t<(std::is_void<T>::value ||
++                            std::is_move_constructible<T>::value) &&
++                           std::is_swappable<T>::value &&
++                           std::is_move_constructible<E>::value &&
++                           std::is_swappable<E>::value> * = nullptr>
+ void swap(expected<T, E> &lhs,
+           expected<T, E> &rhs) noexcept(noexcept(lhs.swap(rhs))) {
+   lhs.swap(rhs);

--- a/wpiutil/src/main/native/thirdparty/expected/include/wpi/expected
+++ b/wpiutil/src/main/native/thirdparty/expected/include/wpi/expected
@@ -222,187 +222,21 @@ template <typename E>
 #endif
 }
 
-#ifndef WPI_TRAITS_MUTEX
-#define WPI_TRAITS_MUTEX
-// C++14-style aliases for brevity
-template <class T> using remove_const_t = typename std::remove_const<T>::type;
-template <class T>
-using remove_reference_t = typename std::remove_reference<T>::type;
-template <class T> using decay_t = typename std::decay<T>::type;
-template <bool E, class T = void>
-using enable_if_t = typename std::enable_if<E, T>::type;
-template <bool B, class T, class F>
-using conditional_t = typename std::conditional<B, T, F>::type;
-
-// std::conjunction from C++17
-template <class...> struct conjunction : std::true_type {};
-template <class B> struct conjunction<B> : B {};
-template <class B, class... Bs>
-struct conjunction<B, Bs...>
-    : std::conditional<bool(B::value), conjunction<Bs...>, B>::type {};
-
-#if defined(_LIBCPP_VERSION) && __cplusplus == 201103L
-#define WPI_TRAITS_LIBCXX_MEM_FN_WORKAROUND
-#endif
-
-// In C++11 mode, there's an issue in libc++'s std::mem_fn
-// which results in a hard-error when using it in a noexcept expression
-// in some cases. This is a check to workaround the common failing case.
-#ifdef WPI_TRAITS_LIBCXX_MEM_FN_WORKAROUND
-template <class T>
-struct is_pointer_to_non_const_member_func : std::false_type {};
-template <class T, class Ret, class... Args>
-struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...)>
-    : std::true_type {};
-template <class T, class Ret, class... Args>
-struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) &>
-    : std::true_type {};
-template <class T, class Ret, class... Args>
-struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) &&>
-    : std::true_type {};
-template <class T, class Ret, class... Args>
-struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) volatile>
-    : std::true_type {};
-template <class T, class Ret, class... Args>
-struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) volatile &>
-    : std::true_type {};
-template <class T, class Ret, class... Args>
-struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) volatile &&>
-    : std::true_type {};
-
-template <class T> struct is_const_or_const_ref : std::false_type {};
-template <class T> struct is_const_or_const_ref<T const &> : std::true_type {};
-template <class T> struct is_const_or_const_ref<T const> : std::true_type {};
-#endif
-
-// std::invoke from C++17
-// https://stackoverflow.com/questions/38288042/c11-14-invoke-workaround
-template <
-    typename Fn, typename... Args,
-#ifdef WPI_TRAITS_LIBCXX_MEM_FN_WORKAROUND
-    typename = enable_if_t<!(is_pointer_to_non_const_member_func<Fn>::value &&
-                             is_const_or_const_ref<Args...>::value)>,
-#endif
-    typename = enable_if_t<std::is_member_pointer<decay_t<Fn>>::value>, int = 0>
-constexpr auto invoke(Fn &&f, Args &&...args) noexcept(
-    noexcept(std::mem_fn(f)(std::forward<Args>(args)...)))
-    -> decltype(std::mem_fn(f)(std::forward<Args>(args)...)) {
-  return std::mem_fn(f)(std::forward<Args>(args)...);
-}
-
-template <typename Fn, typename... Args,
-          typename = enable_if_t<!std::is_member_pointer<decay_t<Fn>>::value>>
-constexpr auto invoke(Fn &&f, Args &&...args) noexcept(
-    noexcept(std::forward<Fn>(f)(std::forward<Args>(args)...)))
-    -> decltype(std::forward<Fn>(f)(std::forward<Args>(args)...)) {
-  return std::forward<Fn>(f)(std::forward<Args>(args)...);
-}
-
-// std::invoke_result from C++17
-template <class F, class, class... Us> struct invoke_result_impl;
-
-template <class F, class... Us>
-struct invoke_result_impl<
-    F,
-    decltype(detail::invoke(std::declval<F>(), std::declval<Us>()...), void()),
-    Us...> {
-  using type =
-      decltype(detail::invoke(std::declval<F>(), std::declval<Us>()...));
-};
-
-template <class F, class... Us>
-using invoke_result = invoke_result_impl<F, void, Us...>;
-
-template <class F, class... Us>
-using invoke_result_t = typename invoke_result<F, Us...>::type;
-
-#if defined(_MSC_VER) && _MSC_VER <= 1900
-// TODO make a version which works with MSVC 2015
-template <class T, class U = T> struct is_swappable : std::true_type {};
-
-template <class T, class U = T> struct is_nothrow_swappable : std::true_type {};
-#else
-// https://stackoverflow.com/questions/26744589/what-is-a-proper-way-to-implement-is-swappable-to-test-for-the-swappable-concept
-namespace swap_adl_tests {
-// if swap ADL finds this then it would call std::swap otherwise (same
-// signature)
-struct tag {};
-
-template <class T> tag swap(T &, T &);
-template <class T, std::size_t N> tag swap(T (&a)[N], T (&b)[N]);
-
-// helper functions to test if an unqualified swap is possible, and if it
-// becomes std::swap
-template <class, class> std::false_type can_swap(...) noexcept(false);
-template <class T, class U,
-          class = decltype(swap(std::declval<T &>(), std::declval<U &>()))>
-std::true_type can_swap(int) noexcept(noexcept(swap(std::declval<T &>(),
-                                                    std::declval<U &>())));
-
-template <class, class> std::false_type uses_std(...);
-template <class T, class U>
-std::is_same<decltype(swap(std::declval<T &>(), std::declval<U &>())), tag>
-uses_std(int);
-
-template <class T>
-struct is_std_swap_noexcept
-    : std::integral_constant<bool,
-                             std::is_nothrow_move_constructible<T>::value &&
-                                 std::is_nothrow_move_assignable<T>::value> {};
-
-template <class T, std::size_t N>
-struct is_std_swap_noexcept<T[N]> : is_std_swap_noexcept<T> {};
-
-template <class T, class U>
-struct is_adl_swap_noexcept
-    : std::integral_constant<bool, noexcept(can_swap<T, U>(0))> {};
-} // namespace swap_adl_tests
-
-template <class T, class U = T>
-struct is_swappable
-    : std::integral_constant<
-          bool,
-          decltype(detail::swap_adl_tests::can_swap<T, U>(0))::value &&
-              (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value ||
-               (std::is_move_assignable<T>::value &&
-                std::is_move_constructible<T>::value))> {};
-
-template <class T, std::size_t N>
-struct is_swappable<T[N], T[N]>
-    : std::integral_constant<
-          bool,
-          decltype(detail::swap_adl_tests::can_swap<T[N], T[N]>(0))::value &&
-              (!decltype(detail::swap_adl_tests::uses_std<T[N], T[N]>(
-                   0))::value ||
-               is_swappable<T, T>::value)> {};
-
-template <class T, class U = T>
-struct is_nothrow_swappable
-    : std::integral_constant<
-          bool,
-          is_swappable<T, U>::value &&
-              ((decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value &&
-                detail::swap_adl_tests::is_std_swap_noexcept<T>::value) ||
-               (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value &&
-                detail::swap_adl_tests::is_adl_swap_noexcept<T, U>::value))> {};
-#endif
-#endif
-
 // Trait for checking if a type is a wpi::expected
 template <class T> struct is_expected_impl : std::false_type {};
 template <class T, class E>
 struct is_expected_impl<expected<T, E>> : std::true_type {};
-template <class T> using is_expected = is_expected_impl<decay_t<T>>;
+template <class T> using is_expected = is_expected_impl<std::decay_t<T>>;
 
 template <class T, class E, class U>
-using expected_enable_forward_value = detail::enable_if_t<
+using expected_enable_forward_value = std::enable_if_t<
     std::is_constructible<T, U &&>::value &&
-    !std::is_same<detail::decay_t<U>, in_place_t>::value &&
-    !std::is_same<expected<T, E>, detail::decay_t<U>>::value &&
-    !std::is_same<unexpected<E>, detail::decay_t<U>>::value>;
+    !std::is_same<std::decay_t<U>, in_place_t>::value &&
+    !std::is_same<expected<T, E>, std::decay_t<U>>::value &&
+    !std::is_same<unexpected<E>, std::decay_t<U>>::value>;
 
 template <class T, class E, class U, class G, class UR, class GR>
-using expected_enable_from_other = detail::enable_if_t<
+using expected_enable_from_other = std::enable_if_t<
     std::is_constructible<T, UR>::value &&
     std::is_constructible<E, GR>::value &&
     !std::is_constructible<T, expected<U, G> &>::value &&
@@ -415,7 +249,7 @@ using expected_enable_from_other = detail::enable_if_t<
     !std::is_convertible<const expected<U, G> &&, T>::value>;
 
 template <class T, class U>
-using is_void_or = conditional_t<std::is_void<T>::value, std::true_type, U>;
+using is_void_or = std::conditional_t<std::is_void<T>::value, std::true_type, U>;
 
 template <class T>
 using is_copy_constructible_or_void =
@@ -450,25 +284,25 @@ struct expected_storage_base {
   constexpr expected_storage_base(no_init_t) : m_no_init(), m_has_val(false) {}
 
   template <class... Args,
-            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+            std::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
                 nullptr>
   constexpr expected_storage_base(in_place_t, Args &&...args)
       : m_val(std::forward<Args>(args)...), m_has_val(true) {}
 
   template <class U, class... Args,
-            detail::enable_if_t<std::is_constructible<
+            std::enable_if_t<std::is_constructible<
                 T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
   constexpr expected_storage_base(in_place_t, std::initializer_list<U> il,
                                   Args &&...args)
       : m_val(il, std::forward<Args>(args)...), m_has_val(true) {}
   template <class... Args,
-            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+            std::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
                 nullptr>
   constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
       : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
 
   template <class U, class... Args,
-            detail::enable_if_t<std::is_constructible<
+            std::enable_if_t<std::is_constructible<
                 E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
   constexpr explicit expected_storage_base(unexpect_t,
                                            std::initializer_list<U> il,
@@ -497,25 +331,25 @@ template <class T, class E> struct expected_storage_base<T, E, true, true> {
   constexpr expected_storage_base(no_init_t) : m_no_init(), m_has_val(false) {}
 
   template <class... Args,
-            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+            std::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
                 nullptr>
   constexpr expected_storage_base(in_place_t, Args &&...args)
       : m_val(std::forward<Args>(args)...), m_has_val(true) {}
 
   template <class U, class... Args,
-            detail::enable_if_t<std::is_constructible<
+            std::enable_if_t<std::is_constructible<
                 T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
   constexpr expected_storage_base(in_place_t, std::initializer_list<U> il,
                                   Args &&...args)
       : m_val(il, std::forward<Args>(args)...), m_has_val(true) {}
   template <class... Args,
-            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+            std::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
                 nullptr>
   constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
       : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
 
   template <class U, class... Args,
-            detail::enable_if_t<std::is_constructible<
+            std::enable_if_t<std::is_constructible<
                 E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
   constexpr explicit expected_storage_base(unexpect_t,
                                            std::initializer_list<U> il,
@@ -538,25 +372,25 @@ template <class T, class E> struct expected_storage_base<T, E, true, false> {
       : m_no_init(), m_has_val(false) {}
 
   template <class... Args,
-            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+            std::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
                 nullptr>
   constexpr expected_storage_base(in_place_t, Args &&...args)
       : m_val(std::forward<Args>(args)...), m_has_val(true) {}
 
   template <class U, class... Args,
-            detail::enable_if_t<std::is_constructible<
+            std::enable_if_t<std::is_constructible<
                 T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
   constexpr expected_storage_base(in_place_t, std::initializer_list<U> il,
                                   Args &&...args)
       : m_val(il, std::forward<Args>(args)...), m_has_val(true) {}
   template <class... Args,
-            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+            std::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
                 nullptr>
   constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
       : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
 
   template <class U, class... Args,
-            detail::enable_if_t<std::is_constructible<
+            std::enable_if_t<std::is_constructible<
                 E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
   constexpr explicit expected_storage_base(unexpect_t,
                                            std::initializer_list<U> il,
@@ -583,25 +417,25 @@ template <class T, class E> struct expected_storage_base<T, E, false, true> {
   constexpr expected_storage_base(no_init_t) : m_no_init(), m_has_val(false) {}
 
   template <class... Args,
-            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+            std::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
                 nullptr>
   constexpr expected_storage_base(in_place_t, Args &&...args)
       : m_val(std::forward<Args>(args)...), m_has_val(true) {}
 
   template <class U, class... Args,
-            detail::enable_if_t<std::is_constructible<
+            std::enable_if_t<std::is_constructible<
                 T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
   constexpr expected_storage_base(in_place_t, std::initializer_list<U> il,
                                   Args &&...args)
       : m_val(il, std::forward<Args>(args)...), m_has_val(true) {}
   template <class... Args,
-            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+            std::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
                 nullptr>
   constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
       : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
 
   template <class U, class... Args,
-            detail::enable_if_t<std::is_constructible<
+            std::enable_if_t<std::is_constructible<
                 E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
   constexpr explicit expected_storage_base(unexpect_t,
                                            std::initializer_list<U> il,
@@ -635,13 +469,13 @@ template <class E> struct expected_storage_base<void, E, false, true> {
   constexpr expected_storage_base(in_place_t) : m_has_val(true) {}
 
   template <class... Args,
-            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+            std::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
                 nullptr>
   constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
       : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
 
   template <class U, class... Args,
-            detail::enable_if_t<std::is_constructible<
+            std::enable_if_t<std::is_constructible<
                 E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
   constexpr explicit expected_storage_base(unexpect_t,
                                            std::initializer_list<U> il,
@@ -665,13 +499,13 @@ template <class E> struct expected_storage_base<void, E, false, false> {
   constexpr expected_storage_base(in_place_t) : m_dummy(), m_has_val(true) {}
 
   template <class... Args,
-            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+            std::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
                 nullptr>
   constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
       : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
 
   template <class U, class... Args,
-            detail::enable_if_t<std::is_constructible<
+            std::enable_if_t<std::is_constructible<
                 E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
   constexpr explicit expected_storage_base(unexpect_t,
                                            std::initializer_list<U> il,
@@ -722,7 +556,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
   // This overload handles the case where we can just copy-construct `T`
   // directly into place without throwing.
   template <class U = T,
-            detail::enable_if_t<std::is_nothrow_copy_constructible<U>::value>
+            std::enable_if_t<std::is_nothrow_copy_constructible<U>::value>
                 * = nullptr>
   void assign(const expected_operations_base &rhs) noexcept {
     if (!this->m_has_val && rhs.m_has_val) {
@@ -736,7 +570,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
   // This overload handles the case where we can attempt to create a copy of
   // `T`, then no-throw move it into place if the copy was successful.
   template <class U = T,
-            detail::enable_if_t<!std::is_nothrow_copy_constructible<U>::value &&
+            std::enable_if_t<!std::is_nothrow_copy_constructible<U>::value &&
                                 std::is_nothrow_move_constructible<U>::value>
                 * = nullptr>
   void assign(const expected_operations_base &rhs) noexcept {
@@ -755,7 +589,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
   // then we move the old unexpected value back into place before rethrowing the
   // exception.
   template <class U = T,
-            detail::enable_if_t<!std::is_nothrow_copy_constructible<U>::value &&
+            std::enable_if_t<!std::is_nothrow_copy_constructible<U>::value &&
                                 !std::is_nothrow_move_constructible<U>::value>
                 * = nullptr>
   void assign(const expected_operations_base &rhs) {
@@ -780,7 +614,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
 
   // These overloads do the same as above, but for rvalues
   template <class U = T,
-            detail::enable_if_t<std::is_nothrow_move_constructible<U>::value>
+            std::enable_if_t<std::is_nothrow_move_constructible<U>::value>
                 * = nullptr>
   void assign(expected_operations_base &&rhs) noexcept {
     if (!this->m_has_val && rhs.m_has_val) {
@@ -792,7 +626,7 @@ struct expected_operations_base : expected_storage_base<T, E> {
   }
 
   template <class U = T,
-            detail::enable_if_t<!std::is_nothrow_move_constructible<U>::value>
+            std::enable_if_t<!std::is_nothrow_move_constructible<U>::value>
                 * = nullptr>
   void assign(expected_operations_base &&rhs) {
     if (!this->m_has_val && rhs.m_has_val) {
@@ -999,9 +833,9 @@ struct expected_move_base<T, E, false> : expected_copy_base<T, E> {
 // This class manages conditionally having a trivial copy assignment operator
 template <class T, class E,
           bool = is_void_or<
-              T, conjunction<WPI_EXPECTED_IS_TRIVIALLY_COPY_ASSIGNABLE(T),
-                             WPI_EXPECTED_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T),
-                             WPI_EXPECTED_IS_TRIVIALLY_DESTRUCTIBLE(T)>>::value
+              T, std::conjunction<WPI_EXPECTED_IS_TRIVIALLY_COPY_ASSIGNABLE(T),
+                                  WPI_EXPECTED_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T),
+                                  WPI_EXPECTED_IS_TRIVIALLY_DESTRUCTIBLE(T)>>::value
               &&WPI_EXPECTED_IS_TRIVIALLY_COPY_ASSIGNABLE(E)::value
                   &&WPI_EXPECTED_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(E)::value
                       &&WPI_EXPECTED_IS_TRIVIALLY_DESTRUCTIBLE(E)::value>
@@ -1033,7 +867,7 @@ struct expected_copy_assign_base<T, E, false> : expected_move_base<T, E> {
 #ifndef WPI_EXPECTED_GCC49
 template <class T, class E,
           bool =
-              is_void_or<T, conjunction<std::is_trivially_destructible<T>,
+              is_void_or<T, std::conjunction<std::is_trivially_destructible<T>,
                                         std::is_trivially_move_constructible<T>,
                                         std::is_trivially_move_assignable<T>>>::
                   value &&std::is_trivially_destructible<E>::value
@@ -1266,14 +1100,14 @@ class expected : private detail::expected_move_assign_base<T, E>,
   }
 
   template <class U = T,
-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
   WPI_EXPECTED_11_CONSTEXPR U &val() {
     return this->m_val;
   }
   WPI_EXPECTED_11_CONSTEXPR unexpected<E> &err() { return this->m_unexpect; }
 
   template <class U = T,
-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
   constexpr const U &val() const {
     return this->m_val;
   }
@@ -1531,23 +1365,23 @@ public:
   expected &operator=(expected &&rhs) = default;
 
   template <class... Args,
-            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+            std::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
                 nullptr>
   constexpr expected(in_place_t, Args &&...args)
       : impl_base(in_place, std::forward<Args>(args)...),
         ctor_base(detail::default_constructor_tag{}) {}
 
   template <class U, class... Args,
-            detail::enable_if_t<std::is_constructible<
+            std::enable_if_t<std::is_constructible<
                 T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
   constexpr expected(in_place_t, std::initializer_list<U> il, Args &&...args)
       : impl_base(in_place, il, std::forward<Args>(args)...),
         ctor_base(detail::default_constructor_tag{}) {}
 
   template <class G = E,
-            detail::enable_if_t<std::is_constructible<E, const G &>::value> * =
+            std::enable_if_t<std::is_constructible<E, const G &>::value> * =
                 nullptr,
-            detail::enable_if_t<!std::is_convertible<const G &, E>::value> * =
+            std::enable_if_t<!std::is_convertible<const G &, E>::value> * =
                 nullptr>
   explicit constexpr expected(const unexpected<G> &e)
       : impl_base(unexpect, e.value()),
@@ -1555,17 +1389,17 @@ public:
 
   template <
       class G = E,
-      detail::enable_if_t<std::is_constructible<E, const G &>::value> * =
+      std::enable_if_t<std::is_constructible<E, const G &>::value> * =
           nullptr,
-      detail::enable_if_t<std::is_convertible<const G &, E>::value> * = nullptr>
+      std::enable_if_t<std::is_convertible<const G &, E>::value> * = nullptr>
   constexpr expected(unexpected<G> const &e)
       : impl_base(unexpect, e.value()),
         ctor_base(detail::default_constructor_tag{}) {}
 
   template <
       class G = E,
-      detail::enable_if_t<std::is_constructible<E, G &&>::value> * = nullptr,
-      detail::enable_if_t<!std::is_convertible<G &&, E>::value> * = nullptr>
+      std::enable_if_t<std::is_constructible<E, G &&>::value> * = nullptr,
+      std::enable_if_t<!std::is_convertible<G &&, E>::value> * = nullptr>
   explicit constexpr expected(unexpected<G> &&e) noexcept(
       std::is_nothrow_constructible<E, G &&>::value)
       : impl_base(unexpect, std::move(e.value())),
@@ -1573,22 +1407,22 @@ public:
 
   template <
       class G = E,
-      detail::enable_if_t<std::is_constructible<E, G &&>::value> * = nullptr,
-      detail::enable_if_t<std::is_convertible<G &&, E>::value> * = nullptr>
+      std::enable_if_t<std::is_constructible<E, G &&>::value> * = nullptr,
+      std::enable_if_t<std::is_convertible<G &&, E>::value> * = nullptr>
   constexpr expected(unexpected<G> &&e) noexcept(
       std::is_nothrow_constructible<E, G &&>::value)
       : impl_base(unexpect, std::move(e.value())),
         ctor_base(detail::default_constructor_tag{}) {}
 
   template <class... Args,
-            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+            std::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
                 nullptr>
   constexpr explicit expected(unexpect_t, Args &&...args)
       : impl_base(unexpect, std::forward<Args>(args)...),
         ctor_base(detail::default_constructor_tag{}) {}
 
   template <class U, class... Args,
-            detail::enable_if_t<std::is_constructible<
+            std::enable_if_t<std::is_constructible<
                 E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
   constexpr explicit expected(unexpect_t, std::initializer_list<U> il,
                               Args &&...args)
@@ -1596,7 +1430,7 @@ public:
         ctor_base(detail::default_constructor_tag{}) {}
 
   template <class U, class G,
-            detail::enable_if_t<!(std::is_convertible<U const &, T>::value &&
+            std::enable_if_t<!(std::is_convertible<U const &, T>::value &&
                                   std::is_convertible<G const &, E>::value)> * =
                 nullptr,
             detail::expected_enable_from_other<T, E, U, G, const U &, const G &>
@@ -1611,7 +1445,7 @@ public:
   }
 
   template <class U, class G,
-            detail::enable_if_t<(std::is_convertible<U const &, T>::value &&
+            std::enable_if_t<(std::is_convertible<U const &, T>::value &&
                                  std::is_convertible<G const &, E>::value)> * =
                 nullptr,
             detail::expected_enable_from_other<T, E, U, G, const U &, const G &>
@@ -1627,7 +1461,7 @@ public:
 
   template <
       class U, class G,
-      detail::enable_if_t<!(std::is_convertible<U &&, T>::value &&
+      std::enable_if_t<!(std::is_convertible<U &&, T>::value &&
                             std::is_convertible<G &&, E>::value)> * = nullptr,
       detail::expected_enable_from_other<T, E, U, G, U &&, G &&> * = nullptr>
   explicit WPI_EXPECTED_11_CONSTEXPR expected(expected<U, G> &&rhs)
@@ -1641,7 +1475,7 @@ public:
 
   template <
       class U, class G,
-      detail::enable_if_t<(std::is_convertible<U &&, T>::value &&
+      std::enable_if_t<(std::is_convertible<U &&, T>::value &&
                            std::is_convertible<G &&, E>::value)> * = nullptr,
       detail::expected_enable_from_other<T, E, U, G, U &&, G &&> * = nullptr>
   WPI_EXPECTED_11_CONSTEXPR expected(expected<U, G> &&rhs)
@@ -1655,27 +1489,27 @@ public:
 
   template <
       class U = T,
-      detail::enable_if_t<!std::is_convertible<U &&, T>::value> * = nullptr,
+      std::enable_if_t<!std::is_convertible<U &&, T>::value> * = nullptr,
       detail::expected_enable_forward_value<T, E, U> * = nullptr>
   explicit WPI_EXPECTED_MSVC2015_CONSTEXPR expected(U &&v)
       : expected(in_place, std::forward<U>(v)) {}
 
   template <
       class U = T,
-      detail::enable_if_t<std::is_convertible<U &&, T>::value> * = nullptr,
+      std::enable_if_t<std::is_convertible<U &&, T>::value> * = nullptr,
       detail::expected_enable_forward_value<T, E, U> * = nullptr>
   WPI_EXPECTED_MSVC2015_CONSTEXPR expected(U &&v)
       : expected(in_place, std::forward<U>(v)) {}
 
   template <
       class U = T, class G = T,
-      detail::enable_if_t<std::is_nothrow_constructible<T, U &&>::value> * =
+      std::enable_if_t<std::is_nothrow_constructible<T, U &&>::value> * =
           nullptr,
-      detail::enable_if_t<!std::is_void<G>::value> * = nullptr,
-      detail::enable_if_t<
-          (!std::is_same<expected<T, E>, detail::decay_t<U>>::value &&
-           !detail::conjunction<std::is_scalar<T>,
-                                std::is_same<T, detail::decay_t<U>>>::value &&
+      std::enable_if_t<!std::is_void<G>::value> * = nullptr,
+      std::enable_if_t<
+          (!std::is_same<expected<T, E>, std::decay_t<U>>::value &&
+           !std::conjunction<std::is_scalar<T>,
+                             std::is_same<T, std::decay_t<U>>>::value &&
            std::is_constructible<T, U>::value &&
            std::is_assignable<G &, U>::value &&
            std::is_nothrow_move_constructible<E>::value)> * = nullptr>
@@ -1693,13 +1527,13 @@ public:
 
   template <
       class U = T, class G = T,
-      detail::enable_if_t<!std::is_nothrow_constructible<T, U &&>::value> * =
+      std::enable_if_t<!std::is_nothrow_constructible<T, U &&>::value> * =
           nullptr,
-      detail::enable_if_t<!std::is_void<U>::value> * = nullptr,
-      detail::enable_if_t<
-          (!std::is_same<expected<T, E>, detail::decay_t<U>>::value &&
-           !detail::conjunction<std::is_scalar<T>,
-                                std::is_same<T, detail::decay_t<U>>>::value &&
+      std::enable_if_t<!std::is_void<U>::value> * = nullptr,
+      std::enable_if_t<
+          (!std::is_same<expected<T, E>, std::decay_t<U>>::value &&
+           !std::conjunction<std::is_scalar<T>,
+                             std::is_same<T, std::decay_t<U>>>::value &&
            std::is_constructible<T, U>::value &&
            std::is_assignable<G &, U>::value &&
            std::is_nothrow_move_constructible<E>::value)> * = nullptr>
@@ -1728,8 +1562,8 @@ public:
   }
 
   template <class G = E,
-            detail::enable_if_t<std::is_nothrow_copy_constructible<G>::value &&
-                                std::is_assignable<G &, G>::value> * = nullptr>
+            std::enable_if_t<std::is_nothrow_copy_constructible<G>::value &&
+                             std::is_assignable<G &, G>::value> * = nullptr>
   expected &operator=(const unexpected<G> &rhs) {
     if (!has_value()) {
       err() = rhs;
@@ -1743,8 +1577,8 @@ public:
   }
 
   template <class G = E,
-            detail::enable_if_t<std::is_nothrow_move_constructible<G>::value &&
-                                std::is_move_assignable<G>::value> * = nullptr>
+            std::enable_if_t<std::is_nothrow_move_constructible<G>::value &&
+                             std::is_move_assignable<G>::value> * = nullptr>
   expected &operator=(unexpected<G> &&rhs) noexcept {
     if (!has_value()) {
       err() = std::move(rhs);
@@ -1757,7 +1591,7 @@ public:
     return *this;
   }
 
-  template <class... Args, detail::enable_if_t<std::is_nothrow_constructible<
+  template <class... Args, std::enable_if_t<std::is_nothrow_constructible<
                                T, Args &&...>::value> * = nullptr>
   void emplace(Args &&...args) {
     if (has_value()) {
@@ -1769,7 +1603,7 @@ public:
     ::new (valptr()) T(std::forward<Args>(args)...);
   }
 
-  template <class... Args, detail::enable_if_t<!std::is_nothrow_constructible<
+  template <class... Args, std::enable_if_t<!std::is_nothrow_constructible<
                                T, Args &&...>::value> * = nullptr>
   void emplace(Args &&...args) {
     if (has_value()) {
@@ -1795,7 +1629,7 @@ public:
   }
 
   template <class U, class... Args,
-            detail::enable_if_t<std::is_nothrow_constructible<
+            std::enable_if_t<std::is_nothrow_constructible<
                 T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
   void emplace(std::initializer_list<U> il, Args &&...args) {
     if (has_value()) {
@@ -1809,7 +1643,7 @@ public:
   }
 
   template <class U, class... Args,
-            detail::enable_if_t<!std::is_nothrow_constructible<
+            std::enable_if_t<!std::is_nothrow_constructible<
                 T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
   void emplace(std::initializer_list<U> il, Args &&...args) {
     if (has_value()) {
@@ -1923,15 +1757,15 @@ private:
 
 public:
   template <class OT = T, class OE = E>
-  detail::enable_if_t<detail::is_swappable<OT>::value &&
-                      detail::is_swappable<OE>::value &&
-                      (std::is_nothrow_move_constructible<OT>::value ||
-                       std::is_nothrow_move_constructible<OE>::value)>
+  std::enable_if_t<std::is_swappable<OT>::value &&
+                   std::is_swappable<OE>::value &&
+                   (std::is_nothrow_move_constructible<OT>::value ||
+                    std::is_nothrow_move_constructible<OE>::value)>
   swap(expected &rhs) noexcept(
       std::is_nothrow_move_constructible<T>::value
-          &&detail::is_nothrow_swappable<T>::value
+          &&std::is_nothrow_swappable<T>::value
               &&std::is_nothrow_move_constructible<E>::value
-                  &&detail::is_nothrow_swappable<E>::value) {
+                  &&std::is_nothrow_swappable<E>::value) {
     if (has_value() && rhs.has_value()) {
       swap_where_both_have_value(rhs, typename std::is_void<T>::type{});
     } else if (!has_value() && rhs.has_value()) {
@@ -1954,25 +1788,25 @@ public:
   }
 
   template <class U = T,
-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
   constexpr const U &operator*() const & {
     WPI_ASSERT(has_value());
     return val();
   }
   template <class U = T,
-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
   WPI_EXPECTED_11_CONSTEXPR U &operator*() & {
     WPI_ASSERT(has_value());
     return val();
   }
   template <class U = T,
-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
   constexpr const U &&operator*() const && {
     WPI_ASSERT(has_value());
     return std::move(val());
   }
   template <class U = T,
-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
   WPI_EXPECTED_11_CONSTEXPR U &&operator*() && {
     WPI_ASSERT(has_value());
     return std::move(val());
@@ -1982,28 +1816,28 @@ public:
   constexpr explicit operator bool() const noexcept { return this->m_has_val; }
 
   template <class U = T,
-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
   WPI_EXPECTED_11_CONSTEXPR const U &value() const & {
     if (!has_value())
       detail::throw_exception(bad_expected_access<E>(err().value()));
     return val();
   }
   template <class U = T,
-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
   WPI_EXPECTED_11_CONSTEXPR U &value() & {
     if (!has_value())
       detail::throw_exception(bad_expected_access<E>(err().value()));
     return val();
   }
   template <class U = T,
-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
   WPI_EXPECTED_11_CONSTEXPR const U &&value() const && {
     if (!has_value())
       detail::throw_exception(bad_expected_access<E>(std::move(err()).value()));
     return std::move(val());
   }
   template <class U = T,
-            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+            std::enable_if_t<!std::is_void<U>::value> * = nullptr>
   WPI_EXPECTED_11_CONSTEXPR U &&value() && {
     if (!has_value())
       detail::throw_exception(bad_expected_access<E>(std::move(err()).value()));
@@ -2042,79 +1876,79 @@ public:
 };
 
 namespace detail {
-template <class Exp> using exp_t = typename detail::decay_t<Exp>::value_type;
-template <class Exp> using err_t = typename detail::decay_t<Exp>::error_type;
+template <class Exp> using exp_t = typename std::decay_t<Exp>::value_type;
+template <class Exp> using err_t = typename std::decay_t<Exp>::error_type;
 template <class Exp, class Ret> using ret_t = expected<Ret, err_t<Exp>>;
 
 #ifdef WPI_EXPECTED_CXX14
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              *std::declval<Exp>()))>
+          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           *std::declval<Exp>()))>
 constexpr auto and_then_impl(Exp &&exp, F &&f) {
   static_assert(detail::is_expected<Ret>::value, "F must return an expected");
 
   return exp.has_value()
-             ? detail::invoke(std::forward<F>(f), *std::forward<Exp>(exp))
+             ? std::invoke(std::forward<F>(f), *std::forward<Exp>(exp))
              : Ret(unexpect, std::forward<Exp>(exp).error());
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>()))>
+          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>()))>
 constexpr auto and_then_impl(Exp &&exp, F &&f) {
   static_assert(detail::is_expected<Ret>::value, "F must return an expected");
 
-  return exp.has_value() ? detail::invoke(std::forward<F>(f))
+  return exp.has_value() ? std::invoke(std::forward<F>(f))
                          : Ret(unexpect, std::forward<Exp>(exp).error());
 }
 #else
 template <class> struct TC;
 template <class Exp, class F,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              *std::declval<Exp>())),
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr>
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           *std::declval<Exp>())),
+          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr>
 auto and_then_impl(Exp &&exp, F &&f) -> Ret {
   static_assert(detail::is_expected<Ret>::value, "F must return an expected");
 
   return exp.has_value()
-             ? detail::invoke(std::forward<F>(f), *std::forward<Exp>(exp))
+             ? std::invoke(std::forward<F>(f), *std::forward<Exp>(exp))
              : Ret(unexpect, std::forward<Exp>(exp).error());
 }
 
 template <class Exp, class F,
-          class Ret = decltype(detail::invoke(std::declval<F>())),
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr>
+          class Ret = decltype(std::invoke(std::declval<F>())),
+          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr>
 constexpr auto and_then_impl(Exp &&exp, F &&f) -> Ret {
   static_assert(detail::is_expected<Ret>::value, "F must return an expected");
 
-  return exp.has_value() ? detail::invoke(std::forward<F>(f))
+  return exp.has_value() ? std::invoke(std::forward<F>(f))
                          : Ret(unexpect, std::forward<Exp>(exp).error());
 }
 #endif
 
 #ifdef WPI_EXPECTED_CXX14
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              *std::declval<Exp>())),
-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           *std::declval<Exp>())),
+          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
 constexpr auto expected_map_impl(Exp &&exp, F &&f) {
-  using result = ret_t<Exp, detail::decay_t<Ret>>;
-  return exp.has_value() ? result(detail::invoke(std::forward<F>(f),
-                                                 *std::forward<Exp>(exp)))
+  using result = ret_t<Exp, std::decay_t<Ret>>;
+  return exp.has_value() ? result(std::invoke(std::forward<F>(f),
+                                              *std::forward<Exp>(exp)))
                          : result(unexpect, std::forward<Exp>(exp).error());
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              *std::declval<Exp>())),
-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           *std::declval<Exp>())),
+          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
 auto expected_map_impl(Exp &&exp, F &&f) {
   using result = expected<void, err_t<Exp>>;
   if (exp.has_value()) {
-    detail::invoke(std::forward<F>(f), *std::forward<Exp>(exp));
+    std::invoke(std::forward<F>(f), *std::forward<Exp>(exp));
     return result();
   }
 
@@ -2122,23 +1956,23 @@ auto expected_map_impl(Exp &&exp, F &&f) {
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>())),
-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>())),
+          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
 constexpr auto expected_map_impl(Exp &&exp, F &&f) {
-  using result = ret_t<Exp, detail::decay_t<Ret>>;
-  return exp.has_value() ? result(detail::invoke(std::forward<F>(f)))
+  using result = ret_t<Exp, std::decay_t<Ret>>;
+  return exp.has_value() ? result(std::invoke(std::forward<F>(f)))
                          : result(unexpect, std::forward<Exp>(exp).error());
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>())),
-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>())),
+          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
 auto expected_map_impl(Exp &&exp, F &&f) {
   using result = expected<void, err_t<Exp>>;
   if (exp.has_value()) {
-    detail::invoke(std::forward<F>(f));
+    std::invoke(std::forward<F>(f));
     return result();
   }
 
@@ -2146,29 +1980,29 @@ auto expected_map_impl(Exp &&exp, F &&f) {
 }
 #else
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              *std::declval<Exp>())),
-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           *std::declval<Exp>())),
+          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
 
 constexpr auto expected_map_impl(Exp &&exp, F &&f)
-    -> ret_t<Exp, detail::decay_t<Ret>> {
-  using result = ret_t<Exp, detail::decay_t<Ret>>;
+    -> ret_t<Exp, std::decay_t<Ret>> {
+  using result = ret_t<Exp, std::decay_t<Ret>>;
 
-  return exp.has_value() ? result(detail::invoke(std::forward<F>(f),
-                                                 *std::forward<Exp>(exp)))
+  return exp.has_value() ? result(std::invoke(std::forward<F>(f),
+                                              *std::forward<Exp>(exp)))
                          : result(unexpect, std::forward<Exp>(exp).error());
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              *std::declval<Exp>())),
-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           *std::declval<Exp>())),
+          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
 
 auto expected_map_impl(Exp &&exp, F &&f) -> expected<void, err_t<Exp>> {
   if (exp.has_value()) {
-    detail::invoke(std::forward<F>(f), *std::forward<Exp>(exp));
+    std::invoke(std::forward<F>(f), *std::forward<Exp>(exp));
     return {};
   }
 
@@ -2176,26 +2010,26 @@ auto expected_map_impl(Exp &&exp, F &&f) -> expected<void, err_t<Exp>> {
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>())),
-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>())),
+          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
 
 constexpr auto expected_map_impl(Exp &&exp, F &&f)
-    -> ret_t<Exp, detail::decay_t<Ret>> {
-  using result = ret_t<Exp, detail::decay_t<Ret>>;
+    -> ret_t<Exp, std::decay_t<Ret>> {
+  using result = ret_t<Exp, std::decay_t<Ret>>;
 
-  return exp.has_value() ? result(detail::invoke(std::forward<F>(f)))
+  return exp.has_value() ? result(std::invoke(std::forward<F>(f)))
                          : result(unexpect, std::forward<Exp>(exp).error());
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>())),
-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>())),
+          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
 
 auto expected_map_impl(Exp &&exp, F &&f) -> expected<void, err_t<Exp>> {
   if (exp.has_value()) {
-    detail::invoke(std::forward<F>(f));
+    std::invoke(std::forward<F>(f));
     return {};
   }
 
@@ -2206,161 +2040,161 @@ auto expected_map_impl(Exp &&exp, F &&f) -> expected<void, err_t<Exp>> {
 #if defined(WPI_EXPECTED_CXX14) && !defined(WPI_EXPECTED_GCC49) &&               \
     !defined(WPI_EXPECTED_GCC54) && !defined(WPI_EXPECTED_GCC55)
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           std::declval<Exp>().error())),
+          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
 constexpr auto map_error_impl(Exp &&exp, F &&f) {
-  using result = expected<exp_t<Exp>, detail::decay_t<Ret>>;
+  using result = expected<exp_t<Exp>, std::decay_t<Ret>>;
   return exp.has_value()
              ? result(*std::forward<Exp>(exp))
-             : result(unexpect, detail::invoke(std::forward<F>(f),
-                                               std::forward<Exp>(exp).error()));
+             : result(unexpect, std::invoke(std::forward<F>(f),
+                                            std::forward<Exp>(exp).error()));
 }
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           std::declval<Exp>().error())),
+          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
 auto map_error_impl(Exp &&exp, F &&f) {
   using result = expected<exp_t<Exp>, monostate>;
   if (exp.has_value()) {
     return result(*std::forward<Exp>(exp));
   }
 
-  detail::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
+  std::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
   return result(unexpect, monostate{});
 }
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           std::declval<Exp>().error())),
+          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
 constexpr auto map_error_impl(Exp &&exp, F &&f) {
-  using result = expected<exp_t<Exp>, detail::decay_t<Ret>>;
+  using result = expected<exp_t<Exp>, std::decay_t<Ret>>;
   return exp.has_value()
              ? result()
-             : result(unexpect, detail::invoke(std::forward<F>(f),
-                                               std::forward<Exp>(exp).error()));
+             : result(unexpect, std::invoke(std::forward<F>(f),
+                                            std::forward<Exp>(exp).error()));
 }
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           std::declval<Exp>().error())),
+          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
 auto map_error_impl(Exp &&exp, F &&f) {
   using result = expected<exp_t<Exp>, monostate>;
   if (exp.has_value()) {
     return result();
   }
 
-  detail::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
+  std::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
   return result(unexpect, monostate{});
 }
 #else
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           std::declval<Exp>().error())),
+          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
 constexpr auto map_error_impl(Exp &&exp, F &&f)
-    -> expected<exp_t<Exp>, detail::decay_t<Ret>> {
-  using result = expected<exp_t<Exp>, detail::decay_t<Ret>>;
+    -> expected<exp_t<Exp>, std::decay_t<Ret>> {
+  using result = expected<exp_t<Exp>, std::decay_t<Ret>>;
 
   return exp.has_value()
              ? result(*std::forward<Exp>(exp))
-             : result(unexpect, detail::invoke(std::forward<F>(f),
-                                               std::forward<Exp>(exp).error()));
+             : result(unexpect, std::invoke(std::forward<F>(f),
+                                            std::forward<Exp>(exp).error()));
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           std::declval<Exp>().error())),
+          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
 auto map_error_impl(Exp &&exp, F &&f) -> expected<exp_t<Exp>, monostate> {
   using result = expected<exp_t<Exp>, monostate>;
   if (exp.has_value()) {
     return result(*std::forward<Exp>(exp));
   }
 
-  detail::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
+  std::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
   return result(unexpect, monostate{});
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           std::declval<Exp>().error())),
+          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
 constexpr auto map_error_impl(Exp &&exp, F &&f)
-    -> expected<exp_t<Exp>, detail::decay_t<Ret>> {
-  using result = expected<exp_t<Exp>, detail::decay_t<Ret>>;
+    -> expected<exp_t<Exp>, std::decay_t<Ret>> {
+  using result = expected<exp_t<Exp>, std::decay_t<Ret>>;
 
   return exp.has_value()
              ? result()
-             : result(unexpect, detail::invoke(std::forward<F>(f),
-                                               std::forward<Exp>(exp).error()));
+             : result(unexpect, std::invoke(std::forward<F>(f),
+                                            std::forward<Exp>(exp).error()));
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+          std::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           std::declval<Exp>().error())),
+          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
 auto map_error_impl(Exp &&exp, F &&f) -> expected<exp_t<Exp>, monostate> {
   using result = expected<exp_t<Exp>, monostate>;
   if (exp.has_value()) {
     return result();
   }
 
-  detail::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
+  std::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
   return result(unexpect, monostate{});
 }
 #endif
 
 #ifdef WPI_EXPECTED_CXX14
 template <class Exp, class F,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           std::declval<Exp>().error())),
+          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
 constexpr auto or_else_impl(Exp &&exp, F &&f) {
   static_assert(detail::is_expected<Ret>::value, "F must return an expected");
   return exp.has_value() ? std::forward<Exp>(exp)
-                         : detail::invoke(std::forward<F>(f),
-                                          std::forward<Exp>(exp).error());
+                         : std::invoke(std::forward<F>(f),
+                                       std::forward<Exp>(exp).error());
 }
 
 template <class Exp, class F,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
-detail::decay_t<Exp> or_else_impl(Exp &&exp, F &&f) {
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           std::declval<Exp>().error())),
+          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+std::decay_t<Exp> or_else_impl(Exp &&exp, F &&f) {
   return exp.has_value() ? std::forward<Exp>(exp)
-                         : (detail::invoke(std::forward<F>(f),
-                                           std::forward<Exp>(exp).error()),
+                         : (std::invoke(std::forward<F>(f),
+                                        std::forward<Exp>(exp).error()),
                             std::forward<Exp>(exp));
 }
 #else
 template <class Exp, class F,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           std::declval<Exp>().error())),
+          std::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
 auto or_else_impl(Exp &&exp, F &&f) -> Ret {
   static_assert(detail::is_expected<Ret>::value, "F must return an expected");
   return exp.has_value() ? std::forward<Exp>(exp)
-                         : detail::invoke(std::forward<F>(f),
-                                          std::forward<Exp>(exp).error());
+                         : std::invoke(std::forward<F>(f),
+                                       std::forward<Exp>(exp).error());
 }
 
 template <class Exp, class F,
-          class Ret = decltype(detail::invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
-detail::decay_t<Exp> or_else_impl(Exp &&exp, F &&f) {
+          class Ret = decltype(std::invoke(std::declval<F>(),
+                                           std::declval<Exp>().error())),
+          std::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+std::decay_t<Exp> or_else_impl(Exp &&exp, F &&f) {
   return exp.has_value() ? std::forward<Exp>(exp)
-                         : (detail::invoke(std::forward<F>(f),
-                                           std::forward<Exp>(exp).error()),
+                         : (std::invoke(std::forward<F>(f),
+                                        std::forward<Exp>(exp).error()),
                             std::forward<Exp>(exp));
 }
 #endif
@@ -2430,11 +2264,11 @@ constexpr bool operator!=(const unexpected<E> &e, const expected<T, E> &x) {
 }
 
 template <class T, class E,
-          detail::enable_if_t<(std::is_void<T>::value ||
-                               std::is_move_constructible<T>::value) &&
-                              detail::is_swappable<T>::value &&
-                              std::is_move_constructible<E>::value &&
-                              detail::is_swappable<E>::value> * = nullptr>
+          std::enable_if_t<(std::is_void<T>::value ||
+                            std::is_move_constructible<T>::value) &&
+                           std::is_swappable<T>::value &&
+                           std::is_move_constructible<E>::value &&
+                           std::is_swappable<E>::value> * = nullptr>
 void swap(expected<T, E> &lhs,
           expected<T, E> &rhs) noexcept(noexcept(lhs.swap(rhs))) {
   lhs.swap(rhs);


### PR DESCRIPTION
Both `wpi/expected` and JSON's `cpp_future.h` would define `enable_if_t` and `conjunction` in `wpi::detail`, causes conflicts if both files were included in the same cpp source file. This fixes the conflict by removing the `WPI_TRAITS_MUTEX` block in `wpi/expected` (which is where it defines `enable_if_t` and `conjunction`, among others), since it only defines shims of standard library traits and functions for use in pre-C++20, which we don't support.