### PR TITLE
Use div instead of divide for kotlin compatibility

### DIFF
--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/EpilogueGenerator.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/EpilogueGenerator.java
@@ -176,7 +176,7 @@ public class EpilogueGenerator {
             out.println("      config.loggingPeriod = Seconds.of(robot.getPeriod());");
             out.println("    }");
             out.println("    if (config.loggingPeriodOffset == null) {");
-            out.println("      config.loggingPeriodOffset = config.loggingPeriod.divide(2);");
+            out.println("      config.loggingPeriodOffset = config.loggingPeriod.div(2);");
             out.println("    }");
             out.println();
             out.println("    robot.addPeriodic(() -> {");

--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/EpilogueGeneratorTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/EpilogueGeneratorTest.java
@@ -172,7 +172,7 @@ class EpilogueGeneratorTest {
               config.loggingPeriod = Seconds.of(robot.getPeriod());
             }
             if (config.loggingPeriodOffset == null) {
-              config.loggingPeriodOffset = config.loggingPeriod.divide(2);
+              config.loggingPeriodOffset = config.loggingPeriod.div(2);
             }
 
             robot.addPeriodic(() -> {
@@ -252,7 +252,7 @@ class EpilogueGeneratorTest {
               config.loggingPeriod = Seconds.of(robot.getPeriod());
             }
             if (config.loggingPeriodOffset == null) {
-              config.loggingPeriodOffset = config.loggingPeriod.divide(2);
+              config.loggingPeriodOffset = config.loggingPeriod.div(2);
             }
 
             robot.addPeriodic(() -> {
@@ -284,7 +284,7 @@ class EpilogueGeneratorTest {
               config.loggingPeriod = Seconds.of(robot.getPeriod());
             }
             if (config.loggingPeriodOffset == null) {
-              config.loggingPeriodOffset = config.loggingPeriod.divide(2);
+              config.loggingPeriodOffset = config.loggingPeriod.div(2);
             }
 
             robot.addPeriodic(() -> {

--- a/wpiunits/src/generate/main/java/Measure-interface.java.jinja
+++ b/wpiunits/src/generate/main/java/Measure-interface.java.jinja
@@ -66,18 +66,18 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
   }
 
   @Override
-  default {{ helpers['type_usage'](name) }} divide(double divisor) {
+  default {{ helpers['type_usage'](name) }} div(double divisor) {
     return ({{ helpers['type_usage'](name) }}) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default {{ config[name]['divide']['Time'] or "Velocity<{}>".format(helpers['mtou'](name)) }} per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 {% for unit in math_units -%}
 {% if unit == "Dimensionless" %}
   @Override
-  default {{ helpers['type_usage'](name) }} divide({{ unit }} divisor) {
+  default {{ helpers['type_usage'](name) }} div({{ unit }} divisor) {
     return ({{ helpers['type_usage'](name) }}) {{ config[name]['base_unit'] }}.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -103,23 +103,23 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
 {% endif -%}
 {% if unit in config[name]['divide'] %}
   @Override
-  default {{ config[name]['divide'][unit] }} divide({{ unit }} divisor) {
+  default {{ config[name]['divide'][unit] }} div({{ unit }} divisor) {
     return {{ config[config[name]['divide'][unit]]['base_unit'] }}.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 {% elif unit == "Time" %}
   @Override
-  default Velocity<{{ helpers['mtou'](name) }}> divide({{ unit }} divisor) {
+  default Velocity<{{ helpers['mtou'](name) }}> div({{ unit }} divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 {% elif unit == name %}
   @Override
-  default Dimensionless divide({{ unit }} divisor) {
+  default Dimensionless div({{ unit }} divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 {% else %}
   @Override
-  default Per<{{ helpers['mtou'](name) }}, {{ helpers['mtou'](unit) }}> divide({{ unit }} divisor) {
-    return (Per<{{ helpers['mtou'](name) }}, {{ helpers['mtou'](unit) }}>) Measure.super.divide(divisor);
+  default Per<{{ helpers['mtou'](name) }}, {{ helpers['mtou'](unit) }}> div({{ unit }} divisor) {
+    return (Per<{{ helpers['mtou'](name) }}, {{ helpers['mtou'](unit) }}>) Measure.super.div(divisor);
   }
 {% endif -%}
 {% endif -%}

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Acceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Acceleration.java
@@ -66,13 +66,13 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Acceleration<D> divide(double divisor) {
+  default Acceleration<D> div(double divisor) {
     return (Acceleration<D>) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<AccelerationUnit<D>> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<AccelerationUnit<D>, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<AccelerationUnit<D>, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, AngleUnit> divide(Angle divisor) {
-    return (Per<AccelerationUnit<D>, AngleUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, AngleUnit> div(Angle divisor) {
+    return (Per<AccelerationUnit<D>, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<AccelerationUnit<D>, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<AccelerationUnit<D>, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<AccelerationUnit<D>, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<AccelerationUnit<D>, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<AccelerationUnit<D>, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<AccelerationUnit<D>, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, CurrentUnit> divide(Current divisor) {
-    return (Per<AccelerationUnit<D>, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, CurrentUnit> div(Current divisor) {
+    return (Per<AccelerationUnit<D>, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Acceleration<D> divide(Dimensionless divisor) {
+  default Acceleration<D> div(Dimensionless divisor) {
     return (Acceleration<D>) unit().of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, DistanceUnit> divide(Distance divisor) {
-    return (Per<AccelerationUnit<D>, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, DistanceUnit> div(Distance divisor) {
+    return (Per<AccelerationUnit<D>, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, EnergyUnit> divide(Energy divisor) {
-    return (Per<AccelerationUnit<D>, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, EnergyUnit> div(Energy divisor) {
+    return (Per<AccelerationUnit<D>, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, ForceUnit> divide(Force divisor) {
-    return (Per<AccelerationUnit<D>, ForceUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, ForceUnit> div(Force divisor) {
+    return (Per<AccelerationUnit<D>, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<AccelerationUnit<D>, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, FrequencyUnit> div(Frequency divisor) {
+    return (Per<AccelerationUnit<D>, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<AccelerationUnit<D>, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<AccelerationUnit<D>, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<AccelerationUnit<D>, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<AccelerationUnit<D>, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<AccelerationUnit<D>, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<AccelerationUnit<D>, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, MassUnit> divide(Mass divisor) {
-    return (Per<AccelerationUnit<D>, MassUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, MassUnit> div(Mass divisor) {
+    return (Per<AccelerationUnit<D>, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<AccelerationUnit<D>, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<AccelerationUnit<D>, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<AccelerationUnit<D>, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<AccelerationUnit<D>, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<AccelerationUnit<D>, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<AccelerationUnit<D>, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, PowerUnit> divide(Power divisor) {
-    return (Per<AccelerationUnit<D>, PowerUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, PowerUnit> div(Power divisor) {
+    return (Per<AccelerationUnit<D>, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<AccelerationUnit<D>, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, ResistanceUnit> div(Resistance divisor) {
+    return (Per<AccelerationUnit<D>, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<AccelerationUnit<D>, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, TemperatureUnit> div(Temperature divisor) {
+    return (Per<AccelerationUnit<D>, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Velocity<AccelerationUnit<D>> divide(Time divisor) {
+  default Velocity<AccelerationUnit<D>> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, TorqueUnit> divide(Torque divisor) {
-    return (Per<AccelerationUnit<D>, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, TorqueUnit> div(Torque divisor) {
+    return (Per<AccelerationUnit<D>, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<AccelerationUnit<D>, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<AccelerationUnit<D>, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   @Override
-  default Per<AccelerationUnit<D>, VoltageUnit> divide(Voltage divisor) {
-    return (Per<AccelerationUnit<D>, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<AccelerationUnit<D>, VoltageUnit> div(Voltage divisor) {
+    return (Per<AccelerationUnit<D>, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Angle.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Angle.java
@@ -66,13 +66,13 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Angle divide(double divisor) {
+  default Angle div(double divisor) {
     return (Angle) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default AngularVelocity per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<AngleUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<AngleUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<AngleUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,7 +93,7 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Dimensionless divide(Angle divisor) {
+  default Dimensionless div(Angle divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -104,8 +104,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<AngleUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<AngleUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<AngleUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<AngleUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<AngleUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<AngleUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<AngleUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, CurrentUnit> div(Current divisor) {
+    return (Per<AngleUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Angle divide(Dimensionless divisor) {
+  default Angle div(Dimensionless divisor) {
     return (Angle) Radians.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<AngleUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<AngleUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<AngleUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<AngleUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, ForceUnit> divide(Force divisor) {
-    return (Per<AngleUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, ForceUnit> div(Force divisor) {
+    return (Per<AngleUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<AngleUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<AngleUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<AngleUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<AngleUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<AngleUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<AngleUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<AngleUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<AngleUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, MassUnit> divide(Mass divisor) {
-    return (Per<AngleUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, MassUnit> div(Mass divisor) {
+    return (Per<AngleUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<AngleUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<AngleUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<AngleUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<AngleUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<AngleUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<AngleUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<AngleUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<AngleUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, PowerUnit> divide(Power divisor) {
-    return (Per<AngleUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, PowerUnit> div(Power divisor) {
+    return (Per<AngleUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<AngleUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<AngleUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<AngleUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<AngleUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default AngularVelocity divide(Time divisor) {
+  default AngularVelocity div(Time divisor) {
     return RadiansPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<AngleUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<AngleUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<AngleUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<AngleUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<AngleUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   @Override
-  default Per<AngleUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<AngleUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<AngleUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<AngleUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularAcceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularAcceleration.java
@@ -66,13 +66,13 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default AngularAcceleration divide(double divisor) {
+  default AngularAcceleration div(double divisor) {
     return (AngularAcceleration) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<AngularAccelerationUnit> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<AngularAccelerationUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<AngularAccelerationUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<AngularAccelerationUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, AngleUnit> div(Angle divisor) {
+    return (Per<AngularAccelerationUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,7 +104,7 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Dimensionless divide(AngularAcceleration divisor) {
+  default Dimensionless div(AngularAcceleration divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -115,8 +115,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<AngularAccelerationUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<AngularAccelerationUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<AngularAccelerationUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<AngularAccelerationUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<AngularAccelerationUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, CurrentUnit> div(Current divisor) {
+    return (Per<AngularAccelerationUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default AngularAcceleration divide(Dimensionless divisor) {
+  default AngularAcceleration div(Dimensionless divisor) {
     return (AngularAcceleration) RadiansPerSecondPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<AngularAccelerationUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<AngularAccelerationUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<AngularAccelerationUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<AngularAccelerationUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, ForceUnit> divide(Force divisor) {
-    return (Per<AngularAccelerationUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, ForceUnit> div(Force divisor) {
+    return (Per<AngularAccelerationUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,7 +191,7 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default AngularVelocity divide(Frequency divisor) {
+  default AngularVelocity div(Frequency divisor) {
     return RadiansPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -202,8 +202,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<AngularAccelerationUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<AngularAccelerationUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<AngularAccelerationUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<AngularAccelerationUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<AngularAccelerationUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<AngularAccelerationUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, MassUnit> divide(Mass divisor) {
-    return (Per<AngularAccelerationUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, MassUnit> div(Mass divisor) {
+    return (Per<AngularAccelerationUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<AngularAccelerationUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<AngularAccelerationUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<AngularAccelerationUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<AngularAccelerationUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<AngularAccelerationUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<AngularAccelerationUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, PowerUnit> divide(Power divisor) {
-    return (Per<AngularAccelerationUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, PowerUnit> div(Power divisor) {
+    return (Per<AngularAccelerationUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<AngularAccelerationUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<AngularAccelerationUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<AngularAccelerationUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<AngularAccelerationUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Velocity<AngularAccelerationUnit> divide(Time divisor) {
+  default Velocity<AngularAccelerationUnit> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<AngularAccelerationUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<AngularAccelerationUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<AngularAccelerationUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<AngularAccelerationUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   @Override
-  default Per<AngularAccelerationUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<AngularAccelerationUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<AngularAccelerationUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<AngularAccelerationUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularMomentum.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularMomentum.java
@@ -66,13 +66,13 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default AngularMomentum divide(double divisor) {
+  default AngularMomentum div(double divisor) {
     return (AngularMomentum) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<AngularMomentumUnit> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<AngularMomentumUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<AngularMomentumUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<AngularMomentumUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, AngleUnit> div(Angle divisor) {
+    return (Per<AngularMomentumUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<AngularMomentumUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<AngularMomentumUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,7 +115,7 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Dimensionless divide(AngularMomentum divisor) {
+  default Dimensionless div(AngularMomentum divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -126,7 +126,7 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default MomentOfInertia divide(AngularVelocity divisor) {
+  default MomentOfInertia div(AngularVelocity divisor) {
     return KilogramSquareMeters.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -137,12 +137,12 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<AngularMomentumUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, CurrentUnit> div(Current divisor) {
+    return (Per<AngularMomentumUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default AngularMomentum divide(Dimensionless divisor) {
+  default AngularMomentum div(Dimensionless divisor) {
     return (AngularMomentum) KilogramMetersSquaredPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<AngularMomentumUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<AngularMomentumUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<AngularMomentumUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<AngularMomentumUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, ForceUnit> divide(Force divisor) {
-    return (Per<AngularMomentumUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, ForceUnit> div(Force divisor) {
+    return (Per<AngularMomentumUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<AngularMomentumUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<AngularMomentumUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<AngularMomentumUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<AngularMomentumUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<AngularMomentumUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<AngularMomentumUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<AngularMomentumUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<AngularMomentumUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, MassUnit> divide(Mass divisor) {
-    return (Per<AngularMomentumUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, MassUnit> div(Mass divisor) {
+    return (Per<AngularMomentumUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<AngularMomentumUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<AngularMomentumUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<AngularMomentumUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<AngularMomentumUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<AngularMomentumUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<AngularMomentumUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, PowerUnit> divide(Power divisor) {
-    return (Per<AngularMomentumUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, PowerUnit> div(Power divisor) {
+    return (Per<AngularMomentumUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<AngularMomentumUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<AngularMomentumUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<AngularMomentumUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<AngularMomentumUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Velocity<AngularMomentumUnit> divide(Time divisor) {
+  default Velocity<AngularMomentumUnit> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<AngularMomentumUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<AngularMomentumUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<AngularMomentumUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<AngularMomentumUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   @Override
-  default Per<AngularMomentumUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<AngularMomentumUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<AngularMomentumUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<AngularMomentumUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularVelocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularVelocity.java
@@ -66,13 +66,13 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default AngularVelocity divide(double divisor) {
+  default AngularVelocity div(double divisor) {
     return (AngularVelocity) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default AngularAcceleration per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<AngularVelocityUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<AngularVelocityUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<AngularVelocityUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, AngleUnit> div(Angle divisor) {
+    return (Per<AngularVelocityUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<AngularVelocityUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<AngularVelocityUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<AngularVelocityUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<AngularVelocityUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,7 +126,7 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Dimensionless divide(AngularVelocity divisor) {
+  default Dimensionless div(AngularVelocity divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -137,12 +137,12 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<AngularVelocityUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, CurrentUnit> div(Current divisor) {
+    return (Per<AngularVelocityUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default AngularVelocity divide(Dimensionless divisor) {
+  default AngularVelocity div(Dimensionless divisor) {
     return (AngularVelocity) RadiansPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<AngularVelocityUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<AngularVelocityUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<AngularVelocityUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<AngularVelocityUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, ForceUnit> divide(Force divisor) {
-    return (Per<AngularVelocityUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, ForceUnit> div(Force divisor) {
+    return (Per<AngularVelocityUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<AngularVelocityUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<AngularVelocityUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<AngularVelocityUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<AngularVelocityUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<AngularVelocityUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<AngularVelocityUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<AngularVelocityUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<AngularVelocityUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, MassUnit> divide(Mass divisor) {
-    return (Per<AngularVelocityUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, MassUnit> div(Mass divisor) {
+    return (Per<AngularVelocityUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<AngularVelocityUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<AngularVelocityUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<AngularVelocityUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<AngularVelocityUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<AngularVelocityUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<AngularVelocityUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, PowerUnit> divide(Power divisor) {
-    return (Per<AngularVelocityUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, PowerUnit> div(Power divisor) {
+    return (Per<AngularVelocityUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<AngularVelocityUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<AngularVelocityUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<AngularVelocityUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<AngularVelocityUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default AngularAcceleration divide(Time divisor) {
+  default AngularAcceleration div(Time divisor) {
     return RadiansPerSecondPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<AngularVelocityUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<AngularVelocityUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<AngularVelocityUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<AngularVelocityUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   @Override
-  default Per<AngularVelocityUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<AngularVelocityUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<AngularVelocityUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<AngularVelocityUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 default Frequency asFrequency() { return Hertz.of(baseUnitMagnitude()); }
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Current.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Current.java
@@ -66,13 +66,13 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Current divide(double divisor) {
+  default Current div(double divisor) {
     return (Current) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<CurrentUnit> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<CurrentUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<CurrentUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<CurrentUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, AngleUnit> div(Angle divisor) {
+    return (Per<CurrentUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<CurrentUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<CurrentUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<CurrentUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<CurrentUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<CurrentUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<CurrentUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Dimensionless divide(Current divisor) {
+  default Dimensionless div(Current divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
   @Override
-  default Current divide(Dimensionless divisor) {
+  default Current div(Dimensionless divisor) {
     return (Current) Amps.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<CurrentUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<CurrentUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<CurrentUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<CurrentUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, ForceUnit> divide(Force divisor) {
-    return (Per<CurrentUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, ForceUnit> div(Force divisor) {
+    return (Per<CurrentUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<CurrentUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<CurrentUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<CurrentUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<CurrentUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<CurrentUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<CurrentUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<CurrentUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<CurrentUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, MassUnit> divide(Mass divisor) {
-    return (Per<CurrentUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, MassUnit> div(Mass divisor) {
+    return (Per<CurrentUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<CurrentUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<CurrentUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<CurrentUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<CurrentUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<CurrentUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<CurrentUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, PowerUnit> divide(Power divisor) {
-    return (Per<CurrentUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, PowerUnit> div(Power divisor) {
+    return (Per<CurrentUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<CurrentUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<CurrentUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<CurrentUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<CurrentUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Velocity<CurrentUnit> divide(Time divisor) {
+  default Velocity<CurrentUnit> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<CurrentUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<CurrentUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<CurrentUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<CurrentUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   @Override
-  default Per<CurrentUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<CurrentUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<CurrentUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<CurrentUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Dimensionless.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Dimensionless.java
@@ -66,13 +66,13 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Dimensionless divide(double divisor) {
+  default Dimensionless div(double divisor) {
     return (Dimensionless) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Frequency per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<DimensionlessUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<DimensionlessUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<DimensionlessUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, AngleUnit> div(Angle divisor) {
+    return (Per<DimensionlessUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<DimensionlessUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<DimensionlessUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<DimensionlessUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<DimensionlessUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<DimensionlessUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<DimensionlessUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<DimensionlessUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, CurrentUnit> div(Current divisor) {
+    return (Per<DimensionlessUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Dimensionless divide(Dimensionless divisor) {
+  default Dimensionless div(Dimensionless divisor) {
     return (Dimensionless) Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<DimensionlessUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<DimensionlessUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<DimensionlessUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<DimensionlessUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, ForceUnit> divide(Force divisor) {
-    return (Per<DimensionlessUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, ForceUnit> div(Force divisor) {
+    return (Per<DimensionlessUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<DimensionlessUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<DimensionlessUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<DimensionlessUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<DimensionlessUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<DimensionlessUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<DimensionlessUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<DimensionlessUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<DimensionlessUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, MassUnit> divide(Mass divisor) {
-    return (Per<DimensionlessUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, MassUnit> div(Mass divisor) {
+    return (Per<DimensionlessUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<DimensionlessUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<DimensionlessUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<DimensionlessUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<DimensionlessUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<DimensionlessUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<DimensionlessUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, PowerUnit> divide(Power divisor) {
-    return (Per<DimensionlessUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, PowerUnit> div(Power divisor) {
+    return (Per<DimensionlessUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<DimensionlessUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<DimensionlessUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<DimensionlessUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<DimensionlessUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Frequency divide(Time divisor) {
+  default Frequency div(Time divisor) {
     return Hertz.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<DimensionlessUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<DimensionlessUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<DimensionlessUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<DimensionlessUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   @Override
-  default Per<DimensionlessUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<DimensionlessUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<DimensionlessUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<DimensionlessUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Distance.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Distance.java
@@ -66,13 +66,13 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Distance divide(double divisor) {
+  default Distance div(double divisor) {
     return (Distance) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default LinearVelocity per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<DistanceUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<DistanceUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<DistanceUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, AngleUnit> div(Angle divisor) {
+    return (Per<DistanceUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<DistanceUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<DistanceUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<DistanceUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<DistanceUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<DistanceUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<DistanceUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<DistanceUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, CurrentUnit> div(Current divisor) {
+    return (Per<DistanceUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Distance divide(Dimensionless divisor) {
+  default Distance div(Dimensionless divisor) {
     return (Distance) Meters.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,7 +158,7 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Dimensionless divide(Distance divisor) {
+  default Dimensionless div(Distance divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -169,8 +169,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<DistanceUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<DistanceUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, ForceUnit> divide(Force divisor) {
-    return (Per<DistanceUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, ForceUnit> div(Force divisor) {
+    return (Per<DistanceUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<DistanceUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<DistanceUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<DistanceUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<DistanceUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<DistanceUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<DistanceUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,7 +224,7 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Time divide(LinearVelocity divisor) {
+  default Time div(LinearVelocity divisor) {
     return Seconds.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -235,8 +235,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, MassUnit> divide(Mass divisor) {
-    return (Per<DistanceUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, MassUnit> div(Mass divisor) {
+    return (Per<DistanceUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<DistanceUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<DistanceUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<DistanceUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<DistanceUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<DistanceUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<DistanceUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, PowerUnit> divide(Power divisor) {
-    return (Per<DistanceUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, PowerUnit> div(Power divisor) {
+    return (Per<DistanceUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<DistanceUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<DistanceUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<DistanceUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<DistanceUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default LinearVelocity divide(Time divisor) {
+  default LinearVelocity div(Time divisor) {
     return MetersPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<DistanceUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<DistanceUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<DistanceUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<DistanceUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   @Override
-  default Per<DistanceUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<DistanceUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<DistanceUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<DistanceUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Energy.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Energy.java
@@ -66,13 +66,13 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Energy divide(double divisor) {
+  default Energy div(double divisor) {
     return (Energy) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Power per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<EnergyUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<EnergyUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<EnergyUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, AngleUnit> div(Angle divisor) {
+    return (Per<EnergyUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<EnergyUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<EnergyUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<EnergyUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<EnergyUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<EnergyUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<EnergyUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<EnergyUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, CurrentUnit> div(Current divisor) {
+    return (Per<EnergyUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Energy divide(Dimensionless divisor) {
+  default Energy div(Dimensionless divisor) {
     return (Energy) Joules.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<EnergyUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<EnergyUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,7 +169,7 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Dimensionless divide(Energy divisor) {
+  default Dimensionless div(Energy divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -180,8 +180,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, ForceUnit> divide(Force divisor) {
-    return (Per<EnergyUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, ForceUnit> div(Force divisor) {
+    return (Per<EnergyUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<EnergyUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<EnergyUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<EnergyUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<EnergyUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<EnergyUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<EnergyUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<EnergyUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<EnergyUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, MassUnit> divide(Mass divisor) {
-    return (Per<EnergyUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, MassUnit> div(Mass divisor) {
+    return (Per<EnergyUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<EnergyUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<EnergyUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<EnergyUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<EnergyUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<EnergyUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<EnergyUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, PowerUnit> divide(Power divisor) {
-    return (Per<EnergyUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, PowerUnit> div(Power divisor) {
+    return (Per<EnergyUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<EnergyUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<EnergyUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<EnergyUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<EnergyUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Power divide(Time divisor) {
+  default Power div(Time divisor) {
     return Watts.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<EnergyUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<EnergyUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<EnergyUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<EnergyUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   @Override
-  default Per<EnergyUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<EnergyUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<EnergyUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<EnergyUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Force.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Force.java
@@ -66,13 +66,13 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Force divide(double divisor) {
+  default Force div(double divisor) {
     return (Force) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<ForceUnit> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<ForceUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<ForceUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<ForceUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<ForceUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, AngleUnit> div(Angle divisor) {
+    return (Per<ForceUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<ForceUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<ForceUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<ForceUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<ForceUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<ForceUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<ForceUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<ForceUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, CurrentUnit> div(Current divisor) {
+    return (Per<ForceUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Force divide(Dimensionless divisor) {
+  default Force div(Dimensionless divisor) {
     return (Force) Newtons.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<ForceUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<ForceUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<ForceUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<ForceUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,7 +180,7 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Dimensionless divide(Force divisor) {
+  default Dimensionless div(Force divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -191,8 +191,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<ForceUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<ForceUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,7 +202,7 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Mass divide(LinearAcceleration divisor) {
+  default Mass div(LinearAcceleration divisor) {
     return Kilograms.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -213,8 +213,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<ForceUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<ForceUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<ForceUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<ForceUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,7 +235,7 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default LinearAcceleration divide(Mass divisor) {
+  default LinearAcceleration div(Mass divisor) {
     return MetersPerSecondPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -246,8 +246,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<ForceUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<ForceUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<ForceUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<ForceUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<ForceUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<ForceUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<ForceUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<ForceUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, PowerUnit> divide(Power divisor) {
-    return (Per<ForceUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, PowerUnit> div(Power divisor) {
+    return (Per<ForceUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<ForceUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<ForceUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<ForceUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<ForceUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Velocity<ForceUnit> divide(Time divisor) {
+  default Velocity<ForceUnit> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<ForceUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<ForceUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<ForceUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<ForceUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<ForceUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   @Override
-  default Per<ForceUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<ForceUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<ForceUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<ForceUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Frequency.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Frequency.java
@@ -66,13 +66,13 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Frequency divide(double divisor) {
+  default Frequency div(double divisor) {
     return (Frequency) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<FrequencyUnit> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<FrequencyUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<FrequencyUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<FrequencyUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, AngleUnit> div(Angle divisor) {
+    return (Per<FrequencyUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<FrequencyUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<FrequencyUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<FrequencyUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<FrequencyUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<FrequencyUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<FrequencyUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<FrequencyUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, CurrentUnit> div(Current divisor) {
+    return (Per<FrequencyUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Frequency divide(Dimensionless divisor) {
+  default Frequency div(Dimensionless divisor) {
     return (Frequency) Hertz.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<FrequencyUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<FrequencyUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<FrequencyUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<FrequencyUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, ForceUnit> divide(Force divisor) {
-    return (Per<FrequencyUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, ForceUnit> div(Force divisor) {
+    return (Per<FrequencyUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,7 +191,7 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Dimensionless divide(Frequency divisor) {
+  default Dimensionless div(Frequency divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -202,8 +202,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<FrequencyUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<FrequencyUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<FrequencyUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<FrequencyUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<FrequencyUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<FrequencyUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, MassUnit> divide(Mass divisor) {
-    return (Per<FrequencyUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, MassUnit> div(Mass divisor) {
+    return (Per<FrequencyUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<FrequencyUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<FrequencyUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<FrequencyUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<FrequencyUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<FrequencyUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<FrequencyUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, PowerUnit> divide(Power divisor) {
-    return (Per<FrequencyUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, PowerUnit> div(Power divisor) {
+    return (Per<FrequencyUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<FrequencyUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<FrequencyUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<FrequencyUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<FrequencyUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Velocity<FrequencyUnit> divide(Time divisor) {
+  default Velocity<FrequencyUnit> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<FrequencyUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<FrequencyUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<FrequencyUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<FrequencyUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   @Override
-  default Per<FrequencyUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<FrequencyUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<FrequencyUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<FrequencyUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 /** Converts this frequency to the time period between cycles. */
 default Time asPeriod() { return Seconds.of(1 / baseUnitMagnitude()); }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearAcceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearAcceleration.java
@@ -66,13 +66,13 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default LinearAcceleration divide(double divisor) {
+  default LinearAcceleration div(double divisor) {
     return (LinearAcceleration) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<LinearAccelerationUnit> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<LinearAccelerationUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<LinearAccelerationUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<LinearAccelerationUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, AngleUnit> div(Angle divisor) {
+    return (Per<LinearAccelerationUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<LinearAccelerationUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<LinearAccelerationUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<LinearAccelerationUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<LinearAccelerationUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<LinearAccelerationUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<LinearAccelerationUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<LinearAccelerationUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, CurrentUnit> div(Current divisor) {
+    return (Per<LinearAccelerationUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default LinearAcceleration divide(Dimensionless divisor) {
+  default LinearAcceleration div(Dimensionless divisor) {
     return (LinearAcceleration) MetersPerSecondPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<LinearAccelerationUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<LinearAccelerationUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<LinearAccelerationUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<LinearAccelerationUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, ForceUnit> divide(Force divisor) {
-    return (Per<LinearAccelerationUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, ForceUnit> div(Force divisor) {
+    return (Per<LinearAccelerationUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,7 +191,7 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default LinearVelocity divide(Frequency divisor) {
+  default LinearVelocity div(Frequency divisor) {
     return MetersPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -202,7 +202,7 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Dimensionless divide(LinearAcceleration divisor) {
+  default Dimensionless div(LinearAcceleration divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -213,8 +213,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<LinearAccelerationUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<LinearAccelerationUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<LinearAccelerationUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<LinearAccelerationUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, MassUnit> divide(Mass divisor) {
-    return (Per<LinearAccelerationUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, MassUnit> div(Mass divisor) {
+    return (Per<LinearAccelerationUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<LinearAccelerationUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<LinearAccelerationUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<LinearAccelerationUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<LinearAccelerationUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<LinearAccelerationUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<LinearAccelerationUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, PowerUnit> divide(Power divisor) {
-    return (Per<LinearAccelerationUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, PowerUnit> div(Power divisor) {
+    return (Per<LinearAccelerationUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<LinearAccelerationUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<LinearAccelerationUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<LinearAccelerationUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<LinearAccelerationUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Velocity<LinearAccelerationUnit> divide(Time divisor) {
+  default Velocity<LinearAccelerationUnit> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<LinearAccelerationUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<LinearAccelerationUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<LinearAccelerationUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<LinearAccelerationUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   @Override
-  default Per<LinearAccelerationUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<LinearAccelerationUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<LinearAccelerationUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<LinearAccelerationUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearMomentum.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearMomentum.java
@@ -66,13 +66,13 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default LinearMomentum divide(double divisor) {
+  default LinearMomentum div(double divisor) {
     return (LinearMomentum) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Force per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<LinearMomentumUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<LinearMomentumUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<LinearMomentumUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, AngleUnit> div(Angle divisor) {
+    return (Per<LinearMomentumUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<LinearMomentumUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<LinearMomentumUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<LinearMomentumUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<LinearMomentumUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<LinearMomentumUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<LinearMomentumUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<LinearMomentumUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, CurrentUnit> div(Current divisor) {
+    return (Per<LinearMomentumUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default LinearMomentum divide(Dimensionless divisor) {
+  default LinearMomentum div(Dimensionless divisor) {
     return (LinearMomentum) KilogramMetersPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<LinearMomentumUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<LinearMomentumUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<LinearMomentumUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<LinearMomentumUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, ForceUnit> divide(Force divisor) {
-    return (Per<LinearMomentumUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, ForceUnit> div(Force divisor) {
+    return (Per<LinearMomentumUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<LinearMomentumUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<LinearMomentumUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<LinearMomentumUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<LinearMomentumUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,7 +213,7 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Dimensionless divide(LinearMomentum divisor) {
+  default Dimensionless div(LinearMomentum divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -224,7 +224,7 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Mass divide(LinearVelocity divisor) {
+  default Mass div(LinearVelocity divisor) {
     return Kilograms.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -235,7 +235,7 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default LinearVelocity divide(Mass divisor) {
+  default LinearVelocity div(Mass divisor) {
     return MetersPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -246,8 +246,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<LinearMomentumUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<LinearMomentumUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<LinearMomentumUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<LinearMomentumUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<LinearMomentumUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<LinearMomentumUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, PowerUnit> divide(Power divisor) {
-    return (Per<LinearMomentumUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, PowerUnit> div(Power divisor) {
+    return (Per<LinearMomentumUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<LinearMomentumUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<LinearMomentumUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<LinearMomentumUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<LinearMomentumUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Force divide(Time divisor) {
+  default Force div(Time divisor) {
     return Newtons.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<LinearMomentumUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<LinearMomentumUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<LinearMomentumUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<LinearMomentumUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   @Override
-  default Per<LinearMomentumUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<LinearMomentumUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<LinearMomentumUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<LinearMomentumUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearVelocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearVelocity.java
@@ -66,13 +66,13 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default LinearVelocity divide(double divisor) {
+  default LinearVelocity div(double divisor) {
     return (LinearVelocity) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default LinearAcceleration per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<LinearVelocityUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<LinearVelocityUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<LinearVelocityUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, AngleUnit> div(Angle divisor) {
+    return (Per<LinearVelocityUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<LinearVelocityUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<LinearVelocityUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<LinearVelocityUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<LinearVelocityUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<LinearVelocityUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<LinearVelocityUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<LinearVelocityUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, CurrentUnit> div(Current divisor) {
+    return (Per<LinearVelocityUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default LinearVelocity divide(Dimensionless divisor) {
+  default LinearVelocity div(Dimensionless divisor) {
     return (LinearVelocity) MetersPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<LinearVelocityUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<LinearVelocityUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<LinearVelocityUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<LinearVelocityUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, ForceUnit> divide(Force divisor) {
-    return (Per<LinearVelocityUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, ForceUnit> div(Force divisor) {
+    return (Per<LinearVelocityUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<LinearVelocityUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<LinearVelocityUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<LinearVelocityUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<LinearVelocityUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<LinearVelocityUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<LinearVelocityUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,7 +224,7 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Dimensionless divide(LinearVelocity divisor) {
+  default Dimensionless div(LinearVelocity divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -235,8 +235,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, MassUnit> divide(Mass divisor) {
-    return (Per<LinearVelocityUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, MassUnit> div(Mass divisor) {
+    return (Per<LinearVelocityUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<LinearVelocityUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<LinearVelocityUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<LinearVelocityUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<LinearVelocityUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<LinearVelocityUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<LinearVelocityUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, PowerUnit> divide(Power divisor) {
-    return (Per<LinearVelocityUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, PowerUnit> div(Power divisor) {
+    return (Per<LinearVelocityUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<LinearVelocityUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<LinearVelocityUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<LinearVelocityUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<LinearVelocityUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default LinearAcceleration divide(Time divisor) {
+  default LinearAcceleration div(Time divisor) {
     return MetersPerSecondPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<LinearVelocityUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<LinearVelocityUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<LinearVelocityUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<LinearVelocityUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   @Override
-  default Per<LinearVelocityUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<LinearVelocityUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<LinearVelocityUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<LinearVelocityUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mass.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mass.java
@@ -66,13 +66,13 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Mass divide(double divisor) {
+  default Mass div(double divisor) {
     return (Mass) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<MassUnit> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<MassUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<MassUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<MassUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<MassUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, AngleUnit> div(Angle divisor) {
+    return (Per<MassUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<MassUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<MassUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<MassUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<MassUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<MassUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<MassUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<MassUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, CurrentUnit> div(Current divisor) {
+    return (Per<MassUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Mass divide(Dimensionless divisor) {
+  default Mass div(Dimensionless divisor) {
     return (Mass) Kilograms.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<MassUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<MassUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<MassUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<MassUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, ForceUnit> divide(Force divisor) {
-    return (Per<MassUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, ForceUnit> div(Force divisor) {
+    return (Per<MassUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<MassUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<MassUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<MassUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<MassUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<MassUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<MassUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<MassUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<MassUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,7 +235,7 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Dimensionless divide(Mass divisor) {
+  default Dimensionless div(Mass divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -246,8 +246,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<MassUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<MassUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<MassUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<MassUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<MassUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<MassUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<MassUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<MassUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, PowerUnit> divide(Power divisor) {
-    return (Per<MassUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, PowerUnit> div(Power divisor) {
+    return (Per<MassUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<MassUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<MassUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<MassUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<MassUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Velocity<MassUnit> divide(Time divisor) {
+  default Velocity<MassUnit> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<MassUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<MassUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<MassUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<MassUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<MassUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   @Override
-  default Per<MassUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<MassUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<MassUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<MassUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MomentOfInertia.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MomentOfInertia.java
@@ -66,13 +66,13 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default MomentOfInertia divide(double divisor) {
+  default MomentOfInertia div(double divisor) {
     return (MomentOfInertia) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<MomentOfInertiaUnit> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<MomentOfInertiaUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<MomentOfInertiaUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<MomentOfInertiaUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, AngleUnit> div(Angle divisor) {
+    return (Per<MomentOfInertiaUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<MomentOfInertiaUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<MomentOfInertiaUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<MomentOfInertiaUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<MomentOfInertiaUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<MomentOfInertiaUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<MomentOfInertiaUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<MomentOfInertiaUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, CurrentUnit> div(Current divisor) {
+    return (Per<MomentOfInertiaUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default MomentOfInertia divide(Dimensionless divisor) {
+  default MomentOfInertia div(Dimensionless divisor) {
     return (MomentOfInertia) KilogramSquareMeters.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<MomentOfInertiaUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<MomentOfInertiaUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<MomentOfInertiaUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<MomentOfInertiaUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, ForceUnit> divide(Force divisor) {
-    return (Per<MomentOfInertiaUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, ForceUnit> div(Force divisor) {
+    return (Per<MomentOfInertiaUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<MomentOfInertiaUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<MomentOfInertiaUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<MomentOfInertiaUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<MomentOfInertiaUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<MomentOfInertiaUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<MomentOfInertiaUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<MomentOfInertiaUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<MomentOfInertiaUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, MassUnit> divide(Mass divisor) {
-    return (Per<MomentOfInertiaUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, MassUnit> div(Mass divisor) {
+    return (Per<MomentOfInertiaUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,7 +246,7 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Dimensionless divide(MomentOfInertia divisor) {
+  default Dimensionless div(MomentOfInertia divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -257,8 +257,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<MomentOfInertiaUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<MomentOfInertiaUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<MomentOfInertiaUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<MomentOfInertiaUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, PowerUnit> divide(Power divisor) {
-    return (Per<MomentOfInertiaUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, PowerUnit> div(Power divisor) {
+    return (Per<MomentOfInertiaUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<MomentOfInertiaUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<MomentOfInertiaUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<MomentOfInertiaUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<MomentOfInertiaUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Velocity<MomentOfInertiaUnit> divide(Time divisor) {
+  default Velocity<MomentOfInertiaUnit> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<MomentOfInertiaUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<MomentOfInertiaUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<MomentOfInertiaUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<MomentOfInertiaUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   @Override
-  default Per<MomentOfInertiaUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<MomentOfInertiaUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<MomentOfInertiaUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<MomentOfInertiaUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mult.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mult.java
@@ -66,13 +66,13 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Mult<A, B> divide(double divisor) {
+  default Mult<A, B> div(double divisor) {
     return (Mult<A, B>) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<MultUnit<A, B>> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<MultUnit<A, B>, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<MultUnit<A, B>, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, AngleUnit> divide(Angle divisor) {
-    return (Per<MultUnit<A, B>, AngleUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, AngleUnit> div(Angle divisor) {
+    return (Per<MultUnit<A, B>, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<MultUnit<A, B>, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<MultUnit<A, B>, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<MultUnit<A, B>, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<MultUnit<A, B>, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<MultUnit<A, B>, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<MultUnit<A, B>, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, CurrentUnit> divide(Current divisor) {
-    return (Per<MultUnit<A, B>, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, CurrentUnit> div(Current divisor) {
+    return (Per<MultUnit<A, B>, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Mult<A, B> divide(Dimensionless divisor) {
+  default Mult<A, B> div(Dimensionless divisor) {
     return (Mult<A, B>) unit().of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, DistanceUnit> divide(Distance divisor) {
-    return (Per<MultUnit<A, B>, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, DistanceUnit> div(Distance divisor) {
+    return (Per<MultUnit<A, B>, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, EnergyUnit> divide(Energy divisor) {
-    return (Per<MultUnit<A, B>, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, EnergyUnit> div(Energy divisor) {
+    return (Per<MultUnit<A, B>, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, ForceUnit> divide(Force divisor) {
-    return (Per<MultUnit<A, B>, ForceUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, ForceUnit> div(Force divisor) {
+    return (Per<MultUnit<A, B>, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<MultUnit<A, B>, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, FrequencyUnit> div(Frequency divisor) {
+    return (Per<MultUnit<A, B>, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<MultUnit<A, B>, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<MultUnit<A, B>, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<MultUnit<A, B>, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<MultUnit<A, B>, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<MultUnit<A, B>, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<MultUnit<A, B>, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, MassUnit> divide(Mass divisor) {
-    return (Per<MultUnit<A, B>, MassUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, MassUnit> div(Mass divisor) {
+    return (Per<MultUnit<A, B>, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<MultUnit<A, B>, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<MultUnit<A, B>, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<MultUnit<A, B>, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<MultUnit<A, B>, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<MultUnit<A, B>, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<MultUnit<A, B>, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, PowerUnit> divide(Power divisor) {
-    return (Per<MultUnit<A, B>, PowerUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, PowerUnit> div(Power divisor) {
+    return (Per<MultUnit<A, B>, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<MultUnit<A, B>, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, ResistanceUnit> div(Resistance divisor) {
+    return (Per<MultUnit<A, B>, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<MultUnit<A, B>, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, TemperatureUnit> div(Temperature divisor) {
+    return (Per<MultUnit<A, B>, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Velocity<MultUnit<A, B>> divide(Time divisor) {
+  default Velocity<MultUnit<A, B>> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, TorqueUnit> divide(Torque divisor) {
-    return (Per<MultUnit<A, B>, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, TorqueUnit> div(Torque divisor) {
+    return (Per<MultUnit<A, B>, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<MultUnit<A, B>, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<MultUnit<A, B>, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   @Override
-  default Per<MultUnit<A, B>, VoltageUnit> divide(Voltage divisor) {
-    return (Per<MultUnit<A, B>, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<MultUnit<A, B>, VoltageUnit> div(Voltage divisor) {
+    return (Per<MultUnit<A, B>, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Per.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Per.java
@@ -66,13 +66,13 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<Dividend, Divisor> divide(double divisor) {
+  default Per<Dividend, Divisor> div(double divisor) {
     return (Per<Dividend, Divisor>) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<PerUnit<Dividend, Divisor>> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, AngleUnit> divide(Angle divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, AngleUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, AngleUnit> div(Angle divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, CurrentUnit> divide(Current divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, CurrentUnit> div(Current divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Per<Dividend, Divisor> divide(Dimensionless divisor) {
+  default Per<Dividend, Divisor> div(Dimensionless divisor) {
     return (Per<Dividend, Divisor>) unit().of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, DistanceUnit> divide(Distance divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, DistanceUnit> div(Distance divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, EnergyUnit> divide(Energy divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, EnergyUnit> div(Energy divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, ForceUnit> divide(Force divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, ForceUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, ForceUnit> div(Force divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, FrequencyUnit> div(Frequency divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, MassUnit> divide(Mass divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, MassUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, MassUnit> div(Mass divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, PowerUnit> divide(Power divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, PowerUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, PowerUnit> div(Power divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, ResistanceUnit> div(Resistance divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, TemperatureUnit> div(Temperature divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Velocity<PerUnit<Dividend, Divisor>> divide(Time divisor) {
+  default Velocity<PerUnit<Dividend, Divisor>> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, TorqueUnit> divide(Torque divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, TorqueUnit> div(Torque divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   @Override
-  default Per<PerUnit<Dividend, Divisor>, VoltageUnit> divide(Voltage divisor) {
-    return (Per<PerUnit<Dividend, Divisor>, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<PerUnit<Dividend, Divisor>, VoltageUnit> div(Voltage divisor) {
+    return (Per<PerUnit<Dividend, Divisor>, VoltageUnit>) Measure.super.div(divisor);
   }
 default Measure<Dividend> timesDivisor(Measure<? extends Divisor> multiplier) {
   return (Measure<Dividend>) baseUnit().numerator().ofBaseUnits(baseUnitMagnitude() * multiplier.baseUnitMagnitude());

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Power.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Power.java
@@ -66,13 +66,13 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Power divide(double divisor) {
+  default Power div(double divisor) {
     return (Power) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<PowerUnit> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<PowerUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<PowerUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<PowerUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<PowerUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, AngleUnit> div(Angle divisor) {
+    return (Per<PowerUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<PowerUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<PowerUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<PowerUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<PowerUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<PowerUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<PowerUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Voltage divide(Current divisor) {
+  default Voltage div(Current divisor) {
     return Volts.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
   @Override
-  default Power divide(Dimensionless divisor) {
+  default Power div(Dimensionless divisor) {
     return (Power) Watts.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<PowerUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<PowerUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,7 +169,7 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Frequency divide(Energy divisor) {
+  default Frequency div(Energy divisor) {
     return Hertz.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -180,8 +180,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, ForceUnit> divide(Force divisor) {
-    return (Per<PowerUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, ForceUnit> div(Force divisor) {
+    return (Per<PowerUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<PowerUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<PowerUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<PowerUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<PowerUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<PowerUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<PowerUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<PowerUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<PowerUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, MassUnit> divide(Mass divisor) {
-    return (Per<PowerUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, MassUnit> div(Mass divisor) {
+    return (Per<PowerUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<PowerUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<PowerUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<PowerUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<PowerUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<PowerUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<PowerUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<PowerUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<PowerUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,7 +279,7 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Dimensionless divide(Power divisor) {
+  default Dimensionless div(Power divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -290,8 +290,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<PowerUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<PowerUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<PowerUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<PowerUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Velocity<PowerUnit> divide(Time divisor) {
+  default Velocity<PowerUnit> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<PowerUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<PowerUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<PowerUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Per<PowerUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<PowerUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<PowerUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<PowerUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,7 +345,7 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   @Override
-  default Current divide(Voltage divisor) {
+  default Current div(Voltage divisor) {
     return Amps.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Resistance.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Resistance.java
@@ -66,13 +66,13 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Resistance divide(double divisor) {
+  default Resistance div(double divisor) {
     return (Resistance) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<ResistanceUnit> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<ResistanceUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<ResistanceUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<ResistanceUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, AngleUnit> div(Angle divisor) {
+    return (Per<ResistanceUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<ResistanceUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<ResistanceUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<ResistanceUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<ResistanceUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<ResistanceUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<ResistanceUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<ResistanceUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, CurrentUnit> div(Current divisor) {
+    return (Per<ResistanceUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Resistance divide(Dimensionless divisor) {
+  default Resistance div(Dimensionless divisor) {
     return (Resistance) Ohms.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<ResistanceUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<ResistanceUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<ResistanceUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<ResistanceUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, ForceUnit> divide(Force divisor) {
-    return (Per<ResistanceUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, ForceUnit> div(Force divisor) {
+    return (Per<ResistanceUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<ResistanceUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<ResistanceUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<ResistanceUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<ResistanceUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<ResistanceUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<ResistanceUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<ResistanceUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<ResistanceUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, MassUnit> divide(Mass divisor) {
-    return (Per<ResistanceUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, MassUnit> div(Mass divisor) {
+    return (Per<ResistanceUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<ResistanceUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<ResistanceUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<ResistanceUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<ResistanceUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<ResistanceUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<ResistanceUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, PowerUnit> divide(Power divisor) {
-    return (Per<ResistanceUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, PowerUnit> div(Power divisor) {
+    return (Per<ResistanceUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,7 +290,7 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Dimensionless divide(Resistance divisor) {
+  default Dimensionless div(Resistance divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -301,8 +301,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<ResistanceUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<ResistanceUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Velocity<ResistanceUnit> divide(Time divisor) {
+  default Velocity<ResistanceUnit> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<ResistanceUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<ResistanceUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<ResistanceUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<ResistanceUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   @Override
-  default Per<ResistanceUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<ResistanceUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<ResistanceUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<ResistanceUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Temperature.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Temperature.java
@@ -66,13 +66,13 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Temperature divide(double divisor) {
+  default Temperature div(double divisor) {
     return (Temperature) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<TemperatureUnit> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<TemperatureUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<TemperatureUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<TemperatureUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, AngleUnit> div(Angle divisor) {
+    return (Per<TemperatureUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<TemperatureUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<TemperatureUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<TemperatureUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<TemperatureUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<TemperatureUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<TemperatureUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<TemperatureUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, CurrentUnit> div(Current divisor) {
+    return (Per<TemperatureUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Temperature divide(Dimensionless divisor) {
+  default Temperature div(Dimensionless divisor) {
     return (Temperature) Kelvin.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<TemperatureUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<TemperatureUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<TemperatureUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<TemperatureUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, ForceUnit> divide(Force divisor) {
-    return (Per<TemperatureUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, ForceUnit> div(Force divisor) {
+    return (Per<TemperatureUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<TemperatureUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<TemperatureUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<TemperatureUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<TemperatureUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<TemperatureUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<TemperatureUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<TemperatureUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<TemperatureUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, MassUnit> divide(Mass divisor) {
-    return (Per<TemperatureUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, MassUnit> div(Mass divisor) {
+    return (Per<TemperatureUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<TemperatureUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<TemperatureUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<TemperatureUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<TemperatureUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<TemperatureUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<TemperatureUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, PowerUnit> divide(Power divisor) {
-    return (Per<TemperatureUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, PowerUnit> div(Power divisor) {
+    return (Per<TemperatureUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<TemperatureUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<TemperatureUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,7 +301,7 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Dimensionless divide(Temperature divisor) {
+  default Dimensionless div(Temperature divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -312,7 +312,7 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Velocity<TemperatureUnit> divide(Time divisor) {
+  default Velocity<TemperatureUnit> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<TemperatureUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<TemperatureUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<TemperatureUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<TemperatureUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   @Override
-  default Per<TemperatureUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<TemperatureUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<TemperatureUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<TemperatureUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Time.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Time.java
@@ -66,13 +66,13 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Time divide(double divisor) {
+  default Time div(double divisor) {
     return (Time) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Dimensionless per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<TimeUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<TimeUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<TimeUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<TimeUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, AngleUnit> div(Angle divisor) {
+    return (Per<TimeUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<TimeUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<TimeUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<TimeUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<TimeUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<TimeUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<TimeUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<TimeUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, CurrentUnit> div(Current divisor) {
+    return (Per<TimeUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Time divide(Dimensionless divisor) {
+  default Time div(Dimensionless divisor) {
     return (Time) Seconds.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<TimeUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<TimeUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<TimeUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<TimeUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, ForceUnit> divide(Force divisor) {
-    return (Per<TimeUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, ForceUnit> div(Force divisor) {
+    return (Per<TimeUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<TimeUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<TimeUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<TimeUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<TimeUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<TimeUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<TimeUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<TimeUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<TimeUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, MassUnit> divide(Mass divisor) {
-    return (Per<TimeUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, MassUnit> div(Mass divisor) {
+    return (Per<TimeUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<TimeUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<TimeUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<TimeUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<TimeUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<TimeUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<TimeUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<TimeUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<TimeUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, PowerUnit> divide(Power divisor) {
-    return (Per<TimeUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, PowerUnit> div(Power divisor) {
+    return (Per<TimeUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<TimeUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<TimeUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<TimeUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<TimeUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Dimensionless divide(Time divisor) {
+  default Dimensionless div(Time divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<TimeUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<TimeUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<TimeUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<TimeUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<TimeUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   @Override
-  default Per<TimeUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<TimeUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<TimeUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<TimeUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 default Frequency asFrequency() { return Hertz.of(1 / baseUnitMagnitude()); }
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Torque.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Torque.java
@@ -66,13 +66,13 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Torque divide(double divisor) {
+  default Torque div(double divisor) {
     return (Torque) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<TorqueUnit> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<TorqueUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<TorqueUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<TorqueUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, AngleUnit> div(Angle divisor) {
+    return (Per<TorqueUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<TorqueUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<TorqueUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<TorqueUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<TorqueUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<TorqueUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<TorqueUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, CurrentUnit> divide(Current divisor) {
-    return (Per<TorqueUnit, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, CurrentUnit> div(Current divisor) {
+    return (Per<TorqueUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Torque divide(Dimensionless divisor) {
+  default Torque div(Dimensionless divisor) {
     return (Torque) NewtonMeters.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,7 +158,7 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Force divide(Distance divisor) {
+  default Force div(Distance divisor) {
     return Newtons.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -169,8 +169,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<TorqueUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<TorqueUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,7 +180,7 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Distance divide(Force divisor) {
+  default Distance div(Force divisor) {
     return Meters.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -191,8 +191,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<TorqueUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<TorqueUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<TorqueUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<TorqueUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<TorqueUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<TorqueUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<TorqueUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<TorqueUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, MassUnit> divide(Mass divisor) {
-    return (Per<TorqueUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, MassUnit> div(Mass divisor) {
+    return (Per<TorqueUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<TorqueUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<TorqueUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<TorqueUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<TorqueUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<TorqueUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<TorqueUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, PowerUnit> divide(Power divisor) {
-    return (Per<TorqueUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, PowerUnit> div(Power divisor) {
+    return (Per<TorqueUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<TorqueUnit, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, ResistanceUnit> div(Resistance divisor) {
+    return (Per<TorqueUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<TorqueUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<TorqueUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Velocity<TorqueUnit> divide(Time divisor) {
+  default Velocity<TorqueUnit> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,7 +323,7 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Dimensionless divide(Torque divisor) {
+  default Dimensionless div(Torque divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -334,8 +334,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<TorqueUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<TorqueUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,8 +345,8 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   @Override
-  default Per<TorqueUnit, VoltageUnit> divide(Voltage divisor) {
-    return (Per<TorqueUnit, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<TorqueUnit, VoltageUnit> div(Voltage divisor) {
+    return (Per<TorqueUnit, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Velocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Velocity.java
@@ -66,13 +66,13 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Velocity<D> divide(double divisor) {
+  default Velocity<D> div(double divisor) {
     return (Velocity<D>) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<VelocityUnit<D>> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<VelocityUnit<D>, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<VelocityUnit<D>, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, AngleUnit> divide(Angle divisor) {
-    return (Per<VelocityUnit<D>, AngleUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, AngleUnit> div(Angle divisor) {
+    return (Per<VelocityUnit<D>, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<VelocityUnit<D>, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<VelocityUnit<D>, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<VelocityUnit<D>, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<VelocityUnit<D>, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<VelocityUnit<D>, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<VelocityUnit<D>, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, CurrentUnit> divide(Current divisor) {
-    return (Per<VelocityUnit<D>, CurrentUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, CurrentUnit> div(Current divisor) {
+    return (Per<VelocityUnit<D>, CurrentUnit>) Measure.super.div(divisor);
   }
 
   @Override
-  default Velocity<D> divide(Dimensionless divisor) {
+  default Velocity<D> div(Dimensionless divisor) {
     return (Velocity<D>) unit().of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, DistanceUnit> divide(Distance divisor) {
-    return (Per<VelocityUnit<D>, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, DistanceUnit> div(Distance divisor) {
+    return (Per<VelocityUnit<D>, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, EnergyUnit> divide(Energy divisor) {
-    return (Per<VelocityUnit<D>, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, EnergyUnit> div(Energy divisor) {
+    return (Per<VelocityUnit<D>, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, ForceUnit> divide(Force divisor) {
-    return (Per<VelocityUnit<D>, ForceUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, ForceUnit> div(Force divisor) {
+    return (Per<VelocityUnit<D>, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<VelocityUnit<D>, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, FrequencyUnit> div(Frequency divisor) {
+    return (Per<VelocityUnit<D>, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<VelocityUnit<D>, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<VelocityUnit<D>, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<VelocityUnit<D>, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<VelocityUnit<D>, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<VelocityUnit<D>, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<VelocityUnit<D>, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, MassUnit> divide(Mass divisor) {
-    return (Per<VelocityUnit<D>, MassUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, MassUnit> div(Mass divisor) {
+    return (Per<VelocityUnit<D>, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<VelocityUnit<D>, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<VelocityUnit<D>, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<VelocityUnit<D>, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<VelocityUnit<D>, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<VelocityUnit<D>, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<VelocityUnit<D>, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, PowerUnit> divide(Power divisor) {
-    return (Per<VelocityUnit<D>, PowerUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, PowerUnit> div(Power divisor) {
+    return (Per<VelocityUnit<D>, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,8 +290,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, ResistanceUnit> divide(Resistance divisor) {
-    return (Per<VelocityUnit<D>, ResistanceUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, ResistanceUnit> div(Resistance divisor) {
+    return (Per<VelocityUnit<D>, ResistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -301,8 +301,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<VelocityUnit<D>, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, TemperatureUnit> div(Temperature divisor) {
+    return (Per<VelocityUnit<D>, TemperatureUnit>) Measure.super.div(divisor);
   }
 
   @Override
@@ -311,7 +311,7 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Velocity<VelocityUnit<D>> divide(Time divisor) {
+  default Velocity<VelocityUnit<D>> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -322,8 +322,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, TorqueUnit> divide(Torque divisor) {
-    return (Per<VelocityUnit<D>, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, TorqueUnit> div(Torque divisor) {
+    return (Per<VelocityUnit<D>, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -333,8 +333,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<VelocityUnit<D>, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<VelocityUnit<D>, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -344,8 +344,8 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
-  default Per<VelocityUnit<D>, VoltageUnit> divide(Voltage divisor) {
-    return (Per<VelocityUnit<D>, VoltageUnit>) Measure.super.divide(divisor);
+  default Per<VelocityUnit<D>, VoltageUnit> div(Voltage divisor) {
+    return (Per<VelocityUnit<D>, VoltageUnit>) Measure.super.div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Voltage.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Voltage.java
@@ -66,13 +66,13 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Voltage divide(double divisor) {
+  default Voltage div(double divisor) {
     return (Voltage) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
   @Override
   default Velocity<VoltageUnit> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
 
@@ -82,8 +82,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
-    return (Per<VoltageUnit, AccelerationUnit<?>>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, AccelerationUnit<?>> div(Acceleration<?> divisor) {
+    return (Per<VoltageUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -93,8 +93,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, AngleUnit> divide(Angle divisor) {
-    return (Per<VoltageUnit, AngleUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, AngleUnit> div(Angle divisor) {
+    return (Per<VoltageUnit, AngleUnit>) Measure.super.div(divisor);
   }
 
 
@@ -104,8 +104,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
-    return (Per<VoltageUnit, AngularAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, AngularAccelerationUnit> div(AngularAcceleration divisor) {
+    return (Per<VoltageUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -115,8 +115,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
-    return (Per<VoltageUnit, AngularMomentumUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
+    return (Per<VoltageUnit, AngularMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -126,8 +126,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
-    return (Per<VoltageUnit, AngularVelocityUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, AngularVelocityUnit> div(AngularVelocity divisor) {
+    return (Per<VoltageUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -137,12 +137,12 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Resistance divide(Current divisor) {
+  default Resistance div(Current divisor) {
     return Ohms.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
   @Override
-  default Voltage divide(Dimensionless divisor) {
+  default Voltage div(Dimensionless divisor) {
     return (Voltage) Volts.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -158,8 +158,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, DistanceUnit> divide(Distance divisor) {
-    return (Per<VoltageUnit, DistanceUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, DistanceUnit> div(Distance divisor) {
+    return (Per<VoltageUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -169,8 +169,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, EnergyUnit> divide(Energy divisor) {
-    return (Per<VoltageUnit, EnergyUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, EnergyUnit> div(Energy divisor) {
+    return (Per<VoltageUnit, EnergyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -180,8 +180,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, ForceUnit> divide(Force divisor) {
-    return (Per<VoltageUnit, ForceUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, ForceUnit> div(Force divisor) {
+    return (Per<VoltageUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
 
@@ -191,8 +191,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, FrequencyUnit> divide(Frequency divisor) {
-    return (Per<VoltageUnit, FrequencyUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, FrequencyUnit> div(Frequency divisor) {
+    return (Per<VoltageUnit, FrequencyUnit>) Measure.super.div(divisor);
   }
 
 
@@ -202,8 +202,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
-    return (Per<VoltageUnit, LinearAccelerationUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, LinearAccelerationUnit> div(LinearAcceleration divisor) {
+    return (Per<VoltageUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
 
@@ -213,8 +213,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
-    return (Per<VoltageUnit, LinearMomentumUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
+    return (Per<VoltageUnit, LinearMomentumUnit>) Measure.super.div(divisor);
   }
 
 
@@ -224,8 +224,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
-    return (Per<VoltageUnit, LinearVelocityUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, LinearVelocityUnit> div(LinearVelocity divisor) {
+    return (Per<VoltageUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
 
@@ -235,8 +235,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, MassUnit> divide(Mass divisor) {
-    return (Per<VoltageUnit, MassUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, MassUnit> div(Mass divisor) {
+    return (Per<VoltageUnit, MassUnit>) Measure.super.div(divisor);
   }
 
 
@@ -246,8 +246,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
-    return (Per<VoltageUnit, MomentOfInertiaUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, MomentOfInertiaUnit> div(MomentOfInertia divisor) {
+    return (Per<VoltageUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
 
@@ -257,8 +257,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
-    return (Per<VoltageUnit, MultUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
+    return (Per<VoltageUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -268,8 +268,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
-    return (Per<VoltageUnit, PerUnit<?, ?>>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, PerUnit<?, ?>> div(Per<?, ?> divisor) {
+    return (Per<VoltageUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
 
@@ -279,8 +279,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, PowerUnit> divide(Power divisor) {
-    return (Per<VoltageUnit, PowerUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, PowerUnit> div(Power divisor) {
+    return (Per<VoltageUnit, PowerUnit>) Measure.super.div(divisor);
   }
 
 
@@ -290,7 +290,7 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Current divide(Resistance divisor) {
+  default Current div(Resistance divisor) {
     return Amps.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -301,8 +301,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, TemperatureUnit> divide(Temperature divisor) {
-    return (Per<VoltageUnit, TemperatureUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, TemperatureUnit> div(Temperature divisor) {
+    return (Per<VoltageUnit, TemperatureUnit>) Measure.super.div(divisor);
   }
 
 
@@ -312,7 +312,7 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Velocity<VoltageUnit> divide(Time divisor) {
+  default Velocity<VoltageUnit> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
@@ -323,8 +323,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, TorqueUnit> divide(Torque divisor) {
-    return (Per<VoltageUnit, TorqueUnit>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, TorqueUnit> div(Torque divisor) {
+    return (Per<VoltageUnit, TorqueUnit>) Measure.super.div(divisor);
   }
 
 
@@ -334,8 +334,8 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Per<VoltageUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
-    return (Per<VoltageUnit, VelocityUnit<?>>) Measure.super.divide(divisor);
+  default Per<VoltageUnit, VelocityUnit<?>> div(Velocity<?> divisor) {
+    return (Per<VoltageUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
 
@@ -345,7 +345,7 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   @Override
-  default Dimensionless divide(Voltage divisor) {
+  default Dimensionless div(Voltage divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 

--- a/wpiunits/src/main/java/edu/wpi/first/units/ImmutableMeasure.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/ImmutableMeasure.java
@@ -81,12 +81,12 @@ public record ImmutableMeasure<U extends Unit>(double magnitude, double baseUnit
   }
 
   @Override
-  public Measure<U> divide(double divisor) {
+  public Measure<U> div(double divisor) {
     return ofBaseUnits(baseUnitMagnitude / divisor, unit);
   }
 
   @Override
-  public Measure<U> divide(Dimensionless divisor) {
+  public Measure<U> div(Dimensionless divisor) {
     return ofBaseUnits(baseUnitMagnitude / divisor.baseUnitMagnitude(), unit);
   }
 }

--- a/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
@@ -614,7 +614,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  Measure<U> divide(double divisor);
+  Measure<U> div(double divisor);
 
   /**
    * Divides this measure by a dimensionless scalar and returns the result.
@@ -622,7 +622,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  Measure<U> divide(Dimensionless divisor);
+  Measure<U> div(Dimensionless divisor);
 
   /**
    * Divides this measurement by another measure and performs some dimensional analysis to reduce
@@ -631,7 +631,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the unit to divide by
    * @return the resulting measure
    */
-  default Measure<?> divide(Measure<?> divisor) {
+  default Measure<?> div(Measure<?> divisor) {
     final double baseUnitResult = baseUnitMagnitude() / divisor.baseUnitMagnitude();
 
     if (unit().getBaseUnit().equals(divisor.unit().getBaseUnit())) {
@@ -671,54 +671,54 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
     }
 
     if (divisor instanceof Acceleration<?> acceleration) {
-      return divide(acceleration);
+      return div(acceleration);
     } else if (divisor instanceof Angle angle) {
-      return divide(angle);
+      return div(angle);
     } else if (divisor instanceof AngularAcceleration angularAcceleration) {
-      return divide(angularAcceleration);
+      return div(angularAcceleration);
     } else if (divisor instanceof AngularMomentum angularMomentum) {
-      return divide(angularMomentum);
+      return div(angularMomentum);
     } else if (divisor instanceof AngularVelocity angularVelocity) {
-      return divide(angularVelocity);
+      return div(angularVelocity);
     } else if (divisor instanceof Current current) {
-      return divide(current);
+      return div(current);
     } else if (divisor instanceof Dimensionless dimensionless) {
       // n.b. this case should already be covered
-      return divide(dimensionless);
+      return div(dimensionless);
     } else if (divisor instanceof Distance distance) {
-      return divide(distance);
+      return div(distance);
     } else if (divisor instanceof Energy energy) {
-      return divide(energy);
+      return div(energy);
     } else if (divisor instanceof Force force) {
-      return divide(force);
+      return div(force);
     } else if (divisor instanceof Frequency frequency) {
-      return divide(frequency);
+      return div(frequency);
     } else if (divisor instanceof LinearAcceleration linearAcceleration) {
-      return divide(linearAcceleration);
+      return div(linearAcceleration);
     } else if (divisor instanceof LinearVelocity linearVelocity) {
-      return divide(linearVelocity);
+      return div(linearVelocity);
     } else if (divisor instanceof Mass mass) {
-      return divide(mass);
+      return div(mass);
     } else if (divisor instanceof MomentOfInertia momentOfInertia) {
-      return divide(momentOfInertia);
+      return div(momentOfInertia);
     } else if (divisor instanceof Mult<?, ?> mult) {
-      return divide(mult);
+      return div(mult);
     } else if (divisor instanceof Per<?, ?> per) {
-      return divide(per);
+      return div(per);
     } else if (divisor instanceof Power power) {
-      return divide(power);
+      return div(power);
     } else if (divisor instanceof Temperature temperature) {
-      return divide(temperature);
+      return div(temperature);
     } else if (divisor instanceof Time time) {
-      return divide(time);
+      return div(time);
     } else if (divisor instanceof Torque torque) {
-      return divide(torque);
+      return div(torque);
     } else if (divisor instanceof Velocity<?> velocity) {
-      return divide(velocity);
+      return div(velocity);
     } else if (divisor instanceof Voltage voltage) {
-      return divide(voltage);
+      return div(voltage);
     } else if (divisor instanceof Resistance resistance) {
-      return divide(resistance);
+      return div(resistance);
     } else {
       // Dimensional analysis fallthrough or a generic input measure type
       // Do a basic unit multiplication
@@ -733,7 +733,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Acceleration<?> divisor) {
+  default Measure<?> div(Acceleration<?> divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -744,7 +744,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Angle divisor) {
+  default Measure<?> div(Angle divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -756,7 +756,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(AngularAcceleration divisor) {
+  default Measure<?> div(AngularAcceleration divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -768,7 +768,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(AngularMomentum divisor) {
+  default Measure<?> div(AngularMomentum divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -780,7 +780,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(AngularVelocity divisor) {
+  default Measure<?> div(AngularVelocity divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -792,7 +792,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Current divisor) {
+  default Measure<?> div(Current divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -803,7 +803,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Distance divisor) {
+  default Measure<?> div(Distance divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -814,7 +814,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Energy divisor) {
+  default Measure<?> div(Energy divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -825,7 +825,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Force divisor) {
+  default Measure<?> div(Force divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -836,7 +836,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Frequency divisor) {
+  default Measure<?> div(Frequency divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -848,7 +848,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(LinearAcceleration divisor) {
+  default Measure<?> div(LinearAcceleration divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -859,7 +859,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(LinearMomentum divisor) {
+  default Measure<?> div(LinearMomentum divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -870,7 +870,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(LinearVelocity divisor) {
+  default Measure<?> div(LinearVelocity divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -881,7 +881,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Mass divisor) {
+  default Measure<?> div(Mass divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -893,7 +893,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(MomentOfInertia divisor) {
+  default Measure<?> div(MomentOfInertia divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -905,7 +905,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Mult<?, ?> divisor) {
+  default Measure<?> div(Mult<?, ?> divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -916,7 +916,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Power divisor) {
+  default Measure<?> div(Power divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -927,7 +927,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Per<?, ?> divisor) {
+  default Measure<?> div(Per<?, ?> divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -938,7 +938,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Temperature divisor) {
+  default Measure<?> div(Temperature divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -951,7 +951,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Time divisor) {
+  default Measure<?> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -962,7 +962,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Torque divisor) {
+  default Measure<?> div(Torque divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -973,7 +973,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Velocity<?> divisor) {
+  default Measure<?> div(Velocity<?> divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -984,7 +984,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Voltage divisor) {
+  default Measure<?> div(Voltage divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -995,7 +995,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * @param divisor the measurement to divide by.
    * @return the division result
    */
-  default Measure<?> divide(Resistance divisor) {
+  default Measure<?> div(Resistance divisor) {
     return PerUnit.combine(unit(), divisor.unit())
         .ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
@@ -1017,13 +1017,13 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
 
   /**
    * Divides this measure by a time period and returns the result in the most appropriate unit. This
-   * is equivalent to {@code divide(period.of(1))}.
+   * is equivalent to {@code div(period.of(1))}.
    *
    * @param period the time period measurement to divide by.
    * @return the division result
    */
   default Measure<?> per(TimeUnit period) {
-    return divide(period.of(1));
+    return div(period.of(1));
   }
 
   /**

--- a/wpiunits/src/main/java/edu/wpi/first/units/mutable/GenericMutableMeasureImpl.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/mutable/GenericMutableMeasureImpl.java
@@ -68,12 +68,12 @@ public final class GenericMutableMeasureImpl<U extends Unit>
   }
 
   @Override
-  public Measure<U> divide(double divisor) {
+  public Measure<U> div(double divisor) {
     return ImmutableMeasure.ofBaseUnits(m_baseUnitMagnitude / divisor, m_unit);
   }
 
   @Override
-  public Measure<U> divide(Dimensionless divisor) {
+  public Measure<U> div(Dimensionless divisor) {
     return ImmutableMeasure.ofBaseUnits(m_baseUnitMagnitude / divisor.baseUnitMagnitude(), m_unit);
   }
 }

--- a/wpiunits/src/test/java/edu/wpi/first/units/MeasureTest.java
+++ b/wpiunits/src/test/java/edu/wpi/first/units/MeasureTest.java
@@ -41,7 +41,7 @@ class MeasureTest {
   void testTimesConversionFactor() {
     Distance m = Units.Feet.of(10);
 
-    Per<AngleUnit, DistanceUnit> conversion = Units.Degrees.of(10).divide(Units.Feet.of(1));
+    Per<AngleUnit, DistanceUnit> conversion = Units.Degrees.of(10).div(Units.Feet.of(1));
     Angle result = m.timesConversionFactor(conversion);
     assertEquals(Units.Degrees.of(100), result);
   }
@@ -53,7 +53,7 @@ class MeasureTest {
     // Using a complex compound unit here
     // (Per<Mult<Mult<Mass, Per<Distance, Time>>, Distance>, Distance>)
     Per<AngularMomentumUnit, DistanceUnit> conversion =
-        Units.KilogramMetersSquaredPerSecond.of(1).divide(Units.Foot.one());
+        Units.KilogramMetersSquaredPerSecond.of(1).div(Units.Foot.one());
 
     AngularMomentum result = m.timesConversionFactor(conversion);
     assertEquals(Units.KilogramMetersSquaredPerSecond.of(1), result);
@@ -71,7 +71,7 @@ class MeasureTest {
   @Test
   void testDivide() {
     Distance m = Units.Meters.of(1);
-    Distance m2 = m.divide(10);
+    Distance m2 = m.div(10);
     assertEquals(0.1, m2.magnitude(), 0);
     assertNotSame(m2, m);
   }
@@ -121,7 +121,7 @@ class MeasureTest {
 
     // 144 Kg / (53 ms) = (1000 / 53) * 144 Kg/s = (144,000 / 53) Kg/s
 
-    var result = measure.divide(dt);
+    var result = measure.div(dt);
     assertEquals(144_000.0 / 53, result.baseUnitMagnitude(), 1e-5);
     assertEquals(Units.Kilograms.per(Units.Milliseconds), result.unit());
   }
@@ -141,13 +141,13 @@ class MeasureTest {
     // Dimensionless divide
     var m1 = Units.Meters.of(6);
     var m2 = Units.Value.of(3);
-    var result = m1.divide(m2);
-    assertEquals(2, m1.divide(m2).magnitude());
+    var result = m1.div(m2);
+    assertEquals(2, m1.div(m2).magnitude());
     assertEquals(Units.Meters, result.unit());
     // Velocity divide
     var m3 = Units.Meters.of(8);
     var m4 = Units.Meters.per(Units.Second).of(4);
-    var time = m3.divide(m4);
+    var time = m3.div(m4);
     assertEquals(2, time.magnitude());
     assertEquals(Units.Second, time.unit());
     // PerUnit divide
@@ -155,7 +155,7 @@ class MeasureTest {
     var m6 = Units.Volts.per(Units.Meter).of(2);
 
     // Voltage/(Voltage/Distance) -> Voltage * Distance/Voltage -> Distance
-    var dist = m5.divide(m6);
+    var dist = m5.div(m6);
     assertEquals(3, dist.magnitude());
     assertEquals(Units.Meter, dist.unit());
   }


### PR DESCRIPTION
Other operators follow the kotlin operator names (whether on purpose of not), and it would be nice if division followed suite
