### PR TITLE
[wpilibj] Watchdog Alert Linking

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Alert.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Alert.java
@@ -47,9 +47,9 @@ public class Alert {
   private static Map<String, SendableAlerts> groups = new HashMap<String, SendableAlerts>();
 
   private final AlertType m_type;
-  private boolean m_active;
-  private double m_activeStartTime;
-  private String m_text;
+  double m_activeStartTime;
+  boolean m_active;
+  String m_text;
 
   /**
    * Creates a new alert in the default group - "Alerts". If this is the first to be instantiated,

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Alert.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Alert.java
@@ -47,8 +47,8 @@ public class Alert {
   private static Map<String, SendableAlerts> groups = new HashMap<String, SendableAlerts>();
 
   private final AlertType m_type;
-  double m_activeStartTime;
   boolean m_active;
+  double m_activeStartTime;
   String m_text;
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -83,6 +83,7 @@ public abstract class IterativeRobotBase extends RobotBase {
   protected IterativeRobotBase(double period) {
     m_period = period;
     m_watchdog = new Watchdog(period, this::printLoopOverrunMessage);
+    m_watchdog.linkToAlert(new Alert("Loop time of " + period + "s overrun", Alert.AlertType.kWarning));
   }
 
   /** Provide an alternate "main loop" via startCompetition(). */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -83,7 +83,8 @@ public abstract class IterativeRobotBase extends RobotBase {
   protected IterativeRobotBase(double period) {
     m_period = period;
     m_watchdog = new Watchdog(period, this::printLoopOverrunMessage);
-    m_watchdog.linkToAlert(new Alert("Loop time of " + period + "s overrun", Alert.AlertType.kWarning));
+    m_watchdog.linkToAlert(
+        new Alert("Loop time of " + period + "s overrun", Alert.AlertType.kWarning));
   }
 
   /** Provide an alternate "main loop" via startCompetition(). */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -29,7 +29,7 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
   private final DoubleConsumer m_callback;
   private double m_lastTimeoutPrintSeconds;
 
-  int m_overruns = 0;
+  int m_overruns;
   private String m_originalAlertText = "";
   private Optional<Alert> m_alert = Optional.empty();
 
@@ -61,12 +61,12 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
     m_tracer = new Tracer();
   }
 
-    /**
+  /**
    * Watchdog constructor.
    *
    * @param timeoutSeconds The watchdog's timeout in seconds with microsecond resolution.
    * @param callback This function is called with the time in seconds since the watchdog was last
-   *    fed when the timeout expires.
+   *     fed when the timeout expires.
    */
   public Watchdog(double timeoutSeconds, DoubleConsumer callback) {
     m_timeoutSeconds = timeoutSeconds;
@@ -99,12 +99,11 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
 
   /**
    * Links the given alert to this watchdog.
-   * 
-   * <p>A linked alert will be activated every time the watchdog times out.
-   * On timeout the activation time will be reset and the text of the alert will
-   * be updated to {@code "<alert-text> [xN]"} where {@code N} is the number
-   * of overruns that have occurred.
-   * 
+   *
+   * <p>A linked alert will be activated every time the watchdog times out. On timeout the
+   * activation time will be reset and the text of the alert will be updated to {@code "<alert-text>
+   * [xN]"} where {@code N} is the number of overruns that have occurred.
+   *
    * @param alert The alert to link to this watchdog.
    */
   public void linkToAlert(Alert alert) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/WatchdogTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/WatchdogTest.java
@@ -171,4 +171,27 @@ class WatchdogTest {
       assertEquals(0, watchdogCounter2.get(), "Watchdog triggered early");
     }
   }
+
+  @Test
+  @ResourceLock("timing")
+  void watchdogAlertTest() {
+    final Alert alert = new Alert("Watchdog Alert", Alert.AlertType.kError);
+    final Watchdog watchdog = new Watchdog(0.2, () -> {});
+    watchdog.linkToAlert(alert);
+
+    double now = 1000.0;
+
+    watchdog.m_overruns = 100;
+    watchdog.updateAlert(now);
+    assertEquals("Watchdog Alert [x100]", alert.m_text, "Alert text incorrect");
+    assertTrue(Math.abs(alert.m_activeStartTime - now) < 1e-6, "Alert start time incorrect");
+
+    now += 123.456;
+    watchdog.m_overruns = 123456;
+    watchdog.updateAlert(now);
+    assertEquals("Watchdog Alert [x123456]", alert.m_text, "Alert text incorrect");
+    assertTrue(Math.abs(alert.m_activeStartTime - now) < 1e-6, "Alert start time incorrect");
+
+    watchdog.close();
+  }
 }


### PR DESCRIPTION
Allows linking an `Alert` to a `Watchdog`.

A linked alert will be activated every time the watchdog times out. On timeout the activation time will be reset and the text of the alert will be updated to `"<alert-text> [xN]"` where `N` is the number of overruns that have occurred.