### PR TITLE
[macos build] Increase keychain timeout to 6 hours

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -121,7 +121,7 @@ jobs:
           matrix.artifact-name == 'macOS' && (github.repository == 'wpilibsuite/allwpilib' &&
           (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
       - name: Set Keychain Lock Timeout
-        run: security set-keychain-settings -lut 3600
+        run: security set-keychain-settings -lut 21600
         if: |
           matrix.artifact-name == 'macOS' && (github.repository == 'wpilibsuite/allwpilib' &&
           (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))

--- a/.github/workflows/sentinel-build.yml
+++ b/.github/workflows/sentinel-build.yml
@@ -119,7 +119,7 @@ jobs:
         if: |
           matrix.artifact-name == 'macOS' && (github.repository_owner == 'wpilibsuite' && github.ref == 'refs/heads/main')
       - name: Set Keychain Lock Timeout
-        run: security set-keychain-settings -lut 3600
+        run: security set-keychain-settings -lut 21600
         if: |
           matrix.artifact-name == 'macOS' && (github.repository_owner == 'wpilibsuite' && github.ref == 'refs/heads/main')
       - name: Set Java Heap Size


### PR DESCRIPTION
The 1 hour timeout is likely causing the occasional hang in macos signing. If the keychain times out before the signing is complete, signing will hang. Setting the keychain timeout to 6 hours will guarantee that this doesn't happen.