### PR TITLE
[ci] Disable caching for setup-go

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -121,6 +121,7 @@ jobs:
       - name: Set up Go 1.15.x
         uses: actions/setup-go@v5
         with:
+          cache: false
           go-version: 1.15.x
         id: go
 


### PR DESCRIPTION
setup-go is warning because it can't find go.sum, which we don't have.