### PR TITLE
[epilogue] Autogenerate nicer data names by default, not just raw element names

### DIFF
--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/ElementHandler.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/ElementHandler.java
@@ -79,8 +79,8 @@ public abstract class ElementHandler {
       // is @Logged itself
       Logged parentConfig = null;
       for (var parent = element.getEnclosingElement();
-           parent != null;
-           parent = parent.getEnclosingElement()) {
+          parent != null;
+          parent = parent.getEnclosingElement()) {
         parentConfig = parent.getAnnotation(Logged.class);
         if (parentConfig != null) {
           break;
@@ -92,7 +92,10 @@ public abstract class ElementHandler {
 
     if (config == null) {
       // Uh oh
-      throw new IllegalStateException("Could not generate a name for element " + element + " without a @Logged annotation AND without being contained within a class with a @Logged annotation!\n\nOpen an issue at https://github.com/wpilibsuite/allwpilib/issues and include a copy of the file that caused this error.");
+      throw new IllegalStateException(
+          "Could not generate a name for element "
+              + element
+              + " without a @Logged annotation AND without being contained within a class with a @Logged annotation!\n\nOpen an issue at https://github.com/wpilibsuite/allwpilib/issues and include a copy of the file that caused this error.");
     }
 
     return switch (config.defaultNaming()) {
@@ -114,8 +117,8 @@ public abstract class ElementHandler {
         }
 
         yield StringUtils.splitToWords(elementName).stream()
-                   .map(StringUtils::capitalize)
-                   .collect(Collectors.joining(" "));
+            .map(StringUtils::capitalize)
+            .collect(Collectors.joining(" "));
       }
     };
   }

--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/ElementHandler.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/ElementHandler.java
@@ -101,14 +101,14 @@ public abstract class ElementHandler {
         // Convert snakeCase field and method names to separate words,
         // while removing common field and method prefixes.
 
-        // Delete common field prefixes (k_Name, m_name, s_name)
+        // Delete common field prefixes (k_name, m_name, s_name)
         elementName = elementName.replaceFirst("^[msk]_", "");
-        if (elementName.matches("^k[A-Z]")) {
+        if (elementName.matches("^k[A-Z].*$")) {
           // Drop leading "k" prefix from fields
           // (though normally these should be static, and thus not logged)
           elementName = elementName.substring(1);
         }
-        if (elementName.matches("^get[A-Z]")) {
+        if (elementName.matches("^get[A-Z].*$")) {
           // Drop leading "get" from accessor methods
           elementName = elementName.substring(3);
         }

--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/ElementHandler.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/ElementHandler.java
@@ -7,7 +7,6 @@ package edu.wpi.first.epilogue.processor;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.logging.ClassSpecificLogger;
 import edu.wpi.first.epilogue.logging.DataLogger;
-import java.util.stream.Collectors;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -63,7 +62,6 @@ public abstract class ElementHandler {
    *     otherwise, the field or method's name with no modifications
    */
   public static String loggedName(Element element) {
-    var elementName = element.getSimpleName().toString();
     var elementConfig = element.getAnnotation(Logged.class);
 
     // Use the name provided on the logged element, if one is present
@@ -98,28 +96,10 @@ public abstract class ElementHandler {
               + " without a @Logged annotation AND without being contained within a class with a @Logged annotation!\n\nOpen an issue at https://github.com/wpilibsuite/allwpilib/issues and include a copy of the file that caused this error.");
     }
 
+    var elementName = element.getSimpleName().toString();
     return switch (config.defaultNaming()) {
       case USE_CODE_NAME -> elementName;
-      case USE_HUMAN_NAME -> {
-        // Convert snakeCase field and method names to separate words,
-        // while removing common field and method prefixes.
-
-        // Delete common field prefixes (k_name, m_name, s_name)
-        elementName = elementName.replaceFirst("^[msk]_", "");
-        if (elementName.matches("^k[A-Z].*$")) {
-          // Drop leading "k" prefix from fields
-          // (though normally these should be static, and thus not logged)
-          elementName = elementName.substring(1);
-        }
-        if (elementName.matches("^get[A-Z].*$")) {
-          // Drop leading "get" from accessor methods
-          elementName = elementName.substring(3);
-        }
-
-        yield StringUtils.splitToWords(elementName).stream()
-            .map(StringUtils::capitalize)
-            .collect(Collectors.joining(" "));
-      }
+      case USE_HUMAN_NAME -> StringUtils.toHumanName(elementName);
     };
   }
 

--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/LoggerGenerator.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/LoggerGenerator.java
@@ -338,6 +338,11 @@ public class LoggerGenerator {
       return false;
     }
 
+    if (methodTree.getBody() == null) {
+      // Abstract or native method, can't be determined to be a getter
+      return false;
+    }
+
     var statements = methodTree.getBody().getStatements();
     if (statements.size() != 1) {
       // More complex than a simple `return m_field` statement

--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/LoggerGenerator.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/LoggerGenerator.java
@@ -321,8 +321,8 @@ public class LoggerGenerator {
    * Checks if a method is a simple "getter" method for a field in the given list. Here, we define
    * "getter" as a method with a single return statement that references the name of a field, with
    * no other expressions. `getX() { return x; }` would be considered a "getter" method, while
-   * `getX() { return x.clone(); }` would not be. Note that the method name is irrelevant; only
-   * the method body is checked.
+   * `getX() { return x.clone(); }` would not be. Note that the method name is irrelevant; only the
+   * method body is checked.
    *
    * @param ex the method to check
    * @param fieldsToLog the fields that will already be logged

--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/StringUtils.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/StringUtils.java
@@ -7,6 +7,7 @@ package edu.wpi.first.epilogue.processor;
 import edu.wpi.first.epilogue.Logged;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.lang.model.element.TypeElement;
 
 public final class StringUtils {
@@ -135,5 +136,32 @@ public final class StringUtils {
     }
 
     return loggerClassName;
+  }
+
+  /**
+   * Converts a camelCase element name to separate words, removing common field and method name
+   * prefixes like "m_" and "get".
+   *
+   * @param elementName the camelcased element name
+   * @return the name split into separate words and sanitized
+   */
+  public static String toHumanName(String elementName) {
+    // Delete common field prefixes (k_name, m_name, s_name)
+    var sanitizedName = elementName.replaceFirst("^[msk]_", "");
+
+    // Drop leading "k" prefix from fields
+    // (though normally these should be static, and thus not logged)
+    if (sanitizedName.matches("^k[A-Z].*$")) {
+      sanitizedName = sanitizedName.substring(1);
+    }
+
+    // Drop leading "get" from accessor methods
+    if (sanitizedName.matches("^get[A-Z].*$")) {
+      sanitizedName = sanitizedName.substring(3);
+    }
+
+    return splitToWords(sanitizedName).stream()
+        .map(StringUtils::capitalize)
+        .collect(Collectors.joining(" "));
   }
 }

--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/StringUtils.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/StringUtils.java
@@ -5,6 +5,8 @@
 package edu.wpi.first.epilogue.processor;
 
 import edu.wpi.first.epilogue.Logged;
+import java.util.Arrays;
+import java.util.List;
 import javax.lang.model.element.TypeElement;
 
 public final class StringUtils {
@@ -57,6 +59,33 @@ public final class StringUtils {
 
     builder.append(str.subSequence(i, str.length()));
     return builder.toString();
+  }
+
+  /**
+   * Splits a camel-cased string like "fooBar" into individual words like ["foo", "Bar"].
+   *
+   * @param camelCasedString the camel-cased string to split
+   * @return the individual words in the input
+   */
+  public static List<String> splitToWords(CharSequence camelCasedString) {
+    // Implementation from https://stackoverflow.com/a/2560017, refactored for readability
+
+    // Uppercase letter not followed by the first letter of the next word
+    // This allows for splitting "IOLayer" into "IO" and "Layer"
+    String penultimateUppercaseLetter = "(?<=[A-Z])(?=[A-Z][a-z])";
+
+    // Any character that's NOT an uppercase letter, immediately followed by an uppercase letter
+    // This allows for splitting "fooBar" into "foo" and "Bar", or "123Bang" into "123" and "Bang"
+    String lastNonUppercaseLetter = "(?<=[^A-Z])(?=[A-Z])";
+
+    // The final letter in a sequence, followed by a non-alpha character like a number or underscore
+    // This allows for splitting "foo123" into "foo" and "123"
+    String finalLetter = "(?<=[A-Za-z])(?=[^A-Za-z])";
+
+    String regex =
+        String.format("%s|%s|%s", penultimateUppercaseLetter, lastNonUppercaseLetter, finalLetter);
+
+    return Arrays.asList(camelCasedString.toString().split(regex));
   }
 
   /**

--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
@@ -300,9 +300,9 @@ class AnnotationProcessorTest {
         byte[] arr1;   // Should be logged
         byte[][] arr2; // Should not be logged
 
-        public byte getX() { return x; }
-        public byte[] getArr1() { return arr1; }
-        public byte[][] getArr2() { return arr2; }
+        public byte getX() { return 0; }
+        public byte[] getArr1() { return null; }
+        public byte[][] getArr2() { return null; }
       }
       """;
 
@@ -347,9 +347,9 @@ class AnnotationProcessorTest {
         char[] arr1;   // Should not be logged
         char[][] arr2; // Should not be logged
 
-        public char getX() { return x; }
-        public char[] getArr1() { return arr1; }
-        public char[][] getArr2() { return arr2; }
+        public char getX() { return 'x'; }
+        public char[] getArr1() { return null; }
+        public char[][] getArr2() { return null; }
       }
       """;
 
@@ -392,9 +392,9 @@ class AnnotationProcessorTest {
         short[] arr1;   // Should not be logged
         short[][] arr2; // Should not be logged
 
-        public short getX() { return x; }
-        public short[] getArr1() { return arr1; }
-        public short[][] getArr2() { return arr2; }
+        public short getX() { return 0; }
+        public short[] getArr1() { return null; }
+        public short[][] getArr2() { return null; }
       }
       """;
 
@@ -437,9 +437,9 @@ class AnnotationProcessorTest {
         int[] arr1;   // Should be logged
         int[][] arr2; // Should not be logged
 
-        public int getX() { return x; }
-        public int[] getArr1() { return arr1; }
-        public int[][] getArr2() { return arr2; }
+        public int getX() { return 0; }
+        public int[] getArr1() { return null; }
+        public int[][] getArr2() { return null; }
       }
       """;
 
@@ -484,9 +484,9 @@ class AnnotationProcessorTest {
         long[] arr1;   // Should be logged
         long[][] arr2; // Should not be logged
 
-        public long getX() { return x; }
-        public long[] getArr1() { return arr1; }
-        public long[][] getArr2() { return arr2; }
+        public long getX() { return 0; }
+        public long[] getArr1() { return null; }
+        public long[][] getArr2() { return null; }
       }
       """;
 
@@ -531,9 +531,9 @@ class AnnotationProcessorTest {
         float[] arr1;   // Should be logged
         float[][] arr2; // Should not be logged
 
-        public float getX() { return x; }
-        public float[] getArr1() { return arr1; }
-        public float[][] getArr2() { return arr2; }
+        public float getX() { return 0; }
+        public float[] getArr1() { return null; }
+        public float[][] getArr2() { return null; }
       }
       """;
 
@@ -581,9 +581,9 @@ class AnnotationProcessorTest {
         double[][] arr2; // Should not be logged
         List<Double> list; // Should not be logged
 
-        public double getX() { return x; }
-        public double[] getArr1() { return arr1; }
-        public double[][] getArr2() { return arr2; }
+        public double getX() { return 0; }
+        public double[] getArr1() { return null; }
+        public double[][] getArr2() { return null; }
       }
       """;
 
@@ -630,9 +630,9 @@ class AnnotationProcessorTest {
         boolean[][] arr2; // Should not be logged
         List<Boolean> list; // Should not be logged
 
-        public boolean getX() { return x; }
-        public boolean[] getArr1() { return arr1; }
-        public boolean[][] getArr2() { return arr2; }
+        public boolean getX() { return false; }
+        public boolean[] getArr1() { return null; }
+        public boolean[][] getArr2() { return null; }
       }
       """;
 
@@ -680,9 +680,9 @@ class AnnotationProcessorTest {
         String[][] arr2; // Should not be logged
         List<String> list;  // Should be logged
 
-        public String getX() { return x; }
-        public String[] getArr1() { return arr1; }
-        public String[][] getArr2() { return arr2; }
+        public String getX() { return null; }
+        public String[] getArr1() { return null; }
+        public String[][] getArr2() { return null; }
       }
       """;
 
@@ -739,9 +739,9 @@ class AnnotationProcessorTest {
         Structable[][] arr2; // Should not be logged
         List<Structable> list; // Should be logged
 
-        public Structable getX() { return x; }
-        public Structable[] getArr1() { return arr1; }
-        public Structable[][] getArr2() { return arr2; }
+        public Structable getX() { return null; }
+        public Structable[] getArr1() { return null; }
+        public Structable[][] getArr2() { return null; }
       }
       """;
 
@@ -1173,7 +1173,7 @@ class AnnotationProcessorTest {
   }
 
   @Test
-  void errorsOnNameConflicts() {
+  void errorsOnFieldNameConflicts() {
     String source =
         """
         package edu.wpi.first.epilogue;
@@ -1214,6 +1214,51 @@ class AnnotationProcessorTest {
                 7,
                 40,
                 errors.get(2)));
+  }
+
+  @Test
+  void doesNotErrorOnGetterMethod() {
+    String source =
+        """
+        package edu.wpi.first.epilogue;
+
+        @Logged
+        class Example {
+          double x;
+          public double x() { return x; }
+          public double getX() { return x; }
+          public double aTotallyArbitraryNameForAnAccessorMethod() { return x; }
+          public double withANoOpTransform() { return x + 0; }
+          public double withTemp() { var temp = x; return temp; }
+        }
+        """;
+
+    String expectedRootLogger =
+        """
+        package edu.wpi.first.epilogue;
+
+        import edu.wpi.first.epilogue.Logged;
+        import edu.wpi.first.epilogue.Epilogue;
+        import edu.wpi.first.epilogue.logging.ClassSpecificLogger;
+        import edu.wpi.first.epilogue.logging.DataLogger;
+
+        public class ExampleLogger extends ClassSpecificLogger<Example> {
+          public ExampleLogger() {
+            super(Example.class);
+          }
+
+          @Override
+          public void update(DataLogger dataLogger, Example object) {
+            if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
+              dataLogger.log("x", object.x);
+              dataLogger.log("withANoOpTransform", object.withANoOpTransform());
+              dataLogger.log("withTemp", object.withTemp());
+            }
+          }
+        }
+        """;
+
+    assertLoggerGenerates(source, expectedRootLogger);
   }
 
   @Test

--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
@@ -49,7 +49,7 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("x", object.x);
+            dataLogger.log("X", object.x);
           }
         }
       }
@@ -88,8 +88,8 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("x", object.x);
-            dataLogger.log("y", object.y);
+            dataLogger.log("X", object.x);
+            dataLogger.log("Y", object.y);
           }
         }
       }
@@ -140,7 +140,7 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("x", (double) $x.get(object));
+            dataLogger.log("X", (double) $x.get(object));
           }
         }
       }
@@ -191,7 +191,7 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            logSendable(dataLogger.getSubLogger("chooser"), (edu.wpi.first.wpilibj.smartdashboard.SendableChooser<java.lang.String>) $chooser.get(object));
+            logSendable(dataLogger.getSubLogger("Chooser"), (edu.wpi.first.wpilibj.smartdashboard.SendableChooser<java.lang.String>) $chooser.get(object));
           }
         }
       }
@@ -231,13 +231,13 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("low", object.low);
+            dataLogger.log("Low", object.low);
           }
           if (Epilogue.shouldLog(Logged.Importance.INFO)) {
-            dataLogger.log("medium", object.medium);
+            dataLogger.log("Medium", object.medium);
           }
           if (Epilogue.shouldLog(Logged.Importance.CRITICAL)) {
-            dataLogger.log("high", object.high);
+            dataLogger.log("High", object.high);
           }
         }
       }
@@ -279,7 +279,7 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("enumValue", object.enumValue);
+            dataLogger.log("Enum Value", object.enumValue);
           }
         }
       }
@@ -323,10 +323,10 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("x", object.x);
-            dataLogger.log("arr1", object.arr1);
-            dataLogger.log("getX", object.getX());
-            dataLogger.log("getArr1", object.getArr1());
+            dataLogger.log("X", object.x);
+            dataLogger.log("Arr 1", object.arr1);
+            dataLogger.log("Get X", object.getX());
+            dataLogger.log("Get Arr 1", object.getArr1());
           }
         }
       }
@@ -370,8 +370,8 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("x", object.x);
-            dataLogger.log("getX", object.getX());
+            dataLogger.log("X", object.x);
+            dataLogger.log("Get X", object.getX());
           }
         }
       }
@@ -415,8 +415,8 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("x", object.x);
-            dataLogger.log("getX", object.getX());
+            dataLogger.log("X", object.x);
+            dataLogger.log("Get X", object.getX());
           }
         }
       }
@@ -433,7 +433,7 @@ class AnnotationProcessorTest {
 
       @Logged
       class Example {
-        int x;           // Should be logged
+        int x;        // Should be logged
         int[] arr1;   // Should be logged
         int[][] arr2; // Should not be logged
 
@@ -460,10 +460,10 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("x", object.x);
-            dataLogger.log("arr1", object.arr1);
-            dataLogger.log("getX", object.getX());
-            dataLogger.log("getArr1", object.getArr1());
+            dataLogger.log("X", object.x);
+            dataLogger.log("Arr 1", object.arr1);
+            dataLogger.log("Get X", object.getX());
+            dataLogger.log("Get Arr 1", object.getArr1());
           }
         }
       }
@@ -507,10 +507,10 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("x", object.x);
-            dataLogger.log("arr1", object.arr1);
-            dataLogger.log("getX", object.getX());
-            dataLogger.log("getArr1", object.getArr1());
+            dataLogger.log("X", object.x);
+            dataLogger.log("Arr 1", object.arr1);
+            dataLogger.log("Get X", object.getX());
+            dataLogger.log("Get Arr 1", object.getArr1());
           }
         }
       }
@@ -554,10 +554,10 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("x", object.x);
-            dataLogger.log("arr1", object.arr1);
-            dataLogger.log("getX", object.getX());
-            dataLogger.log("getArr1", object.getArr1());
+            dataLogger.log("X", object.x);
+            dataLogger.log("Arr 1", object.arr1);
+            dataLogger.log("Get X", object.getX());
+            dataLogger.log("Get Arr 1", object.getArr1());
           }
         }
       }
@@ -604,10 +604,10 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("x", object.x);
-            dataLogger.log("arr1", object.arr1);
-            dataLogger.log("getX", object.getX());
-            dataLogger.log("getArr1", object.getArr1());
+            dataLogger.log("X", object.x);
+            dataLogger.log("Arr 1", object.arr1);
+            dataLogger.log("Get X", object.getX());
+            dataLogger.log("Get Arr 1", object.getArr1());
           }
         }
       }
@@ -653,10 +653,10 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("x", object.x);
-            dataLogger.log("arr1", object.arr1);
-            dataLogger.log("getX", object.getX());
-            dataLogger.log("getArr1", object.getArr1());
+            dataLogger.log("X", object.x);
+            dataLogger.log("Arr 1", object.arr1);
+            dataLogger.log("Get X", object.getX());
+            dataLogger.log("Get Arr 1", object.getArr1());
           }
         }
       }
@@ -703,11 +703,11 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("x", object.x);
-            dataLogger.log("arr1", object.arr1);
-            dataLogger.log("list", object.list);
-            dataLogger.log("getX", object.getX());
-            dataLogger.log("getArr1", object.getArr1());
+            dataLogger.log("X", object.x);
+            dataLogger.log("Arr 1", object.arr1);
+            dataLogger.log("List", object.list);
+            dataLogger.log("Get X", object.getX());
+            dataLogger.log("Get Arr 1", object.getArr1());
           }
         }
       }
@@ -762,11 +762,11 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("x", object.x, edu.wpi.first.epilogue.Example.Structable.struct);
-            dataLogger.log("arr1", object.arr1, edu.wpi.first.epilogue.Example.Structable.struct);
-            dataLogger.log("list", object.list, edu.wpi.first.epilogue.Example.Structable.struct);
-            dataLogger.log("getX", object.getX(), edu.wpi.first.epilogue.Example.Structable.struct);
-            dataLogger.log("getArr1", object.getArr1(), edu.wpi.first.epilogue.Example.Structable.struct);
+            dataLogger.log("X", object.x, edu.wpi.first.epilogue.Example.Structable.struct);
+            dataLogger.log("Arr 1", object.arr1, edu.wpi.first.epilogue.Example.Structable.struct);
+            dataLogger.log("List", object.list, edu.wpi.first.epilogue.Example.Structable.struct);
+            dataLogger.log("Get X", object.getX(), edu.wpi.first.epilogue.Example.Structable.struct);
+            dataLogger.log("Get Arr 1", object.getArr1(), edu.wpi.first.epilogue.Example.Structable.struct);
           }
         }
       }
@@ -813,10 +813,10 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("list", object.list);
-            dataLogger.log("set", object.set);
-            dataLogger.log("queue", object.queue);
-            dataLogger.log("stack", object.stack);
+            dataLogger.log("List", object.list);
+            dataLogger.log("Set", object.set);
+            dataLogger.log("Queue", object.queue);
+            dataLogger.log("Stack", object.stack);
           }
         }
       }
@@ -993,8 +993,8 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("value", object.value);
-            dataLogger.log("upcast", object.upcast());
+            dataLogger.log("Value", object.value);
+            dataLogger.log("Upcast", object.upcast());
           }
         }
       }
@@ -1045,8 +1045,8 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            Epilogue.childLogger.tryUpdate(dataLogger.getSubLogger("child"), object.child, Epilogue.getConfig().errorHandler);
-            Epilogue.ioLogger.tryUpdate(dataLogger.getSubLogger("io"), object.io, Epilogue.getConfig().errorHandler);
+            Epilogue.childLogger.tryUpdate(dataLogger.getSubLogger("Child"), object.child, Epilogue.getConfig().errorHandler);
+            Epilogue.ioLogger.tryUpdate(dataLogger.getSubLogger("Io"), object.io, Epilogue.getConfig().errorHandler);
           }
         }
       }
@@ -1100,7 +1100,7 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            Epilogue.customPointLogger.tryUpdate(dataLogger.getSubLogger("point"), object.point, Epilogue.getConfig().errorHandler);
+            Epilogue.customPointLogger.tryUpdate(dataLogger.getSubLogger("Point"), object.point, Epilogue.getConfig().errorHandler);
           }
         }
       }
@@ -1133,6 +1133,87 @@ class AnnotationProcessorTest {
     assertEquals(
         "[EPILOGUE] Excluded from logs because java.lang.Throwable is not a loggable data type",
         message);
+  }
+
+  @Test
+  void loggingRecords() {
+    String source =
+        """
+        package edu.wpi.first.epilogue;
+
+        @Logged
+        record Example(double x, double y) { }
+        """;
+
+    String expectedRootLogger =
+        """
+        package edu.wpi.first.epilogue;
+
+        import edu.wpi.first.epilogue.Logged;
+        import edu.wpi.first.epilogue.Epilogue;
+        import edu.wpi.first.epilogue.logging.ClassSpecificLogger;
+        import edu.wpi.first.epilogue.logging.DataLogger;
+
+        public class ExampleLogger extends ClassSpecificLogger<Example> {
+          public ExampleLogger() {
+            super(Example.class);
+          }
+
+          @Override
+          public void update(DataLogger dataLogger, Example object) {
+            if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
+              dataLogger.log("X", object.x());
+              dataLogger.log("Y", object.y());
+            }
+          }
+        }
+        """;
+
+    assertLoggerGenerates(source, expectedRootLogger);
+  }
+
+  @Test
+  void errorsOnNameConflicts() {
+    String source =
+        """
+        package edu.wpi.first.epilogue;
+
+        @Logged
+        class Example {
+          @Logged(name = "Custom Name") double x;
+          @Logged(name = "Custom Name") double y;
+          @Logged(name = "Custom Name") double z;
+        }
+        """;
+
+    Compilation compilation =
+        javac()
+            .withProcessors(new AnnotationProcessor())
+            .compile(JavaFileObjects.forSourceString("edu.wpi.first.epilogue.Example", source));
+
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(3);
+
+    List<Diagnostic<? extends JavaFileObject>> errors = compilation.errors();
+    assertAll(
+        () ->
+            assertCompilationError(
+                "[EPILOGUE] Conflicting name detected: \"Custom Name\" is also used by Example.y, Example.z",
+                5,
+                40,
+                errors.get(0)),
+        () ->
+            assertCompilationError(
+                "[EPILOGUE] Conflicting name detected: \"Custom Name\" is also used by Example.x, Example.z",
+                6,
+                40,
+                errors.get(1)),
+        () ->
+            assertCompilationError(
+                "[EPILOGUE] Conflicting name detected: \"Custom Name\" is also used by Example.x, Example.y",
+                7,
+                40,
+                errors.get(2)));
   }
 
   private void assertCompilationError(

--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
@@ -49,7 +49,7 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("X", object.x);
+            dataLogger.log("x", object.x);
           }
         }
       }
@@ -88,8 +88,8 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("X", object.x);
-            dataLogger.log("Y", object.y);
+            dataLogger.log("x", object.x);
+            dataLogger.log("y", object.y);
           }
         }
       }
@@ -140,7 +140,7 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("X", (double) $x.get(object));
+            dataLogger.log("x", (double) $x.get(object));
           }
         }
       }
@@ -191,7 +191,7 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            logSendable(dataLogger.getSubLogger("Chooser"), (edu.wpi.first.wpilibj.smartdashboard.SendableChooser<java.lang.String>) $chooser.get(object));
+            logSendable(dataLogger.getSubLogger("chooser"), (edu.wpi.first.wpilibj.smartdashboard.SendableChooser<java.lang.String>) $chooser.get(object));
           }
         }
       }
@@ -231,13 +231,13 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("Low", object.low);
+            dataLogger.log("low", object.low);
           }
           if (Epilogue.shouldLog(Logged.Importance.INFO)) {
-            dataLogger.log("Medium", object.medium);
+            dataLogger.log("medium", object.medium);
           }
           if (Epilogue.shouldLog(Logged.Importance.CRITICAL)) {
-            dataLogger.log("High", object.high);
+            dataLogger.log("high", object.high);
           }
         }
       }
@@ -279,7 +279,7 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("Enum Value", object.enumValue);
+            dataLogger.log("enumValue", object.enumValue);
           }
         }
       }
@@ -323,10 +323,10 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("X", object.x);
-            dataLogger.log("Arr 1", object.arr1);
-            dataLogger.log("Get X", object.getX());
-            dataLogger.log("Get Arr 1", object.getArr1());
+            dataLogger.log("x", object.x);
+            dataLogger.log("arr1", object.arr1);
+            dataLogger.log("getX", object.getX());
+            dataLogger.log("getArr1", object.getArr1());
           }
         }
       }
@@ -370,8 +370,8 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("X", object.x);
-            dataLogger.log("Get X", object.getX());
+            dataLogger.log("x", object.x);
+            dataLogger.log("getX", object.getX());
           }
         }
       }
@@ -415,8 +415,8 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("X", object.x);
-            dataLogger.log("Get X", object.getX());
+            dataLogger.log("x", object.x);
+            dataLogger.log("getX", object.getX());
           }
         }
       }
@@ -433,7 +433,7 @@ class AnnotationProcessorTest {
 
       @Logged
       class Example {
-        int x;        // Should be logged
+        int x;           // Should be logged
         int[] arr1;   // Should be logged
         int[][] arr2; // Should not be logged
 
@@ -460,10 +460,10 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("X", object.x);
-            dataLogger.log("Arr 1", object.arr1);
-            dataLogger.log("Get X", object.getX());
-            dataLogger.log("Get Arr 1", object.getArr1());
+            dataLogger.log("x", object.x);
+            dataLogger.log("arr1", object.arr1);
+            dataLogger.log("getX", object.getX());
+            dataLogger.log("getArr1", object.getArr1());
           }
         }
       }
@@ -507,10 +507,10 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("X", object.x);
-            dataLogger.log("Arr 1", object.arr1);
-            dataLogger.log("Get X", object.getX());
-            dataLogger.log("Get Arr 1", object.getArr1());
+            dataLogger.log("x", object.x);
+            dataLogger.log("arr1", object.arr1);
+            dataLogger.log("getX", object.getX());
+            dataLogger.log("getArr1", object.getArr1());
           }
         }
       }
@@ -554,10 +554,10 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("X", object.x);
-            dataLogger.log("Arr 1", object.arr1);
-            dataLogger.log("Get X", object.getX());
-            dataLogger.log("Get Arr 1", object.getArr1());
+            dataLogger.log("x", object.x);
+            dataLogger.log("arr1", object.arr1);
+            dataLogger.log("getX", object.getX());
+            dataLogger.log("getArr1", object.getArr1());
           }
         }
       }
@@ -604,10 +604,10 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("X", object.x);
-            dataLogger.log("Arr 1", object.arr1);
-            dataLogger.log("Get X", object.getX());
-            dataLogger.log("Get Arr 1", object.getArr1());
+            dataLogger.log("x", object.x);
+            dataLogger.log("arr1", object.arr1);
+            dataLogger.log("getX", object.getX());
+            dataLogger.log("getArr1", object.getArr1());
           }
         }
       }
@@ -653,10 +653,10 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("X", object.x);
-            dataLogger.log("Arr 1", object.arr1);
-            dataLogger.log("Get X", object.getX());
-            dataLogger.log("Get Arr 1", object.getArr1());
+            dataLogger.log("x", object.x);
+            dataLogger.log("arr1", object.arr1);
+            dataLogger.log("getX", object.getX());
+            dataLogger.log("getArr1", object.getArr1());
           }
         }
       }
@@ -703,11 +703,11 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("X", object.x);
-            dataLogger.log("Arr 1", object.arr1);
-            dataLogger.log("List", object.list);
-            dataLogger.log("Get X", object.getX());
-            dataLogger.log("Get Arr 1", object.getArr1());
+            dataLogger.log("x", object.x);
+            dataLogger.log("arr1", object.arr1);
+            dataLogger.log("list", object.list);
+            dataLogger.log("getX", object.getX());
+            dataLogger.log("getArr1", object.getArr1());
           }
         }
       }
@@ -762,11 +762,11 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("X", object.x, edu.wpi.first.epilogue.Example.Structable.struct);
-            dataLogger.log("Arr 1", object.arr1, edu.wpi.first.epilogue.Example.Structable.struct);
-            dataLogger.log("List", object.list, edu.wpi.first.epilogue.Example.Structable.struct);
-            dataLogger.log("Get X", object.getX(), edu.wpi.first.epilogue.Example.Structable.struct);
-            dataLogger.log("Get Arr 1", object.getArr1(), edu.wpi.first.epilogue.Example.Structable.struct);
+            dataLogger.log("x", object.x, edu.wpi.first.epilogue.Example.Structable.struct);
+            dataLogger.log("arr1", object.arr1, edu.wpi.first.epilogue.Example.Structable.struct);
+            dataLogger.log("list", object.list, edu.wpi.first.epilogue.Example.Structable.struct);
+            dataLogger.log("getX", object.getX(), edu.wpi.first.epilogue.Example.Structable.struct);
+            dataLogger.log("getArr1", object.getArr1(), edu.wpi.first.epilogue.Example.Structable.struct);
           }
         }
       }
@@ -813,10 +813,10 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("List", object.list);
-            dataLogger.log("Set", object.set);
-            dataLogger.log("Queue", object.queue);
-            dataLogger.log("Stack", object.stack);
+            dataLogger.log("list", object.list);
+            dataLogger.log("set", object.set);
+            dataLogger.log("queue", object.queue);
+            dataLogger.log("stack", object.stack);
           }
         }
       }
@@ -993,8 +993,8 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            dataLogger.log("Value", object.value);
-            dataLogger.log("Upcast", object.upcast());
+            dataLogger.log("value", object.value);
+            dataLogger.log("upcast", object.upcast());
           }
         }
       }
@@ -1045,8 +1045,8 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            Epilogue.childLogger.tryUpdate(dataLogger.getSubLogger("Child"), object.child, Epilogue.getConfig().errorHandler);
-            Epilogue.ioLogger.tryUpdate(dataLogger.getSubLogger("Io"), object.io, Epilogue.getConfig().errorHandler);
+            Epilogue.childLogger.tryUpdate(dataLogger.getSubLogger("child"), object.child, Epilogue.getConfig().errorHandler);
+            Epilogue.ioLogger.tryUpdate(dataLogger.getSubLogger("io"), object.io, Epilogue.getConfig().errorHandler);
           }
         }
       }
@@ -1100,7 +1100,7 @@ class AnnotationProcessorTest {
         @Override
         public void update(DataLogger dataLogger, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            Epilogue.customPointLogger.tryUpdate(dataLogger.getSubLogger("Point"), object.point, Epilogue.getConfig().errorHandler);
+            Epilogue.customPointLogger.tryUpdate(dataLogger.getSubLogger("point"), object.point, Epilogue.getConfig().errorHandler);
           }
         }
       }
@@ -1162,8 +1162,8 @@ class AnnotationProcessorTest {
           @Override
           public void update(DataLogger dataLogger, Example object) {
             if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-              dataLogger.log("X", object.x());
-              dataLogger.log("Y", object.y());
+              dataLogger.log("x", object.x());
+              dataLogger.log("y", object.y());
             }
           }
         }

--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/StringUtilsTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/StringUtilsTest.java
@@ -4,8 +4,10 @@
 
 package edu.wpi.first.epilogue.processor;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class StringUtilsTest {
@@ -15,5 +17,23 @@ class StringUtilsTest {
     assertEquals("ledSubsystem", StringUtils.lowerCamelCase("LEDSubsystem"));
     assertEquals("fooBar", StringUtils.lowerCamelCase("FooBar"));
     assertEquals("allcaps", StringUtils.lowerCamelCase("ALLCAPS"));
+  }
+
+  @Test
+  void splitToWords() {
+    assertAll(
+        () -> assertEquals(List.of("IO", "Logger"), StringUtils.splitToWords("IOLogger")),
+        () -> assertEquals(List.of("LED", "Subsystem"), StringUtils.splitToWords("LEDSubsystem")),
+        () -> assertEquals(List.of("Foo", "Bar"), StringUtils.splitToWords("FooBar")),
+        () -> assertEquals(List.of("ALLCAPS"), StringUtils.splitToWords("ALLCAPS")),
+        () ->
+            assertEquals(List.of("k", "First", "Second"), StringUtils.splitToWords("kFirstSecond")),
+        () ->
+            assertEquals(
+                List.of("there", "Is", "A", "Number", "123", "In", "Here", "VERSION", "456"),
+                StringUtils.splitToWords("thereIsANumber123InHereVERSION456")),
+        () ->
+            assertEquals(
+                List.of("get", "First", "Second"), StringUtils.splitToWords("getFirstSecond")));
   }
 }

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/Logged.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/Logged.java
@@ -104,13 +104,13 @@ public @interface Logged {
     USE_CODE_NAME,
 
     /**
-     * Sets the default naming strategy to use a human-readable name based on the name of the
-     * name of the element as it appears in source code. For example, a field {@code double m_x}
-     * would be labeled as {@code "X"} by default, and a {@code getX()} accessor would also be
-     * labeled as {@code "X"}. Because logged names must be unique, this configuration would fail
-     * to compile and require either one of the fields to be excluded from logs (which, for simple
-     * accessors, would be ideal to avoid duplicate data), or to rename one or both elements so
-     * the logged data fields would have unique names.
+     * Sets the default naming strategy to use a human-readable name based on the name of the name
+     * of the element as it appears in source code. For example, a field {@code double m_x} would be
+     * labeled as {@code "X"} by default, and a {@code getX()} accessor would also be labeled as
+     * {@code "X"}. Because logged names must be unique, this configuration would fail to compile
+     * and require either one of the fields to be excluded from logs (which, for simple accessors,
+     * would be ideal to avoid duplicate data), or to rename one or both elements so the logged data
+     * fields would have unique names.
      */
     USE_HUMAN_NAME
   }

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/Logged.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/Logged.java
@@ -119,6 +119,9 @@ public @interface Logged {
    * The default naming behavior to use. Defaults to {@link Naming#USE_CODE_NAME}, which uses the
    * raw code name directly in logs. Any configuration of the {@link #name()} attribute on logged
    * fields and methods will take precedence over an automatically generated name.
+   *
+   * @return the naming strategy for and annotated field or method, or the default naming strategy
+   *     for all logged fields and methods in an annotated class
    */
   Naming defaultNaming() default Naming.USE_CODE_NAME;
 }

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/Logged.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/Logged.java
@@ -89,4 +89,36 @@ public @interface Logged {
    * @return the importance of the annotated element
    */
   Importance importance() default Importance.DEBUG;
+
+  /**
+   * Different behaviors for how Epilogue will generate the names of logged data points. This only
+   * applies to automatically generated names; any specific name provided with {@link #name()} will
+   * take precedence over an automatically generated name.
+   */
+  enum Naming {
+    /**
+     * Sets the default naming strategy to use the name of the element as it appears in source code.
+     * For example, a field {@code double m_x} would be labeled as {@code "m_x"} by default, and a
+     * {@code getX()} accessor would be labeled as {@code "getX"}.
+     */
+    USE_CODE_NAME,
+
+    /**
+     * Sets the default naming strategy to use a human-readable name based on the name of the
+     * name of the element as it appears in source code. For example, a field {@code double m_x}
+     * would be labeled as {@code "X"} by default, and a {@code getX()} accessor would also be
+     * labeled as {@code "X"}. Because logged names must be unique, this configuration would fail
+     * to compile and require either one of the fields to be excluded from logs (which, for simple
+     * accessors, would be ideal to avoid duplicate data), or to rename one or both elements so
+     * the logged data fields would have unique names.
+     */
+    USE_HUMAN_NAME
+  }
+
+  /**
+   * The default naming behavior to use. Defaults to {@link Naming#USE_CODE_NAME}, which uses the
+   * raw code name directly in logs. Any configuration of the {@link #name()} attribute on logged
+   * fields and methods will take precedence over an automatically generated name.
+   */
+  Naming defaultNaming() default Naming.USE_CODE_NAME;
 }


### PR DESCRIPTION
eg "getFoo()" will now be logged as "Foo", or "m_leftMotor" as "Left Motor"

It is now a compilation error to reuse the same logged name for multiple elements (since whatever is declared last would overwrite anything logged before it)

Do not log record fields (just use the accessors). This also fixes an issue where records could never be logged due to identical member and accessor names

Also skips `toString`, `hashCode`, and `clone` methods when generating loggers