### PR TITLE
Fix libssh deprecation warnings

### DIFF
--- a/datalogtool/src/main/native/cpp/Sftp.cpp
+++ b/datalogtool/src/main/native/cpp/Sftp.cpp
@@ -75,25 +75,6 @@ size_t File::Read(void* buf, uint32_t count) {
   return rv;
 }
 
-File::AsyncId File::AsyncReadBegin(uint32_t len) const {
-  int rv = sftp_async_read_begin(m_handle, len);
-  if (rv < 0) {
-    throw Exception{m_handle->sftp};
-  }
-  return rv;
-}
-
-size_t File::AsyncRead(void* data, uint32_t len, AsyncId id) {
-  auto rv = sftp_async_read(m_handle, data, len, id);
-  if (rv == SSH_ERROR) {
-    throw Exception{ssh_get_error(m_handle->sftp->session)};
-  }
-  if (rv == SSH_AGAIN) {
-    return 0;
-  }
-  return rv;
-}
-
 size_t File::Write(std::span<const uint8_t> data) {
   auto rv = sftp_write(m_handle, data.data(), data.size());
   if (rv < 0) {

--- a/datalogtool/src/main/native/cpp/Sftp.h
+++ b/datalogtool/src/main/native/cpp/Sftp.h
@@ -47,11 +47,7 @@ class File {
   void SetNonblocking() { sftp_file_set_nonblocking(m_handle); }
   void SetBlocking() { sftp_file_set_blocking(m_handle); }
 
-  using AsyncId = uint32_t;
-
   size_t Read(void* buf, uint32_t count);
-  AsyncId AsyncReadBegin(uint32_t len) const;
-  size_t AsyncRead(void* data, uint32_t len, AsyncId id);
   size_t Write(std::span<const uint8_t> data);
 
   void Seek(uint64_t offset);


### PR DESCRIPTION
```
/home/tav/frc/wpilib/allwpilib/roborioteamnumbersetter/src/main/native/cpp/SshSession.cpp: In member function ‘void rtns::SshSession::Execute(std::string_view)’:
/home/tav/frc/wpilib/allwpilib/roborioteamnumbersetter/src/main/native/cpp/SshSession.cpp:89:44: warning: ‘int ssh_channel_get_exit_status(ssh_channel)’ is deprecated [-Wdeprecated-declarations]
   89 |   INFO("{} {}", ssh_channel_get_exit_status(channel), cmd);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
```
```
/home/tav/frc/wpilib/allwpilib/roborioteamnumbersetter/src/main/native/cpp/SshSession.cpp:139:44: warning: ‘int ssh_channel_get_exit_status(ssh_channel)’ is deprecated [-Wdeprecated-declarations]
  139 |   INFO("{} {}", ssh_channel_get_exit_status(channel), cmd);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
```
```
/home/tav/frc/wpilib/allwpilib/roborioteamnumbersetter/src/main/native/cpp/SshSession.cpp:143:46: warning: ‘int ssh_channel_get_exit_status(ssh_channel)’ is deprecated [-Wdeprecated-declarations]
  143 |     *exitStatus = ssh_channel_get_exit_status(channel);
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
```
```
/home/tav/frc/wpilib/allwpilib/datalogtool/src/main/native/cpp/Sftp.cpp:79:33: warning: ‘int sftp_async_read_begin(sftp_file, uint32_t)’ is deprecated [-Wdeprecated-declarations]
   79 |   int rv = sftp_async_read_begin(m_handle, len);
      |            ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
```
```
/home/tav/frc/wpilib/allwpilib/datalogtool/src/main/native/cpp/Sftp.cpp: In member function ‘size_t sftp::File::AsyncRead(void*, uint32_t, AsyncId)’:
/home/tav/frc/wpilib/allwpilib/datalogtool/src/main/native/cpp/Sftp.cpp:87:28: warning: ‘int sftp_async_read(sftp_file, void*, uint32_t, uint32_t)’ is deprecated [-Wdeprecated-declarations]
   87 |   auto rv = sftp_async_read(m_handle, data, len, id);
      |             ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
```