### PR TITLE
Fix CAN ID validation and reporting for CTRE and REV devices

### DIFF
--- a/hal/src/main/native/athena/CTREPCM.cpp
+++ b/hal/src/main/native/athena/CTREPCM.cpp
@@ -185,7 +185,7 @@ HAL_CTREPCMHandle HAL_InitializeCTREPCM(int32_t module,
                                            pcm->previousAllocation);
     } else {
       hal::SetLastErrorIndexOutOfRange(status, "Invalid Index for CTRE PCM", 0,
-                                       kNumCTREPCMModules, module);
+                                       kNumCTREPCMModules - 1, module);
     }
     return HAL_kInvalidHandle;  // failed to allocate. Pass error back.
   }

--- a/hal/src/main/native/athena/CTREPDP.cpp
+++ b/hal/src/main/native/athena/CTREPDP.cpp
@@ -133,8 +133,9 @@ HAL_PDPHandle HAL_InitializePDP(int32_t module, const char* allocationLocation,
                                 int32_t* status) {
   hal::init::CheckInit();
   if (!HAL_CheckPDPModule(module)) {
-    *status = PARAMETER_OUT_OF_RANGE;
-    hal::SetLastError(status, fmt::format("Invalid pdp module {}", module));
+    *status = RESOURCE_OUT_OF_RANGE;
+    hal::SetLastErrorIndexOutOfRange(status, "Invalid Index for CTRE PDP", 0,
+                                     kNumCTREPDPModules - 1, module);
     return HAL_kInvalidHandle;
   }
 
@@ -147,7 +148,7 @@ HAL_PDPHandle HAL_InitializePDP(int32_t module, const char* allocationLocation,
                                            pdp->previousAllocation);
     } else {
       hal::SetLastErrorIndexOutOfRange(status, "Invalid Index for CTRE PDP", 0,
-                                       kNumCTREPDPModules, module);
+                                       kNumCTREPDPModules - 1, module);
     }
     return HAL_kInvalidHandle;  // failed to allocate. Pass error back.
   }

