### PR TITLE
[wpiutil] Use wpi::expected in MemoryBuffer::GetFile

### DIFF
--- a/apriltag/src/main/native/cpp/AprilTagFieldLayout.cpp
+++ b/apriltag/src/main/native/cpp/AprilTagFieldLayout.cpp
@@ -15,10 +15,10 @@
 using namespace frc;
 
 AprilTagFieldLayout::AprilTagFieldLayout(std::string_view path) {
-  std::error_code ec;
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer =
-      wpi::MemoryBuffer::GetFile(path, ec);
-  if (fileBuffer == nullptr || ec) {
+  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
+  if (auto buf = wpi::MemoryBuffer::GetFile(path)) {
+    fileBuffer = std::move(*buf);
+  } else {
     throw std::runtime_error(fmt::format("Cannot open file: {}", path));
   }
 

--- a/apriltag/src/main/native/cpp/AprilTagFieldLayout.cpp
+++ b/apriltag/src/main/native/cpp/AprilTagFieldLayout.cpp
@@ -15,14 +15,12 @@
 using namespace frc;
 
 AprilTagFieldLayout::AprilTagFieldLayout(std::string_view path) {
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
-  if (auto buf = wpi::MemoryBuffer::GetFile(path)) {
-    fileBuffer = std::move(*buf);
-  } else {
+  auto fileBuffer = wpi::MemoryBuffer::GetFile(path);
+  if (!fileBuffer) {
     throw std::runtime_error(fmt::format("Cannot open file: {}", path));
   }
 
-  wpi::json json = wpi::json::parse(fileBuffer->GetCharBuffer());
+  wpi::json json = wpi::json::parse(fileBuffer.value()->GetCharBuffer());
 
   for (const auto& tag : json.at("tags").get<std::vector<AprilTag>>()) {
     m_apriltags[tag.ID] = tag;

--- a/cameraserver/multiCameraServer/src/main/native/cpp/main.cpp
+++ b/cameraserver/multiCameraServer/src/main/native/cpp/main.cpp
@@ -94,19 +94,17 @@ bool ReadCameraConfig(const wpi::json& config) {
 
 bool ReadConfig() {
   // open config file
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
-  if (auto buf = wpi::MemoryBuffer::GetFile(configFile)) {
-    fileBuffer = std::move(*buf);
-  } else {
+  auto fileBuffer = wpi::MemoryBuffer::GetFile(configFile);
+  if (!fileBuffer) {
     wpi::print(stderr, "could not open '{}': {}\n", configFile,
-               buf.error().message());
+               fileBuffer.error().message());
     return false;
   }
 
   // parse file
   wpi::json j;
   try {
-    j = wpi::json::parse(fileBuffer->GetCharBuffer());
+    j = wpi::json::parse(fileBuffer.value()->GetCharBuffer());
   } catch (const wpi::json::parse_error& e) {
     wpi::print(stderr, "config error in '{}': byte {}: {}\n", configFile,
                e.byte, e.what());

--- a/cameraserver/multiCameraServer/src/main/native/cpp/main.cpp
+++ b/cameraserver/multiCameraServer/src/main/native/cpp/main.cpp
@@ -94,11 +94,12 @@ bool ReadCameraConfig(const wpi::json& config) {
 
 bool ReadConfig() {
   // open config file
-  std::error_code ec;
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer =
-      wpi::MemoryBuffer::GetFile(configFile, ec);
-  if (fileBuffer == nullptr || ec) {
-    wpi::print(stderr, "could not open '{}': {}\n", configFile, ec.message());
+  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
+  if (auto buf = wpi::MemoryBuffer::GetFile(configFile)) {
+    fileBuffer = std::move(*buf);
+  } else {
+    wpi::print(stderr, "could not open '{}': {}\n", configFile,
+               buf.error().message());
     return false;
   }
 

--- a/datalogtool/src/main/native/cpp/Exporter.cpp
+++ b/datalogtool/src/main/native/cpp/Exporter.cpp
@@ -180,16 +180,14 @@ InputFile::~InputFile() {
 }
 
 static std::unique_ptr<InputFile> LoadDataLog(std::string_view filename) {
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
-  if (auto buf = wpi::MemoryBuffer::GetFile(filename)) {
-    fileBuffer = std::move(*buf);
-  } else {
+  auto fileBuffer = wpi::MemoryBuffer::GetFile(filename);
+  if (!fileBuffer) {
     return std::make_unique<InputFile>(
         filename,
-        fmt::format("Could not open file: {}", buf.error().message()));
+        fmt::format("Could not open file: {}", fileBuffer.error().message()));
   }
 
-  wpi::log::DataLogReader reader{std::move(fileBuffer)};
+  wpi::log::DataLogReader reader{std::move(*fileBuffer)};
   if (!reader.IsValid()) {
     return std::make_unique<InputFile>(filename, "Not a valid datalog file");
   }

--- a/glass/src/lib/native/cpp/Context.cpp
+++ b/glass/src/lib/native/cpp/Context.cpp
@@ -128,50 +128,48 @@ static bool JsonToWindow(const wpi::json& jfile, const char* filename) {
 }
 
 static bool LoadWindowStorageImpl(const std::string& filename) {
-  std::error_code ec;
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer =
-      wpi::MemoryBuffer::GetFile(filename, ec);
-  if (fileBuffer == nullptr || ec) {
-    ImGui::LogText("error opening %s: %s", filename.c_str(),
-                   ec.message().c_str());
-    return false;
+  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
+  if (auto buf = wpi::MemoryBuffer::GetFile(filename)) {
+    fileBuffer = std::move(*buf);
   } else {
-    try {
-      return JsonToWindow(wpi::json::parse(fileBuffer->GetCharBuffer()),
-                          filename.c_str());
-    } catch (wpi::json::parse_error& e) {
-      ImGui::LogText("Error loading %s: %s", filename.c_str(), e.what());
-      return false;
-    }
+    ImGui::LogText("error opening %s: %s", filename.c_str(),
+                   buf.error().message().c_str());
+    return false;
+  }
+  try {
+    return JsonToWindow(wpi::json::parse(fileBuffer->GetCharBuffer()),
+                        filename.c_str());
+  } catch (wpi::json::parse_error& e) {
+    ImGui::LogText("Error loading %s: %s", filename.c_str(), e.what());
+    return false;
   }
 }
 
 static bool LoadStorageRootImpl(Context* ctx, const std::string& filename,
                                 std::string_view rootName) {
-  std::error_code ec;
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer =
-      wpi::MemoryBuffer::GetFile(filename, ec);
-  if (fileBuffer == nullptr || ec) {
-    ImGui::LogText("error opening %s: %s", filename.c_str(),
-                   ec.message().c_str());
-    return false;
+  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
+  if (auto buf = wpi::MemoryBuffer::GetFile(filename)) {
+    fileBuffer = std::move(*buf);
   } else {
-    auto& storage = ctx->storageRoots[rootName];
-    bool createdStorage = false;
-    if (!storage) {
-      storage = std::make_unique<Storage>();
-      createdStorage = true;
+    ImGui::LogText("error opening %s: %s", filename.c_str(),
+                   buf.error().message().c_str());
+    return false;
+  }
+  auto& storage = ctx->storageRoots[rootName];
+  bool createdStorage = false;
+  if (!storage) {
+    storage = std::make_unique<Storage>();
+    createdStorage = true;
+  }
+  try {
+    storage->FromJson(wpi::json::parse(fileBuffer->GetCharBuffer()),
+                      filename.c_str());
+  } catch (wpi::json::parse_error& e) {
+    ImGui::LogText("Error loading %s: %s", filename.c_str(), e.what());
+    if (createdStorage) {
+      ctx->storageRoots.erase(rootName);
     }
-    try {
-      storage->FromJson(wpi::json::parse(fileBuffer->GetCharBuffer()),
-                        filename.c_str());
-    } catch (wpi::json::parse_error& e) {
-      ImGui::LogText("Error loading %s: %s", filename.c_str(), e.what());
-      if (createdStorage) {
-        ctx->storageRoots.erase(rootName);
-      }
-      return false;
-    }
+    return false;
   }
   return true;
 }

--- a/glass/src/lib/native/cpp/Context.cpp
+++ b/glass/src/lib/native/cpp/Context.cpp
@@ -128,16 +128,14 @@ static bool JsonToWindow(const wpi::json& jfile, const char* filename) {
 }
 
 static bool LoadWindowStorageImpl(const std::string& filename) {
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
-  if (auto buf = wpi::MemoryBuffer::GetFile(filename)) {
-    fileBuffer = std::move(*buf);
-  } else {
+  auto fileBuffer = wpi::MemoryBuffer::GetFile(filename);
+  if (!fileBuffer) {
     ImGui::LogText("error opening %s: %s", filename.c_str(),
-                   buf.error().message().c_str());
+                   fileBuffer.error().message().c_str());
     return false;
   }
   try {
-    return JsonToWindow(wpi::json::parse(fileBuffer->GetCharBuffer()),
+    return JsonToWindow(wpi::json::parse(fileBuffer.value()->GetCharBuffer()),
                         filename.c_str());
   } catch (wpi::json::parse_error& e) {
     ImGui::LogText("Error loading %s: %s", filename.c_str(), e.what());
@@ -147,12 +145,10 @@ static bool LoadWindowStorageImpl(const std::string& filename) {
 
 static bool LoadStorageRootImpl(Context* ctx, const std::string& filename,
                                 std::string_view rootName) {
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
-  if (auto buf = wpi::MemoryBuffer::GetFile(filename)) {
-    fileBuffer = std::move(*buf);
-  } else {
+  auto fileBuffer = wpi::MemoryBuffer::GetFile(filename);
+  if (!fileBuffer) {
     ImGui::LogText("error opening %s: %s", filename.c_str(),
-                   buf.error().message().c_str());
+                   fileBuffer.error().message().c_str());
     return false;
   }
   auto& storage = ctx->storageRoots[rootName];
@@ -162,7 +158,7 @@ static bool LoadStorageRootImpl(Context* ctx, const std::string& filename,
     createdStorage = true;
   }
   try {
-    storage->FromJson(wpi::json::parse(fileBuffer->GetCharBuffer()),
+    storage->FromJson(wpi::json::parse(fileBuffer.value()->GetCharBuffer()),
                       filename.c_str());
   } catch (wpi::json::parse_error& e) {
     ImGui::LogText("Error loading %s: %s", filename.c_str(), e.what());

--- a/glass/src/lib/native/cpp/other/Field2D.cpp
+++ b/glass/src/lib/native/cpp/other/Field2D.cpp
@@ -542,7 +542,7 @@ bool FieldInfo::LoadJson(std::span<const char> is, std::string_view filename) {
 void FieldInfo::LoadJsonFile(std::string_view jsonfile) {
   std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
   if (auto buf = wpi::MemoryBuffer::GetFile(jsonfile)) {
-    fileBuffer = std::move(buf);
+    fileBuffer = std::move(*buf);
   } else {
     std::fputs("GUI: could not open field JSON file\n", stderr);
     return;

--- a/glass/src/lib/native/cpp/other/Field2D.cpp
+++ b/glass/src/lib/native/cpp/other/Field2D.cpp
@@ -540,16 +540,14 @@ bool FieldInfo::LoadJson(std::span<const char> is, std::string_view filename) {
 }
 
 void FieldInfo::LoadJsonFile(std::string_view jsonfile) {
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
-  if (auto buf = wpi::MemoryBuffer::GetFile(jsonfile)) {
-    fileBuffer = std::move(*buf);
-  } else {
+  auto fileBuffer = wpi::MemoryBuffer::GetFile(jsonfile);
+  if (!fileBuffer) {
     std::fputs("GUI: could not open field JSON file\n", stderr);
     return;
   }
-  LoadJson(
-      {reinterpret_cast<const char*>(fileBuffer->begin()), fileBuffer->size()},
-      jsonfile);
+  LoadJson({reinterpret_cast<const char*>(fileBuffer.value()->begin()),
+            fileBuffer.value()->size()},
+           jsonfile);
 }
 
 bool FieldInfo::LoadImageImpl(const std::string& fn) {

--- a/glass/src/lib/native/cpp/other/Field2D.cpp
+++ b/glass/src/lib/native/cpp/other/Field2D.cpp
@@ -540,10 +540,10 @@ bool FieldInfo::LoadJson(std::span<const char> is, std::string_view filename) {
 }
 
 void FieldInfo::LoadJsonFile(std::string_view jsonfile) {
-  std::error_code ec;
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer =
-      wpi::MemoryBuffer::GetFile(jsonfile, ec);
-  if (fileBuffer == nullptr || ec) {
+  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
+  if (auto buf = wpi::MemoryBuffer::GetFile(jsonfile)) {
+    fileBuffer = std::move(buf);
+  } else {
     std::fputs("GUI: could not open field JSON file\n", stderr);
     return;
   }

--- a/hal/src/main/native/athena/HAL.cpp
+++ b/hal/src/main/native/athena/HAL.cpp
@@ -304,7 +304,8 @@ void InitializeRoboRioComments(void) {
       return;
     }
     std::string_view fileContents{
-        reinterpret_cast<const char*>(fileBuffer.value()->begin())};
+        reinterpret_cast<const char*>(fileBuffer.value()->begin()),
+        fileBuffer.value()->size()};
     std::string_view searchString = "PRETTY_HOSTNAME=\"";
 
     size_t start = fileContents.find(searchString);

--- a/hal/src/main/native/athena/HAL.cpp
+++ b/hal/src/main/native/athena/HAL.cpp
@@ -297,19 +297,14 @@ void HAL_GetSerialNumber(struct WPI_String* serialNumber) {
 
 void InitializeRoboRioComments(void) {
   if (!roboRioCommentsStringInitialized) {
-    // Store pointer to make sure buffer isn't freed
-    std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
-    std::string_view fileContents;
-    if (auto buf = wpi::MemoryBuffer::GetFile("/etc/machine-info")) {
-      fileBuffer = std::move(*buf);
-      fileContents =
-          std::string_view(reinterpret_cast<const char*>(fileBuffer->begin()),
-                           fileBuffer->size());
-    } else {
+    auto fileBuffer = wpi::MemoryBuffer::GetFile("/etc/machine-info");
+    if (!fileBuffer) {
       roboRioCommentsStringSize = 0;
       roboRioCommentsStringInitialized = true;
       return;
     }
+    std::string_view fileContents{
+        reinterpret_cast<const char*>(fileBuffer.value()->begin())};
     std::string_view searchString = "PRETTY_HOSTNAME=\"";
 
     size_t start = fileContents.find(searchString);

--- a/hal/src/main/native/athena/HAL.cpp
+++ b/hal/src/main/native/athena/HAL.cpp
@@ -297,12 +297,11 @@ void HAL_GetSerialNumber(struct WPI_String* serialNumber) {
 
 void InitializeRoboRioComments(void) {
   if (!roboRioCommentsStringInitialized) {
-    std::error_code ec;
-    std::unique_ptr<wpi::MemoryBuffer> fileBuffer =
-        wpi::MemoryBuffer::GetFile("/etc/machine-info", ec);
-
+    // Store pointer to make sure buffer isn't freed
+    std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
     std::string_view fileContents;
-    if (fileBuffer && !ec) {
+    if (auto buf = wpi::MemoryBuffer::GetFile("/etc/machine-info")) {
+      fileBuffer = std::move(*buf);
       fileContents =
           std::string_view(reinterpret_cast<const char*>(fileBuffer->begin()),
                            fileBuffer->size());

--- a/ntcore/src/main/native/cpp/NetworkServer.cpp
+++ b/ntcore/src/main/native/cpp/NetworkServer.cpp
@@ -351,14 +351,12 @@ void NetworkServer::HandleLocal() {
 }
 
 void NetworkServer::LoadPersistent() {
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
-  if (auto buf = wpi::MemoryBuffer::GetFile(m_persistentFilename)) {
-    fileBuffer = std::move(*buf);
-  } else {
+  auto fileBuffer = wpi::MemoryBuffer::GetFile(m_persistentFilename);
+  if (!fileBuffer) {
     INFO(
         "could not open persistent file '{}': {} "
         "(this can be ignored if you aren't expecting persistent values)",
-        m_persistentFilename, buf.error().message());
+        m_persistentFilename, fileBuffer.error().message());
     // backup file
     std::error_code ec;
     fs::copy_file(m_persistentFilename, m_persistentFilename + ".bak",
@@ -371,7 +369,8 @@ void NetworkServer::LoadPersistent() {
     }
     return;
   }
-  m_persistentData = std::string{fileBuffer->begin(), fileBuffer->end()};
+  m_persistentData =
+      std::string{fileBuffer.value()->begin(), fileBuffer.value()->end()};
   DEBUG4("read data: {}", m_persistentData);
 }
 

--- a/simulation/halsim_ws_server/src/main/native/cpp/HALSimHttpConnection.cpp
+++ b/simulation/halsim_ws_server/src/main/native/cpp/HALSimHttpConnection.cpp
@@ -125,10 +125,8 @@ void HALSimHttpConnection::SendFileResponse(int code, std::string_view codeText,
   }
 
   // open file
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
-  if (auto buf = wpi::MemoryBuffer::GetFile(filename)) {
-    fileBuffer = std::move(*buf);
-  } else {
+  auto fileBuffer = wpi::MemoryBuffer::GetFile(filename);
+  if (!fileBuffer) {
     MySendError(404, "error opening file");
     return;
   }
@@ -144,7 +142,7 @@ void HALSimHttpConnection::SendFileResponse(int code, std::string_view codeText,
   wpi::SmallVector<uv::Buffer, 4> bodyData;
   wpi::raw_uv_ostream bodyOs{bodyData, 4096};
 
-  bodyOs << fileBuffer->GetBuffer();
+  bodyOs << fileBuffer.value()->GetBuffer();
 
   SendData(bodyOs.bufs(), false);
   if (!m_keepAlive) {

--- a/simulation/halsim_ws_server/src/main/native/cpp/HALSimHttpConnection.cpp
+++ b/simulation/halsim_ws_server/src/main/native/cpp/HALSimHttpConnection.cpp
@@ -125,9 +125,10 @@ void HALSimHttpConnection::SendFileResponse(int code, std::string_view codeText,
   }
 
   // open file
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer =
-      wpi::MemoryBuffer::GetFile(filename, ec);
-  if (fileBuffer == nullptr || ec) {
+  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
+  if (auto buf = wpi::MemoryBuffer::GetFile(filename)) {
+    fileBuffer = std::move(*buf);
+  } else {
     MySendError(404, "error opening file");
     return;
   }

--- a/sysid/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/sysid/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -10,7 +10,6 @@
 #include <fmt/format.h>
 #include <units/angle.h>
 #include <wpi/MathExtras.h>
-#include <wpi/MemoryBuffer.h>
 #include <wpi/StringExtras.h>
 #include <wpi/StringMap.h>
 

--- a/sysid/src/main/native/cpp/view/LogLoader.cpp
+++ b/sysid/src/main/native/cpp/view/LogLoader.cpp
@@ -35,15 +35,16 @@ void LogLoader::Display() {
     if (!m_opener->result().empty()) {
       m_filename = m_opener->result()[0];
 
-      std::error_code ec;
-      auto buf = wpi::MemoryBuffer::GetFile(m_filename, ec);
-      if (ec) {
+      std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
+      if (auto buf = wpi::MemoryBuffer::GetFile(m_filename)) {
+        fileBuffer = std::move(*buf);
+      } else {
         ImGui::OpenPopup("Error");
-        m_error = fmt::format("Could not open file: {}", ec.message());
+        m_error = fmt::format("Could not open file: {}", buf.error().message());
         return;
       }
 
-      wpi::log::DataLogReader reader{std::move(buf)};
+      wpi::log::DataLogReader reader{std::move(fileBuffer)};
       if (!reader.IsValid()) {
         ImGui::OpenPopup("Error");
         m_error = "Not a valid datalog file";

--- a/sysid/src/main/native/cpp/view/LogLoader.cpp
+++ b/sysid/src/main/native/cpp/view/LogLoader.cpp
@@ -35,16 +35,15 @@ void LogLoader::Display() {
     if (!m_opener->result().empty()) {
       m_filename = m_opener->result()[0];
 
-      std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
-      if (auto buf = wpi::MemoryBuffer::GetFile(m_filename)) {
-        fileBuffer = std::move(*buf);
-      } else {
+      auto fileBuffer = wpi::MemoryBuffer::GetFile(m_filename);
+      if (!fileBuffer) {
         ImGui::OpenPopup("Error");
-        m_error = fmt::format("Could not open file: {}", buf.error().message());
+        m_error = fmt::format("Could not open file: {}",
+                              fileBuffer.error().message());
         return;
       }
 
-      wpi::log::DataLogReader reader{std::move(fileBuffer)};
+      wpi::log::DataLogReader reader{std::move(*fileBuffer)};
       if (!reader.IsValid()) {
         ImGui::OpenPopup("Error");
         m_error = "Not a valid datalog file";

--- a/wpimath/src/main/native/cpp/trajectory/TrajectoryUtil.cpp
+++ b/wpimath/src/main/native/cpp/trajectory/TrajectoryUtil.cpp
@@ -28,10 +28,10 @@ void TrajectoryUtil::ToPathweaverJson(const Trajectory& trajectory,
 }
 
 Trajectory TrajectoryUtil::FromPathweaverJson(std::string_view path) {
-  std::error_code ec;
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer =
-      wpi::MemoryBuffer::GetFile(path, ec);
-  if (fileBuffer == nullptr || ec) {
+  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
+  if (auto buf = wpi::MemoryBuffer::GetFile(path)) {
+    fileBuffer = std::move(*buf);
+  } else {
     throw std::runtime_error(fmt::format("Cannot open file: {}", path));
   }
 

--- a/wpimath/src/main/native/cpp/trajectory/TrajectoryUtil.cpp
+++ b/wpimath/src/main/native/cpp/trajectory/TrajectoryUtil.cpp
@@ -28,14 +28,12 @@ void TrajectoryUtil::ToPathweaverJson(const Trajectory& trajectory,
 }
 
 Trajectory TrajectoryUtil::FromPathweaverJson(std::string_view path) {
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
-  if (auto buf = wpi::MemoryBuffer::GetFile(path)) {
-    fileBuffer = std::move(*buf);
-  } else {
+  auto fileBuffer = wpi::MemoryBuffer::GetFile(path);
+  if (!fileBuffer) {
     throw std::runtime_error(fmt::format("Cannot open file: {}", path));
   }
 
-  wpi::json json = wpi::json::parse(fileBuffer->GetCharBuffer());
+  wpi::json json = wpi::json::parse(fileBuffer.value()->GetCharBuffer());
 
   return Trajectory{json.get<std::vector<Trajectory::State>>()};
 }

--- a/wpiutil/build.gradle
+++ b/wpiutil/build.gradle
@@ -32,7 +32,7 @@ ext {
                     include '*.cpp'
                 }
                 exportedHeaders {
-                    srcDirs 'src/main/native/include', 'src/main/native/thirdparty/llvm/include', 'src/main/native/thirdparty/json/include', 'src/main/native/thirdparty/fmtlib/include'
+                    srcDirs 'src/main/native/include', 'src/main/native/thirdparty/fmtlib/include', 'src/main/native/thirdparty/json/include', 'src/main/native/thirdparty/llvm/include'
                 }
             }
             llvmCpp(CppSourceSet) {
@@ -41,7 +41,7 @@ ext {
                     include '**/*.cpp'
                 }
                 exportedHeaders {
-                    srcDirs 'src/main/native/include', 'src/main/native/thirdparty/llvm/include', 'src/main/native/thirdparty/fmtlib/include'
+                    srcDirs 'src/main/native/include', 'src/main/native/thirdparty/expected/include', 'src/main/native/thirdparty/fmtlib/include', 'src/main/native/thirdparty/llvm/include'
                 }
             }
             mpackCpp(CppSourceSet) {

--- a/wpiutil/examples/printlog/printlog.cpp
+++ b/wpiutil/examples/printlog/printlog.cpp
@@ -18,12 +18,14 @@ int main(int argc, const char** argv) {
     wpi::print(stderr, "Usage: printlog <file>\n");
     return EXIT_FAILURE;
   }
-  std::error_code ec;
-  wpi::log::DataLogReader reader{wpi::MemoryBuffer::GetFile(argv[1], ec)};
-  if (ec) {
-    wpi::print(stderr, "could not open file: {}\n", ec.message());
+  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
+  if (auto buf = wpi::MemoryBuffer::GetFile(argv[1])) {
+    fileBuffer = std::move(*buf);
+  } else {
+    wpi::print(stderr, "could not open file: {}\n", buf.error().message());
     return EXIT_FAILURE;
   }
+  wpi::log::DataLogReader reader{std::move(fileBuffer)};
   if (!reader) {
     wpi::print(stderr, "not a log file\n");
     return EXIT_FAILURE;

--- a/wpiutil/examples/printlog/printlog.cpp
+++ b/wpiutil/examples/printlog/printlog.cpp
@@ -18,14 +18,13 @@ int main(int argc, const char** argv) {
     wpi::print(stderr, "Usage: printlog <file>\n");
     return EXIT_FAILURE;
   }
-  std::unique_ptr<wpi::MemoryBuffer> fileBuffer;
-  if (auto buf = wpi::MemoryBuffer::GetFile(argv[1])) {
-    fileBuffer = std::move(*buf);
-  } else {
-    wpi::print(stderr, "could not open file: {}\n", buf.error().message());
+  auto fileBuffer = wpi::MemoryBuffer::GetFile(argv[1]);
+  if (!fileBuffer) {
+    wpi::print(stderr, "could not open file: {}\n",
+               fileBuffer.error().message());
     return EXIT_FAILURE;
   }
-  wpi::log::DataLogReader reader{std::move(fileBuffer)};
+  wpi::log::DataLogReader reader{std::move(*fileBuffer)};
   if (!reader) {
     wpi::print(stderr, "not a log file\n");
     return EXIT_FAILURE;

--- a/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/MemoryBuffer.cpp
+++ b/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/MemoryBuffer.cpp
@@ -259,10 +259,14 @@ static std::unique_ptr<WritableMemoryBuffer> GetMemoryBufferForStream(
   return GetMemBufferCopyImpl(buffer, bufferName, ec);
 }
 
-std::unique_ptr<MemoryBuffer> MemoryBuffer::GetFile(std::string_view filename,
-                                                    std::error_code& ec,
+wpi::expected<std::unique_ptr<MemoryBuffer>, std::error_code> MemoryBuffer::GetFile(std::string_view filename,
                                                     int64_t fileSize) {
-  return GetFileAux<MemoryBuffer>(filename, ec, fileSize, fileSize, 0);
+  std::error_code ec;
+  auto ret = GetFileAux<MemoryBuffer>(filename, ec, fileSize, fileSize, 0);
+  if (ec) {
+    return wpi::unexpected{ec};
+  }
+  return ret;
 }
 
 template <typename MB>

--- a/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/MemoryBuffer.cpp
+++ b/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/MemoryBuffer.cpp
@@ -259,8 +259,8 @@ static std::unique_ptr<WritableMemoryBuffer> GetMemoryBufferForStream(
   return GetMemBufferCopyImpl(buffer, bufferName, ec);
 }
 
-wpi::expected<std::unique_ptr<MemoryBuffer>, std::error_code> MemoryBuffer::GetFile(std::string_view filename,
-                                                    int64_t fileSize) {
+wpi::expected<std::unique_ptr<MemoryBuffer>, std::error_code>
+MemoryBuffer::GetFile(std::string_view filename, int64_t fileSize) {
   std::error_code ec;
   auto ret = GetFileAux<MemoryBuffer>(filename, ec, fileSize, fileSize, 0);
   if (ec) {

--- a/wpiutil/src/main/native/thirdparty/llvm/include/wpi/MemoryBuffer.h
+++ b/wpiutil/src/main/native/thirdparty/llvm/include/wpi/MemoryBuffer.h
@@ -24,6 +24,7 @@
 #include <span>
 #include <string_view>
 #include <system_error>
+#include <wpi/expected>
 
 // Duplicated from fs.h to avoid a dependency
 namespace fs {
@@ -77,8 +78,7 @@ class MemoryBuffer {
   /// if successful, otherwise returning null. If FileSize is specified, this
   /// means that the client knows that the file exists and that it has the
   /// specified size.
-  static std::unique_ptr<MemoryBuffer> GetFile(std::string_view filename,
-                                               std::error_code& ec,
+  static wpi::expected<std::unique_ptr<MemoryBuffer>, std::error_code> GetFile(std::string_view filename,
                                                int64_t fileSize = -1);
 
   /// Read all of the specified file into a MemoryBuffer as a stream

--- a/wpiutil/src/main/native/thirdparty/llvm/include/wpi/MemoryBuffer.h
+++ b/wpiutil/src/main/native/thirdparty/llvm/include/wpi/MemoryBuffer.h
@@ -78,8 +78,8 @@ class MemoryBuffer {
   /// if successful, otherwise returning null. If FileSize is specified, this
   /// means that the client knows that the file exists and that it has the
   /// specified size.
-  static wpi::expected<std::unique_ptr<MemoryBuffer>, std::error_code> GetFile(std::string_view filename,
-                                               int64_t fileSize = -1);
+  static wpi::expected<std::unique_ptr<MemoryBuffer>, std::error_code>
+  GetFile(std::string_view filename, int64_t fileSize = -1);
 
   /// Read all of the specified file into a MemoryBuffer as a stream
   /// (i.e. until EOF reached). This is useful for special files that


### PR DESCRIPTION
Closes #7036.

I'm not completely happy with the idiom I went with, but I think it works relatively well. If anyone has suggestions for a cleaner one, I'd be happy to hear it!

Also, I'm a little worried about how long the `GetFile()` declaration line is in the header file, but it's excluded from format so I'm not sure what to do.