### PR TITLE
[glass] Storage: Use std::variant

### DIFF
--- a/datalogtool/src/main/native/cpp/App.cpp
+++ b/datalogtool/src/main/native/cpp/App.cpp
@@ -154,7 +154,7 @@ void Application(std::string_view saveDir) {
   gui::Initialize("Datalog Tool", 925, 510);
 
   gDownloadVisible =
-      &glass::GetStorageRoot().GetChild("download").GetBool("visible", true);
+      &glass::GetStorageRoot().GetChild("download").Get<bool>("visible", true);
 
   gui::Main();
 

--- a/datalogtool/src/main/native/cpp/Downloader.cpp
+++ b/datalogtool/src/main/native/cpp/Downloader.cpp
@@ -29,11 +29,11 @@
 #include "Sftp.h"
 
 Downloader::Downloader(glass::Storage& storage)
-    : m_serverTeam{storage.GetString("serverTeam")},
-      m_remoteDir{storage.GetString("remoteDir", "/home/lvuser/logs")},
-      m_username{storage.GetString("username", "lvuser")},
-      m_localDir{storage.GetString("localDir")},
-      m_deleteAfter{storage.GetBool("deleteAfter", true)},
+    : m_serverTeam{storage.Get<std::string>("serverTeam")},
+      m_remoteDir{storage.Get<std::string>("remoteDir", "/home/lvuser/logs")},
+      m_username{storage.Get<std::string>("username", "lvuser")},
+      m_localDir{storage.Get<std::string>("localDir")},
+      m_deleteAfter{storage.Get<bool>("deleteAfter", true)},
       m_thread{[this] { ThreadMain(); }} {}
 
 Downloader::~Downloader() {

--- a/datalogtool/src/main/native/cpp/Exporter.cpp
+++ b/datalogtool/src/main/native/cpp/Exporter.cpp
@@ -618,7 +618,7 @@ static void ExportCsv(std::string_view outputFolder, int style) {
 }
 
 void DisplayOutput(glass::Storage& storage) {
-  static std::string& outputFolder = storage.GetString("outputFolder");
+  static std::string& outputFolder = storage.Get<std::string>("outputFolder");
   static std::unique_ptr<pfd::select_folder> outputFolderSelector;
 
   SetNextWindowPos(ImVec2{380, 390}, ImGuiCond_FirstUseEver);

--- a/glass/src/app/native/cpp/main.cpp
+++ b/glass/src/app/native/cpp/main.cpp
@@ -353,7 +353,7 @@ int main(int argc, char** argv) {
 
   gui::Initialize("Glass - DISCONNECTED", 1024, 768,
                   ImGuiConfigFlags_DockingEnable);
-  gEnterKey = &glass::GetStorageRoot().GetInt("enterKey", GLFW_KEY_ENTER);
+  gEnterKey = &glass::GetStorageRoot().Get<int>("enterKey", GLFW_KEY_ENTER);
   if (auto win = gui::GetSystemWindow()) {
     gPrevKeyCallback = glfwSetKeyCallback(win, RemapEnterKeyCallback);
   }

--- a/glass/src/lib/native/cpp/Context.cpp
+++ b/glass/src/lib/native/cpp/Context.cpp
@@ -483,7 +483,7 @@ void glass::EndChild() {
 }
 
 bool glass::CollapsingHeader(const char* label, ImGuiTreeNodeFlags flags) {
-  bool& open = GetStorage().GetChild(label).GetBool(
+  bool& open = GetStorage().GetChild(label).Get<bool>(
       "open", (flags & ImGuiTreeNodeFlags_DefaultOpen) != 0);
   ImGui::SetNextItemOpen(open);
   open = ImGui::CollapsingHeader(label, flags);
@@ -492,7 +492,7 @@ bool glass::CollapsingHeader(const char* label, ImGuiTreeNodeFlags flags) {
 
 bool glass::TreeNodeEx(const char* label, ImGuiTreeNodeFlags flags) {
   PushStorageStack(label);
-  bool& open = GetStorage().GetBool(
+  bool& open = GetStorage().Get<bool>(
       "open", (flags & ImGuiTreeNodeFlags_DefaultOpen) != 0);
   ImGui::SetNextItemOpen(open);
   open = ImGui::TreeNodeEx(label, flags);

--- a/glass/src/lib/native/cpp/DataSource.cpp
+++ b/glass/src/lib/native/cpp/DataSource.cpp
@@ -13,7 +13,7 @@ using namespace glass;
 wpi::sig::Signal<const char*, DataSource*> DataSource::sourceCreated;
 
 DataSource::DataSource(std::string_view id)
-    : m_id{id}, m_name{gContext->sourceNameStorage.GetString(m_id)} {
+    : m_id{id}, m_name{gContext->sourceNameStorage.Get<std::string>(m_id)} {
   gContext->sources.try_emplace(m_id, this);
   sourceCreated(m_id.c_str(), this);
 }

--- a/glass/src/lib/native/cpp/Storage.cpp
+++ b/glass/src/lib/native/cpp/Storage.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <imgui.h>
@@ -16,307 +17,22 @@
 
 using namespace glass;
 
-template <typename To>
-bool ConvertFromString(To* out, std::string_view str) {
-  if constexpr (std::same_as<To, bool>) {
-    if (str == "true") {
-      *out = true;
-    } else if (str == "false") {
-      *out = false;
-    } else if (auto val = wpi::parse_integer<int>(str, 10)) {
-      *out = val.value() != 0;
-    } else {
-      return false;
-    }
-  } else if constexpr (std::floating_point<To>) {
-    if (auto val = wpi::parse_float<To>(str)) {
-      *out = val.value();
-    } else {
-      return false;
-    }
-  } else {
-    if (auto val = wpi::parse_integer<To>(str, 10)) {
-      *out = val.value();
-    } else {
-      return false;
-    }
-  }
-  return true;
-}
-
-#define CONVERT(CapsName, LowerName, CType)                                 \
-  static bool Convert##CapsName(Storage::Value* value) {                    \
-    switch (value->type) {                                                  \
-      case Storage::Value::kBool:                                           \
-        value->LowerName##Val = value->boolVal;                             \
-        value->LowerName##Default = value->boolDefault;                     \
-        break;                                                              \
-      case Storage::Value::kDouble:                                         \
-        value->LowerName##Val = value->doubleVal;                           \
-        value->LowerName##Default = value->doubleDefault;                   \
-        break;                                                              \
-      case Storage::Value::kFloat:                                          \
-        value->LowerName##Val = value->floatVal;                            \
-        value->LowerName##Default = value->floatDefault;                    \
-        break;                                                              \
-      case Storage::Value::kInt:                                            \
-        value->LowerName##Val = value->intVal;                              \
-        value->LowerName##Default = value->intDefault;                      \
-        break;                                                              \
-      case Storage::Value::kInt64:                                          \
-        value->LowerName##Val = value->int64Val;                            \
-        value->LowerName##Default = value->int64Default;                    \
-        break;                                                              \
-      case Storage::Value::kString:                                         \
-        if (!ConvertFromString(&value->LowerName##Val, value->stringVal)) { \
-          return false;                                                     \
-        }                                                                   \
-        if (!ConvertFromString(&value->LowerName##Default,                  \
-                               value->stringDefault)) {                     \
-          return false;                                                     \
-        }                                                                   \
-        break;                                                              \
-      default:                                                              \
-        return false;                                                       \
-    }                                                                       \
-    value->type = Storage::Value::k##CapsName;                              \
-    return true;                                                            \
-  }
-
-CONVERT(Int, int, int)
-CONVERT(Int64, int64, int64_t)
-CONVERT(Float, float, float)
-CONVERT(Double, double, double)
-CONVERT(Bool, bool, bool)
-
-static inline bool ConvertString(Storage::Value* value) {
-  return false;
-}
-
-// Arrays can only come from JSON, so we only have to worry about conversions
-// between the various number types, not bool or string
-
-template <typename From, typename To>
-static void ConvertArray(std::vector<To>** outPtr, std::vector<From>** inPtr) {
-  if (*inPtr) {
-    if (*outPtr) {
-      (*outPtr)->assign((*inPtr)->begin(), (*inPtr)->end());
-    } else {
-      std::vector<To>* tmp;
-      tmp = new std::vector<To>{(*inPtr)->begin(), (*inPtr)->end()};
-      delete *inPtr;
-      *outPtr = tmp;
-    }
-  } else {
-    *outPtr = nullptr;
-  }
-}
-
-#define CONVERT_ARRAY(CapsName, LowerName)                           \
-  static bool Convert##CapsName##Array(Storage::Value* value) {      \
-    switch (value->type) {                                           \
-      case Storage::Value::kDoubleArray:                             \
-        ConvertArray(&value->LowerName##Array, &value->doubleArray); \
-        ConvertArray(&value->LowerName##ArrayDefault,                \
-                     &value->doubleArrayDefault);                    \
-        break;                                                       \
-      case Storage::Value::kFloatArray:                              \
-        ConvertArray(&value->LowerName##Array, &value->floatArray);  \
-        ConvertArray(&value->LowerName##ArrayDefault,                \
-                     &value->floatArrayDefault);                     \
-        break;                                                       \
-      case Storage::Value::kIntArray:                                \
-        ConvertArray(&value->LowerName##Array, &value->intArray);    \
-        ConvertArray(&value->LowerName##ArrayDefault,                \
-                     &value->intArrayDefault);                       \
-        break;                                                       \
-      case Storage::Value::kInt64Array:                              \
-        ConvertArray(&value->LowerName##Array, &value->int64Array);  \
-        ConvertArray(&value->LowerName##ArrayDefault,                \
-                     &value->int64ArrayDefault);                     \
-        break;                                                       \
-      default:                                                       \
-        return false;                                                \
-    }                                                                \
-    value->type = Storage::Value::k##CapsName##Array;                \
-    return true;                                                     \
-  }
-
-CONVERT_ARRAY(Int, int)
-CONVERT_ARRAY(Int64, int64)
-CONVERT_ARRAY(Float, float)
-CONVERT_ARRAY(Double, double)
-
-static inline bool ConvertBoolArray(Storage::Value* value) {
-  return false;
-}
-
-static inline bool ConvertStringArray(Storage::Value* value) {
-  return false;
-}
-
-void Storage::Value::Reset(Type newType) {
-  switch (type) {
-    case kChild:
-      delete child;
-      break;
-    case kIntArray:
-      delete intArray;
-      delete intArrayDefault;
-      break;
-    case kInt64Array:
-      delete int64Array;
-      delete int64ArrayDefault;
-      break;
-    case kBoolArray:
-      delete boolArray;
-      delete boolArrayDefault;
-      break;
-    case kFloatArray:
-      delete floatArray;
-      delete floatArrayDefault;
-      break;
-    case kDoubleArray:
-      delete doubleArray;
-      delete doubleArrayDefault;
-      break;
-    case kStringArray:
-      delete stringArray;
-      delete stringArrayDefault;
-      break;
-    case kChildArray:
-      delete childArray;
-      break;
-    default:
-      break;
-  }
-  type = newType;
-}
-
-Storage::Value* Storage::FindValue(std::string_view key) {
-  auto it = m_values.find(key);
-  if (it == m_values.end()) {
-    return nullptr;
-  }
-  return &it->second;
-}
-
-#define DEFUN(CapsName, LowerName, CType, CParamType, ArrCType)                \
-  CType Storage::Read##CapsName(std::string_view key, CParamType defaultVal)   \
-      const {                                                                  \
-    auto it = m_values.find(key);                                              \
-    if (it == m_values.end()) {                                                \
-      return CType{defaultVal};                                                \
-    }                                                                          \
-    Value& value = it->second;                                                 \
-    if (value.type != Value::k##CapsName) {                                    \
-      if (!Convert##CapsName(&value)) {                                        \
-        value.Reset(Value::k##CapsName);                                       \
-        value.LowerName##Val = defaultVal;                                     \
-        value.LowerName##Default = defaultVal;                                 \
-        value.hasDefault = true;                                               \
-      }                                                                        \
-    }                                                                          \
-    return value.LowerName##Val;                                               \
-  }                                                                            \
-                                                                               \
-  void Storage::Set##CapsName(std::string_view key, CParamType val) {          \
-    auto [it, isNew] = m_values.try_emplace(key, Value::k##CapsName);          \
-    if (!isNew) {                                                              \
-      it->second.Reset(Value::k##CapsName);                                    \
-    }                                                                          \
-    it->second.LowerName##Val = val;                                           \
-    it->second.LowerName##Default = {};                                        \
-  }                                                                            \
-                                                                               \
-  CType& Storage::Get##CapsName(std::string_view key, CParamType defaultVal) { \
-    auto [it, setValue] = m_values.try_emplace(key, Value::k##CapsName);       \
-    if (!setValue && it->second.type != Value::k##CapsName) {                  \
-      if (!Convert##CapsName(&it->second)) {                                   \
-        it->second.Reset(Value::k##CapsName);                                  \
-        setValue = true;                                                       \
-      }                                                                        \
-    }                                                                          \
-    Value& value = it->second;                                                 \
-    if (setValue) {                                                            \
-      value.LowerName##Val = defaultVal;                                       \
-    }                                                                          \
-    if (!value.hasDefault) {                                                   \
-      value.LowerName##Default = defaultVal;                                   \
-      value.hasDefault = true;                                                 \
-    }                                                                          \
-    return value.LowerName##Val;                                               \
-  }                                                                            \
-                                                                               \
-  std::vector<ArrCType>& Storage::Get##CapsName##Array(                        \
-      std::string_view key, std::span<const ArrCType> defaultVal) {            \
-    auto [it, setValue] =                                                      \
-        m_values.try_emplace(key, Value::k##CapsName##Array);                  \
-    if (!setValue && it->second.type != Value::k##CapsName##Array) {           \
-      if (!Convert##CapsName##Array(&it->second)) {                            \
-        it->second.Reset(Value::k##CapsName##Array);                           \
-        setValue = true;                                                       \
-      }                                                                        \
-    }                                                                          \
-    Value& value = it->second;                                                 \
-    if (setValue) {                                                            \
-      value.LowerName##Array =                                                 \
-          new std::vector<ArrCType>{defaultVal.begin(), defaultVal.end()};     \
-    }                                                                          \
-    if (!value.hasDefault) {                                                   \
-      if (defaultVal.empty()) {                                                \
-        value.LowerName##ArrayDefault = nullptr;                               \
-      } else {                                                                 \
-        value.LowerName##ArrayDefault =                                        \
-            new std::vector<ArrCType>{defaultVal.begin(), defaultVal.end()};   \
-      }                                                                        \
-      value.hasDefault = true;                                                 \
-    }                                                                          \
-    assert(value.LowerName##Array);                                            \
-    return *value.LowerName##Array;                                            \
-  }
-
-DEFUN(Int, int, int, int, int)
-DEFUN(Int64, int64, int64_t, int64_t, int64_t)
-DEFUN(Bool, bool, bool, bool, int)
-DEFUN(Float, float, float, float, float)
-DEFUN(Double, double, double, double, double)
-DEFUN(String, string, std::string, std::string_view, std::string)
-
 Storage& Storage::GetChild(std::string_view label_id) {
   auto [label, id] = wpi::split(label_id, "###");
   if (id.empty()) {
     id = label;
   }
-  Value& childValue = GetValue(id);
-  if (childValue.type != Value::kChild) {
-    childValue.Reset(Value::kChild);
-    childValue.child = new Storage;
+  Value& value = GetValue(id);
+  if (auto data = std::get_if<Child>(&value.data)) {
+    return **data;
   }
-  return *childValue.child;
-}
-
-std::vector<std::unique_ptr<Storage>>& Storage::GetChildArray(
-    std::string_view key) {
-  auto [it, isNew] = m_values.try_emplace(key, Value::kChildArray);
-  if (!isNew && it->second.type != Value::kChildArray) {
-    it->second.Reset(Value::kChildArray);
-    it->second.childArray = new std::vector<std::unique_ptr<Storage>>();
-  }
-
-  return *it->second.childArray;
-}
-
-void Storage::Erase(std::string_view key) {
-  auto it = m_values.find(key);
-  if (it != m_values.end()) {
-    m_values.erase(it);
-  }
+  return *value.data.emplace<Child>(std::make_shared<Storage>());
 }
 
 void Storage::EraseChildren() {
-  std::erase_if(m_values,
-                [](const auto& kv) { return kv.second.type == Value::kChild; });
+  std::erase_if(m_values, [](const auto& kv) {
+    return std::holds_alternative<Child>(kv.second.data);
+  });
 }
 
 static bool JsonArrayToStorage(Storage::Value* valuePtr, const wpi::json& jarr,
@@ -330,39 +46,24 @@ static bool JsonArrayToStorage(Storage::Value* valuePtr, const wpi::json& jarr,
   // guess array type from first element
   switch (arr[0].type()) {
     case wpi::json::value_t::boolean:
-      if (valuePtr->type != Storage::Value::kBoolArray) {
-        valuePtr->Reset(Storage::Value::kBoolArray);
-        valuePtr->boolArray = new std::vector<int>();
-        valuePtr->boolArrayDefault = nullptr;
-      }
-      break;
+      ImGui::LogText("boolean array in %s, ignoring", filename);
+      return false;
     case wpi::json::value_t::number_float:
-      if (valuePtr->type != Storage::Value::kDoubleArray) {
-        valuePtr->Reset(Storage::Value::kDoubleArray);
-        valuePtr->doubleArray = new std::vector<double>();
-        valuePtr->doubleArrayDefault = nullptr;
-      }
+      valuePtr->data.emplace<std::vector<double>>();
+      valuePtr->dataDefault = {};
       break;
     case wpi::json::value_t::number_integer:
     case wpi::json::value_t::number_unsigned:
-      if (valuePtr->type != Storage::Value::kInt64Array) {
-        valuePtr->Reset(Storage::Value::kInt64Array);
-        valuePtr->int64Array = new std::vector<int64_t>();
-        valuePtr->int64ArrayDefault = nullptr;
-      }
+      valuePtr->data.emplace<std::vector<int>>();
+      valuePtr->dataDefault = {};
       break;
     case wpi::json::value_t::string:
-      if (valuePtr->type != Storage::Value::kStringArray) {
-        valuePtr->Reset(Storage::Value::kStringArray);
-        valuePtr->stringArray = new std::vector<std::string>();
-        valuePtr->stringArrayDefault = nullptr;
-      }
+      valuePtr->data.emplace<std::vector<std::string>>();
+      valuePtr->dataDefault = {};
       break;
     case wpi::json::value_t::object:
-      if (valuePtr->type != Storage::Value::kChildArray) {
-        valuePtr->Reset(Storage::Value::kChildArray);
-        valuePtr->childArray = new std::vector<std::unique_ptr<Storage>>();
-      }
+      valuePtr->data.emplace<std::vector<Storage::Child>>();
+      valuePtr->dataDefault = {};
       break;
     case wpi::json::value_t::array:
       ImGui::LogText("nested array in %s, ignoring", filename);
@@ -376,49 +77,48 @@ static bool JsonArrayToStorage(Storage::Value* valuePtr, const wpi::json& jarr,
   for (auto jvalue : arr) {
     switch (jvalue.type()) {
       case wpi::json::value_t::boolean:
-        if (valuePtr->type == Storage::Value::kBoolArray) {
-          valuePtr->boolArray->push_back(jvalue.get<bool>());
-        } else {
-          goto error;
-        }
-        break;
+        ImGui::LogText("boolean array value in %s, ignoring", filename);
+        return false;
       case wpi::json::value_t::number_float:
-        if (valuePtr->type == Storage::Value::kDoubleArray) {
-          valuePtr->doubleArray->push_back(jvalue.get<double>());
+        if (auto data = std::get_if<std::vector<double>>(&valuePtr->data)) {
+          data->emplace_back(jvalue.get<double>());
         } else {
           goto error;
         }
         break;
       case wpi::json::value_t::number_integer:
-        if (valuePtr->type == Storage::Value::kInt64Array) {
-          valuePtr->int64Array->push_back(jvalue.get<int64_t>());
-        } else if (valuePtr->type == Storage::Value::kDoubleArray) {
-          valuePtr->doubleArray->push_back(jvalue.get<int64_t>());
+        if (auto data = std::get_if<std::vector<int>>(&valuePtr->data)) {
+          data->emplace_back(jvalue.get<int64_t>());
+        } else if (auto data =
+                       std::get_if<std::vector<double>>(&valuePtr->data)) {
+          data->emplace_back(jvalue.get<int64_t>());
         } else {
           goto error;
         }
         break;
       case wpi::json::value_t::number_unsigned:
-        if (valuePtr->type == Storage::Value::kInt64Array) {
-          valuePtr->int64Array->push_back(jvalue.get<uint64_t>());
-        } else if (valuePtr->type == Storage::Value::kDoubleArray) {
-          valuePtr->doubleArray->push_back(jvalue.get<uint64_t>());
+        if (auto data = std::get_if<std::vector<int>>(&valuePtr->data)) {
+          data->emplace_back(jvalue.get<uint64_t>());
+        } else if (auto data =
+                       std::get_if<std::vector<double>>(&valuePtr->data)) {
+          data->emplace_back(jvalue.get<uint64_t>());
         } else {
           goto error;
         }
         break;
       case wpi::json::value_t::string:
-        if (valuePtr->type == Storage::Value::kStringArray) {
-          valuePtr->stringArray->emplace_back(
-              jvalue.get_ref<const std::string&>());
+        if (auto data =
+                std::get_if<std::vector<std::string>>(&valuePtr->data)) {
+          data->emplace_back(jvalue.get_ref<const std::string&>());
         } else {
           goto error;
         }
         break;
       case wpi::json::value_t::object:
-        if (valuePtr->type == Storage::Value::kChildArray) {
-          valuePtr->childArray->emplace_back(std::make_unique<Storage>());
-          valuePtr->childArray->back()->FromJson(jvalue, filename);
+        if (auto data =
+                std::get_if<std::vector<Storage::Child>>(&valuePtr->data)) {
+          data->emplace_back(std::make_shared<Storage>())
+              ->FromJson(jvalue, filename);
         } else {
           goto error;
         }
@@ -452,31 +152,27 @@ bool Storage::FromJson(const wpi::json& json, const char* filename) {
     auto& jvalue = jkv.value();
     switch (jvalue.type()) {
       case wpi::json::value_t::boolean:
-        it->second.Reset(Value::kBool);
-        it->second.boolVal = jvalue.get<bool>();
+        it->second.data = jvalue.get<bool>();
         break;
       case wpi::json::value_t::number_float:
-        it->second.Reset(Value::kDouble);
-        it->second.doubleVal = jvalue.get<double>();
+        it->second.data = jvalue.get<double>();
         break;
       case wpi::json::value_t::number_integer:
-        it->second.Reset(Value::kInt64);
-        it->second.int64Val = jvalue.get<int64_t>();
+        it->second.data = static_cast<int>(jvalue.get<int64_t>());
         break;
       case wpi::json::value_t::number_unsigned:
-        it->second.Reset(Value::kInt64);
-        it->second.int64Val = jvalue.get<uint64_t>();
+        it->second.data = static_cast<int>(jvalue.get<uint64_t>());
         break;
       case wpi::json::value_t::string:
-        it->second.Reset(Value::kString);
-        it->second.stringVal = jvalue.get_ref<const std::string&>();
+        it->second.data = jvalue.get_ref<const std::string&>();
         break;
       case wpi::json::value_t::object:
-        if (it->second.type != Value::kChild) {
-          it->second.Reset(Value::kChild);
-          it->second.child = new Storage;
+        if (auto d = std::get_if<Child>(&it->second.data)) {
+          (*d)->FromJson(jvalue, filename);  // recurse
+        } else {
+          it->second.data.emplace<Child>(std::make_shared<Storage>())
+              ->FromJson(jvalue, filename);  // recurse
         }
-        it->second.child->FromJson(jvalue, filename);  // recurse
         break;
       case wpi::json::value_t::array:
         if (!JsonArrayToStorage(&it->second, jvalue, filename)) {
@@ -496,29 +192,6 @@ bool Storage::FromJson(const wpi::json& json, const char* filename) {
   return true;
 }
 
-template <typename T>
-static wpi::json StorageToJsonArray(const std::vector<T>& arr) {
-  wpi::json jarr = wpi::json::array();
-  for (auto&& v : arr) {
-    jarr.emplace_back(v);
-  }
-  return jarr;
-}
-
-template <>
-wpi::json StorageToJsonArray<std::unique_ptr<Storage>>(
-    const std::vector<std::unique_ptr<Storage>>& arr) {
-  wpi::json jarr = wpi::json::array();
-  for (auto&& v : arr) {
-    jarr.emplace_back(v->ToJson());
-  }
-  // remove any trailing empty items
-  while (!jarr.empty() && jarr.back().empty()) {
-    jarr.get_ref<wpi::json::array_t&>().pop_back();
-  }
-  return jarr;
-}
-
 wpi::json Storage::ToJson() const {
   if (m_toJson) {
     return m_toJson();
@@ -526,163 +199,62 @@ wpi::json Storage::ToJson() const {
 
   wpi::json j = wpi::json::object();
   for (auto&& kv : m_values) {
-    wpi::json jelem;
-    Value& value = kv.second;
-    switch (value.type) {
-#define CASE(CapsName, LowerName)                                        \
-  case Value::k##CapsName:                                               \
-    if (value.hasDefault &&                                              \
-        value.LowerName##Val == value.LowerName##Default) {              \
-      continue;                                                          \
-    }                                                                    \
-    jelem = value.LowerName##Val;                                        \
-    break;                                                               \
-  case Value::k##CapsName##Array:                                        \
-    if (value.hasDefault &&                                              \
-        ((!value.LowerName##ArrayDefault &&                              \
-          value.LowerName##Array->empty()) ||                            \
-         (value.LowerName##ArrayDefault &&                               \
-          *value.LowerName##Array == *value.LowerName##ArrayDefault))) { \
-      continue;                                                          \
-    }                                                                    \
-    jelem = StorageToJsonArray(*value.LowerName##Array);                 \
-    break;
-
-      CASE(Int, int)
-      CASE(Int64, int64)
-      CASE(Bool, bool)
-      CASE(Float, float)
-      CASE(Double, double)
-      CASE(String, string)
-
-      case Value::kChild:
-        jelem = value.child->ToJson();  // recurse
-        if (jelem.empty()) {
-          continue;
-        }
-        break;
-      case Value::kChildArray:
-        jelem = StorageToJsonArray(*value.childArray);
-        if (jelem.empty()) {
-          continue;
-        }
-        break;
-      default:
-        continue;
+    auto jelem = std::visit(
+        [&](auto&& arg) -> wpi::json {
+          using T = std::decay_t<decltype(arg)>;
+          if constexpr (std::same_as<T, Child>) {
+            return arg->ToJson();  // recurse
+          } else if constexpr (std::same_as<T, std::vector<Child>>) {
+            wpi::json jarr = wpi::json::array();
+            for (auto&& v : arg) {
+              jarr.emplace_back(v->ToJson());
+            }
+            // remove any trailing empty items
+            while (!jarr.empty() && jarr.back().empty()) {
+              jarr.get_ref<wpi::json::array_t&>().pop_back();
+            }
+            return jarr;
+          } else if constexpr (std::same_as<T, std::monostate>) {
+            return {};
+          } else if (auto d = std::get_if<T>(&kv.second.dataDefault);
+                     d && *d == arg) {
+            return {};
+          } else {
+            return arg;
+          }
+        },
+        kv.second.data);
+    if (!jelem.empty()) {
+      j.emplace(kv.first, std::move(jelem));
     }
-    j.emplace(kv.first, std::move(jelem));
   }
   return j;
-}
-
-void Storage::Clear() {
-  if (m_clear) {
-    return m_clear();
-  }
-
-  ClearValues();
 }
 
 void Storage::ClearValues() {
   for (auto&& kv : m_values) {
     Value& value = kv.second;
-    switch (value.type) {
-      case Value::kInt:
-        value.intVal = value.intDefault;
-        break;
-      case Value::kInt64:
-        value.int64Val = value.int64Default;
-        break;
-      case Value::kBool:
-        value.boolVal = value.boolDefault;
-        break;
-      case Value::kFloat:
-        value.floatVal = value.floatDefault;
-        break;
-      case Value::kDouble:
-        value.doubleVal = value.doubleDefault;
-        break;
-      case Value::kString:
-        value.stringVal = value.stringDefault;
-        break;
-      case Value::kIntArray:
-        if (value.intArrayDefault) {
-          *value.intArray = *value.intArrayDefault;
-        } else {
-          value.intArray->clear();
-        }
-        break;
-      case Value::kInt64Array:
-        if (value.int64ArrayDefault) {
-          *value.int64Array = *value.int64ArrayDefault;
-        } else {
-          value.int64Array->clear();
-        }
-        break;
-      case Value::kBoolArray:
-        if (value.boolArrayDefault) {
-          *value.boolArray = *value.boolArrayDefault;
-        } else {
-          value.boolArray->clear();
-        }
-        break;
-      case Value::kFloatArray:
-        if (value.floatArrayDefault) {
-          *value.floatArray = *value.floatArrayDefault;
-        } else {
-          value.floatArray->clear();
-        }
-        break;
-      case Value::kDoubleArray:
-        if (value.doubleArrayDefault) {
-          *value.doubleArray = *value.doubleArrayDefault;
-        } else {
-          value.doubleArray->clear();
-        }
-        break;
-      case Value::kStringArray:
-        if (value.stringArrayDefault) {
-          *value.stringArray = *value.stringArrayDefault;
-        } else {
-          value.stringArray->clear();
-        }
-        break;
-      case Value::kChild:
-        value.child->Clear();
-        break;
-      case Value::kChildArray:
-        for (auto&& child : *value.childArray) {
-          child->Clear();
-        }
-        break;
-      default:
-        break;
+    if (auto d = std::get_if<Child>(&value.data)) {
+      (*d)->Clear();
+    } else if (auto d = std::get_if<std::vector<Child>>(&value.data)) {
+      for (auto&& child : *d) {
+        child->Clear();
+      }
+    } else {
+      value.data = value.dataDefault;
     }
   }
-}
-
-void Storage::Apply() {
-  if (m_apply) {
-    return m_apply();
-  }
-
-  ApplyChildren();
 }
 
 void Storage::ApplyChildren() {
   for (auto&& kv : m_values) {
     Value& value = kv.second;
-    switch (value.type) {
-      case Value::kChild:
-        value.child->Apply();
-        break;
-      case Value::kChildArray:
-        for (auto&& child : *value.childArray) {
-          child->Apply();
-        }
-        break;
-      default:
-        break;
+    if (auto d = std::get_if<Child>(&value.data)) {
+      (*d)->Apply();
+    } else if (auto d = std::get_if<std::vector<Child>>(&value.data)) {
+      for (auto&& child : *d) {
+        child->Apply();
+      }
     }
   }
 }

--- a/glass/src/lib/native/cpp/Window.cpp
+++ b/glass/src/lib/native/cpp/Window.cpp
@@ -19,12 +19,13 @@ using namespace glass;
 Window::Window(Storage& storage, std::string_view id,
                Visibility defaultVisibility)
     : m_id{id},
-      m_name{storage.GetString("name")},
+      m_name{storage.Get<std::string>("name")},
       m_defaultName{id},
-      m_visible{storage.GetBool("visible", defaultVisibility != kHide)},
-      m_enabled{storage.GetBool("enabled", defaultVisibility != kDisabled)},
-      m_defaultVisible{storage.GetValue("visible").boolDefault},
-      m_defaultEnabled{storage.GetValue("enabled").boolDefault} {}
+      m_visible{storage.Get<bool>("visible", defaultVisibility != kHide)},
+      m_enabled{storage.Get<bool>("enabled", defaultVisibility != kDisabled)},
+      m_defaultVisible{std::get<bool>(storage.GetValue("visible").dataDefault)},
+      m_defaultEnabled{
+          std::get<bool>(storage.GetValue("enabled").dataDefault)} {}
 
 void Window::SetVisibility(Visibility visibility) {
   m_visible = visibility != kHide;

--- a/glass/src/lib/native/cpp/hardware/AnalogInput.cpp
+++ b/glass/src/lib/native/cpp/hardware/AnalogInput.cpp
@@ -22,7 +22,7 @@ void glass::DisplayAnalogInput(AnalogInputModel* model, int index) {
   }
 
   // build label
-  std::string& name = GetStorage().GetString("name");
+  std::string& name = GetStorage().Get<std::string>("name");
   char label[128];
   if (!name.empty()) {
     wpi::format_to_n_c_str(label, sizeof(label), "{} [{}]###name", name, index);

--- a/glass/src/lib/native/cpp/hardware/AnalogOutput.cpp
+++ b/glass/src/lib/native/cpp/hardware/AnalogOutput.cpp
@@ -31,7 +31,7 @@ void glass::DisplayAnalogOutputsDevice(AnalogOutputsModel* model) {
       PushID(i);
 
       // build label
-      std::string& name = GetStorage().GetString("name");
+      std::string& name = GetStorage().Get<std::string>("name");
       char label[128];
       if (!name.empty()) {
         wpi::format_to_n_c_str(label, sizeof(label), "{} [{}]###name", name, i);

--- a/glass/src/lib/native/cpp/hardware/Encoder.cpp
+++ b/glass/src/lib/native/cpp/hardware/Encoder.cpp
@@ -70,7 +70,7 @@ void glass::DisplayEncoder(EncoderModel* model) {
   int chB = model->GetChannelB();
 
   // build header label
-  std::string& name = GetStorage().GetString("name");
+  std::string& name = GetStorage().Get<std::string>("name");
   char label[128];
   if (!name.empty()) {
     wpi::format_to_n_c_str(label, sizeof(label), "{} [{},{}]###header", name,

--- a/glass/src/lib/native/cpp/hardware/LEDDisplay.cpp
+++ b/glass/src/lib/native/cpp/hardware/LEDDisplay.cpp
@@ -28,10 +28,10 @@ void glass::DisplayLEDDisplay(LEDDisplayModel* model, int index) {
   bool running = model->IsRunning();
   auto& storage = GetStorage();
 
-  int& numColumns = storage.GetInt("columns", 10);
-  bool& serpentine = storage.GetBool("serpentine", false);
-  int& order = storage.GetInt("order", LEDConfig::RowMajor);
-  int& start = storage.GetInt("start", LEDConfig::UpperLeft);
+  int& numColumns = storage.Get<int>("columns", 10);
+  bool& serpentine = storage.Get<bool>("serpentine", false);
+  int& order = storage.Get<int>("order", LEDConfig::RowMajor);
+  int& start = storage.Get<int>("start", LEDConfig::UpperLeft);
 
   ImGui::PushItemWidth(ImGui::GetFontSize() * 6);
   ImGui::LabelText("Length", "%d", length);

--- a/glass/src/lib/native/cpp/hardware/PWM.cpp
+++ b/glass/src/lib/native/cpp/hardware/PWM.cpp
@@ -22,7 +22,7 @@ void glass::DisplayPWM(PWMModel* model, int index, bool outputsEnabled) {
   }
 
   // build label
-  std::string& name = GetStorage().GetString("name");
+  std::string& name = GetStorage().Get<std::string>("name");
   char label[128];
   if (!name.empty()) {
     wpi::format_to_n_c_str(label, sizeof(label), "{} [{}]###name", name, index);

--- a/glass/src/lib/native/cpp/hardware/Pneumatic.cpp
+++ b/glass/src/lib/native/cpp/hardware/Pneumatic.cpp
@@ -45,7 +45,7 @@ bool glass::DisplayPneumaticControlSolenoids(PneumaticControlModel* model,
   }
 
   // build header label
-  std::string& name = GetStorage().GetString("name");
+  std::string& name = GetStorage().Get<std::string>("name");
   char label[128];
   if (!name.empty()) {
     wpi::format_to_n_c_str(label, sizeof(label), "{} [{}]###header", name,

--- a/glass/src/lib/native/cpp/hardware/Relay.cpp
+++ b/glass/src/lib/native/cpp/hardware/Relay.cpp
@@ -34,7 +34,7 @@ void glass::DisplayRelay(RelayModel* model, int index, bool outputsEnabled) {
     }
   }
 
-  std::string& name = GetStorage().GetString("name");
+  std::string& name = GetStorage().Get<std::string>("name");
   ImGui::PushID("name");
   if (!name.empty()) {
     ImGui::Text("%s [%d]", name.c_str(), index);

--- a/glass/src/lib/native/cpp/other/DeviceTree.cpp
+++ b/glass/src/lib/native/cpp/other/DeviceTree.cpp
@@ -53,7 +53,7 @@ bool glass::BeginDevice(const char* id, ImGuiTreeNodeFlags flags) {
   PushID(id);
 
   // build label
-  std::string& name = GetStorage().GetString("name");
+  std::string& name = GetStorage().Get<std::string>("name");
   char label[128];
   if (name.empty()) {
     wpi::format_to_n_c_str(label, sizeof(label), "{}###header", id);

--- a/glass/src/lib/native/cpp/other/Field2D.cpp
+++ b/glass/src/lib/native/cpp/other/Field2D.cpp
@@ -345,14 +345,14 @@ static bool InputPose(frc::Pose2d* pose) {
 }
 
 FieldInfo::FieldInfo(Storage& storage)
-    : m_builtin{storage.GetString("builtin", "2024 Crescendo")},
-      m_filename{storage.GetString("image")},
-      m_width{storage.GetFloat("width", kDefaultWidth.to<float>())},
-      m_height{storage.GetFloat("height", kDefaultHeight.to<float>())},
-      m_top{storage.GetInt("top", 0)},
-      m_left{storage.GetInt("left", 0)},
-      m_bottom{storage.GetInt("bottom", -1)},
-      m_right{storage.GetInt("right", -1)} {}
+    : m_builtin{storage.Get<std::string>("builtin", "2024 Crescendo")},
+      m_filename{storage.Get<std::string>("image")},
+      m_width{storage.Get<float>("width", kDefaultWidth.to<float>())},
+      m_height{storage.Get<float>("height", kDefaultHeight.to<float>())},
+      m_top{storage.Get<int>("top", 0)},
+      m_left{storage.Get<int>("left", 0)},
+      m_bottom{storage.Get<int>("bottom", -1)},
+      m_right{storage.Get<int>("right", -1)} {}
 
 void FieldInfo::DisplaySettings() {
   ImGui::SetNextItemWidth(ImGui::GetFontSize() * 10);
@@ -615,26 +615,26 @@ void FieldInfo::Draw(ImDrawList* drawList, const FieldFrameData& ffd) const {
 }
 
 ObjectInfo::ObjectInfo(Storage& storage)
-    : m_width{storage.GetFloat("width",
-                               DisplayOptions::kDefaultWidth.to<float>())},
-      m_length{storage.GetFloat("length",
-                                DisplayOptions::kDefaultLength.to<float>())},
-      m_style{storage.GetString("style"),
+    : m_width{storage.Get<float>("width",
+                                 DisplayOptions::kDefaultWidth.to<float>())},
+      m_length{storage.Get<float>("length",
+                                  DisplayOptions::kDefaultLength.to<float>())},
+      m_style{storage.Get<std::string>("style"),
               DisplayOptions::kDefaultStyle,
               {"Box/Image", "Line", "Line (Closed)", "Track", "Hidden"}},
-      m_weight{storage.GetFloat("weight", DisplayOptions::kDefaultWeight)},
-      m_color{
-          storage.GetFloatArray("color", DisplayOptions::kDefaultColorFloat)},
-      m_arrows{storage.GetBool("arrows", DisplayOptions::kDefaultArrows)},
+      m_weight{storage.Get<float>("weight", DisplayOptions::kDefaultWeight)},
+      m_color{storage.Get<std::vector<float>>(
+          "color", DisplayOptions::kDefaultColorFloat)},
+      m_arrows{storage.Get<bool>("arrows", DisplayOptions::kDefaultArrows)},
       m_arrowSize{
-          storage.GetInt("arrowSize", DisplayOptions::kDefaultArrowSize)},
-      m_arrowWeight{
-          storage.GetFloat("arrowWeight", DisplayOptions::kDefaultArrowWeight)},
-      m_arrowColor{storage.GetFloatArray(
+          storage.Get<int>("arrowSize", DisplayOptions::kDefaultArrowSize)},
+      m_arrowWeight{storage.Get<float>("arrowWeight",
+                                       DisplayOptions::kDefaultArrowWeight)},
+      m_arrowColor{storage.Get<std::vector<float>>(
           "arrowColor", DisplayOptions::kDefaultArrowColorFloat)},
       m_selectable{
-          storage.GetBool("selectable", DisplayOptions::kDefaultSelectable)},
-      m_filename{storage.GetString("image")} {}
+          storage.Get<bool>("selectable", DisplayOptions::kDefaultSelectable)},
+      m_filename{storage.Get<std::string>("image")} {}
 
 DisplayOptions ObjectInfo::GetDisplayOptions() const {
   DisplayOptions rv{m_texture};
@@ -933,7 +933,7 @@ void glass::DisplayField2DSettings(Field2DModel* model) {
     field = storage.GetData<FieldInfo>();
   }
 
-  EnumSetting displayUnits{GetStorage().GetString("units"),
+  EnumSetting displayUnits{GetStorage().Get<std::string>("units"),
                            kDisplayMeters,
                            {"meters", "feet", "inches"}};
   ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8);

--- a/glass/src/lib/native/cpp/other/Mechanism2D.cpp
+++ b/glass/src/lib/native/cpp/other/Mechanism2D.cpp
@@ -90,7 +90,7 @@ class BackgroundInfo {
 }  // namespace
 
 BackgroundInfo::BackgroundInfo(Storage& storage)
-    : m_filename{storage.GetString("image")} {}
+    : m_filename{storage.Get<std::string>("image")} {}
 
 void BackgroundInfo::DisplaySettings() {
   if (ImGui::Button("Choose image...")) {

--- a/glass/src/lib/native/include/glass/Storage.h
+++ b/glass/src/lib/native/include/glass/Storage.h
@@ -8,12 +8,15 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 #include <vector>
 
+#include <wpi/StringExtras.h>
 #include <wpi/StringMap.h>
 #include <wpi/iterator_range.h>
 #include <wpi/json_fwd.h>
@@ -39,84 +42,43 @@ class ChildIterator;
  */
 class Storage {
  public:
-  struct Value {
-    enum Type {
-      kNone,
-      kInt,
-      kInt64,
-      kBool,
-      kFloat,
-      kDouble,
-      kString,
-      kChild,
-      kIntArray,
-      kInt64Array,
-      kBoolArray,
-      kFloatArray,
-      kDoubleArray,
-      kStringArray,
-      kChildArray
-    };
+  using Child = std::shared_ptr<Storage>;
+
+  class Value {
+   public:
+    using ValueData =
+        std::variant<std::monostate, int, bool, float, double, std::string,
+                     Child, std::vector<int>, std::vector<float>,
+                     std::vector<double>, std::vector<std::string>,
+                     std::vector<Child>>;
 
     Value() = default;
-    explicit Value(Type type) : type{type} {}
-    Value(const Value&) = delete;
-    Value& operator=(const Value&) = delete;
-    Value(Value&& rhs)
-        : type{rhs.type},
-          stringVal{std::move(rhs.stringVal)},
-          stringDefault{std::move(rhs.stringDefault)},
-          hasDefault{rhs.hasDefault} {
-      rhs.type = kNone;
+    explicit Value(ValueData&& data) : data{std::move(data)} {}
+
+    template <typename T, typename R = T>
+    R Read(T&& defaultVal)
+      requires(std::convertible_to<T, R> && std::assignable_from<ValueData&, R>)
+    {
+      if (auto d = std::get_if<R>(&data)) {
+        return *d;
+      }
+      if (auto d = Convert<R>(&data)) {
+        Convert<R>(&dataDefault);
+        return *d;
+      }
+      return Set<R>(std::forward<T>(defaultVal));
     }
-    Value& operator=(Value&& rhs) {
-      Reset(kNone);
-      type = rhs.type;
-      stringVal = std::move(rhs.stringVal);
-      stringDefault = std::move(rhs.stringDefault);
-      hasDefault = rhs.hasDefault;
-      rhs.type = kNone;
-      return *this;
+
+    template <typename T, typename... Args>
+    T& Set(Args&&... args)
+      requires(std::assignable_from<ValueData&, T>)
+    {
+      dataDefault.emplace<T>(args...);
+      return data.emplace<T>(std::forward<Args>(args)...);
     }
-    ~Value() { Reset(kNone); }
 
-    Type type = kNone;
-    union {
-      int intVal;
-      int64_t int64Val;
-      bool boolVal;
-      float floatVal;
-      double doubleVal;
-      Storage* child;
-      std::vector<int>* intArray;
-      std::vector<int64_t>* int64Array;
-      std::vector<int>* boolArray;
-      std::vector<float>* floatArray;
-      std::vector<double>* doubleArray;
-      std::vector<std::string>* stringArray;
-      std::vector<std::unique_ptr<Storage>>* childArray;
-    };
-    std::string stringVal;
-
-    union {
-      int intDefault;
-      int64_t int64Default;
-      bool boolDefault;
-      float floatDefault;
-      double doubleDefault;
-      // pointers may be nullptr to indicate empty
-      std::vector<int>* intArrayDefault;
-      std::vector<int64_t>* int64ArrayDefault;
-      std::vector<int>* boolArrayDefault;
-      std::vector<float>* floatArrayDefault;
-      std::vector<double>* doubleArrayDefault;
-      std::vector<std::string>* stringArrayDefault;
-    };
-    std::string stringDefault;
-
-    bool hasDefault = false;
-
-    void Reset(Type newType);
+    ValueData data;
+    ValueData dataDefault;
   };
 
   using ValueMap = wpi::StringMap<Value>;
@@ -124,50 +86,106 @@ class Storage {
   using ChildIterator = detail::ChildIterator<Iterator>;
 
   // The "Read" functions don't create or overwrite the value
-  int ReadInt(std::string_view key, int defaultVal = 0) const;
-  int64_t ReadInt64(std::string_view key, int64_t defaultVal = 0) const;
-  bool ReadBool(std::string_view key, bool defaultVal = false) const;
-  float ReadFloat(std::string_view key, float defaultVal = 0.0f) const;
-  double ReadDouble(std::string_view key, double defaultVal = 0.0) const;
-  std::string ReadString(std::string_view key,
-                         std::string_view defaultVal = {}) const;
+  template <typename T, typename R = T>
+  R Read(std::string_view key, T&& defaultVal = {}) const
+    requires(std::convertible_to<T, R> &&
+             std::assignable_from<Value::ValueData&, R>)
+  {
+    if (auto value = FindValue(key)) {
+      return value->Read<R>(std::forward<T>(defaultVal));
+    } else {
+      return defaultVal;
+    }
+  }
 
-  void SetInt(std::string_view key, int val);
-  void SetInt64(std::string_view key, int64_t val);
-  void SetBool(std::string_view key, bool val);
-  void SetFloat(std::string_view key, float val);
-  void SetDouble(std::string_view key, double val);
-  void SetString(std::string_view key, std::string_view val);
+  template <typename T>
+  void Set(std::string_view key, T&& val)
+    requires(std::assignable_from<Value::ValueData&, T>)
+  {
+    GetValue(key).Set<T>(std::forward<T>(val));
+  }
+
+  template <typename T>
+  void Set(std::string_view key, const T& val)
+    requires(std::assignable_from<Value::ValueData&, T>)
+  {
+    GetValue(key).Set<T>(val);
+  }
+
+  template <typename T>
+  void Set(std::string_view key, std::span<const typename T::value_type> val)
+    requires(std::assignable_from<Value::ValueData&, T>)
+  {
+    GetValue(key).Set<T>(val.begin(), val.end());
+  }
+
+  void Set(std::string_view key, std::string_view val) {
+    GetValue(key).Set<std::string>(std::string{val});
+  }
 
   // The "Get" functions create or override the current value type.
   // If the value is not set, it is set to the provided default.
-  int& GetInt(std::string_view key, int defaultVal = 0);
-  int64_t& GetInt64(std::string_view key, int64_t defaultVal = 0);
-  bool& GetBool(std::string_view key, bool defaultVal = false);
-  float& GetFloat(std::string_view key, float defaultVal = 0.0f);
-  double& GetDouble(std::string_view key, double defaultVal = 0.0);
-  std::string& GetString(std::string_view key,
-                         std::string_view defaultVal = {});
+  template <typename T>
+  T& Get(std::string_view key, T&& defaultVal = {})
+    requires(!std::same_as<T, Child> &&
+             std::assignable_from<Value::ValueData&, T>)
+  {
+    Value& value = GetValue(key);
+    if (auto data = std::get_if<T>(&value.data)) {
+      return *data;
+    }
+    return value.Set<T>(defaultVal);
+  }
 
-  std::vector<int>& GetIntArray(std::string_view key,
-                                std::span<const int> defaultVal = {});
-  std::vector<int64_t>& GetInt64Array(std::string_view key,
-                                      std::span<const int64_t> defaultVal = {});
-  std::vector<int>& GetBoolArray(std::string_view key,
-                                 std::span<const int> defaultVal = {});
-  std::vector<float>& GetFloatArray(std::string_view key,
-                                    std::span<const float> defaultVal = {});
-  std::vector<double>& GetDoubleArray(std::string_view key,
-                                      std::span<const double> defaultVal = {});
-  std::vector<std::string>& GetStringArray(
-      std::string_view key, std::span<const std::string> defaultVal = {});
-  std::vector<std::unique_ptr<Storage>>& GetChildArray(std::string_view key);
+  template <typename T>
+  T& Get(std::string_view key, const T& defaultVal)
+    requires(!std::same_as<T, Child> &&
+             std::assignable_from<Value::ValueData&, T>)
+  {
+    Value& value = GetValue(key);
+    if (auto data = std::get_if<T>(&value.data)) {
+      return *data;
+    }
+    return value.Set<T>(defaultVal);
+  }
 
-  Value* FindValue(std::string_view key);
+  template <typename T>
+  T& Get(std::string_view key,
+         std::span<const typename T::value_type> defaultVal)
+    requires(!std::same_as<T, Child> &&
+             std::assignable_from<Value::ValueData&, T>)
+  {
+    Value& value = GetValue(key);
+    if (auto data = std::get_if<T>(&value.data)) {
+      return *data;
+    }
+    return value.Set<T>(defaultVal.begin(), defaultVal.end());
+  }
+
+  std::string& Get(std::string_view key, std::string_view defaultVal) {
+    Value& value = GetValue(key);
+    if (auto data = std::get_if<std::string>(&value.data)) {
+      return *data;
+    }
+    return value.Set<std::string>(defaultVal);
+  }
+
+  Value* FindValue(std::string_view key) const {
+    auto it = m_values.find(key);
+    if (it == m_values.end()) {
+      return nullptr;
+    }
+    return &it->second;
+  }
+
   Value& GetValue(std::string_view key) {
-    return m_values.try_emplace(key, Value::kNone).first->second;
+    return m_values.try_emplace(key).first->second;
   }
   Storage& GetChild(std::string_view label_id);
+
+  std::vector<Child>& GetChildArray(std::string_view key) {
+    return Get<std::vector<Child>>(key);
+  }
 
   void SetData(std::shared_ptr<void>&& data) { m_data = std::move(data); }
 
@@ -192,7 +210,7 @@ class Storage {
     m_values.try_emplace(std::string{key}, std::move(value));
   }
 
-  void Erase(std::string_view key);
+  void Erase(std::string_view key) { m_values.erase(key); }
 
   void EraseAll() { m_values.clear(); }
 
@@ -213,7 +231,13 @@ class Storage {
    * Clear settings (set to default).  Calls custom clear function (if set),
    * otherwise calls ClearValues().
    */
-  void Clear();
+  void Clear() {
+    if (m_clear) {
+      m_clear();
+    } else {
+      ClearValues();
+    }
+  }
 
   /**
    * Clear values (and values of children) only (set to default).  Does not
@@ -225,7 +249,13 @@ class Storage {
    * Apply settings (called after all settings have been loaded).  Calls
    * custom apply function (if set), otherwise calls ApplyChildren().
    */
-  void Apply();
+  void Apply() {
+    if (m_apply) {
+      m_apply();
+    } else {
+      ApplyChildren();
+    }
+  }
 
   /**
    * Apply settings to children.  Does not call custom apply function.
@@ -260,6 +290,61 @@ class Storage {
   std::function<wpi::json()> m_toJson;
   std::function<void()> m_clear;
   std::function<void()> m_apply;
+
+  template <typename T>
+  static std::optional<T> ParseString(std::string_view str) {
+    if constexpr (std::same_as<T, bool>) {
+      if (str == "true") {
+        return true;
+      } else if (str == "false") {
+        return false;
+      } else if (auto val = wpi::parse_integer<int>(str, 10)) {
+        return val.value() != 0;
+      } else {
+        return std::nullopt;
+      }
+    } else if constexpr (std::floating_point<T>) {
+      return wpi::parse_float<T>(str);
+    } else {
+      return wpi::parse_integer<T>(str, 10);
+    }
+    return std::nullopt;
+  }
+
+  template <typename T>
+  static T* Convert(Value::ValueData* data) {
+    if constexpr (std::same_as<T, bool>) {
+      if (auto d = std::get_if<std::string>(data)) {
+        if (auto val = ParseString<T>(*d)) {
+          return &data->emplace<T>(*val);
+        }
+      }
+    } else if constexpr (std::same_as<T, int> || std::same_as<T, float> ||
+                         std::same_as<T, double>) {
+      if (auto d = std::get_if<int>(data)) {
+        return &data->emplace<T>(*d);
+      } else if (auto d = std::get_if<float>(data)) {
+        return &data->emplace<T>(*d);
+      } else if (auto d = std::get_if<double>(data)) {
+        return &data->emplace<T>(*d);
+      } else if (auto d = std::get_if<std::string>(data)) {
+        if (auto val = ParseString<T>(*d)) {
+          return &data->emplace<T>(*val);
+        }
+      }
+    } else if constexpr (std::same_as<T, std::vector<int>> ||
+                         std::same_as<T, std::vector<float>> ||
+                         std::same_as<T, std::vector<double>>) {
+      if (auto d = std::get_if<std::vector<int>>(data)) {
+        return &data->emplace(T{d->begin(), d->end()});
+      } else if (auto d = std::get_if<std::vector<float>>(data)) {
+        return &data->emplace(T{d->begin(), d->end()});
+      } else if (auto d = std::get_if<std::vector<double>>(data)) {
+        return &data->emplace(T{d->begin(), d->end()});
+      }
+    }
+    return nullptr;
+  }
 };
 
 namespace detail {
@@ -275,7 +360,8 @@ class ChildIterator {
  public:
   ChildIterator(IteratorType it, IteratorType end) noexcept
       : anchor(it), end(end) {
-    while (anchor != end && anchor->second.type != Storage::Value::kChild) {
+    while (anchor != end &&
+           !std::holds_alternative<Storage::Child>(anchor->second.data)) {
       ++anchor;
     }
   }
@@ -286,7 +372,8 @@ class ChildIterator {
   /// increment operator (needed for range-based for)
   ChildIterator& operator++() {
     ++anchor;
-    while (anchor != end && anchor->second.type != Storage::Value::kChild) {
+    while (anchor != end &&
+           !std::holds_alternative<Storage::Child>(anchor->second.data)) {
       ++anchor;
     }
     return *this;
@@ -301,7 +388,9 @@ class ChildIterator {
   std::string_view key() const { return anchor->first; }
 
   /// return value of the iterator
-  Storage& value() const { return *anchor->second.child; }
+  Storage& value() const {
+    return *std::get<Storage::Child>(anchor->second.data);
+  }
 };
 
 }  // namespace detail

--- a/glass/src/libnt/native/cpp/NetworkTables.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTables.cpp
@@ -2057,23 +2057,23 @@ void glass::DisplayNetworkTables(NetworkTablesModel* model,
 void NetworkTablesFlagsSettings::Update() {
   if (!m_pTreeView) {
     auto& storage = GetStorage();
-    m_pTreeView =
-        &storage.GetBool("tree", m_defaultFlags & NetworkTablesFlags_TreeView);
-    m_pCombinedView = &storage.GetBool(
+    m_pTreeView = &storage.Get<bool>(
+        "tree", m_defaultFlags & NetworkTablesFlags_TreeView);
+    m_pCombinedView = &storage.Get<bool>(
         "combined", m_defaultFlags & NetworkTablesFlags_CombinedView);
-    m_pShowSpecial = &storage.GetBool(
+    m_pShowSpecial = &storage.Get<bool>(
         "special", m_defaultFlags & NetworkTablesFlags_ShowSpecial);
-    m_pShowProperties = &storage.GetBool(
+    m_pShowProperties = &storage.Get<bool>(
         "properties", m_defaultFlags & NetworkTablesFlags_ShowProperties);
-    m_pShowTimestamp = &storage.GetBool(
+    m_pShowTimestamp = &storage.Get<bool>(
         "timestamp", m_defaultFlags & NetworkTablesFlags_ShowTimestamp);
-    m_pShowServerTimestamp = &storage.GetBool(
+    m_pShowServerTimestamp = &storage.Get<bool>(
         "serverTimestamp",
         m_defaultFlags & NetworkTablesFlags_ShowServerTimestamp);
-    m_pCreateNoncanonicalKeys = &storage.GetBool(
+    m_pCreateNoncanonicalKeys = &storage.Get<bool>(
         "createNonCanonical",
         m_defaultFlags & NetworkTablesFlags_CreateNoncanonicalKeys);
-    m_pPrecision = &storage.GetInt(
+    m_pPrecision = &storage.Get<int>(
         "precision", (m_defaultFlags & NetworkTablesFlags_Precision) >>
                          kNetworkTablesFlags_PrecisionBitShift);
   }

--- a/glass/src/libnt/native/cpp/NetworkTablesProvider.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTablesProvider.cpp
@@ -33,12 +33,16 @@ NetworkTablesProvider::NetworkTablesProvider(Storage& storage,
     for (auto&& childIt : m_storage.GetChildren()) {
       auto id = childIt.key();
       auto typePtr = m_typeCache.FindValue(id);
-      if (!typePtr || typePtr->type != Storage::Value::kString) {
+      if (!typePtr) {
+        continue;
+      }
+      auto strPtr = std::get_if<std::string>(&typePtr->data);
+      if (!strPtr) {
         continue;
       }
 
       // only handle ones where we have a builder
-      auto builderIt = m_typeMap.find(typePtr->stringVal);
+      auto builderIt = m_typeMap.find(*strPtr);
       if (builderIt == m_typeMap.end()) {
         continue;
       }
@@ -89,10 +93,13 @@ void NetworkTablesProvider::DisplayMenu() {
       // Add type label to smartdashboard sendables
       if (wpi::starts_with(entry->name, "/SmartDashboard/")) {
         auto typeEntry = m_typeCache.FindValue(entry->name);
-        if (typeEntry) {
+        if (!typeEntry) {
+          continue;
+        }
+        if (auto typeStr = std::get_if<std::string>(&typeEntry->data)) {
           ImGui::SameLine();
           ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
-          ImGui::Text("%s", typeEntry->stringVal.c_str());
+          ImGui::Text("%s", typeStr->c_str());
           ImGui::PopStyleColor();
           ImGui::SameLine();
           ImGui::Dummy(ImVec2(10.0f, 0.0f));
@@ -166,7 +173,7 @@ void NetworkTablesProvider::Update() {
       GetOrCreateView(builderIt->second, nt::Topic{valueData->topic},
                       tableName);
       // cache the type
-      m_typeCache.SetString(tableName, valueData->value.GetString());
+      m_typeCache.Set(tableName, valueData->value.GetString());
     }
   }
 }

--- a/glass/src/libnt/native/cpp/NetworkTablesSettings.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTablesSettings.cpp
@@ -94,17 +94,17 @@ void NetworkTablesSettings::Thread::Main() {
 
 NetworkTablesSettings::NetworkTablesSettings(std::string_view clientName,
                                              Storage& storage, NT_Inst inst)
-    : m_mode{storage.GetString("mode"),
+    : m_mode{storage.Get<std::string>("mode"),
              0,
              {"Disabled", "Client (NT4)", "Client (NT3)", "Server"}},
       m_persistentFilename{
-          storage.GetString("persistentFilename", "networktables.json")},
-      m_serverTeam{storage.GetString("serverTeam")},
-      m_listenAddress{storage.GetString("listenAddress")},
-      m_clientName{storage.GetString("clientName", clientName)},
-      m_port3{storage.GetInt("port3", NT_DEFAULT_PORT3)},
-      m_port4{storage.GetInt("port4", NT_DEFAULT_PORT4)},
-      m_dsClient{storage.GetBool("dsClient", true)} {
+          storage.Get<std::string>("persistentFilename", "networktables.json")},
+      m_serverTeam{storage.Get<std::string>("serverTeam")},
+      m_listenAddress{storage.Get<std::string>("listenAddress")},
+      m_clientName{storage.Get<std::string>("clientName", clientName)},
+      m_port3{storage.Get<int>("port3", NT_DEFAULT_PORT3)},
+      m_port4{storage.Get<int>("port4", NT_DEFAULT_PORT4)},
+      m_dsClient{storage.Get<bool>("dsClient", true)} {
   m_thread.Start(inst);
 }
 

--- a/roborioteamnumbersetter/src/main/native/cpp/App.cpp
+++ b/roborioteamnumbersetter/src/main/native/cpp/App.cpp
@@ -52,7 +52,7 @@ GLFWAPI void glfwSetWindowSize(GLFWwindow* window, int width, int height);
 
 struct TeamNumberRefHolder {
   explicit TeamNumberRefHolder(glass::Storage& storage)
-      : teamNumber{storage.GetInt("TeamNumber", 0)} {}
+      : teamNumber{storage.Get<int>("TeamNumber", 0)} {}
   int& teamNumber;
 };
 

--- a/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
@@ -133,7 +133,7 @@ class KeyboardJoystick : public SystemJoystick {
     float& maxAbsValue;
   };
 
-  std::vector<std::unique_ptr<glass::Storage>>& m_axisStorage;
+  std::vector<glass::Storage::Child>& m_axisStorage;
   std::vector<AxisConfig> m_axisConfig;
 
   static constexpr int kMaxButtonCount = 32;
@@ -152,7 +152,7 @@ class KeyboardJoystick : public SystemJoystick {
     int& key315;
   };
 
-  std::vector<std::unique_ptr<glass::Storage>>& m_povStorage;
+  std::vector<glass::Storage::Child>& m_povStorage;
   std::vector<PovConfig> m_povConfig;
 };
 
@@ -485,11 +485,11 @@ void GlfwSystemJoystick::GetData(HALJoystickData* data, bool mapGamepad) const {
 }
 
 KeyboardJoystick::AxisConfig::AxisConfig(glass::Storage& storage)
-    : incKey{storage.GetInt("incKey", -1)},
-      decKey{storage.GetInt("decKey", -1)},
-      keyRate{storage.GetFloat("keyRate", 0.05f)},
-      decayRate{storage.GetFloat("decayRate", 0.05f)},
-      maxAbsValue{storage.GetFloat("maxAbsValue", 1.0f)} {
+    : incKey{storage.Get<int>("incKey", -1)},
+      decKey{storage.Get<int>("decKey", -1)},
+      keyRate{storage.Get<float>("keyRate", 0.05f)},
+      decayRate{storage.Get<float>("decayRate", 0.05f)},
+      maxAbsValue{storage.Get<float>("maxAbsValue", 1.0f)} {
   // sanity check the key ranges
   if (incKey < -1 || incKey >= IM_ARRAYSIZE(ImGuiIO::KeysDown)) {
     incKey = -1;
@@ -500,14 +500,14 @@ KeyboardJoystick::AxisConfig::AxisConfig(glass::Storage& storage)
 }
 
 KeyboardJoystick::PovConfig::PovConfig(glass::Storage& storage)
-    : key0{storage.GetInt("key0", -1)},
-      key45{storage.GetInt("key45", -1)},
-      key90{storage.GetInt("key90", -1)},
-      key135{storage.GetInt("key135", -1)},
-      key180{storage.GetInt("key180", -1)},
-      key225{storage.GetInt("key225", -1)},
-      key270{storage.GetInt("key270", -1)},
-      key315{storage.GetInt("key315", -1)} {
+    : key0{storage.Get<int>("key0", -1)},
+      key45{storage.Get<int>("key45", -1)},
+      key90{storage.Get<int>("key90", -1)},
+      key135{storage.Get<int>("key135", -1)},
+      key180{storage.Get<int>("key180", -1)},
+      key225{storage.Get<int>("key225", -1)},
+      key270{storage.Get<int>("key270", -1)},
+      key315{storage.Get<int>("key315", -1)} {
   // sanity check the key ranges
   if (key0 < -1 || key0 >= IM_ARRAYSIZE(ImGuiIO::KeysDown)) {
     key0 = -1;
@@ -537,11 +537,11 @@ KeyboardJoystick::PovConfig::PovConfig(glass::Storage& storage)
 
 KeyboardJoystick::KeyboardJoystick(glass::Storage& storage, int index)
     : m_index{index},
-      m_axisCount{storage.GetInt("axisCount", -1)},
-      m_buttonCount{storage.GetInt("buttonCount", -1)},
-      m_povCount{storage.GetInt("povCount", -1)},
+      m_axisCount{storage.Get<int>("axisCount", -1)},
+      m_buttonCount{storage.Get<int>("buttonCount", -1)},
+      m_povCount{storage.Get<int>("povCount", -1)},
       m_axisStorage{storage.GetChildArray("axisConfig")},
-      m_buttonKey{storage.GetIntArray("buttonKeys")},
+      m_buttonKey{storage.Get<std::vector<int>>("buttonKeys")},
       m_povStorage{storage.GetChildArray("povConfig")} {
   wpi::format_to_n_c_str(m_name, sizeof(m_name), "Keyboard {}", index);
   wpi::format_to_n_c_str(m_guid, sizeof(m_guid), "Keyboard{}", index);
@@ -624,7 +624,7 @@ void KeyboardJoystick::SettingsDisplay() {
       }
     }
     while (m_axisCount > static_cast<int>(m_axisConfig.size())) {
-      m_axisStorage.emplace_back(std::make_unique<glass::Storage>());
+      m_axisStorage.emplace_back(std::make_shared<glass::Storage>());
       m_axisConfig.emplace_back(*m_axisStorage.back());
     }
     for (int i = 0; i < m_axisCount; ++i) {
@@ -681,7 +681,7 @@ void KeyboardJoystick::SettingsDisplay() {
       }
     }
     while (m_povCount > static_cast<int>(m_povConfig.size())) {
-      m_povStorage.emplace_back(std::make_unique<glass::Storage>());
+      m_povStorage.emplace_back(std::make_shared<glass::Storage>());
       m_povConfig.emplace_back(*m_povStorage.back());
     }
     for (int i = 0; i < m_povCount; ++i) {
@@ -863,7 +863,7 @@ GlfwKeyboardJoystick::GlfwKeyboardJoystick(glass::Storage& storage, int index)
     if (m_axisCount == -1 && m_axisStorage.empty()) {
       m_axisCount = 3;
       for (int i = 0; i < 3; ++i) {
-        m_axisStorage.emplace_back(std::make_unique<glass::Storage>());
+        m_axisStorage.emplace_back(std::make_shared<glass::Storage>());
         m_axisConfig.emplace_back(*m_axisStorage.back());
       }
       m_axisConfig[0].incKey = GLFW_KEY_D;
@@ -885,7 +885,7 @@ GlfwKeyboardJoystick::GlfwKeyboardJoystick(glass::Storage& storage, int index)
     }
     if (m_povCount == -1 && m_povStorage.empty()) {
       m_povCount = 1;
-      m_povStorage.emplace_back(std::make_unique<glass::Storage>());
+      m_povStorage.emplace_back(std::make_shared<glass::Storage>());
       m_povConfig.emplace_back(*m_povStorage.back());
       m_povConfig[0].key0 = GLFW_KEY_KP_8;
       m_povConfig[0].key45 = GLFW_KEY_KP_9;
@@ -900,7 +900,7 @@ GlfwKeyboardJoystick::GlfwKeyboardJoystick(glass::Storage& storage, int index)
     if (m_axisCount == -1 && m_axisStorage.empty()) {
       m_axisCount = 2;
       for (int i = 0; i < 2; ++i) {
-        m_axisStorage.emplace_back(std::make_unique<glass::Storage>());
+        m_axisStorage.emplace_back(std::make_shared<glass::Storage>());
         m_axisConfig.emplace_back(*m_axisStorage.back());
       }
       m_axisConfig[0].incKey = GLFW_KEY_L;
@@ -920,7 +920,7 @@ GlfwKeyboardJoystick::GlfwKeyboardJoystick(glass::Storage& storage, int index)
     if (m_axisCount == -1 && m_axisStorage.empty()) {
       m_axisCount = 2;
       for (int i = 0; i < 2; ++i) {
-        m_axisStorage.emplace_back(std::make_unique<glass::Storage>());
+        m_axisStorage.emplace_back(std::make_shared<glass::Storage>());
         m_axisConfig.emplace_back(*m_axisStorage.back());
       }
       m_axisConfig[0].incKey = GLFW_KEY_RIGHT;
@@ -976,9 +976,9 @@ const char* GlfwKeyboardJoystick::GetKeyName(int key) const {
 }
 
 RobotJoystick::RobotJoystick(glass::Storage& storage)
-    : name{storage.GetString("name")},
-      guid{storage.GetString("guid")},
-      useGamepad{storage.GetBool("useGamepad")} {}
+    : name{storage.Get<std::string>("name")},
+      guid{storage.Get<std::string>("guid")},
+      useGamepad{storage.Get<bool>("useGamepad")} {}
 
 void RobotJoystick::Update() {
   Clear();
@@ -1420,18 +1420,18 @@ void DriverStationGui::GlobalInit() {
   wpi::gui::AddEarlyExecute(DriverStationExecute);
 
   storageRoot.SetCustomApply([&storageRoot] {
-    gpDisableDS = &storageRoot.GetBool("disable", false);
+    gpDisableDS = &storageRoot.Get<bool>("disable", false);
     gpZeroDisconnectedJoysticks =
-        &storageRoot.GetBool("zeroDisconnectedJoysticks", true);
+        &storageRoot.Get<bool>("zeroDisconnectedJoysticks", true);
     gpUseEnableDisableHotkeys =
-        &storageRoot.GetBool("useEnableDisableHotkeys", false);
-    gpUseEstopHotkey = &storageRoot.GetBool("useEstopHotkey", false);
+        &storageRoot.Get<bool>("useEnableDisableHotkeys", false);
+    gpUseEstopHotkey = &storageRoot.Get<bool>("useEstopHotkey", false);
 
     auto& keyboardStorage = storageRoot.GetChildArray("keyboardJoysticks");
     keyboardStorage.resize(4);
     for (int i = 0; i < 4; ++i) {
       if (!keyboardStorage[i]) {
-        keyboardStorage[i] = std::make_unique<glass::Storage>();
+        keyboardStorage[i] = std::make_shared<glass::Storage>();
       }
       gKeyboardJoysticks.emplace_back(
           std::make_unique<GlfwKeyboardJoystick>(*keyboardStorage[i], i));
@@ -1441,7 +1441,7 @@ void DriverStationGui::GlobalInit() {
     robotJoystickStorage.resize(HAL_kMaxJoysticks);
     for (int i = 0; i < HAL_kMaxJoysticks; ++i) {
       if (!robotJoystickStorage[i]) {
-        robotJoystickStorage[i] = std::make_unique<glass::Storage>();
+        robotJoystickStorage[i] = std::make_shared<glass::Storage>();
       }
       gRobotJoysticks.emplace_back(*robotJoystickStorage[i]);
     }


### PR DESCRIPTION
Replaces custom union with std::variant.

Also replaces macro-generated access functions with templates.

Still a little dangerous to use, because of the way Get() returns references.

Needs more extensive testing before it's ready to merge.