### PR TITLE
[wpiutil] Replace StringBuffer usage with StringBuilder

### DIFF
--- a/wpiutil/src/main/java/edu/wpi/first/util/MsvcRuntimeException.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/MsvcRuntimeException.java
@@ -12,7 +12,7 @@ public class MsvcRuntimeException extends RuntimeException {
       int foundMajor, int foundMinor, int expectedMajor, int expectedMinor, String runtimePath) {
     String jvmLocation = ProcessHandle.current().info().command().orElse("Unknown");
 
-    StringBuffer builder = new StringBuffer(100);
+    StringBuilder builder = new StringBuilder(100);
     builder
         .append("Invalid MSVC Runtime Detected.\n")
         .append(


### PR DESCRIPTION
Squashes a [JdkObsolete] Error Prone warning.

> `StringBuffer` performs synchronization that is rarely necessary and has significant performance overhead. Prefer `StringBuilder`, which does not do synchronization.

This is a local variable that doesn't escape the method, so there's certainly no reason to have synchronization here.

[JdkObsolete]: https://errorprone.info/bugpattern/JdkObsolete