### PR TITLE
[cmd] Add DynamicCommand and `defer` factory with implicit requirements

### DIFF
--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
@@ -11,6 +11,7 @@
 
 #include "frc2/command/ConditionalCommand.h"
 #include "frc2/command/DeferredCommand.h"
+#include "frc2/command/DynamicCommand.h"
 #include "frc2/command/FunctionalCommand.h"
 #include "frc2/command/InstantCommand.h"
 #include "frc2/command/ParallelCommandGroup.h"
@@ -101,6 +102,10 @@ CommandPtr cmd::Either(CommandPtr&& onTrue, CommandPtr&& onFalse,
 CommandPtr cmd::Defer(wpi::unique_function<CommandPtr()> supplier,
                       Requirements requirements) {
   return DeferredCommand(std::move(supplier), requirements).ToPtr();
+}
+
+CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier) {
+  return DynamicCommand(std::move(supplier)).ToPtr();
 }
 
 CommandPtr cmd::Sequence(std::vector<CommandPtr>&& commands) {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/DynamicCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/DynamicCommand.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc2/command/DynamicCommand.h"
+
+#include <string>
+#include <utility>
+
+frc2::DynamicCommand::DynamicCommand(wpi::unique_function<Command*()> supplier)
+    : m_supplier(std::move(supplier)) {}
+
+frc2::DynamicCommand::DynamicCommand(
+    wpi::unique_function<CommandPtr()> supplier)
+    : DynamicCommand([supplier = std::move(supplier),
+                      holder = std::optional<CommandPtr>{}]() mutable {
+        holder = supplier();
+        return holder->get();
+      }) {}
+
+void frc2::DynamicCommand::Initialize() {
+  m_command = m_supplier();
+  m_command->Schedule();
+}
+
+void frc2::DynamicCommand::End(bool interrupted) {
+  if (interrupted) {
+    m_command->Cancel();
+  }
+  m_command = nullptr;
+}
+
+bool frc2::DynamicCommand::IsFinished() {
+  // because we're between `initialize` and `end`, `m_command` is necessarily
+  // not null but if called otherwise and m_command is null, it's UB, so we can
+  // do whatever we want -- like return true.
+  return m_command == nullptr || !m_command->IsScheduled();
+}
+
+void frc2::DynamicCommand::InitSendable(wpi::SendableBuilder& builder) {
+  Command::InitSendable(builder);
+  builder.AddStringProperty(
+      "dynamic",
+      [this] {
+        if (m_command) {
+          return m_command->GetName();
+        } else {
+          return std::string{"null"};
+        }
+      },
+      nullptr);
+}

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
@@ -34,9 +34,7 @@ CommandPtr None();
 
 /**
  * Constructs a command that does nothing until interrupted.
- *
- * @param requirements Subsystems to require
- * @return the command
+ * @param requirements Subsystems to require @return the command
  */
 [[nodiscard]]
 CommandPtr Idle(Requirements requirements = {});
@@ -165,6 +163,14 @@ CommandPtr Select(std::function<Key()> selector,
 [[nodiscard]]
 CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier,
                  Requirements requirements);
+
+/**
+ * Runs the command supplied by the supplier.
+ *
+ * @param supplier the command supplier
+ */
+[[nodiscard]]
+CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier);
 
 /**
  * Constructs a command that schedules the command returned from the supplier

--- a/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
@@ -38,7 +38,6 @@ class DeferredCommand : public CommandHelper<Command, DeferredCommand> {
    *
    * @param supplier The command supplier
    * @param requirements The command requirements.
-   *
    */
   DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
                   Requirements requirements);

--- a/wpilibNewCommands/src/main/native/include/frc2/command/DynamicCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/DynamicCommand.h
@@ -1,0 +1,30 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <wpi/FunctionExtras.h>
+#include <wpi/sendable/SendableBuilder.h>
+
+#include "frc2/command/CommandHelper.h"
+
+namespace frc2 {
+
+class DynamicCommand : public CommandHelper<Command, DynamicCommand> {
+ public:
+  explicit DynamicCommand(wpi::unique_function<Command*()> supplier);
+  explicit DynamicCommand(wpi::unique_function<CommandPtr()> supplier);
+
+  void Initialize() override;
+  void End(bool interrupted) override;
+  bool IsFinished() override;
+
+  void InitSendable(wpi::SendableBuilder& builder) override;
+
+ private:
+  wpi::unique_function<Command*()> m_supplier;
+  Command* m_command;
+};
+
+}  // namespace frc2


### PR DESCRIPTION
Currently if people want to an auto using `RobotModeTriggers.autonomous` they will encounter a major issue, determining requirements for commands at runtime. This provides a solution to this problem. It also fixes the deprecation documentation for `deferredProxy` which previously recommended completely incorrect behaviour.

TODO:
- [ ] Java
- [ ] Tests
- [ ] Documentation