### PR TITLE
Add `DCMotor::Current()` overload accepting torque

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/system/plant/DCMotor.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/system/plant/DCMotor.java
@@ -83,6 +83,16 @@ public class DCMotor implements ProtobufSerializable, StructSerializable {
   }
 
   /**
+   * Calculate current drawn by motor for a given torque.
+   *
+   * @param torqueNm The torque produced by the motor.
+   * @return The current drawn by the motor.
+   */
+  public double getCurrent(double torqueNm) {
+    return torqueNm / KtNMPerAmp;
+  }
+
+  /**
    * Calculate torque produced by the motor with a given current.
    *
    * @param currentAmpere The current drawn by the motor.

--- a/wpimath/src/main/native/include/frc/system/plant/DCMotor.h
+++ b/wpimath/src/main/native/include/frc/system/plant/DCMotor.h
@@ -85,6 +85,15 @@ class WPILIB_DLLEXPORT DCMotor {
   }
 
   /**
+   * Returns current drawn by motor for a given torque.
+   *
+   * @param torque The torque produced by the motor.
+   */
+  constexpr units::ampere_t Current(units::newton_meter_t torque) const {
+    return torque / Kt;
+  }
+
+  /**
    * Returns torque produced by the motor with a given current.
    *
    * @param current     The current drawn by the motor.


### PR DESCRIPTION
This adds an overload to the `DCMotor::Current()` API to get motor current from torque output.
`DCMotor` already had an API to do the reverse (get torque output from motor current), as well as an API to get motor current from voltage and velocity.