### PR TITLE
Allow compilation on android

### DIFF
--- a/wpinet/CMakeLists.txt
+++ b/wpinet/CMakeLists.txt
@@ -202,7 +202,7 @@ foreach(example ${wpinet_examples})
     endif()
 endforeach()
 
-if(UNIX AND NOT APPLE)
+if(UNIX AND NOT APPLE AND NOT ANDROID)
     set(LIBUTIL -lutil)
 else()
     set(LIBUTIL)

--- a/wpinet/examples/dsclient/dsclient.cpp
+++ b/wpinet/examples/dsclient/dsclient.cpp
@@ -32,5 +32,5 @@ int main() {
   });
 
   // wait for a keypress to terminate
-  std::getchar();
+  static_cast<void>(std::getchar());
 }

--- a/wpinet/examples/parallelconnect/parallelconnect.cpp
+++ b/wpinet/examples/parallelconnect/parallelconnect.cpp
@@ -48,5 +48,5 @@ int main() {
   });
 
   // wait for a keypress to terminate
-  std::getchar();
+  static_cast<void>(std::getchar());
 }

--- a/wpinet/examples/webserver/webserver.cpp
+++ b/wpinet/examples/webserver/webserver.cpp
@@ -85,5 +85,5 @@ int main() {
   });
 
   // wait for a keypress to terminate
-  std::getchar();
+  static_cast<void>(std::getchar());
 }

--- a/wpiutil/src/main/native/unix/StackTrace.cpp
+++ b/wpiutil/src/main/native/unix/StackTrace.cpp
@@ -16,6 +16,7 @@
 namespace wpi {
 
 std::string GetStackTraceDefault(int offset) {
+#ifndef __ANDROID__
   void* stackTrace[128];
   int stackSize = backtrace(stackTrace, 128);
   char** mangledSymbols = backtrace_symbols(stackTrace, stackSize);
@@ -38,6 +39,10 @@ std::string GetStackTraceDefault(int offset) {
   std::free(mangledSymbols);
 
   return std::string{trace.str()};
+#else
+  // backtrace_symbols not supported on android
+  return "";
+#endif
 }
 
 }  // namespace wpi


### PR DESCRIPTION
Stacktrace isn't supported until SDK 33, which is pretty new. For now just comment out stacktrace and we can figure this out later.

The other changes are more trivial.