### PR TITLE
[apriltag] Fix AprilTagDetector cols/stride mixup

### DIFF
--- a/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagDetector.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagDetector.java
@@ -297,7 +297,7 @@ public class AprilTagDetector implements AutoCloseable {
    * @return Results (array of AprilTagDetection)
    */
   public AprilTagDetection[] detect(Mat img) {
-    return AprilTagJNI.detect(m_native, img.cols(), img.rows(), img.cols(), img.dataAddr());
+    return AprilTagJNI.detect(m_native, img.cols(), img.rows(), (int)img.step1(), img.dataAddr());
   }
 
   private long m_native;

--- a/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagDetector.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagDetector.java
@@ -297,7 +297,7 @@ public class AprilTagDetector implements AutoCloseable {
    * @return Results (array of AprilTagDetection)
    */
   public AprilTagDetection[] detect(Mat img) {
-    return AprilTagJNI.detect(m_native, img.cols(), img.rows(), (int)img.step1(), img.dataAddr());
+    return AprilTagJNI.detect(m_native, img.cols(), img.rows(), (int) img.step1(), img.dataAddr());
   }
 
   private long m_native;

--- a/apriltag/src/test/java/edu/wpi/first/apriltag/AprilTagDetectorTest.java
+++ b/apriltag/src/test/java/edu/wpi/first/apriltag/AprilTagDetectorTest.java
@@ -132,6 +132,34 @@ class AprilTagDetectorTest {
   }
 
   @Test
+  void testDecodeCropped() {
+    detector.addFamily("tag16h5");
+    detector.addFamily("tag36h11");
+
+    Mat image;
+    try {
+      image = loadImage("tag1_640_480.jpg");
+    } catch (IOException ex) {
+      fail(ex);
+      return;
+    }
+
+    // Pre-knowledge -- the tag is within this ROI of this particular test image
+    var cropped = image.submat(100, 400, 220, 570);
+
+    try {
+      AprilTagDetection[] results = detector.detect(cropped);
+      assertEquals(1, results.length);
+      assertEquals("tag36h11", results[0].getFamily());
+      assertEquals(1, results[0].getId());
+      assertEquals(0, results[0].getHamming());
+    } finally {
+      cropped.release();
+      image.release();
+    }
+  }
+
+  @Test
   void testDecodeAndPose() {
     detector.addFamily("tag16h5");
     detector.addFamily("tag36h11");


### PR DESCRIPTION
Cropped images have stride != cols. However, AprilTagDetector assumed that stride == cols.