### PR TITLE
Remove java requirement from cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,9 +132,6 @@ if(WITH_JAVA OR WITH_JAVA_SOURCE)
     set(CMAKE_JAVA_COMPILE_FLAGS "-encoding" "UTF8" "-Xlint:unchecked")
     find_package(Java REQUIRED COMPONENTS Development)
     find_package(JNI REQUIRED COMPONENTS JVM)
-else()
-    # Protoc requires the java runtime
-    find_package(Java REQUIRED COMPONENTS Runtime)
 endif()
 
 if(WITH_DOCS)


### PR DESCRIPTION
It was leftover from the failed protoc stuff