### PR TITLE
[cmd] Revert "Call wrapped command initSendable (#6471)"

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/WrapperCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/WrapperCommand.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.wpilibj2.command;
 
-import edu.wpi.first.util.sendable.SendableBuilder;
 import java.util.Set;
 
 /**
@@ -100,10 +99,5 @@ public abstract class WrapperCommand extends Command {
   @Override
   public InterruptionBehavior getInterruptionBehavior() {
     return m_command.getInterruptionBehavior();
-  }
-
-  @Override
-  public void initSendable(SendableBuilder builder) {
-    m_command.initSendable(builder);
   }
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/WrapperCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/WrapperCommand.cpp
@@ -45,7 +45,3 @@ Command::InterruptionBehavior WrapperCommand::GetInterruptionBehavior() const {
 wpi::SmallSet<Subsystem*, 4> WrapperCommand::GetRequirements() const {
   return m_command->GetRequirements();
 }
-
-void WrapperCommand::InitSendable(wpi::SendableBuilder& builder) {
-  m_command->InitSendable(builder);
-}

--- a/wpilibNewCommands/src/main/native/include/frc2/command/WrapperCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/WrapperCommand.h
@@ -68,8 +68,6 @@ class WrapperCommand : public CommandHelper<Command, WrapperCommand> {
 
   wpi::SmallSet<Subsystem*, 4> GetRequirements() const override;
 
-  void InitSendable(wpi::SendableBuilder& builder) override;
-
  protected:
   /// Command being wrapped.
   std::unique_ptr<Command> m_command;


### PR DESCRIPTION
Closes #7352
This reverts commit 7bc0380694916fdb0082c6a746d1d937d6258c03.

Calling initSendable on the wrapped command is fundamentally flawed as the wrapper is the command being sent.