### PR TITLE
Fix warning on msvc in parse_integer

### DIFF
--- a/wpiutil/src/main/native/thirdparty/llvm/include/wpi/StringExtras.h
+++ b/wpiutil/src/main/native/thirdparty/llvm/include/wpi/StringExtras.h
@@ -680,7 +680,7 @@ inline std::optional<T> parse_integer(std::string_view str,
       static_cast<Int>(static_cast<T>(val)) != val) {
     return std::nullopt;
   }
-  return val;
+  return static_cast<T>(val);
 }
 
 /**


### PR DESCRIPTION
```
warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data
```