### PR TITLE
[hal] Add MagicBot framework to usage reporting

### DIFF
--- a/hal/src/generate/Instances.txt
+++ b/hal/src/generate/Instances.txt
@@ -13,6 +13,7 @@ kFramework_Timed = 4
 kFramework_ROS = 5
 kFramework_RobotBuilder = 6
 kFramework_AdvantageKit = 7
+kFramework_MagicBot = 8
 kRobotDrive_ArcadeStandard = 1
 kRobotDrive_ArcadeButtonSpin = 2
 kRobotDrive_ArcadeRatioCurve = 3

--- a/hal/src/generated/main/java/edu/wpi/first/hal/FRCNetComm.java
+++ b/hal/src/generated/main/java/edu/wpi/first/hal/FRCNetComm.java
@@ -291,6 +291,8 @@ public final class FRCNetComm {
     public static final int kFramework_RobotBuilder = 6;
     /** kFramework_AdvantageKit = 7. */
     public static final int kFramework_AdvantageKit = 7;
+    /** kFramework_MagicBot = 8. */
+    public static final int kFramework_MagicBot = 8;
     /** kRobotDrive_ArcadeStandard = 1. */
     public static final int kRobotDrive_ArcadeStandard = 1;
     /** kRobotDrive_ArcadeButtonSpin = 2. */

--- a/hal/src/generated/main/native/include/hal/FRCUsageReporting.h
+++ b/hal/src/generated/main/native/include/hal/FRCUsageReporting.h
@@ -184,6 +184,7 @@ namespace HALUsageReporting {
     kFramework_ROS = 5,
     kFramework_RobotBuilder = 6,
     kFramework_AdvantageKit = 7,
+    kFramework_MagicBot = 8,
     kRobotDrive_ArcadeStandard = 1,
     kRobotDrive_ArcadeButtonSpin = 2,
     kRobotDrive_ArcadeRatioCurve = 3,

--- a/hal/src/generated/main/native/include/hal/UsageReporting.h
+++ b/hal/src/generated/main/native/include/hal/UsageReporting.h
@@ -157,6 +157,7 @@ typedef enum
     kFramework_ROS = 5,
     kFramework_RobotBuilder = 6,
     kFramework_AdvantageKit = 7,
+    kFramework_MagicBot = 8,
     kRobotDrive_ArcadeStandard = 1,
     kRobotDrive_ArcadeButtonSpin = 2,
     kRobotDrive_ArcadeRatioCurve = 3,


### PR DESCRIPTION
This adds an enum to enable usage reporting for the RobotPy `magicbot` framework: https://robotpy.readthedocs.io/en/stable/frameworks/magicbot.html