### PR TITLE
[wpimath] Fix C++ pose estimator poseEstimate initialization

### DIFF
--- a/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
@@ -24,4 +24,6 @@ DifferentialDrivePoseEstimator::DifferentialDrivePoseEstimator(
     : PoseEstimator<DifferentialDriveWheelSpeeds,
                     DifferentialDriveWheelPositions>(
           kinematics, m_odometryImpl, stateStdDevs, visionMeasurementStdDevs),
-      m_odometryImpl{gyroAngle, leftDistance, rightDistance, initialPose} {}
+      m_odometryImpl{gyroAngle, leftDistance, rightDistance, initialPose} {
+  ResetPose(m_odometryImpl.GetPose());
+}

--- a/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
@@ -26,4 +26,6 @@ frc::MecanumDrivePoseEstimator::MecanumDrivePoseEstimator(
     const wpi::array<double, 3>& visionMeasurementStdDevs)
     : PoseEstimator<MecanumDriveWheelSpeeds, MecanumDriveWheelPositions>(
           kinematics, m_odometryImpl, stateStdDevs, visionMeasurementStdDevs),
-      m_odometryImpl(kinematics, gyroAngle, wheelPositions, initialPose) {}
+      m_odometryImpl(kinematics, gyroAngle, wheelPositions, initialPose) {
+  ResetPose(m_odometryImpl.GetPose());
+}

--- a/wpimath/src/main/native/include/frc/estimator/PoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/PoseEstimator.h
@@ -45,6 +45,9 @@ class WPILIB_DLLEXPORT PoseEstimator {
   /**
    * Constructs a PoseEstimator.
    *
+   * @warning The initial pose estimate will always be the default pose,
+   * regardless of the odometry's current pose.
+   *
    * @param kinematics A correctly-configured kinematics object for your
    *     drivetrain.
    * @param odometry A correctly-configured odometry object for your drivetrain.
@@ -60,7 +63,7 @@ class WPILIB_DLLEXPORT PoseEstimator {
                 Odometry<WheelSpeeds, WheelPositions>& odometry,
                 const wpi::array<double, 3>& stateStdDevs,
                 const wpi::array<double, 3>& visionMeasurementStdDevs)
-      : m_odometry(odometry), m_poseEstimate(m_odometry.GetPose()) {
+      : m_odometry(odometry) {
     for (size_t i = 0; i < 3; ++i) {
       m_q[i] = stateStdDevs[i] * stateStdDevs[i];
     }
@@ -431,7 +434,7 @@ class WPILIB_DLLEXPORT PoseEstimator {
   // unless there have been no vision measurements after the last reset
   std::map<units::second_t, VisionUpdate> m_visionUpdates;
 
-  Pose2d m_poseEstimate;
+  Pose2d m_poseEstimate{};
 };
 
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/estimator/PoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/PoseEstimator.h
@@ -434,7 +434,7 @@ class WPILIB_DLLEXPORT PoseEstimator {
   // unless there have been no vision measurements after the last reset
   std::map<units::second_t, VisionUpdate> m_visionUpdates;
 
-  Pose2d m_poseEstimate{};
+  Pose2d m_poseEstimate;
 };
 
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
@@ -85,7 +85,9 @@ class SwerveDrivePoseEstimator
       : PoseEstimator<wpi::array<SwerveModuleState, NumModules>,
                       wpi::array<SwerveModulePosition, NumModules>>(
             kinematics, m_odometryImpl, stateStdDevs, visionMeasurementStdDevs),
-        m_odometryImpl{kinematics, gyroAngle, modulePositions, initialPose} {}
+        m_odometryImpl{kinematics, gyroAngle, modulePositions, initialPose} {
+    this->ResetPose(initialPose);
+  }
 
  private:
   SwerveDriveOdometry<NumModules> m_odometryImpl;

--- a/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
@@ -359,8 +359,18 @@ TEST(DifferentialDrivePoseEstimatorTest, TestSampleAt) {
 TEST(DifferentialDrivePoseEstimatorTest, TestReset) {
   frc::DifferentialDriveKinematics kinematics{1_m};
   frc::DifferentialDrivePoseEstimator estimator{
-      kinematics,      frc::Rotation2d{}, 0_m, 0_m, frc::Pose2d{},
-      {1.0, 1.0, 1.0}, {1.0, 1.0, 1.0}};
+      kinematics,
+      frc::Rotation2d{},
+      0_m,
+      0_m,
+      frc::Pose2d{-1_m, -1_m, frc::Rotation2d{1_rad}},
+      {1.0, 1.0, 1.0},
+      {1.0, 1.0, 1.0}};
+
+  // Test initial pose
+  EXPECT_EQ(-1, estimator.GetEstimatedPosition().X().value());
+  EXPECT_EQ(-1, estimator.GetEstimatedPosition().Y().value());
+  EXPECT_EQ(1, estimator.GetEstimatedPosition().Rotation().Radians().value());
 
   // Test reset position
   estimator.ResetPosition(frc::Rotation2d{}, 1_m, 1_m,

--- a/wpimath/src/test/native/cpp/estimator/MecanumDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/MecanumDrivePoseEstimatorTest.cpp
@@ -368,8 +368,17 @@ TEST(MecanumDrivePoseEstimatorTest, TestReset) {
       frc::Translation2d{1_m, 1_m}, frc::Translation2d{1_m, -1_m},
       frc::Translation2d{-1_m, -1_m}, frc::Translation2d{-1_m, 1_m}};
   frc::MecanumDrivePoseEstimator estimator{
-      kinematics,    frc::Rotation2d{}, frc::MecanumDriveWheelPositions{},
-      frc::Pose2d{}, {1.0, 1.0, 1.0},   {1.0, 1.0, 1.0}};
+      kinematics,
+      frc::Rotation2d{},
+      frc::MecanumDriveWheelPositions{},
+      frc::Pose2d{-1_m, -1_m, frc::Rotation2d{1_rad}},
+      {1.0, 1.0, 1.0},
+      {1.0, 1.0, 1.0}};
+
+  // Test initial pose
+  EXPECT_EQ(-1, estimator.GetEstimatedPosition().X().value());
+  EXPECT_EQ(-1, estimator.GetEstimatedPosition().Y().value());
+  EXPECT_EQ(1, estimator.GetEstimatedPosition().Rotation().Radians().value());
 
   // Test reset position
   estimator.ResetPosition(frc::Rotation2d{}, {1_m, 1_m, 1_m, 1_m},

--- a/wpimath/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
@@ -394,9 +394,14 @@ TEST(SwerveDrivePoseEstimatorTest, TestReset) {
       frc::Rotation2d{},
       {frc::SwerveModulePosition{}, frc::SwerveModulePosition{},
        frc::SwerveModulePosition{}, frc::SwerveModulePosition{}},
-      frc::Pose2d{},
+      frc::Pose2d{-1_m, -1_m, frc::Rotation2d{1_rad}},
       {1.0, 1.0, 1.0},
       {1.0, 1.0, 1.0}};
+
+  // Test initial pose
+  EXPECT_EQ(-1, estimator.GetEstimatedPosition().X().value());
+  EXPECT_EQ(-1, estimator.GetEstimatedPosition().Y().value());
+  EXPECT_EQ(1, estimator.GetEstimatedPosition().Rotation().Radians().value());
 
   // Test reset position
   {


### PR DESCRIPTION
Prior to this change, because the base class (`PoseEstimator`) constructor was run before the derived class (e.g., `DifferentialDrivePoseEstimator`) constructor, `m_poseEstimate` would be initialized with `m_odometry.GetPose()` before `m_odometry` was actually initialized. Don't know how this passed asan...

I'm not sure if we should change Java as well, since this part of the initialization already differs.