### PR TITLE
[wpiutil] Add a RawFrame JNI overload for byte[]

### DIFF
--- a/wpiutil/src/main/java/edu/wpi/first/util/RawFrame.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/RawFrame.java
@@ -89,6 +89,25 @@ public class RawFrame implements AutoCloseable {
   }
 
   /**
+   * Set frame data.
+   *
+   * @param data A Java byte[] pointing to the frame data.
+   * @param width The width of the frame, in pixels
+   * @param height The height of the frame, in pixels
+   * @param stride The number of bytes in each row of image data
+   * @param pixelFormat The PixelFormat of the frame
+   */
+  public void setData(byte[] data, int width, int height, int stride, PixelFormat pixelFormat) {
+    m_data = ByteBuffer.wrap(data);
+    m_width = width;
+    m_height = height;
+    m_stride = stride;
+    m_pixelFormat = pixelFormat;
+    WPIUtilJNI.setRawFrameDataArray(
+        m_nativeObj, data, data.length, width, height, stride, pixelFormat.getValue());
+  }
+
+  /**
    * Call to set frame information.
    *
    * @param width The width of the frame, in pixels

--- a/wpiutil/src/main/java/edu/wpi/first/util/WPIUtilJNI.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/WPIUtilJNI.java
@@ -169,6 +169,9 @@ public class WPIUtilJNI {
   static native void setRawFrameData(
       long frame, ByteBuffer data, int size, int width, int height, int stride, int pixelFormat);
 
+  static native void setRawFrameDataArray(
+      long frame, byte[] data, int size, int width, int height, int stride, int pixelFormat);
+
   static native void setRawFrameInfo(
       long frame, int size, int width, int height, int stride, int pixelFormat);
 

--- a/wpiutil/src/main/native/cpp/jni/WPIUtilJNI.cpp
+++ b/wpiutil/src/main/native/cpp/jni/WPIUtilJNI.cpp
@@ -397,6 +397,35 @@ Java_edu_wpi_first_util_WPIUtilJNI_setRawFrameData
 
 /*
  * Class:     edu_wpi_first_util_WPIUtilJNI
+ * Method:    setRawFrameDataArray
+ * Signature: (J[BIIIII)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_util_WPIUtilJNI_setRawFrameDataArray
+  (JNIEnv* env, jclass, jlong frame, jbyteArray data, jint size, jint width,
+   jint height, jint stride, jint pixelFormat)
+{
+  auto* f = reinterpret_cast<wpi::RawFrame*>(frame);
+  if (!f) {
+    wpi::ThrowNullPointerException(env, "frame is null");
+    return;
+  }
+  auto buf = reinterpret_cast<jbyte*>(env->GetByteArrayElements(data, NULL));
+  if (!buf) {
+    wpi::ThrowNullPointerException(env, "data is null");
+    return;
+  }
+  // there's no way to free a passed-in direct byte buffer
+  f->SetData(buf, size, env->GetDirectBufferCapacity(data), nullptr,
+             [](void*, void*, size_t) {});
+  f->width = width;
+  f->height = height;
+  f->stride = stride;
+  f->pixelFormat = pixelFormat;
+}
+
+/*
+ * Class:     edu_wpi_first_util_WPIUtilJNI
  * Method:    setRawFrameInfo
  * Signature: (JIIIII)V
  */


### PR DESCRIPTION
Allows avoiding two copies in https://github.com/wpilibsuite/allwpilib/pull/7176/

cc @mcm001 