### PR TITLE
[wpilib] Add explanation for HID GetBumper/Touchpad deprecations

### DIFF
--- a/wpilibc/src/generate/main/native/include/frc/hid.h.jinja
+++ b/wpilibc/src/generate/main/native/include/frc/hid.h.jinja
@@ -122,6 +122,9 @@ class {{ ConsoleName }}Controller : public GenericHID,
    * Read the value of the left bumper (LB) button on the controller.
    *
    * @return the state of the button
+   * @deprecated Use GetLeftBumperButton instead. This function is deprecated
+   * for removal to make function names consistent to allow the HID classes to
+   * be automatically generated.
    */
   [[deprecated("Use GetLeftBumperButton instead")]]
   bool GetLeftBumper() const;
@@ -130,6 +133,9 @@ class {{ ConsoleName }}Controller : public GenericHID,
    * Read the value of the right bumper (RB) button on the controller.
    *
    * @return the state of the button
+   * @deprecated Use GetRightBumperButton instead. This function is deprecated
+   * for removal to make function names consistent to allow the HID classes to
+   * be automatically generated.
    */
   [[deprecated("Use GetRightBumperButton instead")]]
   bool GetRightBumper() const;
@@ -138,6 +144,9 @@ class {{ ConsoleName }}Controller : public GenericHID,
    * Whether the left bumper (LB) was pressed since the last check.
    *
    * @return Whether the button was pressed since the last check
+   * @deprecated Use GetLeftBumperButtonPressed instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetLeftBumperButtonPressed instead")]]
   bool GetLeftBumperPressed();
@@ -146,6 +155,9 @@ class {{ ConsoleName }}Controller : public GenericHID,
    * Whether the right bumper (RB) was pressed since the last check.
    *
    * @return Whether the button was pressed since the last check
+   * @deprecated Use GetRightBumperButtonPressed instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetRightBumperButtonPressed instead")]]
   bool GetRightBumperPressed();
@@ -154,6 +166,9 @@ class {{ ConsoleName }}Controller : public GenericHID,
    * Whether the left bumper (LB) was released since the last check.
    *
    * @return Whether the button was released since the last check.
+   * @deprecated Use GetLeftBumperButtonReleased instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetLeftBumperButtonReleased instead")]]
   bool GetLeftBumperReleased();
@@ -162,6 +177,9 @@ class {{ ConsoleName }}Controller : public GenericHID,
    * Whether the right bumper (RB) was released since the last check.
    *
    * @return Whether the button was released since the last check.
+   * @deprecated Use GetRightBumperButtonReleased instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetRightBumperButtonReleased instead")]]
   bool GetRightBumperReleased();
@@ -170,6 +188,9 @@ class {{ ConsoleName }}Controller : public GenericHID,
    * Read the value of the touchpad button on the controller.
    *
    * @return The state of the button.
+   * @deprecated Use GetTouchpadButton instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be
+   * automatically generated.
    */
   [[deprecated("Use GetTouchpadButton instead")]]
   bool GetTouchpad() const;
@@ -177,6 +198,9 @@ class {{ ConsoleName }}Controller : public GenericHID,
    * Whether the touchpad was pressed since the last check.
    *
    * @return Whether the touchpad was pressed since the last check.
+   * @deprecated Use GetTouchpadButtonPressed instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetTouchpadButtonPressed instead")]]
   bool GetTouchpadPressed();
@@ -185,6 +209,9 @@ class {{ ConsoleName }}Controller : public GenericHID,
    * Whether the touchpad was released since the last check.
    *
    * @return Whether the touchpad was released since the last check.
+   * @deprecated Use GetLeftBumperButton instead. This function is deprecated
+   * for removal to make function names consistent to allow the HID classes to
+   * be automatically generated.
    */
   [[deprecated("Use GetTouchpadButtonReleased instead")]]
   bool GetTouchpadReleased();