--- a/hal/src/main/native/athena/REVPDH.cpp
+++ b/hal/src/main/native/athena/REVPDH.cpp
@@ -205,17 +205,20 @@ HAL_REVPDHHandle HAL_InitializeREVPDH(int32_t module,
   hal::init::CheckInit();
   if (!HAL_CheckREVPDHModuleNumber(module)) {
     *status = RESOURCE_OUT_OF_RANGE;
+    hal::SetLastErrorIndexOutOfRange(status, "Invalid Index for REV PDH", 1,
+                                     kNumREVPDHModules, module);
     return HAL_kInvalidHandle;
   }
 
   HAL_REVPDHHandle handle;
-  auto hpdh = REVPDHHandles->Allocate(module, &handle, status);
+  // Module starts at 1
+  auto hpdh = REVPDHHandles->Allocate(module - 1, &handle, status);
   if (*status != 0) {
     if (hpdh) {
       hal::SetLastErrorPreviouslyAllocated(status, "REV PDH", module,
                                            hpdh->previousAllocation);
     } else {
-      hal::SetLastErrorIndexOutOfRange(status, "Invalid Index for REV PDH", 0,
+      hal::SetLastErrorIndexOutOfRange(status, "Invalid Index for REV PDH", 1,
                                        kNumREVPDHModules, module);
     }
     return HAL_kInvalidHandle;  // failed to allocate. Pass error back.
@@ -253,7 +256,7 @@ int32_t HAL_GetREVPDHModuleNumber(HAL_REVPDHHandle handle, int32_t* status) {
 }
 
 HAL_Bool HAL_CheckREVPDHModuleNumber(int32_t module) {
-  return ((module >= 1) && (module < kNumREVPDHModules)) ? 1 : 0;
+  return ((module >= 1) && (module <= kNumREVPDHModules)) ? 1 : 0;
 }
 
 HAL_Bool HAL_CheckREVPDHChannelNumber(int32_t channel) {

--- a/hal/src/main/native/athena/REVPH.cpp
+++ b/hal/src/main/native/athena/REVPH.cpp
@@ -249,7 +249,7 @@ void HAL_FreeREVPH(HAL_REVPHHandle handle) {
 }
 
 HAL_Bool HAL_CheckREVPHModuleNumber(int32_t module) {
-  return module >= 1 && module <= kNumREVPDHModules;
+  return module >= 1 && module <= kNumREVPHModules;
 }
 
 HAL_Bool HAL_CheckREVPHSolenoidChannel(int32_t channel) {

--- a/hal/src/main/native/athena/REVPH.cpp
+++ b/hal/src/main/native/athena/REVPH.cpp
@@ -196,13 +196,15 @@ HAL_REVPHHandle HAL_InitializeREVPH(int32_t module,
                                     int32_t* status) {
   hal::init::CheckInit();
   if (!HAL_CheckREVPHModuleNumber(module)) {
+    *status = RESOURCE_OUT_OF_RANGE;
     hal::SetLastErrorIndexOutOfRange(status, "Invalid Index for REV PH", 1,
                                      kNumREVPHModules, module);
     return HAL_kInvalidHandle;
   }
 
   HAL_REVPHHandle handle;
-  auto hph = REVPHHandles->Allocate(module, &handle, status);
+  // Module starts at 1
+  auto hph = REVPHHandles->Allocate(module - 1, &handle, status);
   if (*status != 0) {
     if (hph) {
       hal::SetLastErrorPreviouslyAllocated(status, "REV PH", module,
@@ -247,7 +249,7 @@ void HAL_FreeREVPH(HAL_REVPHHandle handle) {
 }
 
 HAL_Bool HAL_CheckREVPHModuleNumber(int32_t module) {
-  return module >= 1 && module < kNumREVPDHModules;
+  return module >= 1 && module <= kNumREVPDHModules;
 }
 
 HAL_Bool HAL_CheckREVPHSolenoidChannel(int32_t channel) {

--- a/hal/src/main/native/sim/CTREPCM.cpp
+++ b/hal/src/main/native/sim/CTREPCM.cpp
@@ -49,7 +49,7 @@ HAL_CTREPCMHandle HAL_InitializeCTREPCM(int32_t module,
                                            pcm->previousAllocation);
     } else {
       hal::SetLastErrorIndexOutOfRange(status, "Invalid Index for CTRE PCM", 0,
-                                       kNumCTREPCMModules, module);
+                                       kNumCTREPCMModules - 1, module);
     }
     return HAL_kInvalidHandle;  // failed to allocate. Pass error back.
   }

--- a/hal/src/main/native/sim/PowerDistribution.cpp
+++ b/hal/src/main/native/sim/PowerDistribution.cpp
@@ -44,8 +44,14 @@ HAL_PowerDistributionHandle HAL_InitializePowerDistribution(
   }
 
   if (!HAL_CheckPowerDistributionModule(module, type)) {
-    *status = PARAMETER_OUT_OF_RANGE;
-    hal::SetLastError(status, fmt::format("Invalid pdp module {}", module));
+    *status = RESOURCE_OUT_OF_RANGE;
+    if (type == HAL_PowerDistributionType::HAL_PowerDistributionType_kCTRE) {
+      hal::SetLastErrorIndexOutOfRange(status, "Invalid Index for CTRE PDP", 0,
+                                       kNumCTREPDPModules - 1, module);
+    } else {
+      hal::SetLastErrorIndexOutOfRange(status, "Invalid Index for REV PDH", 1,
+                                       kNumREVPDHModules, module);
+    }
     return HAL_kInvalidHandle;
   }
   hal::init::CheckInit();
@@ -74,7 +80,7 @@ HAL_Bool HAL_CheckPowerDistributionModule(int32_t module,
   if (type == HAL_PowerDistributionType::HAL_PowerDistributionType_kCTRE) {
     return module < kNumCTREPDPModules && module >= 0;
   } else {
-    return module < kNumREVPDHModules && module >= 1;
+    return module <= kNumREVPDHModules && module >= 1;
   }
 }
 

--- a/hal/src/main/native/sim/REVPH.cpp
+++ b/hal/src/main/native/sim/REVPH.cpp
@@ -40,14 +40,16 @@ HAL_REVPHHandle HAL_InitializeREVPH(int32_t module,
                                     int32_t* status) {
   hal::init::CheckInit();
 
-  if (module == 0) {
+  if (!HAL_CheckREVPHModuleNumber(module)) {
+    *status = RESOURCE_OUT_OF_RANGE;
     hal::SetLastErrorIndexOutOfRange(status, "Invalid Index for REV PH", 1,
                                      kNumREVPHModules, module);
     return HAL_kInvalidHandle;
   }
 
   HAL_REVPHHandle handle;
-  auto pcm = pcmHandles->Allocate(module, &handle, status);
+  // Module starts at 1
+  auto pcm = pcmHandles->Allocate(module - 1, &handle, status);
 
   if (*status != 0) {
     if (pcm) {
@@ -82,7 +84,7 @@ void HAL_FreeREVPH(HAL_REVPHHandle handle) {
 }
 
 HAL_Bool HAL_CheckREVPHModuleNumber(int32_t module) {
-  return module >= 1 && module < kNumREVPDHModules;
+  return module >= 1 && module <= kNumREVPHModules;
 }
 
 HAL_Bool HAL_CheckREVPHSolenoidChannel(int32_t channel) {


### PR DESCRIPTION
REV: 1-63, 63 devices
CTRE: 0-62, 63 devices

One of the checks for each could also be removed- the resource containers also check the range.