### PR TITLE
[wpilibNewCommands] `After` Command Decorators 

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/PowerDistributionFaults.java
+++ b/hal/src/main/java/edu/wpi/first/hal/PowerDistributionFaults.java
@@ -4,12 +4,20 @@
 
 package edu.wpi.first.hal;
 
+import java.nio.ByteBuffer;
+
+import edu.wpi.first.util.struct.Struct;
+import edu.wpi.first.util.struct.StructSerializable;
+
 /**
  * Faults for a PowerDistribution device. These faults are only active while the condition is
  * active.
  */
 @SuppressWarnings("MemberName")
-public class PowerDistributionFaults {
+public class PowerDistributionFaults implements StructSerializable {
+  /** The faults bitfield the object was constructed with */
+  public final int bitfield;
+
   /** Breaker fault on channel 0. */
   public final boolean Channel0BreakerFault;
 
@@ -136,6 +144,7 @@ public class PowerDistributionFaults {
    * @param faults faults
    */
   public PowerDistributionFaults(int faults) {
+    bitfield = faults;
     Channel0BreakerFault = (faults & 0x1) != 0;
     Channel1BreakerFault = (faults & 0x2) != 0;
     Channel2BreakerFault = (faults & 0x4) != 0;
@@ -163,5 +172,70 @@ public class PowerDistributionFaults {
     Brownout = (faults & 0x1000000) != 0;
     CanWarning = (faults & 0x2000000) != 0;
     HardwareFault = (faults & 0x4000000) != 0;
+  }
+
+  public static final PowerDistributionFaultsStruct struct = new PowerDistributionFaultsStruct();
+
+  protected static final class PowerDistributionFaultsStruct implements Struct<PowerDistributionFaults> {
+    @Override
+    public Class<PowerDistributionFaults> getTypeClass() {
+      return PowerDistributionFaults.class;
+    }
+
+    @Override
+    public int getSize() {
+      return kSizeInt32;
+    }
+
+    @Override
+    public String getSchema() {
+      return "bool channel0BreakerFault:1; "
+          + "bool channel1BreakerFault:1; "
+          + "bool channel2BreakerFault:1; "
+          + "bool channel3BreakerFault:1; "
+          + "bool channel4BreakerFault:1; "
+          + "bool channel5BreakerFault:1; "
+          + "bool channel6BreakerFault:1; "
+          + "bool channel7BreakerFault:1; "
+          + "bool channel8BreakerFault:1; "
+          + "bool channel9BreakerFault:1; "
+          + "bool channel10BreakerFault:1; "
+          + "bool channel11BreakerFault:1; "
+          + "bool channel12BreakerFault:1; "
+          + "bool channel13BreakerFault:1; "
+          + "bool channel14BreakerFault:1; "
+          + "bool channel15BreakerFault:1; "
+          + "bool channel16BreakerFault:1; "
+          + "bool channel17BreakerFault:1; "
+          + "bool channel18BreakerFault:1; "
+          + "bool channel19BreakerFault:1; "
+          + "bool channel20BreakerFault:1; "
+          + "bool channel21BreakerFault:1; "
+          + "bool channel22BreakerFault:1; "
+          + "bool channel23BreakerFault:1; "
+          + "bool brownout:1; "
+          + "bool canWarning:1; "
+          + "bool hardwareFault:1;";
+    }
+
+    @Override
+    public String getTypeName() {
+      return "PowerDistributionFaults";
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, PowerDistributionFaults value) {
+      bb.putInt(value.bitfield);
+    }
+
+    public void pack(ByteBuffer bb, int value) {
+      bb.putInt(value);
+    }
+
+    @Override
+    public PowerDistributionFaults unpack(ByteBuffer bb) {
+      int packed = bb.getInt();
+      return new PowerDistributionFaults(packed);
+    }
   }
 }

--- a/hal/src/main/java/edu/wpi/first/hal/PowerDistributionStickyFaults.java
+++ b/hal/src/main/java/edu/wpi/first/hal/PowerDistributionStickyFaults.java
@@ -4,12 +4,20 @@
 
 package edu.wpi.first.hal;
 
+import java.nio.ByteBuffer;
+
+import edu.wpi.first.util.struct.Struct;
+import edu.wpi.first.util.struct.StructSerializable;
+
 /**
  * Sticky faults for a PowerDistribution device. These faults will remain active until they are
  * reset by the user.
  */
 @SuppressWarnings("MemberName")
-public class PowerDistributionStickyFaults {
+public class PowerDistributionStickyFaults implements StructSerializable {
+  /** The faults bitfield the object was constructed with */
+  public final int bitfield;
+
   /** Breaker fault on channel 0. */
   public final boolean Channel0BreakerFault;
 
@@ -145,6 +153,7 @@ public class PowerDistributionStickyFaults {
    * @param faults faults
    */
   public PowerDistributionStickyFaults(int faults) {
+    bitfield = faults;
     Channel0BreakerFault = (faults & 0x1) != 0;
     Channel1BreakerFault = (faults & 0x2) != 0;
     Channel2BreakerFault = (faults & 0x4) != 0;
@@ -176,4 +185,68 @@ public class PowerDistributionStickyFaults {
     FirmwareFault = (faults & 0x10000000) != 0;
     HasReset = (faults & 0x20000000) != 0;
   }
+
+  protected static final class PowerDistributionStickyFaultsStruct implements Struct<PowerDistributionStickyFaults> {
+    @Override
+    public Class<PowerDistributionStickyFaults> getTypeClass() {
+        return PowerDistributionStickyFaults.class;
+    }
+
+    @Override
+    public int getSize() {
+        return 4; //doing bitfields on a u32
+    }
+
+    @Override
+    public String getSchema() {
+        return "bool channel0BreakerFault:1; "
+            + "bool channel1BreakerFault:1; "
+            + "bool channel2BreakerFault:1; "
+            + "bool channel3BreakerFault:1; "
+            + "bool channel4BreakerFault:1; "
+            + "bool channel5BreakerFault:1; "
+            + "bool channel6BreakerFault:1; "
+            + "bool channel7BreakerFault:1; "
+            + "bool channel8BreakerFault:1; "
+            + "bool channel9BreakerFault:1; "
+            + "bool channel10BreakerFault:1; "
+            + "bool channel11BreakerFault:1; "
+            + "bool channel12BreakerFault:1; "
+            + "bool channel13BreakerFault:1; "
+            + "bool channel14BreakerFault:1; "
+            + "bool channel15BreakerFault:1; "
+            + "bool channel16BreakerFault:1; "
+            + "bool channel17BreakerFault:1; "
+            + "bool channel18BreakerFault:1; "
+            + "bool channel19BreakerFault:1; "
+            + "bool channel20BreakerFault:1; "
+            + "bool channel21BreakerFault:1; "
+            + "bool channel22BreakerFault:1; "
+            + "bool channel23BreakerFault:1; "
+            + "bool brownout:1; "
+            + "bool canWarning:1; "
+            + "bool canBusOff:1; "
+            + "bool hasReset:1;";
+    }
+
+    @Override
+    public String getTypeName() {
+        return "PowerDistributionStickyFaults";
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, PowerDistributionStickyFaults value) {
+        bb.putInt(value.bitfield);
+    }
+
+    public void pack(ByteBuffer bb, int value) {
+        bb.putInt(value);
+    }
+
+    @Override
+    public PowerDistributionStickyFaults unpack(ByteBuffer bb) {
+        int packed = bb.getInt();
+        return new PowerDistributionStickyFaults(packed);
+    }
+}
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
@@ -219,6 +219,56 @@ public abstract class Command implements Sendable {
   }
 
   /**
+   * Decorates this command to run once a condition becomes true.
+   * 
+   * <p>Note: This decorator works by adding this command to a composition. The command the
+   * decorator was called on cannot be scheduled independently or be added to a different
+   * composition (namely, decorators), unless it is manually cleared from the list of composed
+   * commands with {@link CommandScheduler#removeComposedCommand(Command)}. The command composition
+   * returned from this method can be further decorated without issue.
+   * 
+   * @param condition the condition to wait for
+   * @return the decorated command
+   */
+  public SequentialCommandGroup after(BooleanSupplier condition) {
+    // if we want this to bypass the `WaitUntilCommand` if the condition is already true,
+    // we can use a conditional command but it proposes some compositional issues
+    return new SequentialCommandGroup(new WaitUntilCommand(condition), this);
+  }
+
+  /**
+   * Decorates this command to run after a time delay.
+   * 
+   * <p>Note: This decorator works by adding this command to a composition. The command the
+   * decorator was called on cannot be scheduled independently or be added to a different
+   * composition (namely, decorators), unless it is manually cleared from the list of composed
+   * commands with {@link CommandScheduler#removeComposedCommand(Command)}. The command composition
+   * returned from this method can be further decorated without issue.
+   * 
+   * @param seconds the seconds to wait
+   * @return the decorated command
+   */
+  public SequentialCommandGroup afterSeconds(double seconds) {
+    return new SequentialCommandGroup(new WaitCommand(seconds), this);
+  }
+
+  /**
+   * Decorates this command to run after a time delay.
+   * 
+   * <p>Note: This decorator works by adding this command to a composition. The command the
+   * decorator was called on cannot be scheduled independently or be added to a different
+   * composition (namely, decorators), unless it is manually cleared from the list of composed
+   * commands with {@link CommandScheduler#removeComposedCommand(Command)}. The command composition
+   * returned from this method can be further decorated without issue.
+   * 
+   * @param time the time to wait
+   * @return the decorated command
+   */
+  public SequentialCommandGroup afterTime(Time time) {
+    return afterSeconds(time.in(Seconds));
+  }
+
+  /**
    * Decorates this command with a runnable to run before this command starts.
    *
    * <p>Note: This decorator works by adding this command to a composition. The command the

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
@@ -84,6 +84,14 @@ CommandPtr Command::OnlyWhile(std::function<bool()> condition) && {
   return std::move(*this).ToPtr().OnlyWhile(std::move(condition));
 }
 
+CommandPtr After(std::function<bool()> condition) && {
+  return std::move(*this).ToPtr().After(std::move(condition));
+}
+
+CommandPtr AfterTime(units::second_t duration) && {
+  return std::move(*this).ToPtr().AfterTime(duration);
+}
+
 CommandPtr Command::IgnoringDisable(bool doesRunWhenDisabled) && {
   return std::move(*this).ToPtr().IgnoringDisable(doesRunWhenDisabled);
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
@@ -165,6 +165,24 @@ CommandPtr CommandPtr::OnlyIf(std::function<bool()> condition) && {
   return std::move(*this).Unless(std::not_fn(std::move(condition)));
 }
 
+CommandPtr CommandPtr::After(std::function<bool()> condition) && {
+  AssertValid();
+  std::vector<std::unique_ptr<Command>> temp;
+  temp.emplace_back(std::make_unique<WaitUntilCommand>(std::move(condition)));
+  temp.emplace_back(std::move(m_ptr));
+  m_ptr = std::make_unique<SequentialCommandGroup>(std::move(temp));
+  return std::move(*this);
+}
+
+CommandPtr CommandPtr::AfterTime(units::second_t duration) && {
+  AssertValid();
+  std::vector<std::unique_ptr<Command>> temp;
+  temp.emplace_back(std::make_unique<WaitCommand>(duration));
+  temp.emplace_back(std::move(m_ptr));
+  m_ptr = std::make_unique<SequentialCommandGroup>(std::move(temp));
+  return std::move(*this);
+}
+
 CommandPtr CommandPtr::DeadlineWith(CommandPtr&& parallel) && {
   AssertValid();
   std::vector<std::unique_ptr<Command>> vec;

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -218,6 +218,24 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
   CommandPtr OnlyWhile(std::function<bool()> condition) &&;
 
   /**
+   * Decorates this command to run after a condition becomes true.
+   *
+   * @param condition the condition to run after
+   * @return the decorated command
+   */
+  [[nodiscard]]
+  CommandPtr After(std::function<bool()> condition) &&;
+
+  /**
+   * Decorates this command to run after a specified amount of time.
+   *
+   * @param duration the time to wait before running
+   * @return the decorated command
+   */
+  [[nodiscard]]
+  CommandPtr AfterTime(units::second_t duration) &&;
+
+  /**
    * Decorates this command with a runnable to run before this command starts.
    *
    * @param toRun the Runnable to run

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
@@ -183,6 +183,24 @@ class CommandPtr final {
   CommandPtr OnlyIf(std::function<bool()> condition) &&;
 
   /**
+   * Decorates this command to run after a condition becomes true.
+   *
+   * @param condition the condition to run after
+   * @return the decorated command
+   */
+  [[nodiscard]]
+  CommandPtr After(std::function<bool()> condition) &&;
+
+  /**
+   * Decorates this command to run after a specified amount of time.
+   *
+   * @param duration the time to wait before running
+   * @return the decorated command
+   */
+  [[nodiscard]]
+  CommandPtr AfterTime(units::second_t duration) &&;
+
+  /**
    * Decorates this command with a set of commands to run parallel to it, ending
    * when the calling command ends and interrupting all the others. Often more
    * convenient/less-verbose than constructing a new {@link

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistribution.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistribution.java
@@ -4,6 +4,8 @@
 
 package edu.wpi.first.wpilibj;
 
+import java.nio.ByteBuffer;
+
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.PowerDistributionFaults;
@@ -13,6 +15,8 @@ import edu.wpi.first.hal.PowerDistributionVersion;
 import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.util.sendable.SendableRegistry;
+import edu.wpi.first.util.struct.Struct;
+import edu.wpi.first.util.struct.StructSerializable;
 
 /**
  * Class for getting voltage, current, temperature, power and energy from the CTRE Power
@@ -21,6 +25,7 @@ import edu.wpi.first.util.sendable.SendableRegistry;
 public class PowerDistribution implements Sendable, AutoCloseable {
   private final int m_handle;
   private final int m_module;
+  private final PowerDistributionStats m_stats;
 
   /** Default module number. */
   public static final int kDefaultModule = PowerDistributionJNI.DEFAULT_MODULE;
@@ -50,6 +55,7 @@ public class PowerDistribution implements Sendable, AutoCloseable {
   public PowerDistribution(int module, ModuleType moduleType) {
     m_handle = PowerDistributionJNI.initialize(module, moduleType.value);
     m_module = PowerDistributionJNI.getModuleNumber(m_handle);
+    m_stats = new PowerDistributionStats(this);
 
     HAL.report(tResourceType.kResourceType_PDP, m_module + 1);
     SendableRegistry.addLW(this, "PowerDistribution", m_module);
@@ -64,6 +70,7 @@ public class PowerDistribution implements Sendable, AutoCloseable {
   public PowerDistribution() {
     m_handle = PowerDistributionJNI.initialize(kDefaultModule, PowerDistributionJNI.AUTOMATIC_TYPE);
     m_module = PowerDistributionJNI.getModuleNumber(m_handle);
+    m_stats = new PowerDistributionStats(this);
 
     HAL.report(tResourceType.kResourceType_PDP, m_module + 1);
     SendableRegistry.addLW(this, "PowerDistribution", m_module);
@@ -258,5 +265,98 @@ public class PowerDistribution implements Sendable, AutoCloseable {
         "SwitchableChannel",
         () -> PowerDistributionJNI.getSwitchableChannelNoError(m_handle),
         value -> PowerDistributionJNI.setSwitchableChannel(m_handle, value));
+  }
+
+  protected static final class PowerDistributionStats implements StructSerializable {
+    public int faults = 0;
+    public int stickyFaults = 0;
+    public double voltage = 0.0;
+    public double totalCurrent = 0.0;
+    public boolean switchableChannel = false;
+    public double temperature = 0.0;
+    public double[] currents;
+
+    public PowerDistributionStats(final PowerDistribution pd) {
+      currents = new double[pd.getNumChannels()];
+      update(pd);
+    }
+
+    public void update(final PowerDistribution pd) {
+      faults = PowerDistributionJNI.getFaultsNative(pd.m_handle);
+      stickyFaults = PowerDistributionJNI.getStickyFaultsNative(pd.m_handle);
+      voltage = pd.getVoltage();
+      totalCurrent = pd.getTotalCurrent();
+      switchableChannel = pd.getSwitchableChannel();
+      temperature = pd.getTemperature();
+      PowerDistributionJNI.getAllCurrents(pd.m_handle, currents);
+    }
+
+    public final static PDDataStruct struct = new PDDataStruct();
+  }
+
+  protected static final class PDDataStruct implements Struct<PowerDistributionStats> {
+    private static final int kSize = 4 + 4 + 8 + 8 + 1 + 8 + (8 * 24);
+
+    @Override
+    public Class<PowerDistributionStats> getTypeClass() {
+      return PowerDistributionStats.class;
+    }
+
+    @Override
+    public int getSize() {
+      return kSize;
+    }
+
+    @Override
+    public String getSchema() {
+      return "PowerDistributionFaults faults; "
+          + "PowerDistributionStickyFaults stickyFaults; "
+          + "double voltage; "
+          + "double totalCurrent; "
+          + "bool switchableChannel; "
+          + "double temperature;"
+          + "double currents[24];";
+    }
+
+    @Override
+    public String getTypeName() {
+      return "PDData";
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, PowerDistributionStats value) {
+      bb.putInt(value.faults);
+      bb.putInt(value.stickyFaults);
+      bb.putDouble(value.voltage);
+      bb.putDouble(value.totalCurrent);
+      bb.put((byte) (value.switchableChannel ? 1 : 0));
+      bb.putDouble(value.temperature);
+      for (int i = 0; i < value.currents.length; i++) {
+        bb.putDouble(value.currents[i]);
+      }
+    }
+
+    @Override
+    public PowerDistributionStats unpack(ByteBuffer bb) {
+      PowerDistributionStats data = new PowerDistributionStats(null);
+      data.faults = bb.getInt();
+      data.stickyFaults = bb.getInt();
+      data.voltage = bb.getDouble();
+      data.totalCurrent = bb.getDouble();
+      data.switchableChannel = bb.get() == 1;
+      data.temperature = bb.getDouble();
+      for (int i = 0; i < 24; i++) {
+        data.currents[i] = bb.getDouble();
+      }
+      return data;
+    }
+
+    @Override
+    public Struct<?>[] getNested() {
+      return new Struct<?>[] {
+          new PowerDistributionFaultsStruct(),
+          new PowerDistributionStickyFaultsStruct()
+      };
+    }
   }
 }


### PR DESCRIPTION
Adds `After` and `AfterTime` to commands.

These are being upstreamed from choreolib CommandExt

This allows you to do `trajCmd.after(gampiece().negate())` to wait to move until the robot shoots its gamepiece.