### PR TITLE
Force wpiutil to depend on new msvc runtime dll

### DIFF
--- a/wpiutil/src/main/java/edu/wpi/first/util/RuntimeLoader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/RuntimeLoader.java
@@ -25,7 +25,7 @@ public final class RuntimeLoader {
         .append('\n');
     if (System.getProperty("os.name").startsWith("Windows")) {
       msg.append(
-          "A common cause of this error is missing or invalid the C++ runtime.\n"
+          "A common cause of this error is a missing or invalid C++ runtime.\n"
               + "Download the latest at https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads\n");
     }
     return msg.toString();

--- a/wpiutil/src/main/java/edu/wpi/first/util/RuntimeLoader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/RuntimeLoader.java
@@ -25,7 +25,7 @@ public final class RuntimeLoader {
         .append('\n');
     if (System.getProperty("os.name").startsWith("Windows")) {
       msg.append(
-          "A common cause of this error is missing the C++ runtime.\n"
+          "A common cause of this error is missing or invalid the C++ runtime.\n"
               + "Download the latest at https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads\n");
     }
     return msg.toString();

--- a/wpiutil/src/main/native/cpp/MutexHack.cpp
+++ b/wpiutil/src/main/native/cpp/MutexHack.cpp
@@ -1,0 +1,12 @@
+#ifdef _WIN32
+#include <threads.h>
+#endif
+
+namespace wpi::hack {
+void CallACThreadFunction() {
+#ifdef _WIN32
+  mtx_t Mtx{};
+  mtx_init(&Mtx, mtx_plain);
+#endif
+}
+}  // namespace wpi::hack

--- a/wpiutil/src/main/native/cpp/MutexHack.cpp
+++ b/wpiutil/src/main/native/cpp/MutexHack.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 #ifdef _WIN32
 #include <threads.h>
 #endif


### PR DESCRIPTION
Newer MSVC runtimes have some silent breaks if older programs are run against them. Additionally, many JVMs include partial MSVC runtimes. Specifically, newer version of mutex require MSVC 17.8 or newer.

VS 17.8 introduced a new satellite DLL for the C11 thread support. If we force wpiutil to depend on that library, then we can guarantee that library is used. That will enforce that a new runtime library is used with a better error message.