### PR TITLE
[docs] Alert: fix incorrect `set` docs (NFC)

### DIFF
--- a/wpilibc/src/main/native/include/frc/Alert.h
+++ b/wpilibc/src/main/native/include/frc/Alert.h
@@ -89,9 +89,8 @@ class Alert {
   Alert(std::string_view group, std::string_view text, AlertType type);
 
   /**
-   * Sets whether the alert should currently be displayed. When activated, the
-   * alert text will also be sent to the console. This method can be safely
-   * called periodically.
+   * Sets whether the alert should currently be displayed. This method can be
+   * safely called periodically.
    *
    * @param active Whether to display the alert.
    */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Alert.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Alert.java
@@ -83,8 +83,8 @@ public class Alert {
   }
 
   /**
-   * Sets whether the alert should currently be displayed. When activated, the alert text will also
-   * be sent to the console. This method can be safely called periodically.
+   * Sets whether the alert should currently be displayed. This method can be safely called
+   * periodically.
    *
    * @param active Whether to display the alert.
    */


### PR DESCRIPTION
Console printing was removed when Alerts were added to wpilib.