### PR TITLE
[cscore] Add back VideoProperty handle member initializer

### DIFF
--- a/cscore/src/main/native/include/cscore_oo.h
+++ b/cscore/src/main/native/include/cscore_oo.h
@@ -229,7 +229,7 @@ class VideoProperty {
   CS_Status GetLastStatus() const { return m_status; }
 
  private:
-  explicit VideoProperty(CS_Property handle) {
+  explicit VideoProperty(CS_Property handle) : m_handle(handle) {
     m_status = 0;
     if (handle == 0) {
       m_kind = kNone;


### PR DESCRIPTION
This was lost in #7215.