--- a/wpilibc/src/generate/main/native/include/frc/simulation/hidsim.h.jinja
+++ b/wpilibc/src/generate/main/native/include/frc/simulation/hidsim.h.jinja
@@ -63,6 +63,9 @@ class {{ ConsoleName }}ControllerSim : public GenericHIDSim {
    * Change the left bumper value of the joystick.
    *
    * @param value the new value
+   * @deprecated Use SetLeftBumperButton instead. This function is deprecated
+   * for removal to make function names consistent to allow the HID classes to
+   * be automatically generated.
    */
   [[deprecated("Use SetLeftBumperButton instead")]]
   void SetLeftBumper(bool value);
@@ -71,6 +74,9 @@ class {{ ConsoleName }}ControllerSim : public GenericHIDSim {
    * Change the right bumper value of the joystick.
    *
    * @param value the new value
+   * @deprecated Use SetRightBumperButton instead. This function is deprecated
+   * for removal to make function names consistent to allow the HID classes to
+   * be automatically generated.
    */
   [[deprecated("Use SetRightBumperButton instead")]]
   void SetRightBumper(bool value);
@@ -79,6 +85,9 @@ class {{ ConsoleName }}ControllerSim : public GenericHIDSim {
    * Change the value of the touchpad button on the controller.
    *
    * @param value the new value
+   * @deprecated Use SetTouchpadButton instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be
+   * automatically generated.
    */
   [[deprecated("Use SetTouchpadButton instead")]]
   void SetTouchpad(bool value);

--- a/wpilibc/src/generated/main/native/include/frc/PS4Controller.h
+++ b/wpilibc/src/generated/main/native/include/frc/PS4Controller.h
@@ -526,6 +526,9 @@ class PS4Controller : public GenericHID,
    * Read the value of the touchpad button on the controller.
    *
    * @return The state of the button.
+   * @deprecated Use GetTouchpadButton instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be
+   * automatically generated.
    */
   [[deprecated("Use GetTouchpadButton instead")]]
   bool GetTouchpad() const;
@@ -533,6 +536,9 @@ class PS4Controller : public GenericHID,
    * Whether the touchpad was pressed since the last check.
    *
    * @return Whether the touchpad was pressed since the last check.
+   * @deprecated Use GetTouchpadButtonPressed instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetTouchpadButtonPressed instead")]]
   bool GetTouchpadPressed();
@@ -541,6 +547,9 @@ class PS4Controller : public GenericHID,
    * Whether the touchpad was released since the last check.
    *
    * @return Whether the touchpad was released since the last check.
+   * @deprecated Use GetLeftBumperButton instead. This function is deprecated
+   * for removal to make function names consistent to allow the HID classes to
+   * be automatically generated.
    */
   [[deprecated("Use GetTouchpadButtonReleased instead")]]
   bool GetTouchpadReleased();

--- a/wpilibc/src/generated/main/native/include/frc/PS5Controller.h
+++ b/wpilibc/src/generated/main/native/include/frc/PS5Controller.h
@@ -526,6 +526,9 @@ class PS5Controller : public GenericHID,
    * Read the value of the touchpad button on the controller.
    *
    * @return The state of the button.
+   * @deprecated Use GetTouchpadButton instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be
+   * automatically generated.
    */
   [[deprecated("Use GetTouchpadButton instead")]]
   bool GetTouchpad() const;
@@ -533,6 +536,9 @@ class PS5Controller : public GenericHID,
    * Whether the touchpad was pressed since the last check.
    *
    * @return Whether the touchpad was pressed since the last check.
+   * @deprecated Use GetTouchpadButtonPressed instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetTouchpadButtonPressed instead")]]
   bool GetTouchpadPressed();
@@ -541,6 +547,9 @@ class PS5Controller : public GenericHID,
    * Whether the touchpad was released since the last check.
    *
    * @return Whether the touchpad was released since the last check.
+   * @deprecated Use GetLeftBumperButton instead. This function is deprecated
+   * for removal to make function names consistent to allow the HID classes to
+   * be automatically generated.
    */
   [[deprecated("Use GetTouchpadButtonReleased instead")]]
   bool GetTouchpadReleased();

--- a/wpilibc/src/generated/main/native/include/frc/StadiaController.h
+++ b/wpilibc/src/generated/main/native/include/frc/StadiaController.h
@@ -541,6 +541,9 @@ class StadiaController : public GenericHID,
    * Read the value of the left bumper (LB) button on the controller.
    *
    * @return the state of the button
+   * @deprecated Use GetLeftBumperButton instead. This function is deprecated
+   * for removal to make function names consistent to allow the HID classes to
+   * be automatically generated.
    */
   [[deprecated("Use GetLeftBumperButton instead")]]
   bool GetLeftBumper() const;
@@ -549,6 +552,9 @@ class StadiaController : public GenericHID,
    * Read the value of the right bumper (RB) button on the controller.
    *
    * @return the state of the button
+   * @deprecated Use GetRightBumperButton instead. This function is deprecated
+   * for removal to make function names consistent to allow the HID classes to
+   * be automatically generated.
    */
   [[deprecated("Use GetRightBumperButton instead")]]
   bool GetRightBumper() const;
@@ -557,6 +563,9 @@ class StadiaController : public GenericHID,
    * Whether the left bumper (LB) was pressed since the last check.
    *
    * @return Whether the button was pressed since the last check
+   * @deprecated Use GetLeftBumperButtonPressed instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetLeftBumperButtonPressed instead")]]
   bool GetLeftBumperPressed();
@@ -565,6 +574,9 @@ class StadiaController : public GenericHID,
    * Whether the right bumper (RB) was pressed since the last check.
    *
    * @return Whether the button was pressed since the last check
+   * @deprecated Use GetRightBumperButtonPressed instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetRightBumperButtonPressed instead")]]
   bool GetRightBumperPressed();
@@ -573,6 +585,9 @@ class StadiaController : public GenericHID,
    * Whether the left bumper (LB) was released since the last check.
    *
    * @return Whether the button was released since the last check.
+   * @deprecated Use GetLeftBumperButtonReleased instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetLeftBumperButtonReleased instead")]]
   bool GetLeftBumperReleased();
@@ -581,6 +596,9 @@ class StadiaController : public GenericHID,
    * Whether the right bumper (RB) was released since the last check.
    *
    * @return Whether the button was released since the last check.
+   * @deprecated Use GetRightBumperButtonReleased instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetRightBumperButtonReleased instead")]]
   bool GetRightBumperReleased();

--- a/wpilibc/src/generated/main/native/include/frc/XboxController.h
+++ b/wpilibc/src/generated/main/native/include/frc/XboxController.h
@@ -446,6 +446,9 @@ class XboxController : public GenericHID,
    * Read the value of the left bumper (LB) button on the controller.
    *
    * @return the state of the button
+   * @deprecated Use GetLeftBumperButton instead. This function is deprecated
+   * for removal to make function names consistent to allow the HID classes to
+   * be automatically generated.
    */
   [[deprecated("Use GetLeftBumperButton instead")]]
   bool GetLeftBumper() const;
@@ -454,6 +457,9 @@ class XboxController : public GenericHID,
    * Read the value of the right bumper (RB) button on the controller.
    *
    * @return the state of the button
+   * @deprecated Use GetRightBumperButton instead. This function is deprecated
+   * for removal to make function names consistent to allow the HID classes to
+   * be automatically generated.
    */
   [[deprecated("Use GetRightBumperButton instead")]]
   bool GetRightBumper() const;
@@ -462,6 +468,9 @@ class XboxController : public GenericHID,
    * Whether the left bumper (LB) was pressed since the last check.
    *
    * @return Whether the button was pressed since the last check
+   * @deprecated Use GetLeftBumperButtonPressed instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetLeftBumperButtonPressed instead")]]
   bool GetLeftBumperPressed();
@@ -470,6 +479,9 @@ class XboxController : public GenericHID,
    * Whether the right bumper (RB) was pressed since the last check.
    *
    * @return Whether the button was pressed since the last check
+   * @deprecated Use GetRightBumperButtonPressed instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetRightBumperButtonPressed instead")]]
   bool GetRightBumperPressed();
@@ -478,6 +490,9 @@ class XboxController : public GenericHID,
    * Whether the left bumper (LB) was released since the last check.
    *
    * @return Whether the button was released since the last check.
+   * @deprecated Use GetLeftBumperButtonReleased instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetLeftBumperButtonReleased instead")]]
   bool GetLeftBumperReleased();
@@ -486,6 +501,9 @@ class XboxController : public GenericHID,
    * Whether the right bumper (RB) was released since the last check.
    *
    * @return Whether the button was released since the last check.
+   * @deprecated Use GetRightBumperButtonReleased instead. This function is
+   * deprecated for removal to make function names consistent to allow the HID
+   * classes to be automatically generated.
    */
   [[deprecated("Use GetRightBumperButtonReleased instead")]]
   bool GetRightBumperReleased();

--- a/wpilibc/src/generated/main/native/include/frc/simulation/PS4ControllerSim.h
+++ b/wpilibc/src/generated/main/native/include/frc/simulation/PS4ControllerSim.h
@@ -177,6 +177,9 @@ class PS4ControllerSim : public GenericHIDSim {
    * Change the value of the touchpad button on the controller.
    *
    * @param value the new value
+   * @deprecated Use SetTouchpadButton instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be
+   * automatically generated.
    */
   [[deprecated("Use SetTouchpadButton instead")]]
   void SetTouchpad(bool value);

--- a/wpilibc/src/generated/main/native/include/frc/simulation/PS5ControllerSim.h
+++ b/wpilibc/src/generated/main/native/include/frc/simulation/PS5ControllerSim.h
@@ -177,6 +177,9 @@ class PS5ControllerSim : public GenericHIDSim {
    * Change the value of the touchpad button on the controller.
    *
    * @param value the new value
+   * @deprecated Use SetTouchpadButton instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be
+   * automatically generated.
    */
   [[deprecated("Use SetTouchpadButton instead")]]
   void SetTouchpad(bool value);

--- a/wpilibc/src/generated/main/native/include/frc/simulation/XboxControllerSim.h
+++ b/wpilibc/src/generated/main/native/include/frc/simulation/XboxControllerSim.h
@@ -149,6 +149,9 @@ class XboxControllerSim : public GenericHIDSim {
    * Change the left bumper value of the joystick.
    *
    * @param value the new value
+   * @deprecated Use SetLeftBumperButton instead. This function is deprecated
+   * for removal to make function names consistent to allow the HID classes to
+   * be automatically generated.
    */
   [[deprecated("Use SetLeftBumperButton instead")]]
   void SetLeftBumper(bool value);
@@ -157,6 +160,9 @@ class XboxControllerSim : public GenericHIDSim {
    * Change the right bumper value of the joystick.
    *
    * @param value the new value
+   * @deprecated Use SetRightBumperButton instead. This function is deprecated
+   * for removal to make function names consistent to allow the HID classes to
+   * be automatically generated.
    */
   [[deprecated("Use SetRightBumperButton instead")]]
   void SetRightBumper(bool value);

--- a/wpilibj/src/generate/main/java/hid.java.jinja
+++ b/wpilibj/src/generate/main/java/hid.java.jinja
@@ -193,7 +193,8 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    * Read the value of the left bumper (LB) button on the controller.
    *
    * @return The state of the button.
-   * @deprecated Use {@link getLeftBumperButton} instead
+   * @deprecated Use {@link getLeftBumperButton} instead. This function is deprecated for removal
+   * to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumper() {
@@ -204,7 +205,8 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    * Read the value of the right bumper (RB) button on the controller.
    *
    * @return The state of the button.
-   * @deprecated Use {@link getRightBumperButton} instead
+   * @deprecated Use {@link getRightBumperButton} instead. This function is deprecated for removal
+   * to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumper() {
@@ -215,7 +217,9 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    * Whether the left bumper (LB) was pressed since the last check.
    *
    * @return Whether the button was pressed since the last check.
-   * @deprecated Use {@link getLeftBumperButtonPressed} instead
+   * @deprecated Use {@link getLeftBumperButtonPressed} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumperPressed() {
@@ -226,7 +230,9 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    * Whether the right bumper (RB) was pressed since the last check.
    *
    * @return Whether the button was pressed since the last check.
-   * @deprecated Use {@link getRightBumperButtonPressed} instead
+   * @deprecated Use {@link getRightBumperButtonPressed} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumperPressed() {
@@ -237,7 +243,9 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    * Whether the left bumper (LB) was released since the last check.
    *
    * @return Whether the button was released since the last check.
-   * @deprecated Use {@link getLeftBumperButtonReleased} instead
+   * @deprecated Use {@link getLeftBumperButtonReleased} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumperReleased() {
@@ -248,7 +256,9 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    * Whether the right bumper (RB) was released since the last check.
    *
    * @return Whether the button was released since the last check.
-   * @deprecated Use {@link getRightBumperButtonReleased} instead
+   * @deprecated Use {@link getRightBumperButtonReleased} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumperReleased() {
@@ -259,7 +269,8 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    * Read the value of the touchpad on the controller.
    *
    * @return The state of the touchpad.
-   * @deprecated Use {@link getTouchpadButton} instead
+   * @deprecated Use {@link getTouchpadButton} instead. This function is deprecated for removal to
+   * make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpad() {
@@ -270,7 +281,9 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    * Whether the touchpad was pressed since the last check.
    *
    * @return Whether the touchpad was pressed since the last check.
-   * @deprecated Use {@link getTouchpadButtonPressed} instead
+   * @deprecated Use {@link getTouchpadButtonPressed} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpadPressed() {
@@ -281,7 +294,9 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    * Whether the touchpad was released since the last check.
    *
    * @return Whether the touchpad was released since the last check.
-   * @deprecated Use {@link getTouchpadButtonReleased} instead
+   * @deprecated Use {@link getTouchpadButtonReleased} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpadReleased() {

--- a/wpilibj/src/generate/main/java/hid.java.jinja
+++ b/wpilibj/src/generate/main/java/hid.java.jinja
@@ -194,7 +194,7 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    *
    * @return The state of the button.
    * @deprecated Use {@link getLeftBumperButton} instead. This function is deprecated for removal
-   * to make function names consistent to allow the HID classes to be automatically generated.
+   *     to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumper() {
@@ -206,7 +206,7 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    *
    * @return The state of the button.
    * @deprecated Use {@link getRightBumperButton} instead. This function is deprecated for removal
-   * to make function names consistent to allow the HID classes to be automatically generated.
+   *     to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumper() {
@@ -218,8 +218,8 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    *
    * @return Whether the button was pressed since the last check.
    * @deprecated Use {@link getLeftBumperButtonPressed} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumperPressed() {
@@ -231,8 +231,8 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    *
    * @return Whether the button was pressed since the last check.
    * @deprecated Use {@link getRightBumperButtonPressed} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumperPressed() {
@@ -244,8 +244,8 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    *
    * @return Whether the button was released since the last check.
    * @deprecated Use {@link getLeftBumperButtonReleased} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumperReleased() {
@@ -257,8 +257,8 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    *
    * @return Whether the button was released since the last check.
    * @deprecated Use {@link getRightBumperButtonReleased} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumperReleased() {
@@ -270,7 +270,7 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    *
    * @return The state of the touchpad.
    * @deprecated Use {@link getTouchpadButton} instead. This function is deprecated for removal to
-   * make function names consistent to allow the HID classes to be automatically generated.
+   *     make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpad() {
@@ -282,8 +282,8 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    *
    * @return Whether the touchpad was pressed since the last check.
    * @deprecated Use {@link getTouchpadButtonPressed} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpadPressed() {
@@ -295,8 +295,8 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
    *
    * @return Whether the touchpad was released since the last check.
    * @deprecated Use {@link getTouchpadButtonReleased} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpadReleased() {

--- a/wpilibj/src/generate/main/java/hidsim.java.jinja
+++ b/wpilibj/src/generate/main/java/hidsim.java.jinja
@@ -73,7 +73,7 @@ public class {{ ConsoleName }}ControllerSim extends GenericHIDSim {
    *
    * @param state the new value
    * @deprecated Use {@link setLeftBumperButton} instead. This function is deprecated for removal
-   * to make function names consistent to allow the HID classes to be automatically generated.
+   *     to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setLeftBumper(boolean state) {
@@ -85,7 +85,7 @@ public class {{ ConsoleName }}ControllerSim extends GenericHIDSim {
    *
    * @param state the new value
    * @deprecated Use {@link setRightBumperButton} instead. This function is deprecated for removal
-   * to make function names consistent to allow the HID classes to be automatically generated.
+   *     to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setRightBumper(boolean state) {
@@ -97,7 +97,7 @@ public class {{ ConsoleName }}ControllerSim extends GenericHIDSim {
    *
    * @param value the new value
    * @deprecated Use {@link setTouchpadButton} instead. This function is deprecated for removal to
-   * make function names consistent to allow the HID classes to be automatically generated.
+   *     make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setTouchpad(boolean value) {
@@ -109,7 +109,7 @@ public class {{ ConsoleName }}ControllerSim extends GenericHIDSim {
    *
    * @param value the new value
    * @deprecated Use {@link setTouchpadButton} instead. This function is deprecated for removal to
-   * make function names consistent to allow the HID classes to be automatically generated.
+   *     make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setTouchpad(boolean value) {

--- a/wpilibj/src/generate/main/java/hidsim.java.jinja
+++ b/wpilibj/src/generate/main/java/hidsim.java.jinja
@@ -72,7 +72,8 @@ public class {{ ConsoleName }}ControllerSim extends GenericHIDSim {
    * Change the value of the left bumper on the joystick.
    *
    * @param state the new value
-   * @deprecated Use {@link setLeftBumperButton} instead
+   * @deprecated Use {@link setLeftBumperButton} instead. This function is deprecated for removal
+   * to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setLeftBumper(boolean state) {
@@ -83,7 +84,8 @@ public class {{ ConsoleName }}ControllerSim extends GenericHIDSim {
    * Change the value of the right bumper on the joystick.
    *
    * @param state the new value
-   * @deprecated Use {@link setRightBumperButton} instead
+   * @deprecated Use {@link setRightBumperButton} instead. This function is deprecated for removal
+   * to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setRightBumper(boolean state) {
@@ -94,7 +96,8 @@ public class {{ ConsoleName }}ControllerSim extends GenericHIDSim {
    * Change the value of the touchpad button on the controller.
    *
    * @param value the new value
-   * @deprecated Use {@link setTouchpadButton} instead
+   * @deprecated Use {@link setTouchpadButton} instead. This function is deprecated for removal to
+   * make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setTouchpad(boolean value) {
@@ -105,7 +108,8 @@ public class {{ ConsoleName }}ControllerSim extends GenericHIDSim {
    * Change the value of the touchpad button on the controller.
    *
    * @param value the new value
-   * @deprecated Use {@link setTouchpadButton} instead
+   * @deprecated Use {@link setTouchpadButton} instead. This function is deprecated for removal to
+   * make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setTouchpad(boolean value) {

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/PS4Controller.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/PS4Controller.java
@@ -721,7 +721,7 @@ public class PS4Controller extends GenericHID implements Sendable {
    *
    * @return The state of the touchpad.
    * @deprecated Use {@link getTouchpadButton} instead. This function is deprecated for removal to
-   * make function names consistent to allow the HID classes to be automatically generated.
+   *     make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpad() {
@@ -733,8 +733,8 @@ public class PS4Controller extends GenericHID implements Sendable {
    *
    * @return Whether the touchpad was pressed since the last check.
    * @deprecated Use {@link getTouchpadButtonPressed} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpadPressed() {
@@ -746,8 +746,8 @@ public class PS4Controller extends GenericHID implements Sendable {
    *
    * @return Whether the touchpad was released since the last check.
    * @deprecated Use {@link getTouchpadButtonReleased} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpadReleased() {

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/PS4Controller.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/PS4Controller.java
@@ -720,7 +720,8 @@ public class PS4Controller extends GenericHID implements Sendable {
    * Read the value of the touchpad on the controller.
    *
    * @return The state of the touchpad.
-   * @deprecated Use {@link getTouchpadButton} instead
+   * @deprecated Use {@link getTouchpadButton} instead. This function is deprecated for removal to
+   * make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpad() {
@@ -731,7 +732,9 @@ public class PS4Controller extends GenericHID implements Sendable {
    * Whether the touchpad was pressed since the last check.
    *
    * @return Whether the touchpad was pressed since the last check.
-   * @deprecated Use {@link getTouchpadButtonPressed} instead
+   * @deprecated Use {@link getTouchpadButtonPressed} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpadPressed() {
@@ -742,7 +745,9 @@ public class PS4Controller extends GenericHID implements Sendable {
    * Whether the touchpad was released since the last check.
    *
    * @return Whether the touchpad was released since the last check.
-   * @deprecated Use {@link getTouchpadButtonReleased} instead
+   * @deprecated Use {@link getTouchpadButtonReleased} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpadReleased() {

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/PS5Controller.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/PS5Controller.java
@@ -721,7 +721,7 @@ public class PS5Controller extends GenericHID implements Sendable {
    *
    * @return The state of the touchpad.
    * @deprecated Use {@link getTouchpadButton} instead. This function is deprecated for removal to
-   * make function names consistent to allow the HID classes to be automatically generated.
+   *     make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpad() {
@@ -733,8 +733,8 @@ public class PS5Controller extends GenericHID implements Sendable {
    *
    * @return Whether the touchpad was pressed since the last check.
    * @deprecated Use {@link getTouchpadButtonPressed} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpadPressed() {
@@ -746,8 +746,8 @@ public class PS5Controller extends GenericHID implements Sendable {
    *
    * @return Whether the touchpad was released since the last check.
    * @deprecated Use {@link getTouchpadButtonReleased} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpadReleased() {

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/PS5Controller.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/PS5Controller.java
@@ -720,7 +720,8 @@ public class PS5Controller extends GenericHID implements Sendable {
    * Read the value of the touchpad on the controller.
    *
    * @return The state of the touchpad.
-   * @deprecated Use {@link getTouchpadButton} instead
+   * @deprecated Use {@link getTouchpadButton} instead. This function is deprecated for removal to
+   * make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpad() {
@@ -731,7 +732,9 @@ public class PS5Controller extends GenericHID implements Sendable {
    * Whether the touchpad was pressed since the last check.
    *
    * @return Whether the touchpad was pressed since the last check.
-   * @deprecated Use {@link getTouchpadButtonPressed} instead
+   * @deprecated Use {@link getTouchpadButtonPressed} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpadPressed() {
@@ -742,7 +745,9 @@ public class PS5Controller extends GenericHID implements Sendable {
    * Whether the touchpad was released since the last check.
    *
    * @return Whether the touchpad was released since the last check.
-   * @deprecated Use {@link getTouchpadButtonReleased} instead
+   * @deprecated Use {@link getTouchpadButtonReleased} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getTouchpadReleased() {

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/StadiaController.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/StadiaController.java
@@ -736,7 +736,8 @@ public class StadiaController extends GenericHID implements Sendable {
    * Read the value of the left bumper (LB) button on the controller.
    *
    * @return The state of the button.
-   * @deprecated Use {@link getLeftBumperButton} instead
+   * @deprecated Use {@link getLeftBumperButton} instead. This function is deprecated for removal
+   * to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumper() {
@@ -747,7 +748,8 @@ public class StadiaController extends GenericHID implements Sendable {
    * Read the value of the right bumper (RB) button on the controller.
    *
    * @return The state of the button.
-   * @deprecated Use {@link getRightBumperButton} instead
+   * @deprecated Use {@link getRightBumperButton} instead. This function is deprecated for removal
+   * to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumper() {
@@ -758,7 +760,9 @@ public class StadiaController extends GenericHID implements Sendable {
    * Whether the left bumper (LB) was pressed since the last check.
    *
    * @return Whether the button was pressed since the last check.
-   * @deprecated Use {@link getLeftBumperButtonPressed} instead
+   * @deprecated Use {@link getLeftBumperButtonPressed} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumperPressed() {
@@ -769,7 +773,9 @@ public class StadiaController extends GenericHID implements Sendable {
    * Whether the right bumper (RB) was pressed since the last check.
    *
    * @return Whether the button was pressed since the last check.
-   * @deprecated Use {@link getRightBumperButtonPressed} instead
+   * @deprecated Use {@link getRightBumperButtonPressed} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumperPressed() {
@@ -780,7 +786,9 @@ public class StadiaController extends GenericHID implements Sendable {
    * Whether the left bumper (LB) was released since the last check.
    *
    * @return Whether the button was released since the last check.
-   * @deprecated Use {@link getLeftBumperButtonReleased} instead
+   * @deprecated Use {@link getLeftBumperButtonReleased} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumperReleased() {
@@ -791,7 +799,9 @@ public class StadiaController extends GenericHID implements Sendable {
    * Whether the right bumper (RB) was released since the last check.
    *
    * @return Whether the button was released since the last check.
-   * @deprecated Use {@link getRightBumperButtonReleased} instead
+   * @deprecated Use {@link getRightBumperButtonReleased} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumperReleased() {

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/StadiaController.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/StadiaController.java
@@ -737,7 +737,7 @@ public class StadiaController extends GenericHID implements Sendable {
    *
    * @return The state of the button.
    * @deprecated Use {@link getLeftBumperButton} instead. This function is deprecated for removal
-   * to make function names consistent to allow the HID classes to be automatically generated.
+   *     to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumper() {
@@ -749,7 +749,7 @@ public class StadiaController extends GenericHID implements Sendable {
    *
    * @return The state of the button.
    * @deprecated Use {@link getRightBumperButton} instead. This function is deprecated for removal
-   * to make function names consistent to allow the HID classes to be automatically generated.
+   *     to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumper() {
@@ -761,8 +761,8 @@ public class StadiaController extends GenericHID implements Sendable {
    *
    * @return Whether the button was pressed since the last check.
    * @deprecated Use {@link getLeftBumperButtonPressed} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumperPressed() {
@@ -774,8 +774,8 @@ public class StadiaController extends GenericHID implements Sendable {
    *
    * @return Whether the button was pressed since the last check.
    * @deprecated Use {@link getRightBumperButtonPressed} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumperPressed() {
@@ -787,8 +787,8 @@ public class StadiaController extends GenericHID implements Sendable {
    *
    * @return Whether the button was released since the last check.
    * @deprecated Use {@link getLeftBumperButtonReleased} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumperReleased() {
@@ -800,8 +800,8 @@ public class StadiaController extends GenericHID implements Sendable {
    *
    * @return Whether the button was released since the last check.
    * @deprecated Use {@link getRightBumperButtonReleased} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumperReleased() {

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/XboxController.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/XboxController.java
@@ -612,7 +612,8 @@ public class XboxController extends GenericHID implements Sendable {
    * Read the value of the left bumper (LB) button on the controller.
    *
    * @return The state of the button.
-   * @deprecated Use {@link getLeftBumperButton} instead
+   * @deprecated Use {@link getLeftBumperButton} instead. This function is deprecated for removal
+   * to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumper() {
@@ -623,7 +624,8 @@ public class XboxController extends GenericHID implements Sendable {
    * Read the value of the right bumper (RB) button on the controller.
    *
    * @return The state of the button.
-   * @deprecated Use {@link getRightBumperButton} instead
+   * @deprecated Use {@link getRightBumperButton} instead. This function is deprecated for removal
+   * to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumper() {
@@ -634,7 +636,9 @@ public class XboxController extends GenericHID implements Sendable {
    * Whether the left bumper (LB) was pressed since the last check.
    *
    * @return Whether the button was pressed since the last check.
-   * @deprecated Use {@link getLeftBumperButtonPressed} instead
+   * @deprecated Use {@link getLeftBumperButtonPressed} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumperPressed() {
@@ -645,7 +649,9 @@ public class XboxController extends GenericHID implements Sendable {
    * Whether the right bumper (RB) was pressed since the last check.
    *
    * @return Whether the button was pressed since the last check.
-   * @deprecated Use {@link getRightBumperButtonPressed} instead
+   * @deprecated Use {@link getRightBumperButtonPressed} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumperPressed() {
@@ -656,7 +662,9 @@ public class XboxController extends GenericHID implements Sendable {
    * Whether the left bumper (LB) was released since the last check.
    *
    * @return Whether the button was released since the last check.
-   * @deprecated Use {@link getLeftBumperButtonReleased} instead
+   * @deprecated Use {@link getLeftBumperButtonReleased} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumperReleased() {
@@ -667,7 +675,9 @@ public class XboxController extends GenericHID implements Sendable {
    * Whether the right bumper (RB) was released since the last check.
    *
    * @return Whether the button was released since the last check.
-   * @deprecated Use {@link getRightBumperButtonReleased} instead
+   * @deprecated Use {@link getRightBumperButtonReleased} instead. This function is deprecated for
+   * removal to make function names consistent to allow the HID classes to be automatically
+   * generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumperReleased() {

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/XboxController.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/XboxController.java
@@ -613,7 +613,7 @@ public class XboxController extends GenericHID implements Sendable {
    *
    * @return The state of the button.
    * @deprecated Use {@link getLeftBumperButton} instead. This function is deprecated for removal
-   * to make function names consistent to allow the HID classes to be automatically generated.
+   *     to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumper() {
@@ -625,7 +625,7 @@ public class XboxController extends GenericHID implements Sendable {
    *
    * @return The state of the button.
    * @deprecated Use {@link getRightBumperButton} instead. This function is deprecated for removal
-   * to make function names consistent to allow the HID classes to be automatically generated.
+   *     to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumper() {
@@ -637,8 +637,8 @@ public class XboxController extends GenericHID implements Sendable {
    *
    * @return Whether the button was pressed since the last check.
    * @deprecated Use {@link getLeftBumperButtonPressed} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumperPressed() {
@@ -650,8 +650,8 @@ public class XboxController extends GenericHID implements Sendable {
    *
    * @return Whether the button was pressed since the last check.
    * @deprecated Use {@link getRightBumperButtonPressed} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumperPressed() {
@@ -663,8 +663,8 @@ public class XboxController extends GenericHID implements Sendable {
    *
    * @return Whether the button was released since the last check.
    * @deprecated Use {@link getLeftBumperButtonReleased} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getLeftBumperReleased() {
@@ -676,8 +676,8 @@ public class XboxController extends GenericHID implements Sendable {
    *
    * @return Whether the button was released since the last check.
    * @deprecated Use {@link getRightBumperButtonReleased} instead. This function is deprecated for
-   * removal to make function names consistent to allow the HID classes to be automatically
-   * generated.
+   *     removal to make function names consistent to allow the HID classes to be automatically
+   *     generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public boolean getRightBumperReleased() {

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/simulation/PS4ControllerSim.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/simulation/PS4ControllerSim.java
@@ -221,7 +221,7 @@ public class PS4ControllerSim extends GenericHIDSim {
    *
    * @param value the new value
    * @deprecated Use {@link setTouchpadButton} instead. This function is deprecated for removal to
-   * make function names consistent to allow the HID classes to be automatically generated.
+   *     make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setTouchpad(boolean value) {

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/simulation/PS4ControllerSim.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/simulation/PS4ControllerSim.java
@@ -220,7 +220,8 @@ public class PS4ControllerSim extends GenericHIDSim {
    * Change the value of the touchpad button on the controller.
    *
    * @param value the new value
-   * @deprecated Use {@link setTouchpadButton} instead
+   * @deprecated Use {@link setTouchpadButton} instead. This function is deprecated for removal to
+   * make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setTouchpad(boolean value) {

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/simulation/PS5ControllerSim.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/simulation/PS5ControllerSim.java
@@ -220,7 +220,8 @@ public class PS5ControllerSim extends GenericHIDSim {
    * Change the value of the touchpad button on the controller.
    *
    * @param value the new value
-   * @deprecated Use {@link setTouchpadButton} instead
+   * @deprecated Use {@link setTouchpadButton} instead. This function is deprecated for removal to
+   * make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setTouchpad(boolean value) {

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/simulation/PS5ControllerSim.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/simulation/PS5ControllerSim.java
@@ -221,7 +221,7 @@ public class PS5ControllerSim extends GenericHIDSim {
    *
    * @param value the new value
    * @deprecated Use {@link setTouchpadButton} instead. This function is deprecated for removal to
-   * make function names consistent to allow the HID classes to be automatically generated.
+   *     make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setTouchpad(boolean value) {

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/simulation/XboxControllerSim.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/simulation/XboxControllerSim.java
@@ -185,7 +185,7 @@ public class XboxControllerSim extends GenericHIDSim {
    *
    * @param state the new value
    * @deprecated Use {@link setLeftBumperButton} instead. This function is deprecated for removal
-   * to make function names consistent to allow the HID classes to be automatically generated.
+   *     to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setLeftBumper(boolean state) {
@@ -197,7 +197,7 @@ public class XboxControllerSim extends GenericHIDSim {
    *
    * @param state the new value
    * @deprecated Use {@link setRightBumperButton} instead. This function is deprecated for removal
-   * to make function names consistent to allow the HID classes to be automatically generated.
+   *     to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setRightBumper(boolean state) {

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/simulation/XboxControllerSim.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/simulation/XboxControllerSim.java
@@ -184,7 +184,8 @@ public class XboxControllerSim extends GenericHIDSim {
    * Change the value of the left bumper on the joystick.
    *
    * @param state the new value
-   * @deprecated Use {@link setLeftBumperButton} instead
+   * @deprecated Use {@link setLeftBumperButton} instead. This function is deprecated for removal
+   * to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setLeftBumper(boolean state) {
@@ -195,7 +196,8 @@ public class XboxControllerSim extends GenericHIDSim {
    * Change the value of the right bumper on the joystick.
    *
    * @param state the new value
-   * @deprecated Use {@link setRightBumperButton} instead
+   * @deprecated Use {@link setRightBumperButton} instead. This function is deprecated for removal
+   * to make function names consistent to allow the HID classes to be automatically generated.
    */
   @Deprecated(since = "2025", forRemoval = true)
   public void setRightBumper(boolean state) {


### PR DESCRIPTION
Based on feedback that some deprecations seemed to be done for no reason.

This is probably something we should start doing more generally.
