### PR TITLE
[glass] Add Alerts widget

### DIFF
--- a/glass/src/lib/native/cpp/other/Alerts.cpp
+++ b/glass/src/lib/native/cpp/other/Alerts.cpp
@@ -4,6 +4,7 @@
 
 #include "glass/other/Alerts.h"
 
+#include <IconsFontAwesome6.h>
 #include <imgui.h>
 
 using namespace glass;
@@ -18,14 +19,15 @@ void glass::DisplayAlerts(AlertsModel* model) {
   const ImVec4 kErrorColor{1.0, 0.33, 0.33, 1.0};
 
   // show higher severity alerts on top
-
   for (auto&& error : errors) {
-    ImGui::TextColored(kErrorColor, "Error: %s", error.c_str());
+    ImGui::TextColored(kErrorColor, "%s %s", ICON_FA_CIRCLE_XMARK,
+                       error.c_str());
   }
   for (auto&& warning : warnings) {
-    ImGui::TextColored(kWarningColor, "Warning: %s", warning.c_str());
+    ImGui::TextColored(kWarningColor, "%s %s", ICON_FA_TRIANGLE_EXCLAMATION,
+                       warning.c_str());
   }
   for (auto&& info : infos) {
-    ImGui::TextColored(kInfoColor, "Info: %s", info.c_str());
+    ImGui::TextColored(kInfoColor, "%s %s", ICON_FA_CIRCLE_INFO, info.c_str());
   }
 }

--- a/glass/src/lib/native/cpp/other/Alerts.cpp
+++ b/glass/src/lib/native/cpp/other/Alerts.cpp
@@ -13,16 +13,19 @@ void glass::DisplayAlerts(AlertsModel* model) {
   auto& warnings = model->GetWarnings();
   auto& errors = model->GetErrors();
 
-  // TODO: Icons? Colors?
+  const ImVec4 kInfoColor{1.0, 1.0, 1.0, 1.0};
+  const ImVec4 kWarningColor{1.0, 0.66, 0.0, 1.0};
+  const ImVec4 kErrorColor{1.0, 0.33, 0.33, 1.0};
 
   // show higher severity alerts on top
+
   for (auto&& error : errors) {
-    ImGui::Text("E: %s", error.c_str());
+    ImGui::TextColored(kErrorColor, "Error: %s", error.c_str());
   }
   for (auto&& warning : warnings) {
-    ImGui::Text("W: %s", warning.c_str());
+    ImGui::TextColored(kWarningColor, "Warning: %s", warning.c_str());
   }
   for (auto&& info : infos) {
-    ImGui::Text("I: %s", info.c_str());
+    ImGui::TextColored(kInfoColor, "Info: %s", info.c_str());
   }
 }

--- a/glass/src/lib/native/cpp/other/Alerts.cpp
+++ b/glass/src/lib/native/cpp/other/Alerts.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "glass/other/Alerts.h"
+
+#include <imgui.h>
+
+using namespace glass;
+
+void glass::DisplayAlerts(AlertsModel* model) {
+  auto& infos = model->GetInfos();
+  auto& warnings = model->GetWarnings();
+  auto& errors = model->GetErrors();
+
+  // TODO: Icons? Colors?
+
+  // show higher severity alerts on top
+  for (auto&& error : errors) {
+    ImGui::Text("E: %s", error.c_str());
+  }
+  for (auto&& warning : warnings) {
+    ImGui::Text("W: %s", warning.c_str());
+  }
+  for (auto&& info : infos) {
+    ImGui::Text("I: %s", info.c_str());
+  }
+}

