### PR TITLE
[cmd] Deprecate Command.schedule()

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
@@ -615,7 +615,7 @@ public abstract class Command implements Sendable {
         value -> {
           if (value) {
             if (!isScheduled()) {
-              schedule();
+              CommandScheduler.getInstance().schedule(this);
             }
           } else {
             if (isScheduled()) {

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
@@ -533,7 +533,12 @@ public abstract class Command implements Sendable {
         });
   }
 
-  /** Schedules this command. */
+  /**
+   * Schedules this command.
+   *
+   * @deprecated Use CommandScheduler.getInstance().schedule(Command...) instead
+   */
+  @Deprecated(since = "2025", forRemoval = true)
   public void schedule() {
     CommandScheduler.getInstance().schedule(this);
   }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProxyCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProxyCommand.java
@@ -58,7 +58,7 @@ public class ProxyCommand extends Command {
   @Override
   public void initialize() {
     m_command = m_supplier.get();
-    m_command.schedule();
+    CommandScheduler.getInstance().schedule(m_command);
   }
 
   @Override

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ScheduleCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ScheduleCommand.java
@@ -28,7 +28,7 @@ public class ScheduleCommand extends Command {
   @Override
   public void initialize() {
     for (Command command : m_toSchedule) {
-      command.schedule();
+      CommandScheduler.getInstance().schedule(command);
     }
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
@@ -93,7 +93,7 @@ public class Trigger implements BooleanSupplier {
     addBinding(
         (previous, current) -> {
           if (previous != current) {
-            command.schedule();
+            CommandScheduler.getInstance().schedule(command);
           }
         });
     return this;
@@ -110,7 +110,7 @@ public class Trigger implements BooleanSupplier {
     addBinding(
         (previous, current) -> {
           if (!previous && current) {
-            command.schedule();
+            CommandScheduler.getInstance().schedule(command);
           }
         });
     return this;
@@ -127,7 +127,7 @@ public class Trigger implements BooleanSupplier {
     addBinding(
         (previous, current) -> {
           if (previous && !current) {
-            command.schedule();
+            CommandScheduler.getInstance().schedule(command);
           }
         });
     return this;
@@ -148,7 +148,7 @@ public class Trigger implements BooleanSupplier {
     addBinding(
         (previous, current) -> {
           if (!previous && current) {
-            command.schedule();
+            CommandScheduler.getInstance().schedule(command);
           } else if (previous && !current) {
             command.cancel();
           }
@@ -171,7 +171,7 @@ public class Trigger implements BooleanSupplier {
     addBinding(
         (previous, current) -> {
           if (previous && !current) {
-            command.schedule();
+            CommandScheduler.getInstance().schedule(command);
           } else if (!previous && current) {
             command.cancel();
           }
@@ -193,7 +193,7 @@ public class Trigger implements BooleanSupplier {
             if (command.isScheduled()) {
               command.cancel();
             } else {
-              command.schedule();
+              CommandScheduler.getInstance().schedule(command);
             }
           }
         });
@@ -214,7 +214,7 @@ public class Trigger implements BooleanSupplier {
             if (command.isScheduled()) {
               command.cancel();
             } else {
-              command.schedule();
+              CommandScheduler.getInstance().schedule(command);
             }
           }
         });

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
@@ -197,7 +197,7 @@ void Command::InitSendable(wpi::SendableBuilder& builder) {
       [this](bool value) {
         bool isScheduled = IsScheduled();
         if (value && !isScheduled) {
-          Schedule();
+          CommandScheduler::GetInstance().Schedule(this);
         } else if (!value && isScheduled) {
           Cancel();
         }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/ProxyCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/ProxyCommand.cpp
@@ -37,7 +37,7 @@ ProxyCommand::ProxyCommand(std::unique_ptr<Command> command) {
 
 void ProxyCommand::Initialize() {
   m_command = m_supplier();
-  m_command->Schedule();
+  frc2::CommandScheduler::GetInstance().Schedule(m_command);
 }
 
 void ProxyCommand::End(bool interrupted) {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/ScheduleCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/ScheduleCommand.cpp
@@ -18,7 +18,7 @@ ScheduleCommand::ScheduleCommand(Command* toSchedule) {
 
 void ScheduleCommand::Initialize() {
   for (auto command : m_toSchedule) {
-    command->Schedule();
+    frc2::CommandScheduler::GetInstance().Schedule(command);
   }
 }
 

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
@@ -29,7 +29,7 @@ void Trigger::AddBinding(wpi::unique_function<void(bool, bool)>&& body) {
 Trigger Trigger::OnChange(Command* command) {
   AddBinding([command](bool previous, bool current) {
     if (previous != current) {
-      command->Schedule();
+      frc2::CommandScheduler::GetInstance().Schedule(command);
     }
   });
   return *this;
@@ -47,7 +47,7 @@ Trigger Trigger::OnChange(CommandPtr&& command) {
 Trigger Trigger::OnTrue(Command* command) {
   AddBinding([command](bool previous, bool current) {
     if (!previous && current) {
-      command->Schedule();
+      frc2::CommandScheduler::GetInstance().Schedule(command);
     }
   });
   return *this;
@@ -65,7 +65,7 @@ Trigger Trigger::OnTrue(CommandPtr&& command) {
 Trigger Trigger::OnFalse(Command* command) {
   AddBinding([command](bool previous, bool current) {
     if (previous && !current) {
-      command->Schedule();
+      frc2::CommandScheduler::GetInstance().Schedule(command);
     }
   });
   return *this;
@@ -83,7 +83,7 @@ Trigger Trigger::OnFalse(CommandPtr&& command) {
 Trigger Trigger::WhileTrue(Command* command) {
   AddBinding([command](bool previous, bool current) {
     if (!previous && current) {
-      command->Schedule();
+      frc2::CommandScheduler::GetInstance().Schedule(command);
     } else if (previous && !current) {
       command->Cancel();
     }
@@ -105,7 +105,7 @@ Trigger Trigger::WhileTrue(CommandPtr&& command) {
 Trigger Trigger::WhileFalse(Command* command) {
   AddBinding([command](bool previous, bool current) {
     if (previous && !current) {
-      command->Schedule();
+      frc2::CommandScheduler::GetInstance().Schedule(command);
     } else if (!previous && current) {
       command->Cancel();
     }
@@ -130,7 +130,7 @@ Trigger Trigger::ToggleOnTrue(Command* command) {
       if (command->IsScheduled()) {
         command->Cancel();
       } else {
-        command->Schedule();
+        frc2::CommandScheduler::GetInstance().Schedule(command);
       }
     }
   });
@@ -156,7 +156,7 @@ Trigger Trigger::ToggleOnFalse(Command* command) {
       if (command->IsScheduled()) {
         command->Cancel();
       } else {
-        command->Schedule();
+        frc2::CommandScheduler::GetInstance().Schedule(command);
       }
     }
   });

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
@@ -38,7 +38,7 @@ Trigger Trigger::OnChange(Command* command) {
 Trigger Trigger::OnChange(CommandPtr&& command) {
   AddBinding([command = std::move(command)](bool previous, bool current) {
     if (previous != current) {
-      command.Schedule();
+      frc2::CommandScheduler::GetInstance().Schedule(command);
     }
   });
   return *this;
@@ -56,7 +56,7 @@ Trigger Trigger::OnTrue(Command* command) {
 Trigger Trigger::OnTrue(CommandPtr&& command) {
   AddBinding([command = std::move(command)](bool previous, bool current) {
     if (!previous && current) {
-      command.Schedule();
+      frc2::CommandScheduler::GetInstance().Schedule(command);
     }
   });
   return *this;
@@ -74,7 +74,7 @@ Trigger Trigger::OnFalse(Command* command) {
 Trigger Trigger::OnFalse(CommandPtr&& command) {
   AddBinding([command = std::move(command)](bool previous, bool current) {
     if (previous && !current) {
-      command.Schedule();
+      frc2::CommandScheduler::GetInstance().Schedule(command);
     }
   });
   return *this;
@@ -94,7 +94,7 @@ Trigger Trigger::WhileTrue(Command* command) {
 Trigger Trigger::WhileTrue(CommandPtr&& command) {
   AddBinding([command = std::move(command)](bool previous, bool current) {
     if (!previous && current) {
-      command.Schedule();
+      frc2::CommandScheduler::GetInstance().Schedule(command);
     } else if (previous && !current) {
       command.Cancel();
     }
@@ -116,7 +116,7 @@ Trigger Trigger::WhileFalse(Command* command) {
 Trigger Trigger::WhileFalse(CommandPtr&& command) {
   AddBinding([command = std::move(command)](bool previous, bool current) {
     if (!previous && current) {
-      command.Schedule();
+      frc2::CommandScheduler::GetInstance().Schedule(command);
     } else if (previous && !current) {
       command.Cancel();
     }
@@ -143,7 +143,7 @@ Trigger Trigger::ToggleOnTrue(CommandPtr&& command) {
       if (command.IsScheduled()) {
         command.Cancel();
       } else {
-        command.Schedule();
+        frc2::CommandScheduler::GetInstance().Schedule(command);
       }
     }
   });
@@ -169,7 +169,7 @@ Trigger Trigger::ToggleOnFalse(CommandPtr&& command) {
       if (command.IsScheduled()) {
         command.Cancel();
       } else {
-        command.Schedule();
+        frc2::CommandScheduler::GetInstance().Schedule(command);
       }
     }
   });

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -398,7 +398,10 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
 
   /**
    * Schedules this command.
+   *
+   * @deprecated Use CommandScheduler::GetInstance().Schedule() instead
    */
+  [[deprecated("Use CommandScheduler::GetInstance().Schedule() instead.")]]
   void Schedule();
 
   /**

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
@@ -277,7 +277,10 @@ CommandPtr final {
 
   /**
    * Schedules this command.
+   *
+   * @deprecated Use CommandScheduler::GetInstance().Schedule() instead
    */
+  [[deprecated("Use CommandScheduler::GetInstance().Schedule() instead.")]]
   void Schedule() const&;
 
   // Prevent calls on a temporary, as the returned pointer would be invalid

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandSendableButtonTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandSendableButtonTest.java
@@ -55,7 +55,7 @@ class CommandSendableButtonTest extends CommandTestBase {
   @Test
   void trueAndScheduledNoOp() {
     // Scheduled and true -> no-op
-    m_command.schedule();
+    CommandScheduler.getInstance().schedule(m_command);
     CommandScheduler.getInstance().run();
     SmartDashboard.updateValues();
     assertTrue(m_command.isScheduled());
@@ -90,7 +90,7 @@ class CommandSendableButtonTest extends CommandTestBase {
   @Test
   void falseAndScheduledCancel() {
     // Scheduled and false -> cancel
-    m_command.schedule();
+    CommandScheduler.getInstance().schedule(m_command);
     CommandScheduler.getInstance().run();
     SmartDashboard.updateValues();
     assertTrue(m_command.isScheduled());

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/ProxyCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/ProxyCommandTest.java
@@ -22,7 +22,7 @@ class ProxyCommandTest extends CommandTestBase {
 
       scheduler.schedule(scheduleCommand);
 
-      verify(command1).schedule();
+      verify(command1).initialize();
     }
   }
 

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/ScheduleCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/ScheduleCommandTest.java
@@ -22,8 +22,8 @@ class ScheduleCommandTest extends CommandTestBase {
 
       scheduler.schedule(scheduleCommand);
 
-      verify(command1).schedule();
-      verify(command2).schedule();
+      verify(command1).initialize();
+      verify(command2).initialize();
     }
   }
 

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/NetworkButtonTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/NetworkButtonTest.java
@@ -39,10 +39,10 @@ class NetworkButtonTest extends CommandTestBase {
     pub.set(false);
     button.onTrue(command);
     scheduler.run();
-    verify(command, never()).schedule();
+    verify(command, never()).initialize();
     pub.set(true);
     scheduler.run();
     scheduler.run();
-    verify(command).schedule();
+    verify(command).initialize();
   }
 }

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/TriggerTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/TriggerTest.java
@@ -207,7 +207,7 @@ class TriggerTest extends CommandTestBase {
             .until(button);
 
     button.setPressed(false);
-    command1.schedule();
+    scheduler.schedule(command1);
     scheduler.run();
     assertEquals(1, startCounter.get());
     assertEquals(0, endCounter.get());
@@ -258,13 +258,13 @@ class TriggerTest extends CommandTestBase {
 
     button.setPressed(true);
     scheduler.run();
-    verify(command, never()).schedule();
+    verify(command, never()).initialize();
 
     SimHooks.stepTiming(0.3);
 
     button.setPressed(true);
     scheduler.run();
-    verify(command).schedule();
+    verify(command).initialize();
   }
 
   @Test

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandSendableButtonTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandSendableButtonTest.cpp
@@ -82,7 +82,7 @@ TEST_F(CommandSendableButtonTest, falseAndNotScheduledNoOp) {
 
 TEST_F(CommandSendableButtonTest, falseAndScheduledCancel) {
   // Scheduled and false -> cancel
-  frc2::CommandScheduler::GetInstance().Schedule(m_command);
+  frc2::CommandScheduler::GetInstance().Schedule(m_command.value());
   GetScheduler().Run();
   frc::SmartDashboard::UpdateValues();
   EXPECT_TRUE(m_command->IsScheduled());

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandSendableButtonTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandSendableButtonTest.cpp
@@ -49,7 +49,7 @@ TEST_F(CommandSendableButtonTest, trueAndNotScheduledSchedules) {
 
 TEST_F(CommandSendableButtonTest, trueAndScheduledNoOp) {
   // Scheduled and true -> no-op
-  frc2::CommandScheduler::GetInstance().Schedule(m_command);
+  frc2::CommandScheduler::GetInstance().Schedule(m_command.value());
   GetScheduler().Run();
   frc::SmartDashboard::UpdateValues();
   EXPECT_TRUE(m_command->IsScheduled());

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandSendableButtonTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandSendableButtonTest.cpp
@@ -49,7 +49,7 @@ TEST_F(CommandSendableButtonTest, trueAndNotScheduledSchedules) {
 
 TEST_F(CommandSendableButtonTest, trueAndScheduledNoOp) {
   // Scheduled and true -> no-op
-  m_command->Schedule();
+  frc2::CommandScheduler::GetInstance().Schedule(m_command);
   GetScheduler().Run();
   frc::SmartDashboard::UpdateValues();
   EXPECT_TRUE(m_command->IsScheduled());
@@ -82,7 +82,7 @@ TEST_F(CommandSendableButtonTest, falseAndNotScheduledNoOp) {
 
 TEST_F(CommandSendableButtonTest, falseAndScheduledCancel) {
   // Scheduled and false -> cancel
-  m_command->Schedule();
+  frc2::CommandScheduler::GetInstance().Schedule(m_command);
   GetScheduler().Run();
   frc::SmartDashboard::UpdateValues();
   EXPECT_TRUE(m_command->IsScheduled());

--- a/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/cpp/Robot.cpp
@@ -38,7 +38,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand) {
-    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand.value());
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/cpp/Robot.cpp
@@ -38,7 +38,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand) {
-    m_autonomousCommand->Schedule();
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/Robot.cpp
@@ -47,7 +47,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand != nullptr) {
-    m_autonomousCommand->Schedule();
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/Robot.cpp
@@ -47,7 +47,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand != nullptr) {
-    m_autonomousCommand->Schedule();
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/cpp/Robot.cpp
@@ -38,7 +38,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand) {
-    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand.value());
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/cpp/Robot.cpp
@@ -38,7 +38,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand) {
-    m_autonomousCommand->Schedule();
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/Robot.cpp
@@ -26,7 +26,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_robot.GetAutonomousCommand();
 
   if (m_autonomousCommand) {
-    m_autonomousCommand->Schedule();
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/Robot.cpp
@@ -26,7 +26,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_robot.GetAutonomousCommand();
 
   if (m_autonomousCommand) {
-    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand.value());
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/cpp/Robot.cpp
@@ -37,7 +37,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand != nullptr) {
-    m_autonomousCommand->Schedule();
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/SelectCommand/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SelectCommand/cpp/Robot.cpp
@@ -38,7 +38,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand != nullptr) {
-    m_autonomousCommand->Schedule();
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/Robot.cpp
@@ -38,7 +38,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand) {
-    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand.value());
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/Robot.cpp
@@ -38,7 +38,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand) {
-    m_autonomousCommand->Schedule();
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/cpp/Robot.cpp
@@ -22,7 +22,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand) {
-    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand.value());
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/cpp/Robot.cpp
@@ -22,7 +22,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand) {
-    m_autonomousCommand->Schedule();
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/XRPReference/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/XRPReference/cpp/Robot.cpp
@@ -37,7 +37,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand != nullptr) {
-    m_autonomousCommand->Schedule();
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/templates/commandbased/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandbased/cpp/Robot.cpp
@@ -37,7 +37,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand) {
-    m_autonomousCommand->Schedule();
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/templates/commandbased/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandbased/cpp/Robot.cpp
@@ -37,7 +37,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand) {
-    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand.value());
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/templates/commandbasedskeleton/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandbasedskeleton/cpp/Robot.cpp
@@ -22,7 +22,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand) {
-    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand.value());
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/templates/commandbasedskeleton/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandbasedskeleton/cpp/Robot.cpp
@@ -22,7 +22,7 @@ void Robot::AutonomousInit() {
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
   if (m_autonomousCommand) {
-    m_autonomousCommand->Schedule();
+    frc2::CommandScheduler::GetInstance().Schedule(m_autonomousCommand);
   }
 }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/drivedistanceoffboard/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/drivedistanceoffboard/Robot.java
@@ -65,7 +65,7 @@ public class Robot extends TimedRobot {
 
     // schedule the autonomous command (example)
     if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/Robot.java
@@ -67,7 +67,7 @@ public class Robot extends TimedRobot {
 
     // schedule the autonomous command (example)
     if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/Robot.java
@@ -74,7 +74,7 @@ public class Robot extends TimedRobot {
 
     // schedule the autonomous command (example)
     if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/Robot.java
@@ -65,7 +65,7 @@ public class Robot extends TimedRobot {
 
     // schedule the autonomous command (example)
     if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/rapidreactcommandbot/Robot.java
@@ -63,7 +63,7 @@ public class Robot extends TimedRobot {
     m_autonomousCommand = m_robot.getAutonomousCommand();
 
     if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/romireference/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/romireference/Robot.java
@@ -58,7 +58,7 @@ public class Robot extends TimedRobot {
 
     // schedule the autonomous command (example)
     if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/selectcommand/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/selectcommand/Robot.java
@@ -65,7 +65,7 @@ public class Robot extends TimedRobot {
 
     // schedule the autonomous command (example)
     if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/Robot.java
@@ -65,7 +65,7 @@ public class Robot extends TimedRobot {
 
     // schedule the autonomous command (example)
     if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/sysidroutine/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/sysidroutine/Robot.java
@@ -55,7 +55,7 @@ public class Robot extends TimedRobot {
     m_autonomousCommand = m_robot.getAutonomousCommand();
 
     if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/xrpreference/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/xrpreference/Robot.java
@@ -58,7 +58,7 @@ public class Robot extends TimedRobot {
 
     // schedule the autonomous command (example)
     if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/commandbased/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/commandbased/Robot.java
@@ -58,7 +58,7 @@ public class Robot extends TimedRobot {
 
     // schedule the autonomous command (example)
     if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/commandbasedskeleton/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/commandbasedskeleton/Robot.java
@@ -36,7 +36,7 @@ public class Robot extends TimedRobot {
     m_autonomousCommand = m_robotContainer.getAutonomousCommand();
 
     if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/romicommandbased/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/romicommandbased/Robot.java
@@ -58,7 +58,7 @@ public class Robot extends TimedRobot {
 
     // schedule the autonomous command (example)
     if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/xrpcommandbased/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/xrpcommandbased/Robot.java
@@ -58,7 +58,7 @@ public class Robot extends TimedRobot {
 
     // schedule the autonomous command (example)
     if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
     }
   }
 


### PR DESCRIPTION
It's a footgun and syntactic sugar over the CommandScheduler's schedule method. We don't need syntactic sugar for a footgun.