### PR TITLE
[ci] Use one script to pregenerate everything

### DIFF
--- a/.github/workflows/comment-command.yml
+++ b/.github/workflows/comment-command.yml
@@ -89,20 +89,8 @@ jobs:
         run: python -m pip install jinja2
       - name: Install protobuf dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler && wget https://github.com/HebiRobotics/QuickBuffers/releases/download/1.3.3/protoc-gen-quickbuf-1.3.3-linux-x86_64.exe && chmod +x protoc-gen-quickbuf-1.3.3-linux-x86_64.exe
-      - name: Run hal
-        run: ./hal/generate_usage_reporting.py
-      - name: Run ntcore
-        run: ./ntcore/generate_topics.py
-      - name: Run wpimath
-        run: ./wpimath/generate_numbers.py && ./wpimath/generate_quickbuf.py --quickbuf_plugin=protoc-gen-quickbuf-1.3.3-linux-x86_64.exe
-      - name: Run HIDs
-        run: ./wpilibj/generate_hids.py && ./wpilibc/generate_hids.py && ./wpilibNewCommands/generate_hids.py
-      - name: Run PWM Controllers
-        run: ./wpilibj/generate_pwm_motor_controllers.py && ./wpilibc/generate_pwm_motor_controllers.py
-      - name: Run imgui gl3w
-        run: ./thirdparty/imgui_suite/generate_gl3w.py
-      - name: Run imgui fonts
-        run: ./thirdparty/imgui_suite/generate_fonts.sh
+      - name: Regenerate all
+        run: ./.github/workflows/pregen_all.py --quickbuf_plugin=protoc-gen-quickbuf-1.3.3-linux-x86_64.exe
       - name: Commit
         run: |
           # Set credentials

--- a/.github/workflows/pregen_all.py
+++ b/.github/workflows/pregen_all.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main(argv):
+    script_path = Path(__file__).resolve()
+    REPO_ROOT = script_path.parent.parent.parent
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--quickbuf_plugin",
+        help="Path to the quickbuf protoc plugin",
+        required=True,
+    )
+    args = parser.parse_args(argv)
+    subprocess.run(["python", f"{REPO_ROOT}/hal/generate_usage_reporting.py"])
+    subprocess.run(["python", f"{REPO_ROOT}/ntcore/generate_topics.py"])
+    subprocess.run(["python", f"{REPO_ROOT}/wpimath/generate_numbers.py"])
+    subprocess.run(
+        [
+            "python",
+            f"{REPO_ROOT}/wpimath/generate_quickbuf.py",
+            f"--quickbuf_plugin={args.quickbuf_plugin}",
+        ]
+    )
+    subprocess.run(["python", f"{REPO_ROOT}/wpiunits/generate_units.py"])
+    subprocess.run(["python", f"{REPO_ROOT}/wpilibc/generate_hids.py"])
+    subprocess.run(["python", f"{REPO_ROOT}/wpilibj/generate_hids.py"])
+    subprocess.run(["python", f"{REPO_ROOT}/wpilibNewCommands/generate_hids.py"])
+    subprocess.run(["python", f"{REPO_ROOT}/wpilibc/generate_pwm_motor_controllers.py"])
+    subprocess.run(["python", f"{REPO_ROOT}/wpilibj/generate_pwm_motor_controllers.py"])
+    subprocess.run(["python", f"{REPO_ROOT}/thirdparty/imgui_suite/generate_gl3w.py"])
+    subprocess.run(f"{REPO_ROOT}/thirdparty/imgui_suite/generate_fonts.sh")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/.github/workflows/pregenerate.yml
+++ b/.github/workflows/pregenerate.yml
@@ -26,22 +26,8 @@ jobs:
         run: python -m pip install jinja2
       - name: Install protobuf dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler && wget https://github.com/HebiRobotics/QuickBuffers/releases/download/1.3.3/protoc-gen-quickbuf-1.3.3-linux-x86_64.exe && chmod +x protoc-gen-quickbuf-1.3.3-linux-x86_64.exe
-      - name: Run hal
-        run: ./hal/generate_usage_reporting.py
-      - name: Run ntcore
-        run: ./ntcore/generate_topics.py
-      - name: Run wpimath
-        run: ./wpimath/generate_numbers.py && ./wpimath/generate_quickbuf.py --quickbuf_plugin=protoc-gen-quickbuf-1.3.3-linux-x86_64.exe
-      - name: Run wpiunits
-        run: ./wpiunits/generate_units.py
-      - name: Run HIDs
-        run: ./wpilibj/generate_hids.py && ./wpilibc/generate_hids.py && ./wpilibNewCommands/generate_hids.py
-      - name: Run PWM Controllers
-        run: ./wpilibj/generate_pwm_motor_controllers.py && ./wpilibc/generate_pwm_motor_controllers.py
-      - name: Run imgui gl3w
-        run: ./thirdparty/imgui_suite/generate_gl3w.py
-      - name: Run imgui fonts
-        run: ./thirdparty/imgui_suite/generate_fonts.sh
+      - name: Regenerate all
+        run: python ./.github/workflows/pregen_all.py --quickbuf_plugin protoc-gen-quickbuf-1.3.3-linux-x86_64.exe
       - name: Add untracked files to index so they count as changes
         run: git add -A
       - name: Check output


### PR DESCRIPTION
A pregen_all Python script was added that calls all the other pregen scripts. This prevents the generated file checks and pregen command from falling out of sync. This is meant to only run in CI, since the script is not portable across platforms.