### PR TITLE
Use static runtime for 32 bit ntcoreffi

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -96,9 +96,16 @@ jobs:
             task: "build"
             outputs: "build/allOutputs"
           - os: windows-2022
-            artifact-name: Win32
+            artifact-name: Win32FFI
             architecture: x86
             task: ":ntcoreffi:build"
+            build-options: "-Pntcoreffibuild"
+            outputs: "ntcoreffi/build/outputs"
+          - os: windows-2022
+            artifact-name: Win64FFI
+            architecture: x64
+            task: ":ntcoreffi:build"
+            build-options: "-Pntcoreffibuild -Pbuildwinarm64"
             outputs: "ntcoreffi/build/outputs"
     name: "Build - ${{ matrix.artifact-name }}"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -99,7 +99,7 @@ jobs:
             artifact-name: Win32FFI
             architecture: x86
             task: ":ntcoreffi:build"
-            build-options: "-Pntcoreffibuild -Dorg.gradle.jvmargs=-Xmx1096m"
+            build-options: "-Pntcoreffibuild \"-Dorg.gradle.jvmargs=-Xmx1096m\""
             outputs: "ntcoreffi/build/outputs"
           - os: windows-2022
             artifact-name: Win64FFI

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -99,7 +99,7 @@ jobs:
             artifact-name: Win32FFI
             architecture: x86
             task: ":ntcoreffi:build"
-            build-options: "-Pntcoreffibuild"
+            build-options: "-Pntcoreffibuild -Dorg.gradle.jvmargs=-Xmx1096m"
             outputs: "ntcoreffi/build/outputs"
           - os: windows-2022
             artifact-name: Win64FFI

--- a/ntcoreffi/build.gradle
+++ b/ntcoreffi/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.internal.os.OperatingSystem
+
 plugins {
     id 'c'
     id 'cpp'
@@ -117,6 +119,10 @@ task cppHeadersZip(type: Zip) {
         dependsOn it
         from zipTree(it.archiveFile)
     }
+}
+
+if (OperatingSystem.current().isWindows() && !project.hasProperty('ntcoreffibuild')) {
+    return
 }
 
 build.dependsOn cppHeadersZip

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -41,6 +41,18 @@ nativeUtils.platformConfigs.each {
 
 nativeUtils.platformConfigs.linuxathena.linker.args.add("-Wl,--fatal-warnings")
 
+// On windows x86, for ntcoreffi, use static runtime
+def windowsx86Platform = nativeUtils.platformConfigs.windowsx86
+windowsx86Platform.cCompiler.releaseArgs.remove('/MD')
+windowsx86Platform.cppCompiler.releaseArgs.remove('/MD')
+windowsx86Platform.cCompiler.debugArgs.remove('/MDd')
+windowsx86Platform.cppCompiler.debugArgs.remove('/MDd')
+
+windowsx86Platform.cCompiler.releaseArgs.add('/MT')
+windowsx86Platform.cppCompiler.releaseArgs.add('/MT')
+windowsx86Platform.cCompiler.debugArgs.add('/MTd')
+windowsx86Platform.cppCompiler.debugArgs.add('/MTd')
+
 model {
     components {
         all {

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -41,17 +41,22 @@ nativeUtils.platformConfigs.each {
 
 nativeUtils.platformConfigs.linuxathena.linker.args.add("-Wl,--fatal-warnings")
 
-// On windows x86, for ntcoreffi, use static runtime
-def windowsx86Platform = nativeUtils.platformConfigs.windowsx86
-windowsx86Platform.cCompiler.releaseArgs.remove('/MD')
-windowsx86Platform.cppCompiler.releaseArgs.remove('/MD')
-windowsx86Platform.cCompiler.debugArgs.remove('/MDd')
-windowsx86Platform.cppCompiler.debugArgs.remove('/MDd')
+if (project.hasProperty('ntcoreffibuild')) {
+  // On windows, for ntcoreffi, use static runtime
+  nativeUtils.platformConfigs.each {
+    if (it.name.contains('windows')) {
+      it.cCompiler.releaseArgs.remove('/MD')
+      it.cppCompiler.releaseArgs.remove('/MD')
+      it.cCompiler.debugArgs.remove('/MDd')
+      it.cppCompiler.debugArgs.remove('/MDd')
 
-windowsx86Platform.cCompiler.releaseArgs.add('/MT')
-windowsx86Platform.cppCompiler.releaseArgs.add('/MT')
-windowsx86Platform.cCompiler.debugArgs.add('/MTd')
-windowsx86Platform.cppCompiler.debugArgs.add('/MTd')
+      it.cCompiler.releaseArgs.add('/MT')
+      it.cppCompiler.releaseArgs.add('/MT')
+      it.cCompiler.debugArgs.add('/MTd')
+      it.cppCompiler.debugArgs.add('/MTd')
+    }
+  }
+}
 
 model {
     components {


### PR DESCRIPTION
NI has a hard time upgrading their MSVC runtime. The solution will be make their binary not require the static runtime