### PR TITLE
Extend annotation support to all future Java language versions

### DIFF
--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/AnnotationProcessor.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/AnnotationProcessor.java
@@ -48,6 +48,19 @@ public class AnnotationProcessor extends AbstractProcessor {
   private LoggerGenerator m_loggerGenerator;
   private List<ElementHandler> m_handlers;
 
+  /**
+   * Sets the latest supported Java version to the current compiler release.
+   *
+   * @return the release level of the invoked compiler, that is, the
+   *     {@code javac} that is compiling the code, in effect declaring that
+   *     {@link AnnotationProcessor} supports <b>any</b> Java compiler.
+   * @see AbstractProcessor#getSupportedSourceVersion()
+   */
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latestSupported();
+  }
+
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
     if (annotations.isEmpty()) {


### PR DESCRIPTION
Overrode AnnotationProcessor.getSupportedSourceVersion() to return the version of the Java compiler that is currently compiling the code. This assures that the annotation processor will support the latest Java language version.