### PR TITLE
[bazel] Fix test attempting to upload to readonly cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -38,7 +38,7 @@ build:build_buddy --experimental_profile_include_target_label
 build:build_buddy --experimental_profile_include_primary_output
 build:build_buddy --nolegacy_important_outputs
 
-build:build_buddy_readonly --noremote_upload_local_results
+common:build_buddy_readonly --noremote_upload_local_results
 
 # This config should be used locally. It downloads more than the CI version
 build:remote_user --config=build_buddy


### PR DESCRIPTION
`bazel test` on PRs are attempting to upload test results to the cache, when it doesn't have write access to the cache. [Example logs](https://github.com/wpilibsuite/allwpilib/actions/runs/11420801969/job/31776919754?pr=7231#step:5:565):

```
WARNING: Uploading BEP referenced local file /home/runner/.cache/bazel/_bazel_runner/21cc697b9aacf6d939b45791c283629b/execroot/__main__/bazel-out/k8-opt/testlogs/hal/hal-cpp-test/test.xml hash: "f9a3afd21f34b5b8d94a495dd06000d292b1003d22b8a6d0f9f88b8dccffab1b"
size_bytes: 5493
: FAILED_PRECONDITION: 
  _________________________________________________________________________  
 |                                                                         | 
 |                           Deprecation Notice                            | 
 |                                                                         | 
 |  Anonymous BuildBuddy access is deprecated, and will soon be disabled.  | 
 |                                                                         | 
 |  No BuildBuddy API key was found attached to this build.                | 
 |                                                                         | 
 |  To continue using BuildBuddy, create a free account at                 | 
 |  https://app.buildbuddy.io/ and use the Quick Start guide               | 
 |  to configure your build to use an API key.                             | 
 |                                                                         | 
 |_________________________________________________________________________| 


java.io.IOException: Error while uploading artifact with digest 'f9a3afd21f34b5b8d94a495dd06000d292b1003d22b8a6d0f9f88b8dccffab1b/5493'
	at com.google.devtools.build.lib.remote.ByteStreamUploader.lambda$uploadBlobAsync$0(ByteStreamUploader.java:176)
	at com.google.common.util.concurrent.AbstractCatchingFuture$AsyncCatchingFuture.doFallback(AbstractCatchingFuture.java:205)
```

This fixes `--noremote_upload_local_results` to apply to `bazel test` as well as `bazel build`.