### PR TITLE
[ci] Use artifactory for sccache backend

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  SCCACHE_WEBDAV_ENDPOINT: "https://frcmaven.wpi.edu/artifactory/wpilib-generic-cache-cmake"
+
 jobs:
   build:
     strategy:
@@ -34,7 +37,7 @@ jobs:
         run: brew install opencv protobuf@3 ninja
         if: runner.os == 'macOS'
 
-      - name: Run sccache-cache
+      - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.5
 
       - uses: actions/checkout@v4
@@ -42,12 +45,14 @@ jobs:
       - name: configure
         run: cmake ${{ matrix.flags }}
         env:
-          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_WEBDAV_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_USERNAME }}
 
       - name: build
         run: cmake --build build-cmake --parallel $(nproc)
         env:
-          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_WEBDAV_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_USERNAME }}
 
       - name: test
         working-directory: build-cmake
@@ -76,12 +81,14 @@ jobs:
       - name: configure
         run: cmake --preset sccache -DCMAKE_BUILD_TYPE=Release -DWITH_JAVA=OFF -DWITH_EXAMPLES=ON -DUSE_SYSTEM_FMTLIB=ON -DUSE_SYSTEM_LIBUV=ON -DUSE_SYSTEM_EIGEN=OFF -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_INSTALL_OPTIONS=--clean-after-build -DVCPKG_TARGET_TRIPLET=x64-windows-release -DVCPKG_HOST_TRIPLET=x64-windows-release
         env:
-          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_WEBDAV_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_USERNAME }}
 
       - name: build
         run: cmake --build build-cmake --parallel $(nproc)
         env:
-          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_WEBDAV_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_USERNAME }}
 
       - name: test
         working-directory: build-cmake

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,13 +46,13 @@ jobs:
         run: cmake ${{ matrix.flags }}
         env:
           SCCACHE_WEBDAV_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_USERNAME }}
+          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
       - name: build
         run: cmake --build build-cmake --parallel $(nproc)
         env:
           SCCACHE_WEBDAV_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_USERNAME }}
+          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
       - name: test
         working-directory: build-cmake
@@ -82,13 +82,13 @@ jobs:
         run: cmake --preset sccache -DCMAKE_BUILD_TYPE=Release -DWITH_JAVA=OFF -DWITH_EXAMPLES=ON -DUSE_SYSTEM_FMTLIB=ON -DUSE_SYSTEM_LIBUV=ON -DUSE_SYSTEM_EIGEN=OFF -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_INSTALL_OPTIONS=--clean-after-build -DVCPKG_TARGET_TRIPLET=x64-windows-release -DVCPKG_HOST_TRIPLET=x64-windows-release
         env:
           SCCACHE_WEBDAV_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_USERNAME }}
+          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
       - name: build
         run: cmake --build build-cmake --parallel $(nproc)
         env:
           SCCACHE_WEBDAV_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_USERNAME }}
+          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
       - name: test
         working-directory: build-cmake

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  SCCACHE_WEBDAV_ENDPOINT: "https://frcmaven.wpi.edu/artifactory/wpilib-generic-cache-cmake"
+
 jobs:
   build:
     strategy:
@@ -31,7 +34,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update && sudo apt-get install -y libopencv-dev libopencv4.5-java clang-14 libprotobuf-dev protobuf-compiler ninja-build
 
-      - name: Run sccache-cache
+      - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.5
 
       - uses: actions/checkout@v4
@@ -39,13 +42,15 @@ jobs:
       - name: configure
         run: mkdir build && cd build && cmake -G Ninja -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER:FILEPATH=/usr/bin/clang-14 -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/clang++-14 -DWITH_JAVA=OFF ${{ matrix.cmake-flags }} ..
         env:
-          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_WEBDAV_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_USERNAME }}
 
       - name: build
         working-directory: build
         run: cmake --build . --parallel $(nproc)
         env:
-          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_WEBDAV_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_USERNAME }}
 
       - name: test
         working-directory: build

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -43,14 +43,14 @@ jobs:
         run: mkdir build && cd build && cmake -G Ninja -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER:FILEPATH=/usr/bin/clang-14 -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/clang++-14 -DWITH_JAVA=OFF ${{ matrix.cmake-flags }} ..
         env:
           SCCACHE_WEBDAV_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_USERNAME }}
+          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
       - name: build
         working-directory: build
         run: cmake --build . --parallel $(nproc)
         env:
           SCCACHE_WEBDAV_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_USERNAME }}
+          SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
       - name: test
         working-directory: build


### PR DESCRIPTION
Supercedes #7025 

The GHA cache is not sufficient for the amount of data the cmake jobs are caching. Its eviction policy allows PR builds to evict entries from main, and PR caches can only be read by that PR, which results in even more thrashing as later PRs miss the cache and store their own entries.

This should work as-is- it's set up with the same user gradle uses, and is pointed at the `wpilib-generic-cache-cmake` repository.

Sccache won't continue trying to write if it doesn't have write access (PR builds).

There is one caveat- if for some reason artifactory is inaccessible when the sccache server starts for the first time, the build will fail. For some reason sccache doesn't allow graceful failure at startup.