### PR TITLE
[wpilibc] Solenoid classes: Make methods non-virtual

### DIFF
--- a/wpilibc/src/main/native/include/frc/DoubleSolenoid.h
+++ b/wpilibc/src/main/native/include/frc/DoubleSolenoid.h
@@ -70,14 +70,14 @@ class DoubleSolenoid : public wpi::Sendable,
    *
    * @param value The value to set (Off, Forward or Reverse)
    */
-  virtual void Set(Value value);
+  void Set(Value value);
 
   /**
    * Read the current value of the solenoid.
    *
    * @return The current value of the solenoid.
    */
-  virtual Value Get() const;
+  Value Get() const;
 
   /**
    * Toggle the value of the solenoid.

--- a/wpilibc/src/main/native/include/frc/Solenoid.h
+++ b/wpilibc/src/main/native/include/frc/Solenoid.h
@@ -52,14 +52,14 @@ class Solenoid : public wpi::Sendable, public wpi::SendableHelper<Solenoid> {
    *
    * @param on Turn the solenoid output off or on.
    */
-  virtual void Set(bool on);
+  void Set(bool on);
 
   /**
    * Read the current value of the solenoid.
    *
    * @return The current value of the solenoid.
    */
-  virtual bool Get() const;
+  bool Get() const;
 
   /**
    * Toggle the value of the solenoid.

--- a/wpilibc/src/main/native/include/frc/simulation/SolenoidSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/SolenoidSim.h
@@ -16,7 +16,7 @@ class SolenoidSim {
   SolenoidSim(std::shared_ptr<PneumaticsBaseSim> moduleSim, int channel);
   SolenoidSim(int module, PneumaticsModuleType type, int channel);
   SolenoidSim(PneumaticsModuleType type, int channel);
-  virtual ~SolenoidSim() = default;
+  ~SolenoidSim() = default;
 
   bool GetOutput() const;
   void SetOutput(bool output);
@@ -31,7 +31,7 @@ class SolenoidSim {
    * callback.
    */
   [[nodiscard]]
-  virtual std::unique_ptr<CallbackStore> RegisterOutputCallback(
+  std::unique_ptr<CallbackStore> RegisterOutputCallback(
       NotifyCallback callback, bool initialNotify);
 
   std::shared_ptr<PneumaticsBaseSim> GetModuleSim() const;

--- a/wpilibc/src/main/native/include/frc/simulation/SolenoidSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/SolenoidSim.h
@@ -31,8 +31,8 @@ class SolenoidSim {
    * callback.
    */
   [[nodiscard]]
-  std::unique_ptr<CallbackStore> RegisterOutputCallback(
-      NotifyCallback callback, bool initialNotify);
+  std::unique_ptr<CallbackStore> RegisterOutputCallback(NotifyCallback callback,
+                                                        bool initialNotify);
 
   std::shared_ptr<PneumaticsBaseSim> GetModuleSim() const;
 


### PR DESCRIPTION
Relic from when SolenoidBase existed