### PR TITLE
[cmd] Undeprecate deferredProxy

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -198,15 +198,11 @@ public final class Commands {
    *
    * @param supplier the command supplier
    * @return the command
-   * @deprecated The ProxyCommand supplier constructor has been deprecated in favor of directly
-   *     proxying a {@link DeferredCommand}, see ProxyCommand documentation for more details. As a
-   *     replacement, consider using `defer(supplier).asProxy()`.
    * @see ProxyCommand
+   * @see DeferredCommand
    */
-  @Deprecated(since = "2025", forRemoval = true)
-  @SuppressWarnings("removal")
   public static Command deferredProxy(Supplier<Command> supplier) {
-    return new ProxyCommand(supplier);
+    return defer(() -> supplier.get().asProxy(), Set.of());
   }
 
   // Command Groups

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
@@ -169,15 +169,11 @@ CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier,
 /**
  * Constructs a command that schedules the command returned from the supplier
  * when initialized, and ends when it is no longer scheduled. The supplier is
- * called when the command is initialized. As a replacement, consider using
- * `Defer(supplier).AsProxy()`.
+ * called when the command is initialized.
  *
  * @param supplier the command supplier
  */
-WPI_IGNORE_DEPRECATED
-[[nodiscard]] [[deprecated(
-    "The ProxyCommand supplier constructor has been deprecated. Use "
-    "Defer(supplier).AsProxy() instead.")]]
+[[nodiscard]]
 CommandPtr DeferredProxy(wpi::unique_function<Command*()> supplier);
 
 /**
@@ -187,11 +183,8 @@ CommandPtr DeferredProxy(wpi::unique_function<Command*()> supplier);
  *
  * @param supplier the command supplier
  */
-[[nodiscard]] [[deprecated(
-    "The ProxyCommand supplier constructor has been deprecated. Use "
-    "Defer(supplier).AsProxy() instead.")]]
+[[nodiscard]]
 CommandPtr DeferredProxy(wpi::unique_function<CommandPtr()> supplier);
-WPI_UNIGNORE_DEPRECATED
 // Command Groups
 
 namespace impl {


### PR DESCRIPTION
This changes the way deferred proxy is implemented to not use the deprecated ProxyCommand constructor.

This function serves a good purpose that should be kept IMO. The constructor was confusing but this is just good syntactic sugar over `defer(() -> supplier.get().asProxy())`.