### PR TITLE
[upstream_utils] Restore Eigen intellisense fix

### DIFF
--- a/upstream_utils/eigen_patches/0002-Intellisense-fix.patch
+++ b/upstream_utils/eigen_patches/0002-Intellisense-fix.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Peter Johnson <johnson.peter@gmail.com>
+Date: Fri, 20 Jan 2023 23:41:56 -0800
+Subject: [PATCH 2/2] Intellisense fix
+
+---
+ Eigen/src/Core/util/ConfigureVectorization.h | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/Eigen/src/Core/util/ConfigureVectorization.h b/Eigen/src/Core/util/ConfigureVectorization.h
+index 47ddd4f8ae33405f2a6600dc33bd3d07a668e63f..d0fd181ecfdeb9a80e065b1d81e8860d6a6ad57c 100644
+--- a/Eigen/src/Core/util/ConfigureVectorization.h
++++ b/Eigen/src/Core/util/ConfigureVectorization.h
+@@ -174,6 +174,13 @@
+ 
+ //----------------------------------------------------------------------
+ 
++// Disable vectorization in intellisense
++#ifdef __INTELLISENSE__
++#ifndef EIGEN_DONT_VECTORIZE
++#define EIGEN_DONT_VECTORIZE
++#endif
++#endif
++
+ // if alignment is disabled, then disable vectorization. Note: EIGEN_MAX_ALIGN_BYTES is the proper check, it takes into
+ // account both the user's will (EIGEN_MAX_ALIGN_BYTES,EIGEN_DONT_ALIGN) and our own platform checks
+ #if EIGEN_MAX_ALIGN_BYTES == 0

--- a/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/util/ConfigureVectorization.h
+++ b/wpimath/src/main/native/thirdparty/eigen/include/Eigen/src/Core/util/ConfigureVectorization.h
@@ -174,6 +174,13 @@
 
 //----------------------------------------------------------------------
 
+// Disable vectorization in intellisense
+#ifdef __INTELLISENSE__
+#ifndef EIGEN_DONT_VECTORIZE
+#define EIGEN_DONT_VECTORIZE
+#endif
+#endif
+
 // if alignment is disabled, then disable vectorization. Note: EIGEN_MAX_ALIGN_BYTES is the proper check, it takes into
 // account both the user's will (EIGEN_MAX_ALIGN_BYTES,EIGEN_DONT_ALIGN) and our own platform checks
 #if EIGEN_MAX_ALIGN_BYTES == 0


### PR DESCRIPTION
This reverts commit d1de7663d3febc18e67d1100854a3cad7c8c3bfe.

This is still broken on Windows Athena target with the error `incomplete type "Eigen::Matrix<double, 3, 3, 0, 3, 3>" is not allowed`.