### PR TITLE
DataLogBackgroundWriter: Normalize empty path name

### DIFF
--- a/wpiutil/src/main/native/cpp/DataLogBackgroundWriter.cpp
+++ b/wpiutil/src/main/native/cpp/DataLogBackgroundWriter.cpp
@@ -176,7 +176,8 @@ static std::string MakeRandomFilename() {
 }
 
 struct DataLogBackgroundWriter::WriterThreadState {
-  explicit WriterThreadState(std::string_view dir) : dirPath{dir} {}
+  explicit WriterThreadState(std::string_view dir)
+      : dirPath{dir.empty() ? "." : dir} {}
   WriterThreadState(const WriterThreadState&) = delete;
   WriterThreadState& operator=(const WriterThreadState&) = delete;
   ~WriterThreadState() { Close(); }


### PR DESCRIPTION
An empty path isn't valid on it's own, so fs::space always returns an error. This results in `UINT_MAX_MAX` bytes being used instead of the actual free space, which means a default constructed DataLogBackgroundWriter won't stop for low space.
```DataLog: Logging to 'wpilog_4fbdb51d975c52e7.wpilog' (17179869184.0 GiB free space)```

Using "." instead makes the directory path the current working directory, which is the desired behavior