### PR TITLE
[ci] Check return code of subprocesses in pregen_all

### DIFF
--- a/.github/workflows/pregen_all.py
+++ b/.github/workflows/pregen_all.py
@@ -59,5 +59,6 @@ def main(argv):
     )
     subprocess.run(f"{REPO_ROOT}/thirdparty/imgui_suite/generate_fonts.sh", check=True)
 
+
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/.github/workflows/pregen_all.py
+++ b/.github/workflows/pregen_all.py
@@ -16,25 +16,48 @@ def main(argv):
         required=True,
     )
     args = parser.parse_args(argv)
-    subprocess.run(["python", f"{REPO_ROOT}/hal/generate_usage_reporting.py"])
-    subprocess.run(["python", f"{REPO_ROOT}/ntcore/generate_topics.py"])
-    subprocess.run(["python", f"{REPO_ROOT}/wpimath/generate_numbers.py"])
+    subprocess.run(
+        [sys.executable, f"{REPO_ROOT}/hal/generate_usage_reporting.py"], check=True
+    )
+    subprocess.run(
+        [sys.executable, f"{REPO_ROOT}/ntcore/generate_topics.py"], check=True
+    )
+    subprocess.run(
+        [sys.executable, f"{REPO_ROOT}/wpimath/generate_numbers.py"], check=True
+    )
     subprocess.run(
         [
-            "python",
+            sys.executable,
             f"{REPO_ROOT}/wpimath/generate_quickbuf.py",
             f"--quickbuf_plugin={args.quickbuf_plugin}",
-        ]
+        ],
+        check=True,
     )
-    subprocess.run(["python", f"{REPO_ROOT}/wpiunits/generate_units.py"])
-    subprocess.run(["python", f"{REPO_ROOT}/wpilibc/generate_hids.py"])
-    subprocess.run(["python", f"{REPO_ROOT}/wpilibj/generate_hids.py"])
-    subprocess.run(["python", f"{REPO_ROOT}/wpilibNewCommands/generate_hids.py"])
-    subprocess.run(["python", f"{REPO_ROOT}/wpilibc/generate_pwm_motor_controllers.py"])
-    subprocess.run(["python", f"{REPO_ROOT}/wpilibj/generate_pwm_motor_controllers.py"])
-    subprocess.run(["python", f"{REPO_ROOT}/thirdparty/imgui_suite/generate_gl3w.py"])
-    subprocess.run(f"{REPO_ROOT}/thirdparty/imgui_suite/generate_fonts.sh")
-
+    subprocess.run(
+        [sys.executable, f"{REPO_ROOT}/wpiunits/generate_units.py"], check=True
+    )
+    subprocess.run(
+        [sys.executable, f"{REPO_ROOT}/wpilibc/generate_hids.py"], check=True
+    )
+    subprocess.run(
+        [sys.executable, f"{REPO_ROOT}/wpilibj/generate_hids.py"], check=True
+    )
+    subprocess.run(
+        [sys.executable, f"{REPO_ROOT}/wpilibNewCommands/generate_hids.py"], check=True
+    )
+    subprocess.run(
+        [sys.executable, f"{REPO_ROOT}/wpilibc/generate_pwm_motor_controllers.py"],
+        check=True,
+    )
+    subprocess.run(
+        [sys.executable, f"{REPO_ROOT}/wpilibj/generate_pwm_motor_controllers.py"],
+        check=True,
+    )
+    subprocess.run(
+        [sys.executable, f"{REPO_ROOT}/thirdparty/imgui_suite/generate_gl3w.py"],
+        check=True,
+    )
+    subprocess.run(f"{REPO_ROOT}/thirdparty/imgui_suite/generate_fonts.sh", check=True)
 
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
Previously errors were ignored

Also makes the script more cross-platform by using the current python executable to run the subprocesses