### PR TITLE
[sysid] Fix crash when all data is filtered out during analysis

### DIFF
--- a/sysid/src/main/native/cpp/analysis/FilteringUtils.cpp
+++ b/sysid/src/main/native/cpp/analysis/FilteringUtils.cpp
@@ -326,9 +326,11 @@ static units::second_t GetMaxStepTime(
     auto& dataset = it.getValue();
 
     if (IsRaw(key) && wpi::contains(key, "dynamic")) {
-      auto duration = dataset.back().timestamp - dataset.front().timestamp;
-      if (duration > maxStepTime) {
-        maxStepTime = duration;
+      if (dataset.size() > 0) {
+        auto duration = dataset.back().timestamp - dataset.front().timestamp;
+        if (duration > maxStepTime) {
+          maxStepTime = duration;
+        }
       }
     }
   }

--- a/sysid/src/main/native/cpp/analysis/FilteringUtils.cpp
+++ b/sysid/src/main/native/cpp/analysis/FilteringUtils.cpp
@@ -326,7 +326,7 @@ static units::second_t GetMaxStepTime(
     auto& dataset = it.getValue();
 
     if (IsRaw(key) && wpi::contains(key, "dynamic")) {
-      if (dataset.size() > 0) {
+      if (!dataset.empty()) {
         auto duration = dataset.back().timestamp - dataset.front().timestamp;
         if (duration > maxStepTime) {
           maxStepTime = duration;


### PR DESCRIPTION
Fixes #6438.

Here's what the error screen looks like when trying to load the log in the issue:
![image](https://github.com/user-attachments/assets/2db6fab1-284d-49d3-813a-12a0fe28c54f)
A bunch of the UI elements aren't present, but I think that's fine here since analysis isn't possible. The plot in the background is from a previous analysis.