### PR TITLE
[wpilibc] Check for invalid handle in destructors (pt 2)

### DIFF
--- a/wpilibc/src/main/native/cpp/Counter.cpp
+++ b/wpilibc/src/main/native/cpp/Counter.cpp
@@ -84,10 +84,12 @@ Counter::Counter(EncodingType encodingType,
 }
 
 Counter::~Counter() {
-  try {
-    SetUpdateWhenEmpty(true);
-  } catch (const RuntimeError& e) {
-    e.Report();
+  if (m_counter != HAL_kInvalidHandle) {
+    try {
+      SetUpdateWhenEmpty(true);
+    } catch (const RuntimeError& e) {
+      e.Report();
+    }
   }
 }
 

--- a/wpilibc/src/main/native/cpp/DigitalOutput.cpp
+++ b/wpilibc/src/main/native/cpp/DigitalOutput.cpp
@@ -37,11 +37,13 @@ DigitalOutput::DigitalOutput(int channel) {
 }
 
 DigitalOutput::~DigitalOutput() {
-  // Disable the PWM in case it was running.
-  try {
-    DisablePWM();
-  } catch (const RuntimeError& e) {
-    e.Report();
+  if (m_handle != HAL_kInvalidHandle) {
+    // Disable the PWM in case it was running.
+    try {
+      DisablePWM();
+    } catch (const RuntimeError& e) {
+      e.Report();
+    }
   }
 }
 

--- a/wpilibc/src/main/native/cpp/PWM.cpp
+++ b/wpilibc/src/main/native/cpp/PWM.cpp
@@ -45,9 +45,11 @@ PWM::PWM(int channel, bool registerSendable) {
 }
 
 PWM::~PWM() {
-  int32_t status = 0;
-  HAL_SetPWMDisabled(m_handle, &status);
-  FRC_ReportError(status, "Channel {}", m_channel);
+  if (m_handle != HAL_kInvalidHandle) {
+    int32_t status = 0;
+    HAL_SetPWMDisabled(m_handle, &status);
+    FRC_ReportError(status, "Channel {}", m_channel);
+  }
 }
 
 void PWM::SetPulseTime(units::microsecond_t time) {

--- a/wpilibc/src/main/native/cpp/Relay.cpp
+++ b/wpilibc/src/main/native/cpp/Relay.cpp
@@ -61,8 +61,12 @@ Relay::Relay(int channel, Relay::Direction direction)
 
 Relay::~Relay() {
   int32_t status = 0;
-  HAL_SetRelay(m_forwardHandle, false, &status);
-  HAL_SetRelay(m_reverseHandle, false, &status);
+  if (m_forwardHandle != HAL_kInvalidHandle) {
+    HAL_SetRelay(m_forwardHandle, false, &status);
+  }
+  if (m_reverseHandle != HAL_kInvalidHandle) {
+    HAL_SetRelay(m_reverseHandle, false, &status);
+  }
 }
 
 void Relay::Set(Relay::Value value) {

--- a/wpilibc/src/main/native/cpp/TimedRobot.cpp
+++ b/wpilibc/src/main/native/cpp/TimedRobot.cpp
@@ -90,10 +90,11 @@ TimedRobot::TimedRobot(units::second_t period) : IterativeRobotBase(period) {
 }
 
 TimedRobot::~TimedRobot() {
-  int32_t status = 0;
-
-  HAL_StopNotifier(m_notifier, &status);
-  FRC_ReportError(status, "StopNotifier");
+  if (m_notifier != HAL_kInvalidHandle) {
+    int32_t status = 0;
+    HAL_StopNotifier(m_notifier, &status);
+    FRC_ReportError(status, "StopNotifier");
+  }
 }
 
 void TimedRobot::AddPeriodic(std::function<void()> callback,


### PR DESCRIPTION
Moved-from objects have invalid handles.

I *think* that's everything that uses a handle and does something with it in the destructor.