### PR TITLE
[wpiutil] Make circular buffer classes constexpr

### DIFF
--- a/wpiutil/src/main/native/include/wpi/circular_buffer.h
+++ b/wpiutil/src/main/native/include/wpi/circular_buffer.h
@@ -24,12 +24,12 @@ class circular_buffer {
    *
    * @param size Maximum number of buffer elements.
    */
-  explicit circular_buffer(size_t size) : m_data(size, T{}) {}
+  constexpr explicit circular_buffer(size_t size) : m_data(size, T{}) {}
 
-  circular_buffer(const circular_buffer&) = default;
-  circular_buffer& operator=(const circular_buffer&) = default;
-  circular_buffer(circular_buffer&&) = default;
-  circular_buffer& operator=(circular_buffer&&) = default;
+  constexpr circular_buffer(const circular_buffer&) = default;
+  constexpr circular_buffer& operator=(const circular_buffer&) = default;
+  constexpr circular_buffer(circular_buffer&&) = default;
+  constexpr circular_buffer& operator=(circular_buffer&&) = default;
 
   class iterator {
    public:
@@ -39,20 +39,20 @@ class circular_buffer {
     using pointer = T*;
     using reference = T&;
 
-    iterator(circular_buffer* buffer, size_t index)
+    constexpr iterator(circular_buffer* buffer, size_t index)
         : m_buffer{buffer}, m_index{index} {}
 
-    iterator& operator++() {
+    constexpr iterator& operator++() {
       ++m_index;
       return *this;
     }
-    iterator operator++(int) {
+    constexpr iterator operator++(int) {
       iterator retval = *this;
       ++(*this);
       return retval;
     }
-    bool operator==(const iterator&) const = default;
-    reference operator*() { return (*m_buffer)[m_index]; }
+    constexpr bool operator==(const iterator&) const = default;
+    constexpr reference operator*() { return (*m_buffer)[m_index]; }
 
    private:
     circular_buffer* m_buffer;
@@ -67,53 +67,55 @@ class circular_buffer {
     using pointer = T*;
     using const_reference = const T&;
 
-    const_iterator(const circular_buffer* buffer, size_t index)
+    constexpr const_iterator(const circular_buffer* buffer, size_t index)
         : m_buffer{buffer}, m_index{index} {}
 
-    const_iterator& operator++() {
+    constexpr const_iterator& operator++() {
       ++m_index;
       return *this;
     }
-    const_iterator operator++(int) {
+    constexpr const_iterator operator++(int) {
       const_iterator retval = *this;
       ++(*this);
       return retval;
     }
-    bool operator==(const const_iterator&) const = default;
-    const_reference operator*() const { return (*m_buffer)[m_index]; }
+    constexpr bool operator==(const const_iterator&) const = default;
+    constexpr const_reference operator*() const { return (*m_buffer)[m_index]; }
 
    private:
     const circular_buffer* m_buffer;
     size_t m_index;
   };
 
-  iterator begin() { return iterator(this, 0); }
-  iterator end() { return iterator(this, ::wpi::circular_buffer<T>::size()); }
+  constexpr iterator begin() { return iterator(this, 0); }
+  constexpr iterator end() {
+    return iterator(this, ::wpi::circular_buffer<T>::size());
+  }
 
-  const_iterator begin() const { return const_iterator(this, 0); }
-  const_iterator end() const {
+  constexpr const_iterator begin() const { return const_iterator(this, 0); }
+  constexpr const_iterator end() const {
     return const_iterator(this, ::wpi::circular_buffer<T>::size());
   }
 
-  const_iterator cbegin() const { return const_iterator(this, 0); }
-  const_iterator cend() const {
+  constexpr const_iterator cbegin() const { return const_iterator(this, 0); }
+  constexpr const_iterator cend() const {
     return const_iterator(this, ::wpi::circular_buffer<T>::size());
   }
 
   /**
    * Returns number of elements in buffer
    */
-  size_t size() const { return m_length; }
+  constexpr size_t size() const { return m_length; }
 
   /**
    * Returns value at front of buffer
    */
-  T& front() { return (*this)[0]; }
+  constexpr T& front() { return (*this)[0]; }
 
   /**
    * Returns value at front of buffer
    */
-  const T& front() const { return (*this)[0]; }
+  constexpr const T& front() const { return (*this)[0]; }
 
   /**
    * Returns value at back of buffer
@@ -121,7 +123,9 @@ class circular_buffer {
    * If there are no elements in the buffer, calling this function results in
    * undefined behavior.
    */
-  T& back() { return m_data[(m_front + m_length - 1) % m_data.size()]; }
+  constexpr T& back() {
+    return m_data[(m_front + m_length - 1) % m_data.size()];
+  }
 
   /**
    * Returns value at back of buffer
@@ -129,7 +133,7 @@ class circular_buffer {
    * If there are no elements in the buffer, calling this function results in
    * undefined behavior.
    */
-  const T& back() const {
+  constexpr const T& back() const {
     return m_data[(m_front + m_length - 1) % m_data.size()];
   }
 
@@ -138,7 +142,7 @@ class circular_buffer {
    *
    * The value at the back is overwritten if the buffer is full.
    */
-  void push_front(T value) {
+  constexpr void push_front(T value) {
     if (m_data.size() == 0) {
       return;
     }
@@ -157,7 +161,7 @@ class circular_buffer {
    *
    * The value at the front is overwritten if the buffer is full.
    */
-  void push_back(T value) {
+  constexpr void push_back(T value) {
     if (m_data.size() == 0) {
       return;
     }
@@ -179,7 +183,7 @@ class circular_buffer {
    * The value at the back is overwritten if the buffer is full.
    */
   template <class... Args>
-  void emplace_front(Args&&... args) {
+  constexpr void emplace_front(Args&&... args) {
     if (m_data.size() == 0) {
       return;
     }
@@ -200,7 +204,7 @@ class circular_buffer {
    * The value at the front is overwritten if the buffer is full.
    */
   template <class... Args>
-  void emplace_back(Args&&... args) {
+  constexpr void emplace_back(Args&&... args) {
     if (m_data.size() == 0) {
       return;
     }
@@ -221,7 +225,7 @@ class circular_buffer {
    * If there are no elements in the buffer, calling this function results in
    * undefined behavior.
    */
-  T pop_front() {
+  constexpr T pop_front() {
     T& temp = m_data[m_front];
     m_front = ModuloInc(m_front);
     m_length--;
@@ -234,7 +238,7 @@ class circular_buffer {
    * If there are no elements in the buffer, calling this function results in
    * undefined behavior.
    */
-  T pop_back() {
+  constexpr T pop_back() {
     m_length--;
     return m_data[(m_front + m_length) % m_data.size()];
   }
@@ -242,7 +246,7 @@ class circular_buffer {
   /**
    * Resizes internal buffer to given size.
    */
-  void resize(size_t size) {
+  constexpr void resize(size_t size) {
     if (size > m_data.size()) {
       // Find end of buffer
       size_t insertLocation = (m_front + m_length) % m_data.size();
@@ -294,7 +298,7 @@ class circular_buffer {
   /**
    * Empties internal buffer.
    */
-  void reset() {
+  constexpr void reset() {
     m_front = 0;
     m_length = 0;
   }
@@ -302,14 +306,14 @@ class circular_buffer {
   /**
    * @return Element at index starting from front of buffer.
    */
-  T& operator[](size_t index) {
+  constexpr T& operator[](size_t index) {
     return m_data[(m_front + index) % m_data.size()];
   }
 
   /**
    * @return Element at index starting from front of buffer.
    */
-  const T& operator[](size_t index) const {
+  constexpr const T& operator[](size_t index) const {
     return m_data[(m_front + index) % m_data.size()];
   }
 
@@ -328,7 +332,9 @@ class circular_buffer {
    * @param index Index into the buffer.
    * @return The incremented index.
    */
-  size_t ModuloInc(size_t index) { return (index + 1) % m_data.size(); }
+  constexpr size_t ModuloInc(size_t index) {
+    return (index + 1) % m_data.size();
+  }
 
   /**
    * Decrement an index modulo the size of the buffer.
@@ -336,7 +342,7 @@ class circular_buffer {
    * @param index Index into the buffer.
    * @return The decremented index.
    */
-  size_t ModuloDec(size_t index) {
+  constexpr size_t ModuloDec(size_t index) {
     if (index == 0) {
       return m_data.size() - 1;
     } else {

--- a/wpiutil/src/main/native/include/wpi/static_circular_buffer.h
+++ b/wpiutil/src/main/native/include/wpi/static_circular_buffer.h
@@ -30,20 +30,20 @@ class static_circular_buffer {
     using pointer = T*;
     using reference = T&;
 
-    iterator(static_circular_buffer* buffer, size_t index)
+    constexpr iterator(static_circular_buffer* buffer, size_t index)
         : m_buffer{buffer}, m_index{index} {}
 
-    iterator& operator++() {
+    constexpr iterator& operator++() {
       ++m_index;
       return *this;
     }
-    iterator operator++(int) {
+    constexpr iterator operator++(int) {
       iterator retval = *this;
       ++(*this);
       return retval;
     }
-    bool operator==(const iterator&) const = default;
-    reference operator*() { return (*m_buffer)[m_index]; }
+    constexpr bool operator==(const iterator&) const = default;
+    constexpr reference operator*() { return (*m_buffer)[m_index]; }
 
    private:
     static_circular_buffer* m_buffer;
@@ -58,20 +58,20 @@ class static_circular_buffer {
     using pointer = T*;
     using const_reference = const T&;
 
-    const_iterator(const static_circular_buffer* buffer, size_t index)
+    constexpr const_iterator(const static_circular_buffer* buffer, size_t index)
         : m_buffer{buffer}, m_index{index} {}
 
-    const_iterator& operator++() {
+    constexpr const_iterator& operator++() {
       ++m_index;
       return *this;
     }
-    const_iterator operator++(int) {
+    constexpr const_iterator operator++(int) {
       const_iterator retval = *this;
       ++(*this);
       return retval;
     }
-    bool operator==(const const_iterator&) const = default;
-    const_reference operator*() const { return (*m_buffer)[m_index]; }
+    constexpr bool operator==(const const_iterator&) const = default;
+    constexpr const_reference operator*() const { return (*m_buffer)[m_index]; }
 
    private:
     const static_circular_buffer* m_buffer;
@@ -81,53 +81,53 @@ class static_circular_buffer {
   /**
    * Returns begin iterator.
    */
-  iterator begin() { return iterator(this, 0); }
+  constexpr iterator begin() { return iterator(this, 0); }
 
   /**
    * Returns end iterator.
    */
-  iterator end() {
+  constexpr iterator end() {
     return iterator(this, ::wpi::static_circular_buffer<T, N>::size());
   }
 
   /**
    * Returns begin iterator.
    */
-  const_iterator begin() const { return const_iterator(this, 0); }
+  constexpr const_iterator begin() const { return const_iterator(this, 0); }
 
   /**
    * Returns end iterator.
    */
-  const_iterator end() const {
+  constexpr const_iterator end() const {
     return const_iterator(this, ::wpi::static_circular_buffer<T, N>::size());
   }
 
   /**
    * Returns begin iterator.
    */
-  const_iterator cbegin() const { return const_iterator(this, 0); }
+  constexpr const_iterator cbegin() const { return const_iterator(this, 0); }
 
   /**
    * Returns end iterator.
    */
-  const_iterator cend() const {
+  constexpr const_iterator cend() const {
     return const_iterator(this, ::wpi::static_circular_buffer<T, N>::size());
   }
 
   /**
    * Returns number of elements in buffer
    */
-  size_t size() const { return m_length; }
+  constexpr size_t size() const { return m_length; }
 
   /**
    * Returns value at front of buffer
    */
-  T& front() { return (*this)[0]; }
+  constexpr T& front() { return (*this)[0]; }
 
   /**
    * Returns value at front of buffer
    */
-  const T& front() const { return (*this)[0]; }
+  constexpr const T& front() const { return (*this)[0]; }
 
   /**
    * Returns value at back of buffer
@@ -135,7 +135,7 @@ class static_circular_buffer {
    * If there are no elements in the buffer, calling this function results in
    * undefined behavior.
    */
-  T& back() { return m_data[(m_front + m_length - 1) % N]; }
+  constexpr T& back() { return m_data[(m_front + m_length - 1) % N]; }
 
   /**
    * Returns value at back of buffer
@@ -143,14 +143,16 @@ class static_circular_buffer {
    * If there are no elements in the buffer, calling this function results in
    * undefined behavior.
    */
-  const T& back() const { return m_data[(m_front + m_length - 1) % N]; }
+  constexpr const T& back() const {
+    return m_data[(m_front + m_length - 1) % N];
+  }
 
   /**
    * Push a new value onto the front of the buffer.
    *
    * The value at the back is overwritten if the buffer is full.
    */
-  void push_front(T value) {
+  constexpr void push_front(T value) {
     m_front = ModuloDec(m_front);
 
     m_data[m_front] = value;
@@ -165,7 +167,7 @@ class static_circular_buffer {
    *
    * The value at the front is overwritten if the buffer is full.
    */
-  void push_back(T value) {
+  constexpr void push_back(T value) {
     m_data[(m_front + m_length) % N] = value;
 
     if (m_length < N) {
@@ -183,7 +185,7 @@ class static_circular_buffer {
    * The value at the back is overwritten if the buffer is full.
    */
   template <class... Args>
-  void emplace_front(Args&&... args) {
+  constexpr void emplace_front(Args&&... args) {
     m_front = ModuloDec(m_front);
 
     m_data[m_front] = T{args...};
@@ -200,7 +202,7 @@ class static_circular_buffer {
    * The value at the front is overwritten if the buffer is full.
    */
   template <class... Args>
-  void emplace_back(Args&&... args) {
+  constexpr void emplace_back(Args&&... args) {
     m_data[(m_front + m_length) % N] = T{args...};
 
     if (m_length < N) {
@@ -217,7 +219,7 @@ class static_circular_buffer {
    * If there are no elements in the buffer, calling this function results in
    * undefined behavior.
    */
-  T pop_front() {
+  constexpr T pop_front() {
     T& temp = m_data[m_front];
     m_front = ModuloInc(m_front);
     m_length--;
@@ -230,7 +232,7 @@ class static_circular_buffer {
    * If there are no elements in the buffer, calling this function results in
    * undefined behavior.
    */
-  T pop_back() {
+  constexpr T pop_back() {
     m_length--;
     return m_data[(m_front + m_length) % N];
   }
@@ -238,7 +240,7 @@ class static_circular_buffer {
   /**
    * Empties internal buffer.
    */
-  void reset() {
+  constexpr void reset() {
     m_front = 0;
     m_length = 0;
   }
@@ -246,12 +248,14 @@ class static_circular_buffer {
   /**
    * @return Element at index starting from front of buffer.
    */
-  T& operator[](size_t index) { return m_data[(m_front + index) % N]; }
+  constexpr T& operator[](size_t index) {
+    return m_data[(m_front + index) % N];
+  }
 
   /**
    * @return Element at index starting from front of buffer.
    */
-  const T& operator[](size_t index) const {
+  constexpr const T& operator[](size_t index) const {
     return m_data[(m_front + index) % N];
   }
 
@@ -269,14 +273,14 @@ class static_circular_buffer {
    *
    * @return The result of the modulo operation.
    */
-  size_t ModuloInc(size_t index) { return (index + 1) % N; }
+  constexpr size_t ModuloInc(size_t index) { return (index + 1) % N; }
 
   /**
    * Decrement an index modulo the length of the buffer.
    *
    * @return The result of the modulo operation.
    */
-  size_t ModuloDec(size_t index) {
+  constexpr size_t ModuloDec(size_t index) {
     if (index == 0) {
       return N - 1;
     } else {


### PR DESCRIPTION
The circular buffer class that uses std::vector internally can be used in a constant expression as long as it doesn't survive to runtime.