### PR TITLE
[wpilib] ADIS IMUs: Add back null checks

### DIFF
--- a/wpilibc/src/main/native/cpp/ADIS16448_IMU.cpp
+++ b/wpilibc/src/main/native/cpp/ADIS16448_IMU.cpp
@@ -99,7 +99,6 @@ ADIS16448_IMU::ADIS16448_IMU(IMUAxis yaw_axis, SPI::Port port,
 
     ConfigCalTime(cal_time);
 
-    // Configure standard SPI
     if (!SwitchToStandardSPI()) {
       return;
     }
@@ -174,7 +173,6 @@ ADIS16448_IMU::ADIS16448_IMU(IMUAxis yaw_axis, SPI::Port port,
           "required!");
     }
 
-    // Configure and enable auto SPI
     if (!SwitchToAutoSPI()) {
       return;
     }
@@ -366,7 +364,6 @@ bool ADIS16448_IMU::SwitchToStandardSPI() {
       }
     }
   }
-  // There doesn't seem to be a SPI port active. Let's try to set one up
   if (m_spi == nullptr) {
     m_spi = new SPI(m_spi_port);
     m_spi->SetClockRate(1000000);

--- a/wpilibc/src/main/native/cpp/ADIS16448_IMU.cpp
+++ b/wpilibc/src/main/native/cpp/ADIS16448_IMU.cpp
@@ -99,10 +99,6 @@ ADIS16448_IMU::ADIS16448_IMU(IMUAxis yaw_axis, SPI::Port port,
 
     ConfigCalTime(cal_time);
 
-    m_spi = new SPI(m_spi_port);
-    m_spi->SetClockRate(1000000);
-    m_spi->SetMode(frc::SPI::Mode::kMode3);
-    m_spi->SetChipSelectActiveLow();
     // Configure standard SPI
     if (!SwitchToStandardSPI()) {
       return;
@@ -178,7 +174,6 @@ ADIS16448_IMU::ADIS16448_IMU(IMUAxis yaw_axis, SPI::Port port,
           "required!");
     }
 
-    m_auto_interrupt = new DigitalInput(10);
     // Configure and enable auto SPI
     if (!SwitchToAutoSPI()) {
       return;
@@ -352,7 +347,7 @@ bool ADIS16448_IMU::SwitchToStandardSPI() {
       Wait(10_ms);
     }
     // Maybe we're in auto SPI mode? If so, kill auto SPI, and then SPI.
-    if (m_auto_configured) {
+    if (m_spi != nullptr && m_auto_configured) {
       m_spi->StopAuto();
       // We need to get rid of all the garbage left in the auto SPI buffer after
       // stopping it.
@@ -370,6 +365,13 @@ bool ADIS16448_IMU::SwitchToStandardSPI() {
         data_count = m_spi->ReadAutoReceivedData(trashBuffer, 0, 0_s);
       }
     }
+  }
+  // There doesn't seem to be a SPI port active. Let's try to set one up
+  if (m_spi == nullptr) {
+    m_spi = new SPI(m_spi_port);
+    m_spi->SetClockRate(1000000);
+    m_spi->SetMode(frc::SPI::Mode::kMode3);
+    m_spi->SetChipSelectActiveLow();
   }
   ReadRegister(PROD_ID);  // Dummy read
   // Validate the product ID
@@ -412,6 +414,15 @@ void ADIS16448_IMU::InitOffsetBuffer(int size) {
  *are hard-coded to work only with the ADIS16448 IMU.
  **/
 bool ADIS16448_IMU::SwitchToAutoSPI() {
+  // No SPI port has been set up. Go set one up first.
+  if (m_spi == nullptr && !SwitchToStandardSPI()) {
+    REPORT_ERROR("Failed to start/restart auto SPI");
+    return false;
+  }
+  // Only set up the interrupt if needed.
+  if (m_auto_interrupt == nullptr) {
+    m_auto_interrupt = new DigitalInput(10);
+  }
   // The auto SPI controller gets angry if you try to set up two instances on
   // one bus.
   if (!m_auto_configured) {

--- a/wpilibc/src/main/native/cpp/ADIS16470_IMU.cpp
+++ b/wpilibc/src/main/native/cpp/ADIS16470_IMU.cpp
@@ -118,10 +118,6 @@ ADIS16470_IMU::ADIS16470_IMU(IMUAxis yaw_axis, IMUAxis pitch_axis,
     m_reset_in = new DigitalInput(27);  // Set SPI CS2 (IMU RST) high
     Wait(500_ms);                       // Wait for reset to complete
 
-    m_spi = new SPI(m_spi_port);
-    m_spi->SetClockRate(2000000);
-    m_spi->SetMode(frc::SPI::Mode::kMode3);
-    m_spi->SetChipSelectActiveLow();
     // Configure standard SPI
     if (!SwitchToStandardSPI()) {
       return;
@@ -186,7 +182,6 @@ ADIS16470_IMU::ADIS16470_IMU(IMUAxis yaw_axis, IMUAxis pitch_axis,
     // Write offset calibration command to IMU
     WriteRegister(GLOB_CMD, 0x0001);
 
-    m_auto_interrupt = new DigitalInput(26);
     // Configure and enable auto SPI
     if (!SwitchToAutoSPI()) {
       return;
@@ -331,7 +326,7 @@ bool ADIS16470_IMU::SwitchToStandardSPI() {
       Wait(10_ms);
     }
     // Maybe we're in auto SPI mode? If so, kill auto SPI, and then SPI.
-    if (m_auto_configured) {
+    if (m_spi != nullptr && m_auto_configured) {
       m_spi->StopAuto();
       // We need to get rid of all the garbage left in the auto SPI buffer after
       // stopping it.
@@ -348,6 +343,13 @@ bool ADIS16470_IMU::SwitchToStandardSPI() {
         data_count = m_spi->ReadAutoReceivedData(trashBuffer, 0, 0_s);
       }
     }
+  }
+  // There doesn't seem to be a SPI port active. Let's try to set one up
+  if (m_spi == nullptr) {
+    m_spi = new SPI(m_spi_port);
+    m_spi->SetClockRate(2000000);
+    m_spi->SetMode(frc::SPI::Mode::kMode3);
+    m_spi->SetChipSelectActiveLow();
   }
   ReadRegister(PROD_ID);  // Dummy read
   // Validate the product ID
@@ -377,6 +379,16 @@ bool ADIS16470_IMU::SwitchToStandardSPI() {
  *are hard-coded to work only with the ADIS16470 IMU.
  **/
 bool ADIS16470_IMU::SwitchToAutoSPI() {
+  // No SPI port has been set up. Go set one up first.
+  if (m_spi == nullptr && !SwitchToStandardSPI()) {
+    REPORT_ERROR("Failed to start/restart auto SPI");
+    return false;
+  }
+
+  // Only set up the interrupt if needed.
+  if (m_auto_interrupt == nullptr) {
+    m_auto_interrupt = new DigitalInput(26);
+  }
   // The auto SPI controller gets angry if you try to set up two instances on
   // one bus.
   if (!m_auto_configured) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16448_IMU.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16448_IMU.java
@@ -338,7 +338,6 @@ public class ADIS16448_IMU implements AutoCloseable, Sendable {
             "ADIS16448: Flash and RAM configuration consistent. No flash update required!", false);
       }
 
-      // Configure standard SPI
       if (!switchToAutoSPI()) {
         return;
       }
@@ -418,9 +417,7 @@ public class ADIS16448_IMU implements AutoCloseable, Sendable {
         System.out.println("Paused auto SPI successfully.");
       }
     }
-    // There doesn't seem to be a SPI port active. Let's try to set one up
     if (m_spi == null) {
-      System.out.println("Setting up a new SPI port.");
       m_spi = new SPI(m_spi_port);
       m_spi.setClockRate(1000000);
       m_spi.setMode(SPI.Mode.kMode3);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16448_IMU.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16448_IMU.java
@@ -270,10 +270,6 @@ public class ADIS16448_IMU implements AutoCloseable, Sendable {
 
       configCalTime(cal_time);
 
-      m_spi = new SPI(m_spi_port);
-      m_spi.setClockRate(1000000);
-      m_spi.setMode(SPI.Mode.kMode3);
-      m_spi.setChipSelectActiveLow();
       if (!switchToStandardSPI()) {
         return;
       }
@@ -342,8 +338,6 @@ public class ADIS16448_IMU implements AutoCloseable, Sendable {
             "ADIS16448: Flash and RAM configuration consistent. No flash update required!", false);
       }
 
-      // Set up the interrupt
-      m_auto_interrupt = new DigitalInput(10); // MXP DIO0
       // Configure standard SPI
       if (!switchToAutoSPI()) {
         return;
@@ -403,7 +397,7 @@ public class ADIS16448_IMU implements AutoCloseable, Sendable {
       }
       System.out.println("Paused the IMU processing thread successfully!");
       // Maybe we're in auto SPI mode? If so, kill auto SPI, and then SPI.
-      if (m_auto_configured) {
+      if (m_spi != null && m_auto_configured) {
         m_spi.stopAuto();
         // We need to get rid of all the garbage left in the auto SPI buffer after
         // stopping it.
@@ -424,6 +418,14 @@ public class ADIS16448_IMU implements AutoCloseable, Sendable {
         System.out.println("Paused auto SPI successfully.");
       }
     }
+    // There doesn't seem to be a SPI port active. Let's try to set one up
+    if (m_spi == null) {
+      System.out.println("Setting up a new SPI port.");
+      m_spi = new SPI(m_spi_port);
+      m_spi.setClockRate(1000000);
+      m_spi.setMode(SPI.Mode.kMode3);
+      m_spi.setChipSelectActiveLow();
+    }
     readRegister(PROD_ID); // Dummy read
     // Validate the product ID
     if (readRegister(PROD_ID) != 16448) {
@@ -435,6 +437,15 @@ public class ADIS16448_IMU implements AutoCloseable, Sendable {
   }
 
   boolean switchToAutoSPI() {
+    // No SPI port has been set up. Go set one up first.
+    if (m_spi == null && !switchToStandardSPI()) {
+      DriverStation.reportError("Failed to start/restart auto SPI", false);
+      return false;
+    }
+    // Only set up the interrupt if needed.
+    if (m_auto_interrupt == null) {
+      m_auto_interrupt = new DigitalInput(10); // MXP DIO0
+    }
     // The auto SPI controller gets angry if you try to set up two instances on one
     // bus.
     if (!m_auto_configured) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16470_IMU.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16470_IMU.java
@@ -398,7 +398,6 @@ public class ADIS16470_IMU implements AutoCloseable, Sendable {
       // Write offset calibration command to IMU
       writeRegister(GLOB_CMD, 0x0001);
 
-      // Configure and enable auto SPI
       if (!switchToAutoSPI()) {
         return;
       }
@@ -472,9 +471,7 @@ public class ADIS16470_IMU implements AutoCloseable, Sendable {
         System.out.println("Paused auto SPI successfully.");
       }
     }
-    // There doesn't seem to be a SPI port active. Let's try to set one up
     if (m_spi == null) {
-      System.out.println("Setting up a new SPI port.");
       m_spi = new SPI(m_spi_port);
       m_spi.setClockRate(2000000);
       m_spi.setMode(SPI.Mode.kMode3);


### PR DESCRIPTION
They were removed in #6719, but I've since realized that the null checks prevented crashes when the IMUs were disconnected, so I'm adding them back in.