### PR TITLE
[examples] fix flaky ArmSimulationTest

### DIFF
--- a/wpilibcExamples/src/test/cpp/examples/ArmSimulation/cpp/ArmSimulationTest.cpp
+++ b/wpilibcExamples/src/test/cpp/examples/ArmSimulation/cpp/ArmSimulationTest.cpp
@@ -52,7 +52,7 @@ TEST_P(ArmSimulationTest, Teleop) {
   EXPECT_TRUE(frc::Preferences::ContainsKey(kArmPKey));
   frc::Preferences::SetDouble(kArmPositionKey, GetParam().value());
   units::degree_t setpoint = GetParam();
-  EXPECT_DOUBLE_EQ(GetParam().value(),
+  EXPECT_DOUBLE_EQ(setpoint.value(),
                    frc::Preferences::GetDouble(kArmPositionKey, NAN));
 
   // teleop init

--- a/wpilibcExamples/src/test/cpp/examples/ArmSimulation/cpp/ArmSimulationTest.cpp
+++ b/wpilibcExamples/src/test/cpp/examples/ArmSimulation/cpp/ArmSimulationTest.cpp
@@ -50,11 +50,11 @@ class ArmSimulationTest : public testing::TestWithParam<units::degree_t> {
 TEST_P(ArmSimulationTest, Teleop) {
   EXPECT_TRUE(frc::Preferences::ContainsKey(kArmPositionKey));
   EXPECT_TRUE(frc::Preferences::ContainsKey(kArmPKey));
-  EXPECT_DOUBLE_EQ(kDefaultArmSetpoint.value(),
-                   frc::Preferences::GetDouble(kArmPositionKey, NAN));
-
   frc::Preferences::SetDouble(kArmPositionKey, GetParam().value());
   units::degree_t setpoint = GetParam();
+  EXPECT_DOUBLE_EQ(GetParam().value(),
+                   frc::Preferences::GetDouble(kArmPositionKey, NAN));
+
   // teleop init
   {
     frc::sim::DriverStationSim::SetAutonomous(false);
@@ -68,7 +68,7 @@ TEST_P(ArmSimulationTest, Teleop) {
   {
     frc::sim::StepTiming(3_s);
 
-    // Ensure elevator is still at 0.
+    // Ensure arm is still at minimum angle.
     EXPECT_NEAR(kMinAngle.value(), m_encoderSim.GetDistance(), 2.0);
   }
 

--- a/wpilibjExamples/src/test/java/edu/wpi/first/wpilibj/examples/armsimulation/ArmSimulationTest.java
+++ b/wpilibjExamples/src/test/java/edu/wpi/first/wpilibj/examples/armsimulation/ArmSimulationTest.java
@@ -84,10 +84,10 @@ class ArmSimulationTest {
     }
 
     {
-      // advance 50 timesteps
+      // advance 150 timesteps
       SimHooks.stepTiming(3);
 
-      // Ensure elevator is still at 0.
+      // Ensure arm is still at minimum angle.
       assertEquals(Constants.kMinAngleRads, m_encoderSim.getDistance(), 2.0);
     }
 
@@ -112,7 +112,7 @@ class ArmSimulationTest {
       m_joystickSim.setTrigger(false);
       m_joystickSim.notifyNewData();
 
-      // advance 75 timesteps
+      // advance 150 timesteps
       SimHooks.stepTiming(3.0);
 
       assertEquals(Constants.kMinAngleRads, m_encoderSim.getDistance(), 2.0);

--- a/wpilibjExamples/src/test/java/edu/wpi/first/wpilibj/examples/armsimulation/ArmSimulationTest.java
+++ b/wpilibjExamples/src/test/java/edu/wpi/first/wpilibj/examples/armsimulation/ArmSimulationTest.java
@@ -71,11 +71,8 @@ class ArmSimulationTest {
   void teleopTest(double setpoint) {
     assertTrue(Preferences.containsKey(Constants.kArmPositionKey));
     assertTrue(Preferences.containsKey(Constants.kArmPKey));
-    assertEquals(
-        Constants.kDefaultArmSetpointDegrees,
-        Preferences.getDouble(Constants.kArmPositionKey, Double.NaN));
-
     Preferences.setDouble(Constants.kArmPositionKey, setpoint);
+    assertEquals(setpoint, Preferences.getDouble(Constants.kArmPositionKey, Double.NaN));
     // teleop init
     {
       DriverStationSim.setAutonomous(false);


### PR DESCRIPTION
Fixes issue #5908 

It seems that all of the checks were for the default arm position in the Preferences class instead of the current setpoint

The checks at the beginning of `teleopTest `were if the two keys were in the Preferences class and then checking if the arm position key was set to the default.  Then the preferences key was set to the setpoint.  I'm amazed the test didn't fail more often.  I guess it could on other systems.  I feel like the intended behavior was to check after the key was set to the tested setpoint if the preferences value contained that value before continuing.  That is basically the change I made here.  I also noticed some commenting issues.  It look like this class was originally a duplicate of the `ElevatorSimulationTest `which doesn't have this problem.  The `ElevatorSimulationTest `just testing one value and doesn't use the Preferences class.  I suppose to completely eliminate any possiblity of race conditions 3 difference tests could be made requiring the Arm example to have difference triggered setpoints.  