### PR TITLE
[glass] Align Field2d border and image padding for custom images

### DIFF
--- a/glass/src/lib/native/cpp/other/Field2D.cpp
+++ b/glass/src/lib/native/cpp/other/Field2D.cpp
@@ -591,6 +591,12 @@ FieldFrameData FieldInfo::GetFrameData(ImVec2 min, ImVec2 max) const {
     max.x -= 20;
     min.y += 20;
     max.y -= 20;
+
+    // also pad the image so it's the same size as the box
+    ffd.imageMin.x += 20;
+    ffd.imageMax.x -= 20;
+    ffd.imageMin.y += 20;
+    ffd.imageMax.y -= 20;
   }
 
   ffd.min = min;


### PR DESCRIPTION
Aligns the yellow border and the image for the Field2d widget when using a custom image without JSON.

Potential fix for #7211 

Before: 
![Screenshot from 2024-10-15 17-46-35](https://github.com/user-attachments/assets/ea17640c-34a4-4e62-a205-cd190e29bf4a)
After:
![Screenshot from 2024-10-15 23-28-41](https://github.com/user-attachments/assets/26fd06db-2cf2-4852-8d68-35d20618c2d6)
