### PR TITLE
Revert "[glass] Storage: Store Value by value"

### DIFF
--- a/glass/src/lib/native/include/glass/Storage.h
+++ b/glass/src/lib/native/include/glass/Storage.h
@@ -62,22 +62,6 @@ class Storage {
     explicit Value(Type type) : type{type} {}
     Value(const Value&) = delete;
     Value& operator=(const Value&) = delete;
-    Value(Value&& rhs)
-        : type{rhs.type},
-          stringVal{std::move(rhs.stringVal)},
-          stringDefault{std::move(rhs.stringDefault)},
-          hasDefault{rhs.hasDefault} {
-      rhs.type = kNone;
-    }
-    Value& operator=(Value&& rhs) {
-      Reset(kNone);
-      type = rhs.type;
-      stringVal = std::move(rhs.stringVal);
-      stringDefault = std::move(rhs.stringDefault);
-      hasDefault = rhs.hasDefault;
-      rhs.type = kNone;
-      return *this;
-    }
     ~Value() { Reset(kNone); }
 
     Type type = kNone;
@@ -119,7 +103,7 @@ class Storage {
     void Reset(Type newType);
   };
 
-  using ValueMap = wpi::StringMap<Value>;
+  using ValueMap = wpi::StringMap<std::unique_ptr<Value>>;
   template <typename Iterator>
   using ChildIterator = detail::ChildIterator<Iterator>;
 
@@ -164,9 +148,7 @@ class Storage {
   std::vector<std::unique_ptr<Storage>>& GetChildArray(std::string_view key);
 
   Value* FindValue(std::string_view key);
-  Value& GetValue(std::string_view key) {
-    return m_values.try_emplace(key, Value::kNone).first->second;
-  }
+  Value& GetValue(std::string_view key);
   Storage& GetChild(std::string_view label_id);
 
   void SetData(std::shared_ptr<void>&& data) { m_data = std::move(data); }
@@ -176,23 +158,15 @@ class Storage {
     return static_cast<T*>(m_data.get());
   }
 
-  template <typename T, typename... Args>
-  T& GetOrNewData(Args&&... args) {
-    if (!m_data) {
-      m_data = std::make_shared<T>(std::forward<Args>(args)...);
-    }
-    return *static_cast<T*>(m_data.get());
-  }
-
   Storage() = default;
   Storage(const Storage&) = delete;
   Storage& operator=(const Storage&) = delete;
 
-  void Insert(std::string_view key, Value&& value) {
-    m_values.try_emplace(std::string{key}, std::move(value));
+  void Insert(std::string_view key, std::unique_ptr<Value> value) {
+    m_values[key] = std::move(value);
   }
 
-  void Erase(std::string_view key);
+  std::unique_ptr<Value> Erase(std::string_view key);
 
   void EraseAll() { m_values.clear(); }
 
@@ -275,7 +249,7 @@ class ChildIterator {
  public:
   ChildIterator(IteratorType it, IteratorType end) noexcept
       : anchor(it), end(end) {
-    while (anchor != end && anchor->second.type != Storage::Value::kChild) {
+    while (anchor != end && anchor->second->type != Storage::Value::kChild) {
       ++anchor;
     }
   }
@@ -286,7 +260,7 @@ class ChildIterator {
   /// increment operator (needed for range-based for)
   ChildIterator& operator++() {
     ++anchor;
-    while (anchor != end && anchor->second.type != Storage::Value::kChild) {
+    while (anchor != end && anchor->second->type != Storage::Value::kChild) {
       ++anchor;
     }
     return *this;
@@ -301,7 +275,7 @@ class ChildIterator {
   std::string_view key() const { return anchor->first; }
 
   /// return value of the iterator
-  Storage& value() const { return *anchor->second.child; }
+  Storage& value() const { return *anchor->second->child; }
 };
 
 }  // namespace detail


### PR DESCRIPTION
This reverts commit 309b370223e0e6db5197ec84417f18250868b23f.

Storage::GetChildArray never initializes the child array when the entry is new, so it returns invalid references.