### PR TITLE
Add an event in CommandScheduler before each command is executed

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -85,6 +85,7 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
 
   // Lists of user-supplied actions to be executed on scheduling events for every command.
   private final List<Consumer<Command>> m_initActions = new ArrayList<>();
+  private final List<Consumer<Command>> m_beforeExecuteActions = new ArrayList<>();
   private final List<Consumer<Command>> m_executeActions = new ArrayList<>();
   private final List<BiConsumer<Command, Optional<Command>>> m_interruptActions = new ArrayList<>();
   private final List<Consumer<Command>> m_finishActions = new ArrayList<>();
@@ -285,6 +286,9 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
         continue;
       }
 
+      for (Consumer<Command> action : m_beforeExecuteActions) {
+        action.accept(command);
+      }
       command.execute();
       for (Consumer<Command> action : m_executeActions) {
         action.accept(command);
@@ -562,7 +566,16 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   }
 
   /**
-   * Adds an action to perform on the execution of any command by the scheduler.
+   * Adds an action to perform before the execution of any command by the scheduler.
+   *
+   * @param action the action to perform
+   */
+  public void onCommandBeforeExecute(Consumer<Command> action) {
+    m_beforeExecuteActions.add(requireNonNullParam(action, "action", "onCommandBeforeExecute"));
+  }
+
+  /**
+   * Adds an action to perform after the execution of any command by the scheduler.
    *
    * @param action the action to perform
    */

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -51,6 +51,7 @@ class CommandScheduler::Impl {
   // Lists of user-supplied actions to be executed on scheduling events for
   // every command.
   wpi::SmallVector<Action, 4> initActions;
+  wpi::SmallVector<Action, 4> beforeExecuteActions;
   wpi::SmallVector<Action, 4> executeActions;
   wpi::SmallVector<InterruptAction, 4> interruptActions;
   wpi::SmallVector<Action, 4> finishActions;
@@ -206,6 +207,9 @@ void CommandScheduler::Run() {
       continue;
     }
 
+    for (auto&& action : m_impl->beforeExecuteActions) {
+      action(*command);
+    }
     command->Execute();
     for (auto&& action : m_impl->executeActions) {
       action(*command);
@@ -438,6 +442,10 @@ void CommandScheduler::PrintWatchdogEpochs() {
 
 void CommandScheduler::OnCommandInitialize(Action action) {
   m_impl->initActions.emplace_back(std::move(action));
+}
+
+void CommandScheduler::OnCommandBeforeExecute(Action action) {
+  m_impl->beforeExecuteActions.emplace_back(std::move(action));
 }
 
 void CommandScheduler::OnCommandExecute(Action action) {

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -347,7 +347,16 @@ class CommandScheduler final : public wpi::Sendable,
   void OnCommandInitialize(Action action);
 
   /**
-   * Adds an action to perform on the execution of any command by the scheduler.
+   * Adds an action to perform before the execution of any command by the
+   * scheduler.
+   *
+   * @param action the action to perform
+   */
+  void OnCommandBeforeExecute(Action action);
+
+  /**
+   * Adds an action to perform after the execution of any command by the
+   * scheduler.
    *
    * @param action the action to perform
    */


### PR DESCRIPTION
The new `onBeforeExecute` event parallels the existing `onCommandExecute`, but `onBeforeExecute` is run immediately before the `execute()` of each Command, whereas `onCommandExecute` is run immediately after. This allows for such uses as profiling the runtime of each Command, or reporting which Command is currently running.