### PR TITLE
[wpimath] Remove unhelpful test fixtures

### DIFF
--- a/wpimath/src/test/java/edu/wpi/first/math/controller/BangBangInputOutputTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/BangBangInputOutputTest.java
@@ -6,24 +6,20 @@ package edu.wpi.first.math.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class BangBangInputOutputTest {
-  private BangBangController m_controller;
-
-  @BeforeEach
-  void setUp() {
-    m_controller = new BangBangController();
-  }
-
   @Test
   void shouldOutput() {
-    assertEquals(m_controller.calculate(0, 1), 1);
+    var controller = new BangBangController();
+
+    assertEquals(controller.calculate(0, 1), 1);
   }
 
   @Test
   void shouldNotOutput() {
-    assertEquals(m_controller.calculate(1, 0), 0);
+    var controller = new BangBangController();
+
+    assertEquals(controller.calculate(1, 0), 0);
   }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/BangBangToleranceTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/BangBangToleranceTest.java
@@ -7,28 +7,24 @@ package edu.wpi.first.math.controller;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class BangBangToleranceTest {
-  private BangBangController m_controller;
-
-  @BeforeEach
-  void setUp() {
-    m_controller = new BangBangController(0.1);
-  }
-
   @Test
   void inTolerance() {
-    m_controller.setSetpoint(1);
-    m_controller.calculate(1);
-    assertTrue(m_controller.atSetpoint());
+    var controller = new BangBangController(0.1);
+
+    controller.setSetpoint(1);
+    controller.calculate(1);
+    assertTrue(controller.atSetpoint());
   }
 
   @Test
   void outOfTolerance() {
-    m_controller.setSetpoint(1);
-    m_controller.calculate(0);
-    assertFalse(m_controller.atSetpoint());
+    var controller = new BangBangController(0.1);
+
+    controller.setSetpoint(1);
+    controller.calculate(0);
+    assertFalse(controller.atSetpoint());
   }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/PIDInputOutputTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/PIDInputOutputTest.java
@@ -6,73 +6,77 @@ package edu.wpi.first.math.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class PIDInputOutputTest {
-  private PIDController m_controller;
-
-  @BeforeEach
-  void setUp() {
-    m_controller = new PIDController(0, 0, 0);
-  }
-
   @Test
   void continuousInputTest() {
-    m_controller.setP(1);
-    m_controller.enableContinuousInput(-180, 180);
-    assertEquals(m_controller.calculate(-179, 179), -2, 1e-5);
+    var controller = new PIDController(0.0, 0.0, 0.0);
 
-    m_controller.enableContinuousInput(0, 360);
-    assertEquals(m_controller.calculate(1, 359), -2, 1e-5);
+    controller.setP(1);
+    controller.enableContinuousInput(-180, 180);
+    assertEquals(controller.calculate(-179, 179), -2, 1e-5);
+
+    controller.enableContinuousInput(0, 360);
+    assertEquals(controller.calculate(1, 359), -2, 1e-5);
   }
 
   @Test
   void proportionalGainOutputTest() {
-    m_controller.setP(4);
+    var controller = new PIDController(0.0, 0.0, 0.0);
 
-    assertEquals(-0.1, m_controller.calculate(0.025, 0), 1e-5);
+    controller.setP(4);
+
+    assertEquals(-0.1, controller.calculate(0.025, 0), 1e-5);
   }
 
   @Test
   void integralGainOutputTest() {
-    m_controller.setI(4);
+    var controller = new PIDController(0.0, 0.0, 0.0);
+
+    controller.setI(4);
 
     double out = 0;
 
     for (int i = 0; i < 5; i++) {
-      out = m_controller.calculate(0.025, 0);
+      out = controller.calculate(0.025, 0);
     }
 
-    assertEquals(-0.5 * m_controller.getPeriod(), out, 1e-5);
+    assertEquals(-0.5 * controller.getPeriod(), out, 1e-5);
   }
 
   @Test
   void derivativeGainOutputTest() {
-    m_controller.setD(4);
+    var controller = new PIDController(0.0, 0.0, 0.0);
 
-    m_controller.calculate(0, 0);
+    controller.setD(4);
 
-    assertEquals(-0.01 / m_controller.getPeriod(), m_controller.calculate(0.0025, 0), 1e-5);
+    controller.calculate(0, 0);
+
+    assertEquals(-0.01 / controller.getPeriod(), controller.calculate(0.0025, 0), 1e-5);
   }
 
   @Test
   void iZoneNoOutputTest() {
-    m_controller.setI(1);
-    m_controller.setIZone(1);
+    var controller = new PIDController(0.0, 0.0, 0.0);
 
-    double out = m_controller.calculate(2, 0);
+    controller.setI(1);
+    controller.setIZone(1);
+
+    double out = controller.calculate(2, 0);
 
     assertEquals(0, out, 1e-5);
   }
 
   @Test
   void iZoneOutputTest() {
-    m_controller.setI(1);
-    m_controller.setIZone(1);
+    var controller = new PIDController(0.0, 0.0, 0.0);
 
-    double out = m_controller.calculate(1, 0);
+    controller.setI(1);
+    controller.setIZone(1);
 
-    assertEquals(-1 * m_controller.getPeriod(), out, 1e-5);
+    double out = controller.calculate(1, 0);
+
+    assertEquals(-1 * controller.getPeriod(), out, 1e-5);
   }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/ProfiledPIDInputOutputTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/ProfiledPIDInputOutputTest.java
@@ -8,107 +8,120 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ProfiledPIDInputOutputTest {
-  private ProfiledPIDController m_controller;
-
-  @BeforeEach
-  void setUp() {
-    m_controller = new ProfiledPIDController(0, 0, 0, new TrapezoidProfile.Constraints(360, 180));
-  }
-
   @Test
   void continuousInputTest1() {
-    m_controller.setP(1);
-    m_controller.enableContinuousInput(-180, 180);
+    var controller =
+        new ProfiledPIDController(0.0, 0.0, 0.0, new TrapezoidProfile.Constraints(360, 180));
+
+    controller.setP(1);
+    controller.enableContinuousInput(-180, 180);
 
     final double kSetpoint = -179.0;
     final double kMeasurement = -179.0;
     final double kGoal = 179.0;
 
-    m_controller.reset(kSetpoint);
-    assertTrue(m_controller.calculate(kMeasurement, kGoal) < 0.0);
+    controller.reset(kSetpoint);
+    assertTrue(controller.calculate(kMeasurement, kGoal) < 0.0);
 
     // Error must be less than half the input range at all times
-    assertTrue(Math.abs(m_controller.getSetpoint().position - kMeasurement) < 180.0);
+    assertTrue(Math.abs(controller.getSetpoint().position - kMeasurement) < 180.0);
   }
 
   @Test
   void continuousInputTest2() {
-    m_controller.setP(1);
-    m_controller.enableContinuousInput(-Math.PI, Math.PI);
+    var controller =
+        new ProfiledPIDController(0.0, 0.0, 0.0, new TrapezoidProfile.Constraints(360, 180));
+
+    controller.setP(1);
+    controller.enableContinuousInput(-Math.PI, Math.PI);
 
     final double kSetpoint = -3.4826633343199735;
     final double kMeasurement = -3.1352207333939606;
     final double kGoal = -3.534162788601621;
 
-    m_controller.reset(kSetpoint);
-    assertTrue(m_controller.calculate(kMeasurement, kGoal) < 0.0);
+    controller.reset(kSetpoint);
+    assertTrue(controller.calculate(kMeasurement, kGoal) < 0.0);
 
     // Error must be less than half the input range at all times
-    assertTrue(Math.abs(m_controller.getSetpoint().position - kMeasurement) < Math.PI);
+    assertTrue(Math.abs(controller.getSetpoint().position - kMeasurement) < Math.PI);
   }
 
   @Test
   void continuousInputTest3() {
-    m_controller.setP(1);
-    m_controller.enableContinuousInput(-Math.PI, Math.PI);
+    var controller =
+        new ProfiledPIDController(0.0, 0.0, 0.0, new TrapezoidProfile.Constraints(360, 180));
+
+    controller.setP(1);
+    controller.enableContinuousInput(-Math.PI, Math.PI);
 
     final double kSetpoint = -3.5176604690006377;
     final double kMeasurement = 3.1191729343822456;
     final double kGoal = 2.709680418117445;
 
-    m_controller.reset(kSetpoint);
-    assertTrue(m_controller.calculate(kMeasurement, kGoal) < 0.0);
+    controller.reset(kSetpoint);
+    assertTrue(controller.calculate(kMeasurement, kGoal) < 0.0);
 
     // Error must be less than half the input range at all times
-    assertTrue(Math.abs(m_controller.getSetpoint().position - kMeasurement) < Math.PI);
+    assertTrue(Math.abs(controller.getSetpoint().position - kMeasurement) < Math.PI);
   }
 
   @Test
   void continuousInputTest4() {
-    m_controller.setP(1);
-    m_controller.enableContinuousInput(0, 2.0 * Math.PI);
+    var controller =
+        new ProfiledPIDController(0.0, 0.0, 0.0, new TrapezoidProfile.Constraints(360, 180));
+
+    controller.setP(1);
+    controller.enableContinuousInput(0, 2.0 * Math.PI);
 
     final double kSetpoint = 2.78;
     final double kMeasurement = 3.12;
     final double kGoal = 2.71;
 
-    m_controller.reset(kSetpoint);
-    assertTrue(m_controller.calculate(kMeasurement, kGoal) < 0.0);
+    controller.reset(kSetpoint);
+    assertTrue(controller.calculate(kMeasurement, kGoal) < 0.0);
 
     // Error must be less than half the input range at all times
-    assertTrue(Math.abs(m_controller.getSetpoint().position - kMeasurement) < Math.PI / 2.0);
+    assertTrue(Math.abs(controller.getSetpoint().position - kMeasurement) < Math.PI / 2.0);
   }
 
   @Test
   void proportionalGainOutputTest() {
-    m_controller.setP(4);
+    var controller =
+        new ProfiledPIDController(0.0, 0.0, 0.0, new TrapezoidProfile.Constraints(360, 180));
 
-    assertEquals(-0.1, m_controller.calculate(0.025, 0), 1e-5);
+    controller.setP(4);
+
+    assertEquals(-0.1, controller.calculate(0.025, 0), 1e-5);
   }
 
   @Test
   void integralGainOutputTest() {
-    m_controller.setI(4);
+    var controller =
+        new ProfiledPIDController(0.0, 0.0, 0.0, new TrapezoidProfile.Constraints(360, 180));
+
+    controller.setI(4);
 
     double out = 0;
 
     for (int i = 0; i < 5; i++) {
-      out = m_controller.calculate(0.025, 0);
+      out = controller.calculate(0.025, 0);
     }
 
-    assertEquals(-0.5 * m_controller.getPeriod(), out, 1e-5);
+    assertEquals(-0.5 * controller.getPeriod(), out, 1e-5);
   }
 
   @Test
   void derivativeGainOutputTest() {
-    m_controller.setD(4);
+    var controller =
+        new ProfiledPIDController(0.0, 0.0, 0.0, new TrapezoidProfile.Constraints(360, 180));
 
-    m_controller.calculate(0, 0);
+    controller.setD(4);
 
-    assertEquals(-0.01 / m_controller.getPeriod(), m_controller.calculate(0.0025, 0), 1e-5);
+    controller.calculate(0, 0);
+
+    assertEquals(-0.01 / controller.getPeriod(), controller.calculate(0.0025, 0), 1e-5);
   }
 }

--- a/wpimath/src/test/native/cpp/controller/BangBangInputOutputTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/BangBangInputOutputTest.cpp
@@ -6,15 +6,14 @@
 
 #include "frc/controller/BangBangController.h"
 
-class BangBangInputOutputTest : public testing::Test {
- protected:
+TEST(BangBangInputOutputTest, ShouldOutput) {
   frc::BangBangController controller;
-};
 
-TEST_F(BangBangInputOutputTest, ShouldOutput) {
   EXPECT_DOUBLE_EQ(controller.Calculate(0, 1), 1);
 }
 
-TEST_F(BangBangInputOutputTest, ShouldNotOutput) {
+TEST(BangBangInputOutputTest, ShouldNotOutput) {
+  frc::BangBangController controller;
+
   EXPECT_DOUBLE_EQ(controller.Calculate(1, 0), 0);
 }

--- a/wpimath/src/test/native/cpp/controller/BangBangToleranceTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/BangBangToleranceTest.cpp
@@ -6,18 +6,17 @@
 
 #include "frc/controller/BangBangController.h"
 
-class BangBangToleranceTest : public testing::Test {
- protected:
+TEST(BangBangToleranceTest, InTolerance) {
   frc::BangBangController controller{0.1};
-};
 
-TEST_F(BangBangToleranceTest, InTolerance) {
   controller.SetSetpoint(1);
   controller.Calculate(1);
   EXPECT_TRUE(controller.AtSetpoint());
 }
 
-TEST_F(BangBangToleranceTest, OutOfTolerance) {
+TEST(BangBangToleranceTest, OutOfTolerance) {
+  frc::BangBangController controller{0.1};
+
   controller.SetSetpoint(1);
   controller.Calculate(0);
   EXPECT_FALSE(controller.AtSetpoint());

--- a/wpimath/src/test/native/cpp/controller/PIDInputOutputTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/PIDInputOutputTest.cpp
@@ -6,65 +6,68 @@
 
 #include "frc/controller/PIDController.h"
 
-class PIDInputOutputTest : public testing::Test {
- protected:
-  frc::PIDController* controller;
+TEST(PIDInputOutputTest, ContinuousInput) {
+  frc::PIDController controller{0.0, 0.0, 0.0};
 
-  void SetUp() override { controller = new frc::PIDController{0, 0, 0}; }
+  controller.SetP(1);
+  controller.EnableContinuousInput(-180, 180);
+  EXPECT_DOUBLE_EQ(controller.Calculate(-179, 179), -2);
 
-  void TearDown() override { delete controller; }
-};
-
-TEST_F(PIDInputOutputTest, ContinuousInput) {
-  controller->SetP(1);
-  controller->EnableContinuousInput(-180, 180);
-  EXPECT_DOUBLE_EQ(controller->Calculate(-179, 179), -2);
-
-  controller->EnableContinuousInput(0, 360);
-  EXPECT_DOUBLE_EQ(controller->Calculate(1, 359), -2);
+  controller.EnableContinuousInput(0, 360);
+  EXPECT_DOUBLE_EQ(controller.Calculate(1, 359), -2);
 }
 
-TEST_F(PIDInputOutputTest, ProportionalGainOutput) {
-  controller->SetP(4);
+TEST(PIDInputOutputTest, ProportionalGainOutput) {
+  frc::PIDController controller{0.0, 0.0, 0.0};
 
-  EXPECT_DOUBLE_EQ(-0.1, controller->Calculate(0.025, 0));
+  controller.SetP(4);
+
+  EXPECT_DOUBLE_EQ(-0.1, controller.Calculate(0.025, 0));
 }
 
-TEST_F(PIDInputOutputTest, IntegralGainOutput) {
-  controller->SetI(4);
+TEST(PIDInputOutputTest, IntegralGainOutput) {
+  frc::PIDController controller{0.0, 0.0, 0.0};
+
+  controller.SetI(4);
 
   double out = 0;
 
   for (int i = 0; i < 5; i++) {
-    out = controller->Calculate(0.025, 0);
+    out = controller.Calculate(0.025, 0);
   }
 
-  EXPECT_DOUBLE_EQ(-0.5 * controller->GetPeriod().value(), out);
+  EXPECT_DOUBLE_EQ(-0.5 * controller.GetPeriod().value(), out);
 }
 
-TEST_F(PIDInputOutputTest, DerivativeGainOutput) {
-  controller->SetD(4);
+TEST(PIDInputOutputTest, DerivativeGainOutput) {
+  frc::PIDController controller{0.0, 0.0, 0.0};
 
-  controller->Calculate(0, 0);
+  controller.SetD(4);
 
-  EXPECT_DOUBLE_EQ(-10_ms / controller->GetPeriod(),
-                   controller->Calculate(0.0025, 0));
+  controller.Calculate(0, 0);
+
+  EXPECT_DOUBLE_EQ(-10_ms / controller.GetPeriod(),
+                   controller.Calculate(0.0025, 0));
 }
 
-TEST_F(PIDInputOutputTest, IZoneNoOutput) {
-  controller->SetI(1);
-  controller->SetIZone(1);
+TEST(PIDInputOutputTest, IZoneNoOutput) {
+  frc::PIDController controller{0.0, 0.0, 0.0};
 
-  double out = controller->Calculate(2, 0);
+  controller.SetI(1);
+  controller.SetIZone(1);
+
+  double out = controller.Calculate(2, 0);
 
   EXPECT_DOUBLE_EQ(0, out);
 }
 
-TEST_F(PIDInputOutputTest, IZoneOutput) {
-  controller->SetI(1);
-  controller->SetIZone(1);
+TEST(PIDInputOutputTest, IZoneOutput) {
+  frc::PIDController controller{0.0, 0.0, 0.0};
 
-  double out = controller->Calculate(1, 0);
+  controller.SetI(1);
+  controller.SetIZone(1);
 
-  EXPECT_DOUBLE_EQ(-1 * controller->GetPeriod().value(), out);
+  double out = controller.Calculate(1, 0);
+
+  EXPECT_DOUBLE_EQ(-1 * controller.GetPeriod().value(), out);
 }

--- a/wpimath/src/test/native/cpp/controller/ProfiledPIDInputOutputTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/ProfiledPIDInputOutputTest.cpp
@@ -11,108 +11,117 @@
 #include "units/angular_acceleration.h"
 #include "units/angular_velocity.h"
 
-class ProfiledPIDInputOutputTest : public testing::Test {
- protected:
-  frc::ProfiledPIDController<units::degrees>* controller;
+TEST(ProfiledPIDInputOutputTest, ContinuousInput1) {
+  frc::ProfiledPIDController<units::degree> controller{
+      0.0, 0.0, 0.0, {360_deg_per_s, 180_deg_per_s_sq}};
 
-  void SetUp() override {
-    controller = new frc::ProfiledPIDController<units::degrees>(
-        0, 0, 0, {360_deg_per_s, 180_deg_per_s_sq});
-  }
-
-  void TearDown() override { delete controller; }
-};
-
-TEST_F(ProfiledPIDInputOutputTest, ContinuousInput1) {
-  controller->SetP(1);
-  controller->EnableContinuousInput(-180_deg, 180_deg);
+  controller.SetP(1);
+  controller.EnableContinuousInput(-180_deg, 180_deg);
 
   static constexpr units::degree_t kSetpoint{-179.0};
   static constexpr units::degree_t kMeasurement{-179.0};
   static constexpr units::degree_t kGoal{179.0};
 
-  controller->Reset(kSetpoint);
-  EXPECT_LT(controller->Calculate(kMeasurement, kGoal), 0.0);
+  controller.Reset(kSetpoint);
+  EXPECT_LT(controller.Calculate(kMeasurement, kGoal), 0.0);
 
   // Error must be less than half the input range at all times
-  EXPECT_LT(units::math::abs(controller->GetSetpoint().position - kMeasurement),
+  EXPECT_LT(units::math::abs(controller.GetSetpoint().position - kMeasurement),
             180_deg);
 }
 
-TEST_F(ProfiledPIDInputOutputTest, ContinuousInput2) {
-  controller->SetP(1);
-  controller->EnableContinuousInput(-units::radian_t{std::numbers::pi},
-                                    units::radian_t{std::numbers::pi});
+TEST(ProfiledPIDInputOutputTest, ContinuousInput2) {
+  frc::ProfiledPIDController<units::degree> controller{
+      0.0, 0.0, 0.0, {360_deg_per_s, 180_deg_per_s_sq}};
+
+  controller.SetP(1);
+  controller.EnableContinuousInput(-units::radian_t{std::numbers::pi},
+                                   units::radian_t{std::numbers::pi});
 
   static constexpr units::radian_t kSetpoint{-3.4826633343199735};
   static constexpr units::radian_t kMeasurement{-3.1352207333939606};
   static constexpr units::radian_t kGoal{-3.534162788601621};
 
-  controller->Reset(kSetpoint);
-  EXPECT_LT(controller->Calculate(kMeasurement, kGoal), 0.0);
+  controller.Reset(kSetpoint);
+  EXPECT_LT(controller.Calculate(kMeasurement, kGoal), 0.0);
 
   // Error must be less than half the input range at all times
-  EXPECT_LT(units::math::abs(controller->GetSetpoint().position - kMeasurement),
+  EXPECT_LT(units::math::abs(controller.GetSetpoint().position - kMeasurement),
             units::radian_t{std::numbers::pi});
 }
 
-TEST_F(ProfiledPIDInputOutputTest, ContinuousInput3) {
-  controller->SetP(1);
-  controller->EnableContinuousInput(-units::radian_t{std::numbers::pi},
-                                    units::radian_t{std::numbers::pi});
+TEST(ProfiledPIDInputOutputTest, ContinuousInput3) {
+  frc::ProfiledPIDController<units::degree> controller{
+      0.0, 0.0, 0.0, {360_deg_per_s, 180_deg_per_s_sq}};
+
+  controller.SetP(1);
+  controller.EnableContinuousInput(-units::radian_t{std::numbers::pi},
+                                   units::radian_t{std::numbers::pi});
 
   static constexpr units::radian_t kSetpoint{-3.5176604690006377};
   static constexpr units::radian_t kMeasurement{3.1191729343822456};
   static constexpr units::radian_t kGoal{2.709680418117445};
 
-  controller->Reset(kSetpoint);
-  EXPECT_LT(controller->Calculate(kMeasurement, kGoal), 0.0);
+  controller.Reset(kSetpoint);
+  EXPECT_LT(controller.Calculate(kMeasurement, kGoal), 0.0);
 
   // Error must be less than half the input range at all times
-  EXPECT_LT(units::math::abs(controller->GetSetpoint().position - kMeasurement),
+  EXPECT_LT(units::math::abs(controller.GetSetpoint().position - kMeasurement),
             units::radian_t{std::numbers::pi});
 }
 
-TEST_F(ProfiledPIDInputOutputTest, ContinuousInput4) {
-  controller->SetP(1);
-  controller->EnableContinuousInput(0_rad,
-                                    units::radian_t{2.0 * std::numbers::pi});
+TEST(ProfiledPIDInputOutputTest, ContinuousInput4) {
+  frc::ProfiledPIDController<units::degree> controller{
+      0.0, 0.0, 0.0, {360_deg_per_s, 180_deg_per_s_sq}};
+
+  controller.SetP(1);
+  controller.EnableContinuousInput(0_rad,
+                                   units::radian_t{2.0 * std::numbers::pi});
 
   static constexpr units::radian_t kSetpoint{2.78};
   static constexpr units::radian_t kMeasurement{3.12};
   static constexpr units::radian_t kGoal{2.71};
 
-  controller->Reset(kSetpoint);
-  EXPECT_LT(controller->Calculate(kMeasurement, kGoal), 0.0);
+  controller.Reset(kSetpoint);
+  EXPECT_LT(controller.Calculate(kMeasurement, kGoal), 0.0);
 
   // Error must be less than half the input range at all times
-  EXPECT_LT(units::math::abs(controller->GetSetpoint().position - kMeasurement),
+  EXPECT_LT(units::math::abs(controller.GetSetpoint().position - kMeasurement),
             units::radian_t{std::numbers::pi});
 }
 
-TEST_F(ProfiledPIDInputOutputTest, ProportionalGainOutput) {
-  controller->SetP(4);
+TEST(ProfiledPIDInputOutputTest, ProportionalGainOutput) {
+  frc::ProfiledPIDController<units::degree> controller{
+      0.0, 0.0, 0.0, {360_deg_per_s, 180_deg_per_s_sq}};
 
-  EXPECT_DOUBLE_EQ(-0.1, controller->Calculate(0.025_deg, 0_deg));
+  controller.SetP(4);
+
+  EXPECT_DOUBLE_EQ(-0.1, controller.Calculate(0.025_deg, 0_deg));
 }
 
-TEST_F(ProfiledPIDInputOutputTest, IntegralGainOutput) {
-  controller->SetI(4);
+TEST(ProfiledPIDInputOutputTest, IntegralGainOutput) {
+  frc::ProfiledPIDController<units::degree> controller{
+      0.0, 0.0, 0.0, {360_deg_per_s, 180_deg_per_s_sq}};
+
+  controller.SetI(4);
 
   double out = 0;
 
   for (int i = 0; i < 5; i++) {
-    out = controller->Calculate(0.025_deg, 0_deg);
+    out = controller.Calculate(0.025_deg, 0_deg);
   }
 
-  EXPECT_DOUBLE_EQ(-0.5 * controller->GetPeriod().value(), out);
+  EXPECT_DOUBLE_EQ(-0.5 * controller.GetPeriod().value(), out);
 }
 
-TEST_F(ProfiledPIDInputOutputTest, DerivativeGainOutput) {
-  controller->SetD(4);
+TEST(ProfiledPIDInputOutputTest, DerivativeGainOutput) {
+  frc::ProfiledPIDController<units::degree> controller{
+      0.0, 0.0, 0.0, {360_deg_per_s, 180_deg_per_s_sq}};
 
-  controller->Calculate(0_deg, 0_deg);
+  controller.SetD(4);
 
-  EXPECT_DOUBLE_EQ(-10_ms / controller->GetPeriod(),
-                   controller->Calculate(0.0025_deg, 0_deg));
+  controller.Calculate(0_deg, 0_deg);
+
+  EXPECT_DOUBLE_EQ(-10_ms / controller.GetPeriod(),
+                   controller.Calculate(0.0025_deg, 0_deg));
 }


### PR DESCRIPTION
These test fixtures were adding complexity while only saving one line of object initialization per test. Our other tests like this just make the object at the top of each test.