### PR TITLE
[c++ cmd] Allow CommandPtrs to be owned by the scheduler

### DIFF
--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -7,7 +7,6 @@
 #include <cstdio>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -67,7 +66,7 @@ class CommandScheduler::Impl {
   // Map of Command* -> CommandPtr for CommandPtrs transferred to the scheduler
   // via Schedule(CommandPtr&&). These are erased (destroyed) at the very end of
   // the loop cycle when the command lifecycle is complete.
-  std::unordered_map<Command*, CommandPtr> ownedCommands;
+  wpi::DenseMap<Command*, CommandPtr> ownedCommands;
 };
 
 template <typename TMap, typename TKey>
@@ -182,7 +181,7 @@ void CommandScheduler::Schedule(const CommandPtr& command) {
 
 void CommandScheduler::Schedule(CommandPtr&& command) {
   auto ptr = command.get();
-  m_impl->ownedCommands.emplace(ptr, std::move(command));
+  m_impl->ownedCommands.try_emplace(ptr, std::move(command));
   Schedule(ptr);
 }
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -95,9 +95,22 @@ class CommandScheduler final : public wpi::Sendable,
   /**
    * Schedules a command for execution. Does nothing if the command is already
    * scheduled. If a command's requirements are not available, it will only be
+   * started if all the commands currently using those requirements are
+   * interruptible. If this is the case, they will be interrupted and the
+   * command will be scheduled.
+   *
+   * @param command the command to schedule
+   */
+  void Schedule(CommandPtr&& command);
+
+  /**
+   * Schedules a command for execution. Does nothing if the command is already
+   * scheduled. If a command's requirements are not available, it will only be
    * started if all the commands currently using those requirements have been
    * scheduled as interruptible. If this is the case, they will be interrupted
    * and the command will be scheduled.
+   *
+   * The pointer must remain valid through the entire lifecycle of the command.
    *
    * @param command the command to schedule
    */


### PR DESCRIPTION
Previously users would have to keep track of dynamically created CommandPtrs. This adds an ownership-taking version of schedule which places the command in a temporary store in the scheduler. The command will be freed when the command's lifecycle ends.