### PR TITLE
[wpimath] Add proto files back to JAR

### DIFF
--- a/wpimath/build.gradle
+++ b/wpimath/build.gradle
@@ -91,6 +91,7 @@ dependencies {
 }
 
 sourceSets.main.java.srcDir "${projectDir}/src/generated/main/java"
+sourceSets.main.resources.srcDir "${projectDir}/src/main/proto"
 
 task unitsHeaders(type: Zip) {
     destinationDirectory = file("$buildDir/outputs")


### PR DESCRIPTION
PhotonVision depends on these being in the JAR to generate quickbuf classes.