### PR TITLE
[wpimath] Fix PIDController error tolerance getters

### DIFF
--- a/wpimath/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpimath/src/main/native/cpp/controller/PIDController.cpp
@@ -103,11 +103,11 @@ units::second_t PIDController::GetPeriod() const {
 }
 
 double PIDController::GetPositionTolerance() const {
-  return m_error;
+  return m_errorTolerance;
 }
 
 double PIDController::GetVelocityTolerance() const {
-  return m_errorDerivative;
+  return m_errorDerivativeTolerance;
 }
 
 double PIDController::GetAccumulatedError() const {
@@ -166,7 +166,7 @@ void PIDController::SetTolerance(double errorTolerance,
 }
 
 double PIDController::GetErrorTolerance() const {
-  return m_error;
+  return m_errorTolerance;
 }
 
 double PIDController::GetErrorDerivativeTolerance() const {


### PR DESCRIPTION
Almost all of the C++ getters added in #7088 weren't implemented correctly.