### PR TITLE
[wpilib] Timer: Add getLoopTimestamp()

### DIFF
--- a/wpilibc/src/main/native/cpp/TimedRobot.cpp
+++ b/wpilibc/src/main/native/cpp/TimedRobot.cpp
@@ -46,7 +46,7 @@ void TimedRobot::StartCompetition() {
     if (currentTime.count() == 0 || status != 0) {
       break;
     }
-    Timer::s_loopTimestamp = currentTime;
+    Timer::SetLoopTimestamp(currentTime);
 
     callback.func();
 

--- a/wpilibc/src/main/native/cpp/TimedRobot.cpp
+++ b/wpilibc/src/main/native/cpp/TimedRobot.cpp
@@ -14,6 +14,7 @@
 #include <hal/Notifier.h>
 
 #include "frc/Errors.h"
+#include "frc/Timer.h"
 
 using namespace frc;
 
@@ -45,6 +46,7 @@ void TimedRobot::StartCompetition() {
     if (currentTime.count() == 0 || status != 0) {
       break;
     }
+    Timer::s_loopTimestamp = currentTime;
 
     callback.func();
 

--- a/wpilibc/src/main/native/cpp/Timer.cpp
+++ b/wpilibc/src/main/native/cpp/Timer.cpp
@@ -30,6 +30,8 @@ units::second_t GetTime() {
 
 using namespace frc;
 
+units::second_t Timer::s_loopTimestamp = 0_s;
+
 Timer::Timer() {
   Reset();
 }

--- a/wpilibc/src/main/native/include/frc/Timer.h
+++ b/wpilibc/src/main/native/include/frc/Timer.h
@@ -34,8 +34,6 @@ units::second_t GetTime();
  * the timer so Get() won't return a negative duration.
  */
 class Timer {
-  friend class TimedRobot;
-
  public:
   /**
    * Create a new timer object.
@@ -132,15 +130,26 @@ class Timer {
 
   /**
    * Return the system clock time in seconds for the start of the current
-   * periodic loop. This is in the same time base as getFPGATimestamp(), but is
+   * periodic loop. This is in the same time base as GetFPGATimestamp(), but is
    * stable through a loop. This value is only valid for robot programs that use
    * TimedRobot. It is updated at the beginning of every periodic callback
-   * (including the normal periodic loop).
+   * (including the normal periodic loop). Calling this from threads other than
+   * than the main periodic loop has undefined behavior.
    *
    * @return Robot running time in seconds, as of the start of the current
    * periodic function.
    */
   static units::second_t GetLoopTimestamp() { return s_loopTimestamp; }
+
+  /**
+   * Sets the timestamp returned by GetLoopTimestamp(). Intended for library
+   * use; calling this from team code may result in unexpected behavior.
+   *
+   * @param timestamp timestamp in seconds
+   */
+  static void SetLoopTimestamp(units::second_t timestamp) {
+    s_loopTimestamp = timestamp;
+  }
 
   /**
    * Return the approximate match time.

--- a/wpilibc/src/main/native/include/frc/Timer.h
+++ b/wpilibc/src/main/native/include/frc/Timer.h
@@ -34,6 +34,8 @@ units::second_t GetTime();
  * the timer so Get() won't return a negative duration.
  */
 class Timer {
+  friend class TimedRobot;
+
  public:
   /**
    * Create a new timer object.
@@ -129,6 +131,18 @@ class Timer {
   static units::second_t GetFPGATimestamp();
 
   /**
+   * Return the system clock time in seconds for the start of the current
+   * periodic loop. This is in the same time base as getFPGATimestamp(), but is
+   * stable through a loop. This value is only valid for robot programs that use
+   * TimedRobot. It is updated at the beginning of every periodic callback
+   * (including the normal periodic loop).
+   *
+   * @return Robot running time in seconds, as of the start of the current
+   * periodic function.
+   */
+  static units::second_t GetLoopTimestamp() { return s_loopTimestamp; }
+
+  /**
    * Return the approximate match time.
    *
    * The FMS does not send an official match time to the robots, but does send
@@ -146,6 +160,7 @@ class Timer {
   static units::second_t GetMatchTime();
 
  private:
+  static units::second_t s_loopTimestamp;
   units::second_t m_startTime = 0_s;
   units::second_t m_accumulatedTime = 0_s;
   bool m_running = false;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/TimedRobot.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/TimedRobot.java
@@ -127,7 +127,7 @@ public class TimedRobot extends IterativeRobotBase {
       if (currentTime == 0) {
         break;
       }
-      Timer.s_loopTimestamp = currentTime / 1000000.0;
+      Timer.setLoopTimestamp(currentTime / 1000000.0);
 
       callback.func.run();
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/TimedRobot.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/TimedRobot.java
@@ -127,6 +127,7 @@ public class TimedRobot extends IterativeRobotBase {
       if (currentTime == 0) {
         break;
       }
+      Timer.s_loopTimestamp = currentTime / 1000000.0;
 
       callback.func.run();
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Timer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Timer.java
@@ -11,6 +11,8 @@ package edu.wpi.first.wpilibj;
  * get() won't return a negative duration.
  */
 public class Timer {
+  static double s_loopTimestamp;
+
   /**
    * Return the system clock time in seconds. Return the time from the FPGA hardware clock in
    * seconds since the FPGA started.
@@ -19,6 +21,18 @@ public class Timer {
    */
   public static double getFPGATimestamp() {
     return RobotController.getFPGATime() / 1000000.0;
+  }
+
+  /**
+   * Return the system clock time in seconds for the start of the current periodic loop. This is
+   * in the same time base as getFPGATimestamp(), but is stable through a loop. This value is only
+   * valid for robot programs that use TimedRobot. It is updated at the beginning of every periodic
+   * callback (including the normal periodic loop).
+   *
+   * @return Robot running time in seconds, as of the start of the current periodic function.
+   */
+  public static double getLoopTimestamp() {
+    return s_loopTimestamp;
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Timer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Timer.java
@@ -11,7 +11,7 @@ package edu.wpi.first.wpilibj;
  * get() won't return a negative duration.
  */
 public class Timer {
-  static double s_loopTimestamp;
+  private static double s_loopTimestamp;
 
   /**
    * Return the system clock time in seconds. Return the time from the FPGA hardware clock in
@@ -27,12 +27,23 @@ public class Timer {
    * Return the system clock time in seconds for the start of the current periodic loop. This is
    * in the same time base as getFPGATimestamp(), but is stable through a loop. This value is only
    * valid for robot programs that use TimedRobot. It is updated at the beginning of every periodic
-   * callback (including the normal periodic loop).
+   * callback (including the normal periodic loop). Calling this from threads other than than the
+   * main periodic loop has undefined behavior.
    *
    * @return Robot running time in seconds, as of the start of the current periodic function.
    */
   public static double getLoopTimestamp() {
     return s_loopTimestamp;
+  }
+
+  /**
+   * Sets the timestamp returned by getLoopTimestamp(). Intended for library use; calling this from
+   * team code may result in unexpected behavior.
+   *
+   * @param timestamp timestamp in seconds
+   */
+  public static void setLoopTimestamp(double timestamp) {
+    s_loopTimestamp = timestamp;
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Timer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Timer.java
@@ -24,8 +24,8 @@ public class Timer {
   }
 
   /**
-   * Return the system clock time in seconds for the start of the current periodic loop. This is
-   * in the same time base as getFPGATimestamp(), but is stable through a loop. This value is only
+   * Return the system clock time in seconds for the start of the current periodic loop. This is in
+   * the same time base as getFPGATimestamp(), but is stable through a loop. This value is only
    * valid for robot programs that use TimedRobot. It is updated at the beginning of every periodic
    * callback (including the normal periodic loop). Calling this from threads other than than the
    * main periodic loop has undefined behavior.


### PR DESCRIPTION
This is updated at the start of each periodic function in TimedRobot, so is stable throughout the callback function execution.

TODO:
- [ ] Finalize naming (GetLoopTimestamp?  GetPeriodicTimestamp?  GetLoopStartTimestamp?)
- [x] Provide access for testability in C++ (Java can use introspection)
- [ ] Update WPILib classes to use this where appropriate (should MathShared use it?  should Timer use it?)