### PR TITLE
[wpiutil] Refactor FileLogger

### DIFF
--- a/wpiutil/src/main/native/cpp/FileLogger.cpp
+++ b/wpiutil/src/main/native/cpp/FileLogger.cpp
@@ -31,9 +31,9 @@ FileLogger::FileLogger(std::string_view file,
         char eventBuf[sizeof(struct inotify_event) + NAME_MAX + 1];
         lseek(m_fileHandle, 0, SEEK_END);
         while (read(m_inotifyHandle, eventBuf, sizeof(eventBuf)) > 0) {
-          while ((bufLen = read(m_fileHandle, buf, sizeof(buf)) > 0)) {
+          int bufLen = 0;
+          while ((bufLen = read(m_fileHandle, buf, sizeof(buf))) > 0) {
             callback(std::string_view{buf, static_cast<size_t>(bufLen)});
-            bufLen = read(m_fileHandle, buf, sizeof(buf));
           }
           std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }

--- a/wpiutil/src/main/native/cpp/FileLogger.cpp
+++ b/wpiutil/src/main/native/cpp/FileLogger.cpp
@@ -93,9 +93,7 @@ std::function<void(std::string_view)> FileLogger::LineBuffer(
     }
     auto combinedData =
         fmt::format("{}{}", std::string_view{buf.data(), buf.size()}, data);
-    std::string_view wholeData;
-    std::string_view extra;
-    std::tie(wholeData, extra) = wpi::rsplit(combinedData, "\n");
+    auto [wholeData, extra] = wpi::rsplit(combinedData, "\n");
 
     callback(wholeData);
     buf.clear();

--- a/wpiutil/src/main/native/cpp/FileLogger.cpp
+++ b/wpiutil/src/main/native/cpp/FileLogger.cpp
@@ -3,7 +3,6 @@
 // the WPILib BSD license file in the root directory of this project.
 
 #include "wpi/FileLogger.h"
-#include "fmt/format.h"
 
 #ifdef __linux__
 #include <fcntl.h>
@@ -16,6 +15,8 @@
 #include <thread>
 #include <tuple>
 #include <utility>
+
+#include <fmt/format.h>
 
 #include "wpi/StringExtras.h"
 

--- a/wpiutil/src/main/native/include/wpi/FileLogger.h
+++ b/wpiutil/src/main/native/include/wpi/FileLogger.h
@@ -41,13 +41,13 @@ class FileLogger {
   FileLogger& operator=(FileLogger&& rhs);
   ~FileLogger();
   /**
-   * Creates a function that chunks incoming data into lines before calling the
-   * callback with the individual line.
+   * Creates a function that chunks incoming data into blocks of whole lines and
+   * stores incomplete lines to add to the next block of data.
    *
-   * @param callback The callback that logs lines.
+   * @param callback A callback that accepts the blocks of whole lines.
    * @return The function.
    */
-  static std::function<void(std::string_view)> LineBuffer(
+  static std::function<void(std::string_view)> Buffer(
       std::function<void(std::string_view)> callback);
 
  private:

--- a/wpiutil/src/test/native/cpp/FileLoggerTest.cpp
+++ b/wpiutil/src/test/native/cpp/FileLoggerTest.cpp
@@ -10,25 +10,25 @@
 
 #include "wpi/FileLogger.h"
 
-TEST(FileLoggerTest, LineBufferSingleLine) {
+TEST(FileLoggerTest, BufferSingleLine) {
   std::vector<std::string> buf;
-  auto func = wpi::FileLogger::LineBuffer(
+  auto func = wpi::FileLogger::Buffer(
       [&buf](std::string_view line) { buf.emplace_back(line); });
   func("qwertyuiop\n");
   EXPECT_EQ("qwertyuiop", buf[0]);
 }
 
-TEST(FileLoggerTest, LineBufferMultiLine) {
+TEST(FileLoggerTest, BufferMultiLine) {
   std::vector<std::string> buf;
-  auto func = wpi::FileLogger::LineBuffer(
+  auto func = wpi::FileLogger::Buffer(
       [&buf](std::string_view line) { buf.emplace_back(line); });
   func("line 1\nline 2\nline 3\n");
   EXPECT_EQ("line 1\nline 2\nline 3", buf[0]);
 }
 
-TEST(FileLoggerTest, LineBufferPartials) {
+TEST(FileLoggerTest, BufferPartials) {
   std::vector<std::string> buf;
-  auto func = wpi::FileLogger::LineBuffer(
+  auto func = wpi::FileLogger::Buffer(
       [&buf](std::string_view line) { buf.emplace_back(line); });
   func("part 1");
   func("part 2\npart 3");
@@ -37,9 +37,9 @@ TEST(FileLoggerTest, LineBufferPartials) {
   EXPECT_EQ("part 3", buf[1]);
 }
 
-TEST(FileLoggerTest, LineBufferMultiplePartials) {
+TEST(FileLoggerTest, BufferMultiplePartials) {
   std::vector<std::string> buf;
-  auto func = wpi::FileLogger::LineBuffer(
+  auto func = wpi::FileLogger::Buffer(
       [&buf](std::string_view line) { buf.emplace_back(line); });
   func("part 1");
   func("part 2");
@@ -47,9 +47,9 @@ TEST(FileLoggerTest, LineBufferMultiplePartials) {
   func("part 4\n");
   EXPECT_EQ("part 1part 2part 3part 4", buf[0]);
 }
-TEST(FileLoggerTest, LineBufferMultipleMultiLinePartials) {
+TEST(FileLoggerTest, BufferMultipleMultiLinePartials) {
   std::vector<std::string> buf;
-  auto func = wpi::FileLogger::LineBuffer(
+  auto func = wpi::FileLogger::Buffer(
       [&buf](std::string_view line) { buf.emplace_back(line); });
   func("part 1");
   func("part 2\npart 3");

--- a/wpiutil/src/test/native/cpp/FileLoggerTest.cpp
+++ b/wpiutil/src/test/native/cpp/FileLoggerTest.cpp
@@ -15,8 +15,7 @@ TEST(FileLoggerTest, LineBufferSingleLine) {
   auto func = wpi::FileLogger::LineBuffer(
       [&buf](std::string_view line) { buf.emplace_back(line); });
   func("qwertyuiop\n");
-  EXPECT_EQ(buf.front(), "qwertyuiop");
-  buf.clear();
+  EXPECT_EQ("qwertyuiop", buf[0]);
 }
 
 TEST(FileLoggerTest, LineBufferMultiLine) {
@@ -24,9 +23,7 @@ TEST(FileLoggerTest, LineBufferMultiLine) {
   auto func = wpi::FileLogger::LineBuffer(
       [&buf](std::string_view line) { buf.emplace_back(line); });
   func("line 1\nline 2\nline 3\n");
-  EXPECT_EQ("line 1", buf[0]);
-  EXPECT_EQ("line 2", buf[1]);
-  EXPECT_EQ("line 3", buf[2]);
+  EXPECT_EQ("line 1\nline 2\nline 3", buf[0]);
 }
 
 TEST(FileLoggerTest, LineBufferPartials) {
@@ -35,10 +32,9 @@ TEST(FileLoggerTest, LineBufferPartials) {
       [&buf](std::string_view line) { buf.emplace_back(line); });
   func("part 1");
   func("part 2\npart 3");
-  EXPECT_EQ("part 1part 2", buf.front());
-  buf.clear();
+  EXPECT_EQ("part 1part 2", buf[0]);
   func("\n");
-  EXPECT_EQ("part 3", buf.front());
+  EXPECT_EQ("part 3", buf[1]);
 }
 
 TEST(FileLoggerTest, LineBufferMultiplePartials) {
@@ -49,5 +45,15 @@ TEST(FileLoggerTest, LineBufferMultiplePartials) {
   func("part 2");
   func("part 3");
   func("part 4\n");
-  EXPECT_EQ("part 1part 2part 3part 4", buf.front());
+  EXPECT_EQ("part 1part 2part 3part 4", buf[0]);
+}
+TEST(FileLoggerTest, LineBufferMultipleMultiLinePartials) {
+  std::vector<std::string> buf;
+  auto func = wpi::FileLogger::LineBuffer(
+      [&buf](std::string_view line) { buf.emplace_back(line); });
+  func("part 1");
+  func("part 2\npart 3");
+  func("part 4\n");
+  EXPECT_EQ("part 1part 2", buf[0]);
+  EXPECT_EQ("part 3part 4", buf[1]);
 }


### PR DESCRIPTION
FileLogger now logs entire flushed blocks of data, instead of breaking it up into lines.

Fixes #7135.