### PR TITLE
[epilogue] Generate unique names for variables used in instanceof chains

### DIFF
--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/LoggableHandler.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/LoggableHandler.java
@@ -111,9 +111,9 @@ public class LoggableHandler extends ElementHandler {
   private static String cacheVariableName(Element element) {
     // Generate unique names in case a field and a method share the same name
     if (element instanceof VariableElement) {
-      return "$%s".formatted(element.getSimpleName().toString());
+      return "$$%s".formatted(element.getSimpleName().toString());
     } else if (element instanceof ExecutableElement) {
-      return "_%s".formatted(element.getSimpleName().toString());
+      return "__%s".formatted(element.getSimpleName().toString());
     } else {
       // Generic fallback (shouldn't get here, since only fields and methods are logged)
       return element.getSimpleName().toString();

--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
@@ -1134,29 +1134,29 @@ class AnnotationProcessorTest {
           @Override
           public void update(DataLogger dataLogger, Example object) {
             if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-              var $asInterface = object.asInterface;
-              if ($asInterface instanceof edu.wpi.first.epilogue.Impl1 edu_wpi_first_epilogue_Impl1) {
+              var $$asInterface = object.asInterface;
+              if ($$asInterface instanceof edu.wpi.first.epilogue.Impl1 edu_wpi_first_epilogue_Impl1) {
                 Epilogue.impl1Logger.tryUpdate(dataLogger.getSubLogger("asInterface"), edu_wpi_first_epilogue_Impl1, Epilogue.getConfig().errorHandler);
-              } else if ($asInterface instanceof edu.wpi.first.epilogue.Impl2 edu_wpi_first_epilogue_Impl2) {
+              } else if ($$asInterface instanceof edu.wpi.first.epilogue.Impl2 edu_wpi_first_epilogue_Impl2) {
                 Epilogue.impl2Logger.tryUpdate(dataLogger.getSubLogger("asInterface"), edu_wpi_first_epilogue_Impl2, Epilogue.getConfig().errorHandler);
               } else {
                 // Base type edu.wpi.first.epilogue.IFace
-                Epilogue.iFaceLogger.tryUpdate(dataLogger.getSubLogger("asInterface"), $asInterface, Epilogue.getConfig().errorHandler);
+                Epilogue.iFaceLogger.tryUpdate(dataLogger.getSubLogger("asInterface"), $$asInterface, Epilogue.getConfig().errorHandler);
               };
               Epilogue.impl1Logger.tryUpdate(dataLogger.getSubLogger("firstImpl"), object.firstImpl, Epilogue.getConfig().errorHandler);
               Epilogue.impl2Logger.tryUpdate(dataLogger.getSubLogger("secondImpl"), object.secondImpl, Epilogue.getConfig().errorHandler);
-              var $complex = object.complex;
-              if ($complex instanceof edu.wpi.first.epilogue.ConcreteLogged edu_wpi_first_epilogue_ConcreteLogged) {
+              var $$complex = object.complex;
+              if ($$complex instanceof edu.wpi.first.epilogue.ConcreteLogged edu_wpi_first_epilogue_ConcreteLogged) {
                 Epilogue.concreteLoggedLogger.tryUpdate(dataLogger.getSubLogger("complex"), edu_wpi_first_epilogue_ConcreteLogged, Epilogue.getConfig().errorHandler);
-              } else if ($complex instanceof edu.wpi.first.epilogue.I4 edu_wpi_first_epilogue_I4) {
+              } else if ($$complex instanceof edu.wpi.first.epilogue.I4 edu_wpi_first_epilogue_I4) {
                 Epilogue.i4Logger.tryUpdate(dataLogger.getSubLogger("complex"), edu_wpi_first_epilogue_I4, Epilogue.getConfig().errorHandler);
-              } else if ($complex instanceof edu.wpi.first.epilogue.I2 edu_wpi_first_epilogue_I2) {
+              } else if ($$complex instanceof edu.wpi.first.epilogue.I2 edu_wpi_first_epilogue_I2) {
                 Epilogue.i2Logger.tryUpdate(dataLogger.getSubLogger("complex"), edu_wpi_first_epilogue_I2, Epilogue.getConfig().errorHandler);
-              } else if ($complex instanceof edu.wpi.first.epilogue.I3 edu_wpi_first_epilogue_I3) {
+              } else if ($$complex instanceof edu.wpi.first.epilogue.I3 edu_wpi_first_epilogue_I3) {
                 Epilogue.i3Logger.tryUpdate(dataLogger.getSubLogger("complex"), edu_wpi_first_epilogue_I3, Epilogue.getConfig().errorHandler);
               } else {
                 // Base type edu.wpi.first.epilogue.I
-                Epilogue.iLogger.tryUpdate(dataLogger.getSubLogger("complex"), $complex, Epilogue.getConfig().errorHandler);
+                Epilogue.iLogger.tryUpdate(dataLogger.getSubLogger("complex"), $$complex, Epilogue.getConfig().errorHandler);
               };
             }
           }
@@ -1210,14 +1210,14 @@ class AnnotationProcessorTest {
           @Override
           public void update(DataLogger dataLogger, Example object) {
             if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-              var $theField = object.theField;
-              if ($theField instanceof edu.wpi.first.epilogue.Base edu_wpi_first_epilogue_Base) {
+              var $$theField = object.theField;
+              if ($$theField instanceof edu.wpi.first.epilogue.Base edu_wpi_first_epilogue_Base) {
                 Epilogue.baseLogger.tryUpdate(dataLogger.getSubLogger("theField"), edu_wpi_first_epilogue_Base, Epilogue.getConfig().errorHandler);
-              } else if ($theField instanceof edu.wpi.first.epilogue.ExtendingInterface edu_wpi_first_epilogue_ExtendingInterface) {
+              } else if ($$theField instanceof edu.wpi.first.epilogue.ExtendingInterface edu_wpi_first_epilogue_ExtendingInterface) {
                 Epilogue.extendingInterfaceLogger.tryUpdate(dataLogger.getSubLogger("theField"), edu_wpi_first_epilogue_ExtendingInterface, Epilogue.getConfig().errorHandler);
               } else {
                 // Base type edu.wpi.first.epilogue.I
-                Epilogue.iLogger.tryUpdate(dataLogger.getSubLogger("theField"), $theField, Epilogue.getConfig().errorHandler);
+                Epilogue.iLogger.tryUpdate(dataLogger.getSubLogger("theField"), $$theField, Epilogue.getConfig().errorHandler);
               };
             }
           }


### PR DESCRIPTION
Fixes an issue where the variable names would clash with the field names of the associated VarHandles