--- a/glass/src/lib/native/cpp/other/Alerts.cpp
+++ b/glass/src/lib/native/cpp/other/Alerts.cpp
@@ -14,9 +14,9 @@ void glass::DisplayAlerts(AlertsModel* model) {
   auto& warnings = model->GetWarnings();
   auto& errors = model->GetErrors();
 
-  const ImVec4 kInfoColor{1.0, 1.0, 1.0, 1.0};
-  const ImVec4 kWarningColor{1.0, 0.66, 0.0, 1.0};
-  const ImVec4 kErrorColor{1.0, 0.33, 0.33, 1.0};
+  const ImVec4 kInfoColor{1.0f, 1.0f, 1.0f, 1.0f};
+  const ImVec4 kWarningColor{1.0f, 0.66f, 0.0f, 1.0f};
+  const ImVec4 kErrorColor{1.0f, 0.33f, 0.33f, 1.0f};
 
   // show higher severity alerts on top
   for (auto&& error : errors) {

--- a/glass/src/lib/native/cpp/other/Alerts.cpp
+++ b/glass/src/lib/native/cpp/other/Alerts.cpp
@@ -14,9 +14,8 @@ void glass::DisplayAlerts(AlertsModel* model) {
   auto& warnings = model->GetWarnings();
   auto& errors = model->GetErrors();
 
-  const ImVec4 kInfoColor{1.0f, 1.0f, 1.0f, 1.0f};
-  const ImVec4 kWarningColor{1.0f, 0.66f, 0.0f, 1.0f};
-  const ImVec4 kErrorColor{1.0f, 0.33f, 0.33f, 1.0f};
+  const ImVec4 kWarningColor{0.85f, 0.56f, 0.0f, 1.0f};
+  const ImVec4 kErrorColor{0.9f, 0.25f, 0.25f, 1.0f};
 
   // show higher severity alerts on top
   for (auto&& error : errors) {
@@ -28,6 +27,6 @@ void glass::DisplayAlerts(AlertsModel* model) {
                        warning.c_str());
   }
   for (auto&& info : infos) {
-    ImGui::TextColored(kInfoColor, "%s %s", ICON_FA_CIRCLE_INFO, info.c_str());
+    ImGui::Text("%s %s", ICON_FA_CIRCLE_INFO, info.c_str());
   }
 }

--- a/glass/src/lib/native/include/glass/other/Alerts.h
+++ b/glass/src/lib/native/include/glass/other/Alerts.h
@@ -1,0 +1,23 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "glass/Model.h"
+
+namespace glass {
+
+class AlertsModel : public Model {
+ public:
+  virtual const std::vector<std::string>& GetInfos() = 0;
+  virtual const std::vector<std::string>& GetWarnings() = 0;
+  virtual const std::vector<std::string>& GetErrors() = 0;
+};
+
+void DisplayAlerts(AlertsModel* model);
+
+}  // namespace glass

--- a/glass/src/libnt/native/cpp/NTAlerts.cpp
+++ b/glass/src/libnt/native/cpp/NTAlerts.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "glass/networktables/NTAlerts.h"
+
+#include <utility>
+
+#include <fmt/format.h>
+
+using namespace glass;
+
+NTAlertsModel::NTAlertsModel(std::string_view path)
+    : NTAlertsModel{nt::NetworkTableInstance::GetDefault(), path} {}
+
+NTAlertsModel::NTAlertsModel(nt::NetworkTableInstance inst,
+			     std::string_view path)
+    : m_inst{inst},
+      m_infos{m_inst.GetStringArrayTopic(fmt::format("{}/infos", path))
+                  .Subscribe({})},
+      m_warnings{m_inst.GetStringArrayTopic(fmt::format("{}/warnings", path))
+                     .Subscribe({})},
+      m_errors{m_inst.GetStringArrayTopic(fmt::format("{}/errors", path))
+                   .Subscribe({})} {}
+
+void NTAlertsModel::Update() {
+  if (!m_infos.Exists()) {
+    m_infosValue.clear();
+  }
+  for (auto&& v : m_infos.ReadQueue()) {
+    m_infosValue = std::move(v.value);
+  }
+
+  if (!m_warnings.Exists()) {
+    m_warningsValue.clear();
+  }
+  for (auto&& v : m_warnings.ReadQueue()) {
+    m_warningsValue = std::move(v.value);
+  }
+
+  if (!m_errors.Exists()) {
+    m_errorsValue.clear();
+  }
+  for (auto&& v : m_errors.ReadQueue()) {
+    m_errorsValue = std::move(v.value);
+  }
+}
+
+bool NTAlertsModel::Exists() {
+  return m_infos.Exists();
+}

--- a/glass/src/libnt/native/cpp/NTAlerts.cpp
+++ b/glass/src/libnt/native/cpp/NTAlerts.cpp
@@ -14,7 +14,7 @@ NTAlertsModel::NTAlertsModel(std::string_view path)
     : NTAlertsModel{nt::NetworkTableInstance::GetDefault(), path} {}
 
 NTAlertsModel::NTAlertsModel(nt::NetworkTableInstance inst,
-			     std::string_view path)
+                             std::string_view path)
     : m_inst{inst},
       m_infos{m_inst.GetStringArrayTopic(fmt::format("{}/infos", path))
                   .Subscribe({})},

--- a/glass/src/libnt/native/cpp/StandardNetworkTables.cpp
+++ b/glass/src/libnt/native/cpp/StandardNetworkTables.cpp
@@ -32,9 +32,8 @@ void glass::AddStandardNetworkTablesViews(NetworkTablesProvider& provider) {
       },
       [](Window* win, Model* model, const char*) {
         win->SetDefaultSize(300, 150);
-        return MakeFunctionView([=] {
-          DisplayAlerts(static_cast<NTAlertsModel*>(model));
-        });
+        return MakeFunctionView(
+            [=] { DisplayAlerts(static_cast<NTAlertsModel*>(model)); });
       });
   provider.Register(
       NTCommandSchedulerModel::kType,

--- a/glass/src/libnt/native/cpp/StandardNetworkTables.cpp
+++ b/glass/src/libnt/native/cpp/StandardNetworkTables.cpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 
+#include "glass/networktables/NTAlerts.h"
 #include "glass/networktables/NTCommandScheduler.h"
 #include "glass/networktables/NTCommandSelector.h"
 #include "glass/networktables/NTDifferentialDrive.h"
@@ -24,6 +25,17 @@
 using namespace glass;
 
 void glass::AddStandardNetworkTablesViews(NetworkTablesProvider& provider) {
+  provider.Register(
+      NTAlertsModel::kType,
+      [](nt::NetworkTableInstance inst, const char* path) {
+        return std::make_unique<NTAlertsModel>(inst, path);
+      },
+      [](Window* win, Model* model, const char*) {
+        win->SetDefaultSize(300, 150);
+        return MakeFunctionView([=] {
+          DisplayAlerts(static_cast<NTAlertsModel*>(model));
+        });
+      });
   provider.Register(
       NTCommandSchedulerModel::kType,
       [](nt::NetworkTableInstance inst, const char* path) {

--- a/glass/src/libnt/native/include/glass/networktables/NTAlerts.h
+++ b/glass/src/libnt/native/include/glass/networktables/NTAlerts.h
@@ -1,0 +1,53 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <networktables/NetworkTableInstance.h>
+#include <networktables/StringArrayTopic.h>
+
+#include "glass/other/Alerts.h"
+
+namespace glass {
+
+class NTAlertsModel : public AlertsModel {
+ public:
+  static constexpr const char* kType = "Alerts";
+
+  // path is to the table containing ".type", excluding the trailing /
+  explicit NTAlertsModel(std::string_view path);
+  NTAlertsModel(nt::NetworkTableInstance inst, std::string_view path);
+
+  const std::vector<std::string>& GetInfos() override {
+    return m_infosValue;
+  }
+
+  const std::vector<std::string>& GetWarnings() override {
+    return m_warningsValue;
+  }
+
+  const std::vector<std::string>& GetErrors() override {
+    return m_errorsValue;
+  }
+
+  void Update() override;
+  bool Exists() override;
+  bool IsReadOnly() override { return false; }
+
+ private:
+  nt::NetworkTableInstance m_inst;
+  nt::StringArraySubscriber m_infos;
+  nt::StringArraySubscriber m_warnings;
+  nt::StringArraySubscriber m_errors;
+
+  std::vector<std::string> m_infosValue;
+  std::vector<std::string> m_warningsValue;
+  std::vector<std::string> m_errorsValue;
+};
+
+}  // namespace glass

--- a/glass/src/libnt/native/include/glass/networktables/NTAlerts.h
+++ b/glass/src/libnt/native/include/glass/networktables/NTAlerts.h
@@ -23,17 +23,13 @@ class NTAlertsModel : public AlertsModel {
   explicit NTAlertsModel(std::string_view path);
   NTAlertsModel(nt::NetworkTableInstance inst, std::string_view path);
 
-  const std::vector<std::string>& GetInfos() override {
-    return m_infosValue;
-  }
+  const std::vector<std::string>& GetInfos() override { return m_infosValue; }
 
   const std::vector<std::string>& GetWarnings() override {
     return m_warningsValue;
   }
 
-  const std::vector<std::string>& GetErrors() override {
-    return m_errorsValue;
-  }
+  const std::vector<std::string>& GetErrors() override { return m_errorsValue; }
 
   void Update() override;
   bool Exists() override;


### PR DESCRIPTION
This adds a widget to Glass for the Alerts published with https://github.com/wpilibsuite/allwpilib/blob/main/wpilibj/src/main/java/edu/wpi/first/wpilibj/Alert.java.

![Screenshot from 2024-10-16 11-53-14](https://github.com/user-attachments/assets/bf4011c2-a013-4cc7-b560-b20b74425897)

Currently the types of messages are distinguished by a label and by color. I think it would be nice to add icons like this:
https://raw.githubusercontent.com/Mechanical-Advantage/NetworkAlerts/main/example.png
The icons would be nice to make it more obvious and be helpful for people with color blindness. I'm not sure what the best way to do that is, so I would appreciate help with it.