### PR TITLE
[wpilibc] SPI & I2C: Use handle wrapper to close port

### DIFF
--- a/hal/src/main/native/include/hal/I2CTypes.h
+++ b/hal/src/main/native/include/hal/I2CTypes.h
@@ -19,16 +19,4 @@ HAL_ENUM(HAL_I2CPort) {
   HAL_I2C_kOnboard,
   HAL_I2C_kMXP
 };
-
-#ifdef __cplusplus
-namespace hal {
-
-/**
- * A move-only C++ wrapper around HAL_I2CPort.
- * Does not ensure destruction.
- */
-using I2CPort = Handle<HAL_I2CPort, nullptr, HAL_I2C_kInvalid>;
-
-}  // namespace hal
-#endif
 /** @} */

--- a/hal/src/main/native/include/hal/SPITypes.h
+++ b/hal/src/main/native/include/hal/SPITypes.h
@@ -41,16 +41,4 @@ HAL_ENUM(HAL_SPIMode) {
   /** Clock idle high, data sampled on rising edge. */
   HAL_SPI_kMode3 = 3,
 };
-
-#ifdef __cplusplus
-namespace hal {
-
-/**
- * A move-only C++ wrapper around HAL_SPIPort.
- * Does not ensure destruction.
- */
-using SPIPort = Handle<HAL_SPIPort, nullptr, HAL_SPI_kInvalid>;
-
-}  // namespace hal
-#endif
 /** @} */

--- a/wpilibc/src/main/native/cpp/SPI.cpp
+++ b/wpilibc/src/main/native/cpp/SPI.cpp
@@ -165,8 +165,6 @@ SPI::SPI(Port port) : m_port(static_cast<HAL_SPIPort>(port)) {
              static_cast<uint8_t>(port) + 1);
 }
 
-SPI::~SPI() = default;
-
 SPI::Port SPI::GetPort() const {
   return static_cast<Port>(static_cast<int>(m_port));
 }

--- a/wpilibc/src/main/native/cpp/SPI.cpp
+++ b/wpilibc/src/main/native/cpp/SPI.cpp
@@ -165,6 +165,8 @@ SPI::SPI(Port port) : m_port(static_cast<HAL_SPIPort>(port)) {
              static_cast<uint8_t>(port) + 1);
 }
 
+SPI::~SPI() = default;
+
 SPI::Port SPI::GetPort() const {
   return static_cast<Port>(static_cast<int>(m_port));
 }

--- a/wpilibc/src/main/native/include/frc/I2C.h
+++ b/wpilibc/src/main/native/include/frc/I2C.h
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 
+#include <hal/I2C.h>
 #include <hal/I2CTypes.h>
 
 namespace frc {
@@ -156,7 +157,7 @@ class I2C {
   bool VerifySensor(int registerAddress, int count, const uint8_t* expected);
 
  private:
-  hal::I2CPort m_port;
+  hal::Handle<HAL_I2CPort, HAL_CloseI2C, HAL_I2C_kInvalid> m_port;
   int m_deviceAddress;
 };
 

--- a/wpilibc/src/main/native/include/frc/SPI.h
+++ b/wpilibc/src/main/native/include/frc/SPI.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <span>
 
+#include <hal/SPI.h>
 #include <hal/SPITypes.h>
 #include <units/time.h>
 
@@ -356,7 +357,7 @@ class SPI {
   double GetAccumulatorIntegratedAverage() const;
 
  protected:
-  hal::SPIPort m_port;
+  hal::Handle<HAL_SPIPort, HAL_CloseSPI, HAL_SPI_kInvalid> m_port;
   HAL_SPIMode m_mode = HAL_SPIMode::HAL_SPI_kMode0;
 
  private:


### PR DESCRIPTION
This was overlooked by mistake in #7016. The destructors were removed but the handle wrappers didn't handle closing the ports. 