### PR TITLE
Remove argv usage from Python scripts

### DIFF
--- a/.github/workflows/pregen_all.py
+++ b/.github/workflows/pregen_all.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 
-def main(argv):
+def main():
     script_path = Path(__file__).resolve()
     REPO_ROOT = script_path.parent.parent.parent
     parser = argparse.ArgumentParser()
@@ -15,7 +15,7 @@ def main(argv):
         help="Path to the quickbuf protoc plugin",
         required=True,
     )
-    args = parser.parse_args(argv)
+    args = parser.parse_args()
     subprocess.run(
         [sys.executable, f"{REPO_ROOT}/hal/generate_usage_reporting.py"], check=True
     )
@@ -61,4 +61,4 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/hal/generate_usage_reporting.py
+++ b/hal/generate_usage_reporting.py
@@ -3,8 +3,8 @@
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
+
 import argparse
-import sys
 from pathlib import Path
 
 
@@ -68,8 +68,7 @@ def generate_usage_reporting(output_directory: Path, template_directory: Path):
         usage_reporting_hdr.write_text(contents, encoding="utf-8", newline="\n")
 
 
-def main(argv):
-
+def main():
     dirname = Path(__file__).parent
 
     parser = argparse.ArgumentParser()
@@ -85,10 +84,10 @@ def main(argv):
         default=dirname / "src/generate",
         type=Path,
     )
-    args = parser.parse_args(argv)
+    args = parser.parse_args()
 
     generate_usage_reporting(args.output_directory, args.template_root)
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/ntcore/generate_topics.py
+++ b/ntcore/generate_topics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+
 import argparse
 import json
-import sys
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
@@ -122,7 +122,7 @@ def generate_topics(
     Output(output_directory / jni_subdirectory, "types_jni.cpp", output)
 
 
-def main(argv):
+def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
@@ -145,10 +145,10 @@ def main(argv):
         default=dirname / "src/generate",
         type=Path,
     )
-    args = parser.parse_args(argv)
+    args = parser.parse_args()
 
     generate_topics(args.output_directory, args.template_root, args.types_schema_file)
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/thirdparty/imgui_suite/generate_gl3w.py
+++ b/thirdparty/imgui_suite/generate_gl3w.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
-import os
-import sys
 import argparse
+import os
 from pathlib import Path
+import sys
 
-def main(argv):
+def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
@@ -16,8 +16,8 @@ def main(argv):
         default=dirname / "generated/gl3w",
         type=Path,
     )
-    args = parser.parse_args(argv)
-    
+    args = parser.parse_args()
+
     sys.path.append(str(dirname / "gl3w"))
 
     args.output_directory.mkdir(parents=True, exist_ok=True)
@@ -27,4 +27,4 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/upstream_utils/upstream_utils.py
+++ b/upstream_utils/upstream_utils.py
@@ -475,13 +475,8 @@ class Lib:
 
         self.copy_upstream_src(self.wpilib_root)
 
-    def main(self, argv=sys.argv[1:]):
-        """Processes the given arguments.
-
-        Keyword argument:
-        argv -- The arguments to process. Defaults to the arguments passed to
-        the program.
-        """
+    def main(self):
+        """Process arguments of upstream_utils script"""
         parser = argparse.ArgumentParser(
             description=f"CLI manager of the {self.name} upstream library"
         )
@@ -515,7 +510,7 @@ class Lib:
             help="Copies files from the upstream repository into the thirdparty directory in allwpilib",
         )
 
-        args = parser.parse_args(argv)
+        args = parser.parse_args()
 
         self.wpilib_root = get_repo_root()
         if args.subcommand == "info":

--- a/wpilibNewCommands/generate_hids.py
+++ b/wpilibNewCommands/generate_hids.py
@@ -3,9 +3,9 @@
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
+
 import argparse
 import json
-import sys
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
@@ -63,7 +63,7 @@ def generate_hids(output_directory: Path, template_directory: Path, schema_file:
         write_controller_file(root_path, controllerName, output)
 
 
-def main(argv):
+def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
@@ -86,10 +86,10 @@ def main(argv):
         default="wpilibj/src/generate/hids.json",
         type=Path,
     )
-    args = parser.parse_args(argv)
+    args = parser.parse_args()
 
     generate_hids(args.output_directory, args.template_root, args.schema_file)
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/wpilibc/generate_hids.py
+++ b/wpilibc/generate_hids.py
@@ -3,9 +3,9 @@
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
+
 import argparse
 import json
