### PR TITLE
Use project configured groupId in generated output artifact names

### DIFF
--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.google.protobuf'
 
 def baseArtifactId = project.baseId
 def artifactGroupId = project.groupId
-def javaBaseName = "_GROUP_edu_wpi_first_${project.baseId}_ID_${project.baseId}-java_CLS"
+def javaBaseName = "_GROUP_${project.groupId.replace('.', '_')}_ID_${project.baseId}-java_CLS"
 
 def outputsFolder = file("$project.buildDir/outputs")
 


### PR DESCRIPTION
Instead of hardcoding to use the project name after `edu_wpi_first_`, which broke epilogue publishing. Both projects publish to the `edu.wpi.first.epilogue` group ID, instead of the `edu.wpi.first.epilogue-processor/runtime` group IDs that were computed by the build script.

This bug did not affect local maven publishing, since those tasks do not use those specially named and configured artifacts
