### PR TITLE
Remove VS 2019 16.4.0 workaround

### DIFF
--- a/cscore/src/main/native/cpp/HttpCameraImpl.cpp
+++ b/cscore/src/main/native/cpp/HttpCameraImpl.cpp
@@ -458,11 +458,7 @@ std::unique_ptr<PropertyImpl> HttpCameraImpl::CreateEmptyProperty(
 }
 
 bool HttpCameraImpl::CacheProperties(CS_Status* status) const {
-#ifdef _MSC_VER  // work around VS2019 16.4.0 bug
-  std::scoped_lock<wpi::mutex> lock(m_mutex);
-#else
   std::scoped_lock lock(m_mutex);
-#endif
 
   // Pretty typical set of video modes
   m_videoModes.clear();

--- a/cscore/src/main/native/cpp/UnlimitedHandleResource.h
+++ b/cscore/src/main/native/cpp/UnlimitedHandleResource.h
@@ -75,11 +75,7 @@ template <typename THandle, typename TStruct, int typeValue, typename TMutex>
 template <typename... Args>
 THandle UnlimitedHandleResource<THandle, TStruct, typeValue, TMutex>::Allocate(
     Args&&... args) {
-#ifdef _MSC_VER  // work around VS2019 16.4.0 bug
-  std::scoped_lock<TMutex> lock(m_handleMutex);
-#else
   std::scoped_lock sync(m_handleMutex);
-#endif
   size_t i;
   for (i = 0; i < m_structures.size(); i++) {
     if (m_structures[i] == nullptr) {

--- a/hal/src/main/native/include/hal/simulation/SimCallbackRegistry.h
+++ b/hal/src/main/native/include/hal/simulation/SimCallbackRegistry.h
@@ -79,11 +79,7 @@ class SimCallbackRegistry : public impl::SimCallbackRegistryBase {
 
   template <typename... U>
   void Invoke(U&&... u) const {
-#ifdef _MSC_VER  // work around VS2019 16.4.0 bug
-    std::scoped_lock<wpi::recursive_spinlock> lock(m_mutex);
-#else
     std::scoped_lock lock(m_mutex);
-#endif
     if (m_callbacks) {
       const char* name = GetName();
       for (auto&& cb : *m_callbacks) {

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -44,11 +44,7 @@ class SimPeriodicCallbackRegistry : public impl::SimCallbackRegistryBase {
   }
 
   void operator()() const {
-#ifdef _MSC_VER  // work around VS2019 16.4.0 bug
-    std::scoped_lock<wpi::recursive_spinlock> lock(m_mutex);
-#else
     std::scoped_lock lock(m_mutex);
-#endif
     if (m_callbacks) {
       for (auto&& cb : *m_callbacks) {
         reinterpret_cast<HALSIM_SimPeriodicCallback>(cb.callback)(cb.param);


### PR DESCRIPTION
Mostly reverts #2171.