-import sys
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
@@ -76,7 +76,7 @@ def generate_hids(output_directory: Path, template_directory: Path, schema_file:
         write_controller_file(root_path, controllerName, output)
 
 
-def main(argv):
+def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
@@ -99,10 +99,10 @@ def main(argv):
         default="wpilibj/src/generate/hids.json",
         type=Path,
     )
-    args = parser.parse_args(argv)
+    args = parser.parse_args()
 
     generate_hids(args.output_directory, args.template_root, args.schema_file)
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/wpilibc/generate_pwm_motor_controllers.py
+++ b/wpilibc/generate_pwm_motor_controllers.py
@@ -3,10 +3,10 @@
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
+
 import argparse
 import json
 import os
-import sys
 from pathlib import Path
 from typing import Any, Dict
 
@@ -67,7 +67,7 @@ def generate_pwm_motor_controllers(
     generate_cpp_sources(output_root, template_root, controllers)
 
 
-def main(argv):
+def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
@@ -90,7 +90,7 @@ def main(argv):
         default=dirname / "src/generate",
         type=Path,
     )
-    args = parser.parse_args(argv)
+    args = parser.parse_args()
 
     generate_pwm_motor_controllers(
         args.output_directory, args.template_root, args.schema_root
@@ -98,4 +98,4 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/wpilibj/generate_hids.py
+++ b/wpilibj/generate_hids.py
@@ -3,9 +3,9 @@
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
+
 import argparse
 import json
-import sys
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
@@ -43,7 +43,7 @@ def generate_hids(output_directory: Path, template_directory: Path):
         write_controller_file(rootPath, controllerName, output)
 
 
-def main(argv):
+def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
@@ -60,10 +60,10 @@ def main(argv):
         default=dirname / "src/generate",
         type=Path,
     )
-    args = parser.parse_args(argv)
+    args = parser.parse_args()
 
     generate_hids(args.output_directory, args.template_root)
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/wpilibj/generate_pwm_motor_controllers.py
+++ b/wpilibj/generate_pwm_motor_controllers.py
@@ -3,9 +3,9 @@
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
+
 import argparse
 import json
-import sys
 from pathlib import Path
 from typing import Any, Dict
 
@@ -40,7 +40,7 @@ def generate_pwm_motor_controllers(output_root, template_root):
         render_template(template, root_path, controller_name, controller)
 
 
-def main(argv):
+def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
@@ -57,10 +57,10 @@ def main(argv):
         default=dirname / "src/generate",
         type=Path,
     )
-    args = parser.parse_args(argv)
+    args = parser.parse_args()
 
     generate_pwm_motor_controllers(args.output_directory, args.template_root)
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/wpimath/generate_numbers.py
+++ b/wpimath/generate_numbers.py
@@ -5,7 +5,6 @@
 # the WPILib BSD license file in the root directory of this project.
 
 import argparse
-import sys
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
@@ -39,7 +38,7 @@ def generate_numbers(output_directory: Path, template_root: Path):
     output(rootPath, "Nat.java", contents)
 
 
-def main(argv):
+def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
@@ -56,10 +55,10 @@ def main(argv):
         default=dirname / "src/generate",
         type=Path,
     )
-    args = parser.parse_args(argv)
+    args = parser.parse_args()
 
     generate_numbers(args.output_directory, args.template_root)
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/wpimath/generate_quickbuf.py
+++ b/wpimath/generate_quickbuf.py
@@ -3,9 +3,9 @@
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
+
 import argparse
 import subprocess
-import sys
 from pathlib import Path
 
 
@@ -37,7 +37,7 @@ def generate_quickbuf(
         )
 
 
-def main(argv):
+def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
@@ -64,7 +64,7 @@ def main(argv):
         default=dirname / "src/main/proto",
         type=Path,
     )
-    args = parser.parse_args(argv)
+    args = parser.parse_args()
 
     generate_quickbuf(
         args.protoc, args.quickbuf_plugin, args.output_directory, args.proto_directory
@@ -72,4 +72,4 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/wpiunits/generate_units.py
+++ b/wpiunits/generate_units.py
@@ -4,8 +4,9 @@
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
 
-# This script generates unit-specific interfaces and mutable and immutable implementations of
-# those interfaces.
+# This script generates unit-specific interfaces and mutable and immutable
+# implementations of those interfaces.
+#
 # Generated files will be located in wpiunits/src/generated/main/
 
 import argparse


### PR DESCRIPTION
argparse will automatically read sys.argv, so we don't need to pass it in manually. Furthermore, none of our scripts customize argv.