### PR TITLE
Fix resolver thread on newer versions of macOS

### DIFF
--- a/wpinet/src/main/native/macOS/ResolverThread.cpp
+++ b/wpinet/src/main/native/macOS/ResolverThread.cpp
@@ -35,7 +35,7 @@ void ResolverThread::AddServiceRef(DNSServiceRef serviceRef,
       thread.join();
     }
     running = true;
-    thread = std::thread([=] { ThreadMain(); });
+    thread = std::thread([this] { ThreadMain(); });
   }
 }
 


### PR DESCRIPTION
Implicit capture of this is deprecated, so fix it