### PR TITLE
[wpimath] Remove units from trapezoid profile classes

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrapezoidProfile.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrapezoidProfile.java
@@ -6,10 +6,6 @@ package edu.wpi.first.math.trajectory;
 
 import edu.wpi.first.math.MathSharedStore;
 import edu.wpi.first.math.MathUsageId;
-import edu.wpi.first.units.Measure;
-import edu.wpi.first.units.PerUnit;
-import edu.wpi.first.units.TimeUnit;
-import edu.wpi.first.units.Unit;
 import java.util.Objects;
 
 /**
@@ -72,20 +68,6 @@ public class TrapezoidProfile {
       this.maxAcceleration = maxAcceleration;
       MathSharedStore.reportUsage(MathUsageId.kTrajectory_TrapezoidProfile, 1);
     }
-
-    /**
-     * Constructs constraints for a TrapezoidProfile.
-     *
-     * @param <U> Unit type.
-     * @param maxVelocity maximum velocity
-     * @param maxAcceleration maximum acceleration
-     */
-    public <U extends Unit> Constraints(
-        Measure<? extends PerUnit<? extends U, TimeUnit>> maxVelocity,
-        Measure<? extends PerUnit<? extends PerUnit<? extends U, TimeUnit>, TimeUnit>>
-            maxAcceleration) {
-      this(maxVelocity.baseUnitMagnitude(), maxAcceleration.baseUnitMagnitude());
-    }
   }
 
   /** Profile state. */
@@ -108,18 +90,6 @@ public class TrapezoidProfile {
     public State(double position, double velocity) {
       this.position = position;
       this.velocity = velocity;
-    }
-
-    /**
-     * Constructs constraints for a Trapezoid Profile.
-     *
-     * @param <U> Unit type.
-     * @param position The position at this state.
-     * @param velocity The velocity at this state.
-     */
-    public <U extends Unit> State(
-        Measure<U> position, Measure<? extends PerUnit<? extends U, TimeUnit>> velocity) {
-      this(position.baseUnitMagnitude(), velocity.baseUnitMagnitude());
     }
 
     @Override


### PR DESCRIPTION
They were assuming inputs were always going to be in SI units, which is not the case