### PR TITLE
wpiutil[sendable] include add property overloads without setter argument.  

### DIFF
--- a/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableBuilder.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableBuilder.java
@@ -51,6 +51,16 @@ public interface SendableBuilder extends AutoCloseable {
   void setSafeState(Runnable func);
 
   /**
+   * Add a read only boolean property.
+   *
+   * @param key property name
+   * @param getter getter function (returns current value)
+   */
+  default void addBooleanProperty(String key, BooleanSupplier getter){
+    addBooleanProperty(key, getter, null);
+  }
+
+  /**
    * Add a boolean property.
    *
    * @param key property name
@@ -66,6 +76,16 @@ public interface SendableBuilder extends AutoCloseable {
    * @param value the value
    */
   void publishConstBoolean(String key, boolean value);
+
+  /**
+   * Add a read only integer property.
+   *
+   * @param key property name
+   * @param getter getter function (returns current value)
+   */
+  default void addIntegerProperty(String key, LongSupplier getter){
+    addIntegerProperty(key, getter, null);
+  }
 
   /**
    * Add an integer property.
@@ -85,6 +105,17 @@ public interface SendableBuilder extends AutoCloseable {
   void publishConstInteger(String key, long value);
 
   /**
+   * Add a read only float property.
+   * The setter is null.
+   *
+   * @param key property name
+   * @param getter getter function (returns current value)
+   */
+  default void addFloatProperty(String key, FloatSupplier getter){
+    addFloatProperty(key, getter, null);
+  }
+
+  /**
    * Add a float property.
    *
    * @param key property name
@@ -100,6 +131,16 @@ public interface SendableBuilder extends AutoCloseable {
    * @param value the value
    */
   void publishConstFloat(String key, float value);
+
+  /**
+   * Add a read only double property.
+   *
+   * @param key property name
+   * @param getter getter function (returns current value)
+   */
+  default void addDoubleProperty(String key, DoubleSupplier getter){
+    addDoubleProperty(key, getter, null);
+  };
 
   /**
    * Add a double property.
@@ -119,6 +160,16 @@ public interface SendableBuilder extends AutoCloseable {
   void publishConstDouble(String key, double value);
 
   /**
+   * Add a read only string property.
+   *
+   * @param key property name
+   * @param getter getter function (returns current value)
+   */
+  default void addStringProperty(String key, Supplier<String> getter){
+    addStringProperty(key, getter, null);
+  }
+
+  /**
    * Add a string property.
    *
    * @param key property name
@@ -134,6 +185,16 @@ public interface SendableBuilder extends AutoCloseable {
    * @param value the value
    */
   void publishConstString(String key, String value);
+
+  /**
+   * Add a read only boolean array property.
+   *
+   * @param key property name
+   * @param getter getter function (returns current value)
+   */
+  default void addBooleanArrayProperty(String key, Supplier<boolean[]> getter){
+    addBooleanArrayProperty(key, getter, null);
+  }
 
   /**
    * Add a boolean array property.
@@ -153,6 +214,16 @@ public interface SendableBuilder extends AutoCloseable {
   void publishConstBooleanArray(String key, boolean[] value);
 
   /**
+   * Add a read only integer array property.
+   *
+   * @param key property name
+   * @param getter getter function (returns current value)
+   */
+  default void addIntegerArrayProperty(String key, Supplier<long[]> getter){
+    addIntegerArrayProperty(key, getter, null);
+  }
+
+  /**
    * Add an integer array property.
    *
    * @param key property name
@@ -168,6 +239,16 @@ public interface SendableBuilder extends AutoCloseable {
    * @param value the value
    */
   void publishConstIntegerArray(String key, long[] value);
+
+    /**
+   * Add a read only float array property.
+   *
+   * @param key property name
+   * @param getter getter function (returns current value)
+   */
+  default void addFloatArrayProperty(String key, Supplier<float[]> getter){
+    addFloatArrayProperty(key, getter, null);
+  }
 
   /**
    * Add a float array property.
@@ -185,6 +266,16 @@ public interface SendableBuilder extends AutoCloseable {
    * @param value the value
    */
   void publishConstFloatArray(String key, float[] value);
+
+    /**
+   * Add a read only double array property.
+   *
+   * @param key property name
+   * @param getter getter function (returns current value)
+   */
+  default void addDoubleArrayProperty(String key, Supplier<double[]> getter){
+    addDoubleArrayProperty(key, getter, null);
+  }
 
   /**
    * Add a double array property.
@@ -204,6 +295,16 @@ public interface SendableBuilder extends AutoCloseable {
   void publishConstDoubleArray(String key, double[] value);
 
   /**
+   * Add a read only string array property.
+   *
+   * @param key property name
+   * @param getter getter function (returns current value)
+   */
+  default void addStringArrayProperty(String key, Supplier<String[]> getter){
+    addStringArrayProperty(key, getter, null);
+  }
+
+  /**
    * Add a string array property.
    *
    * @param key property name
@@ -219,6 +320,18 @@ public interface SendableBuilder extends AutoCloseable {
    * @param value the value
    */
   void publishConstStringArray(String key, String[] value);
+
+  /**
+   * Add a read only raw property.
+   *
+   * @param key property name
+   * @param typeString type string
+   * @param getter getter function (returns current value)
+   */
+  default void addRawProperty(
+      String key, String typeString, Supplier<byte[]> getter){
+        addRawProperty(key, typeString, getter, null);
+      }
 
   /**
    * Add a raw property.

--- a/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableBuilder.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableBuilder.java
@@ -56,7 +56,7 @@ public interface SendableBuilder extends AutoCloseable {
    * @param key property name
    * @param getter getter function (returns current value)
    */
-  default void addBooleanProperty(String key, BooleanSupplier getter){
+  default void addBooleanProperty(String key, BooleanSupplier getter) {
     addBooleanProperty(key, getter, null);
   }
 
@@ -83,7 +83,7 @@ public interface SendableBuilder extends AutoCloseable {
    * @param key property name
    * @param getter getter function (returns current value)
    */
-  default void addIntegerProperty(String key, LongSupplier getter){
+  default void addIntegerProperty(String key, LongSupplier getter) {
     addIntegerProperty(key, getter, null);
   }
 
@@ -105,13 +105,12 @@ public interface SendableBuilder extends AutoCloseable {
   void publishConstInteger(String key, long value);
 
   /**
-   * Add a read only float property.
-   * The setter is null.
+   * Add a read only float property. The setter is null.
    *
    * @param key property name
    * @param getter getter function (returns current value)
    */
-  default void addFloatProperty(String key, FloatSupplier getter){
+  default void addFloatProperty(String key, FloatSupplier getter) {
     addFloatProperty(key, getter, null);
   }
 
@@ -138,9 +137,10 @@ public interface SendableBuilder extends AutoCloseable {
    * @param key property name
    * @param getter getter function (returns current value)
    */
-  default void addDoubleProperty(String key, DoubleSupplier getter){
+  default void addDoubleProperty(String key, DoubleSupplier getter) {
     addDoubleProperty(key, getter, null);
-  };
+  }
+  ;
 
   /**
    * Add a double property.
@@ -165,7 +165,7 @@ public interface SendableBuilder extends AutoCloseable {
    * @param key property name
    * @param getter getter function (returns current value)
    */
-  default void addStringProperty(String key, Supplier<String> getter){
+  default void addStringProperty(String key, Supplier<String> getter) {
     addStringProperty(key, getter, null);
   }
 
@@ -192,7 +192,7 @@ public interface SendableBuilder extends AutoCloseable {
    * @param key property name
    * @param getter getter function (returns current value)
    */
-  default void addBooleanArrayProperty(String key, Supplier<boolean[]> getter){
+  default void addBooleanArrayProperty(String key, Supplier<boolean[]> getter) {
     addBooleanArrayProperty(key, getter, null);
   }
 
@@ -219,7 +219,7 @@ public interface SendableBuilder extends AutoCloseable {
    * @param key property name
    * @param getter getter function (returns current value)
    */
-  default void addIntegerArrayProperty(String key, Supplier<long[]> getter){
+  default void addIntegerArrayProperty(String key, Supplier<long[]> getter) {
     addIntegerArrayProperty(key, getter, null);
   }
 
@@ -240,13 +240,13 @@ public interface SendableBuilder extends AutoCloseable {
    */
   void publishConstIntegerArray(String key, long[] value);
 
-    /**
+  /**
    * Add a read only float array property.
    *
    * @param key property name
    * @param getter getter function (returns current value)
    */
-  default void addFloatArrayProperty(String key, Supplier<float[]> getter){
+  default void addFloatArrayProperty(String key, Supplier<float[]> getter) {
     addFloatArrayProperty(key, getter, null);
   }
 
@@ -267,13 +267,13 @@ public interface SendableBuilder extends AutoCloseable {
    */
   void publishConstFloatArray(String key, float[] value);
 
-    /**
+  /**
    * Add a read only double array property.
    *
    * @param key property name
    * @param getter getter function (returns current value)
    */
-  default void addDoubleArrayProperty(String key, Supplier<double[]> getter){
+  default void addDoubleArrayProperty(String key, Supplier<double[]> getter) {
     addDoubleArrayProperty(key, getter, null);
   }
 
@@ -300,7 +300,7 @@ public interface SendableBuilder extends AutoCloseable {
    * @param key property name
    * @param getter getter function (returns current value)
    */
-  default void addStringArrayProperty(String key, Supplier<String[]> getter){
+  default void addStringArrayProperty(String key, Supplier<String[]> getter) {
     addStringArrayProperty(key, getter, null);
   }
 
@@ -328,10 +328,9 @@ public interface SendableBuilder extends AutoCloseable {
    * @param typeString type string
    * @param getter getter function (returns current value)
    */
-  default void addRawProperty(
-      String key, String typeString, Supplier<byte[]> getter){
-        addRawProperty(key, typeString, getter, null);
-      }
+  default void addRawProperty(String key, String typeString, Supplier<byte[]> getter) {
+    addRawProperty(key, typeString, getter, null);
+  }
 
   /**
    * Add a raw property.


### PR DESCRIPTION
This PR provides default overloads to the add property methods such as addIntegerProperty, addBooleanProperty, etc that doesn't require a setter argument.  Null is just passed in.  