### PR TITLE
[cmd] Allow specifying initial condition of Trigger bindings

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
@@ -24,6 +24,20 @@ import java.util.function.BooleanSupplier;
  * <p>This class is provided by the NewCommands VendorDep
  */
 public class Trigger implements BooleanSupplier {
+  /**
+   * Enum specifying the initial state to use for a binding. This impacts whether or not the binding will be triggered immediately.
+   */
+  public enum InitialState {
+    /** Indicates the binding should assume the condition starts as false. */
+    FALSE,
+    /** Indicates the binding should assume the condition starts as true. */
+    TRUE,
+    /** Indicates the binding should use the trigger's condition. */
+    CONDITION,
+    /** Indicates the binding should use the negated trigger's condition. */
+    NEG_CONDITION;
+  }
+
   private final BooleanSupplier m_condition;
   private final EventLoop m_loop;
 
@@ -50,16 +64,42 @@ public class Trigger implements BooleanSupplier {
   }
 
   /**
-   * Starts the command when the condition changes.
+   * Gets the initial state for a binding based on an initial state policy.
+   *
+   * @param initialState Initial state policy.
+   * @return The initial state to use.
+   */
+  private boolean getInitialState(InitialState initialState) {
+    return switch (initialState) {
+      case FALSE -> false;
+      case TRUE -> true;
+      case CONDITION -> m_condition.getAsBoolean();
+      case NEG_CONDITION -> !m_condition.getAsBoolean();
+    };
+  }
+
+  /**
+   * Starts the command when the condition changes. The command is never started immediately.
    *
    * @param command the command to start
    * @return this trigger, so calls can be chained
    */
   public Trigger onChange(Command command) {
+    return onChange(command, InitialState.CONDITION);
+  }
+
+  /**
+   * Starts the command when the condition changes.
+   *
+   * @param command the command to start
+   * @param initialState the initial state to use
+   * @return this trigger, so calls can be chained
+   */
+  public Trigger onChange(Command command, InitialState initialState) {
     requireNonNullParam(command, "command", "onChange");
     m_loop.bind(
         new Runnable() {
-          private boolean m_pressedLast = m_condition.getAsBoolean();
+          private boolean m_pressedLast = getInitialState(initialState);
 
           @Override
           public void run() {
@@ -76,16 +116,27 @@ public class Trigger implements BooleanSupplier {
   }
 
   /**
-   * Starts the given command whenever the condition changes from `false` to `true`.
+   * Starts the given command whenever the condition changes from `false` to `true`. The command is never started immediately.
    *
    * @param command the command to start
    * @return this trigger, so calls can be chained
    */
   public Trigger onTrue(Command command) {
+    return onTrue(command, InitialState.CONDITION);
+  }
+
+  /**
+   * Starts the given command whenever the condition changes from `false` to `true`.
+   *
+   * @param command the command to start
+   * @param initialState the initial state to use
+   * @return this trigger, so calls can be chained
+   */
+  public Trigger onTrue(Command command, InitialState initialState) {
     requireNonNullParam(command, "command", "onTrue");
     m_loop.bind(
         new Runnable() {
-          private boolean m_pressedLast = m_condition.getAsBoolean();
+          private boolean m_pressedLast = getInitialState(initialState);
 
           @Override
           public void run() {
@@ -102,16 +153,27 @@ public class Trigger implements BooleanSupplier {
   }
 
   /**
-   * Starts the given command whenever the condition changes from `true` to `false`.
+   * Starts the given command whenever the condition changes from `true` to `false`. The command is never started immediately.
    *
    * @param command the command to start
    * @return this trigger, so calls can be chained
    */
   public Trigger onFalse(Command command) {
+    return onFalse(command, InitialState.CONDITION);
+  }
+
+  /**
+   * Starts the given command whenever the condition changes from `true` to `false`.
+   *
+   * @param command the command to start
+   * @param initialState the initial state to use
+   * @return this trigger, so calls can be chained
+   */
+  public Trigger onFalse(Command command, InitialState initialState) {
     requireNonNullParam(command, "command", "onFalse");
     m_loop.bind(
         new Runnable() {
-          private boolean m_pressedLast = m_condition.getAsBoolean();
+          private boolean m_pressedLast = getInitialState(initialState);
 
           @Override
           public void run() {
@@ -129,7 +191,7 @@ public class Trigger implements BooleanSupplier {
 
   /**
    * Starts the given command when the condition changes to `true` and cancels it when the condition
-   * changes to `false`.
+   * changes to `false`. The command is never started immediately.
    *
    * <p>Doesn't re-start the command if it ends while the condition is still `true`. If the command
    * should restart, see {@link edu.wpi.first.wpilibj2.command.RepeatCommand}.
@@ -138,10 +200,25 @@ public class Trigger implements BooleanSupplier {
    * @return this trigger, so calls can be chained
    */
   public Trigger whileTrue(Command command) {
+    return whileTrue(command, InitialState.CONDITION);
+  }
+
+  /**
+   * Starts the given command when the condition changes to `true` and cancels it when the condition
+   * changes to `false`.
+   *
+   * <p>Doesn't re-start the command if it ends while the condition is still `true`. If the command
+   * should restart, see {@link edu.wpi.first.wpilibj2.command.RepeatCommand}.
+   *
+   * @param command the command to start
+   * @param initialState the initial state to use
+   * @return this trigger, so calls can be chained
+   */
+  public Trigger whileTrue(Command command, InitialState initialState) {
     requireNonNullParam(command, "command", "whileTrue");
     m_loop.bind(
         new Runnable() {
-          private boolean m_pressedLast = m_condition.getAsBoolean();
+          private boolean m_pressedLast = getInitialState(initialState);
 
           @Override
           public void run() {
@@ -161,7 +238,7 @@ public class Trigger implements BooleanSupplier {
 
   /**
    * Starts the given command when the condition changes to `false` and cancels it when the
-   * condition changes to `true`.
+   * condition changes to `true`. The command is never started immediately.
    *
    * <p>Doesn't re-start the command if it ends while the condition is still `false`. If the command
    * should restart, see {@link edu.wpi.first.wpilibj2.command.RepeatCommand}.
@@ -170,10 +247,25 @@ public class Trigger implements BooleanSupplier {
    * @return this trigger, so calls can be chained
    */
   public Trigger whileFalse(Command command) {
+    return whileFalse(command, InitialState.CONDITION);
+  }
+
+  /**
+   * Starts the given command when the condition changes to `false` and cancels it when the
+   * condition changes to `true`.
+   *
+   * <p>Doesn't re-start the command if it ends while the condition is still `false`. If the command
+   * should restart, see {@link edu.wpi.first.wpilibj2.command.RepeatCommand}.
+   *
+   * @param command the command to start
+   * @param initialState the initial state to use
+   * @return this trigger, so calls can be chained
+   */
+  public Trigger whileFalse(Command command, InitialState initialState) {
     requireNonNullParam(command, "command", "whileFalse");
     m_loop.bind(
         new Runnable() {
-          private boolean m_pressedLast = m_condition.getAsBoolean();
+          private boolean m_pressedLast = getInitialState(initialState);
 
           @Override
           public void run() {
@@ -192,16 +284,27 @@ public class Trigger implements BooleanSupplier {
   }
 
   /**
-   * Toggles a command when the condition changes from `false` to `true`.
+   * Toggles a command when the condition changes from `false` to `true`. The command is never toggled immediately.
    *
    * @param command the command to toggle
    * @return this trigger, so calls can be chained
    */
   public Trigger toggleOnTrue(Command command) {
+    return toggleOnTrue(command, InitialState.CONDITION);
+  }
+
+  /**
+   * Toggles a command when the condition changes from `false` to `true`.
+   *
+   * @param command the command to toggle
+   * @param initialState the initial state to use
+   * @return this trigger, so calls can be chained
+   */
+  public Trigger toggleOnTrue(Command command, InitialState initialState) {
     requireNonNullParam(command, "command", "toggleOnTrue");
     m_loop.bind(
         new Runnable() {
-          private boolean m_pressedLast = m_condition.getAsBoolean();
+          private boolean m_pressedLast = getInitialState(initialState);
 
           @Override
           public void run() {
@@ -222,16 +325,27 @@ public class Trigger implements BooleanSupplier {
   }
 
   /**
-   * Toggles a command when the condition changes from `true` to `false`.
+   * Toggles a command when the condition changes from `true` to `false`. The command is never toggled immediately.
    *
    * @param command the command to toggle
    * @return this trigger, so calls can be chained
    */
   public Trigger toggleOnFalse(Command command) {
+    return toggleOnFalse(command, InitialState.CONDITION);
+  }
+
+  /**
+   * Toggles a command when the condition changes from `true` to `false`.
+   *
+   * @param command the command to toggle
+   * @param initialState the initial state to use
+   * @return this trigger, so calls can be chained
+   */
+  public Trigger toggleOnFalse(Command command, InitialState initialState) {
     requireNonNullParam(command, "command", "toggleOnFalse");
     m_loop.bind(
         new Runnable() {
-          private boolean m_pressedLast = m_condition.getAsBoolean();
+          private boolean m_pressedLast = getInitialState(initialState);
 
           @Override
           public void run() {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
@@ -15,22 +15,23 @@ using namespace frc2;
 
 Trigger::Trigger(const Trigger& other) = default;
 
-Trigger Trigger::OnChange(Command* command) {
-  m_loop->Bind(
-      [condition = m_condition, previous = m_condition(), command]() mutable {
-        bool current = condition();
+Trigger Trigger::OnChange(Command* command, InitialState initialState) {
+  m_loop->Bind([condition = m_condition,
+                previous = GetInitialState(initialState), command]() mutable {
+    bool current = condition();
 
-        if (previous != current) {
-          command->Schedule();
-        }
+    if (previous != current) {
+      command->Schedule();
+    }
 
-        previous = current;
-      });
+    previous = current;
+  });
   return *this;
 }
 
-Trigger Trigger::OnChange(CommandPtr&& command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
+Trigger Trigger::OnChange(CommandPtr&& command, InitialState initialState) {
+  m_loop->Bind([condition = m_condition,
+                previous = GetInitialState(initialState),
                 command = std::move(command)]() mutable {
     bool current = condition();
 
@@ -43,22 +44,23 @@ Trigger Trigger::OnChange(CommandPtr&& command) {
   return *this;
 }
 
-Trigger Trigger::OnTrue(Command* command) {
-  m_loop->Bind(
-      [condition = m_condition, previous = m_condition(), command]() mutable {
-        bool current = condition();
+Trigger Trigger::OnTrue(Command* command, InitialState initialState) {
+  m_loop->Bind([condition = m_condition,
+                previous = GetInitialState(initialState), command]() mutable {
+    bool current = condition();
 
-        if (!previous && current) {
-          command->Schedule();
-        }
+    if (!previous && current) {
+      command->Schedule();
+    }
 
-        previous = current;
-      });
+    previous = current;
+  });
   return *this;
 }
 
-Trigger Trigger::OnTrue(CommandPtr&& command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
+Trigger Trigger::OnTrue(CommandPtr&& command, InitialState initialState) {
+  m_loop->Bind([condition = m_condition,
+                previous = GetInitialState(initialState),
                 command = std::move(command)]() mutable {
     bool current = condition();
 
@@ -71,22 +73,23 @@ Trigger Trigger::OnTrue(CommandPtr&& command) {
   return *this;
 }
 
-Trigger Trigger::OnFalse(Command* command) {
-  m_loop->Bind(
-      [condition = m_condition, previous = m_condition(), command]() mutable {
-        bool current = condition();
+Trigger Trigger::OnFalse(Command* command, InitialState initialState) {
+  m_loop->Bind([condition = m_condition,
+                previous = GetInitialState(initialState), command]() mutable {
+    bool current = condition();
 
-        if (previous && !current) {
-          command->Schedule();
-        }
+    if (previous && !current) {
+      command->Schedule();
+    }
 
-        previous = current;
-      });
+    previous = current;
+  });
   return *this;
 }
 
-Trigger Trigger::OnFalse(CommandPtr&& command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
+Trigger Trigger::OnFalse(CommandPtr&& command, InitialState initialState) {
+  m_loop->Bind([condition = m_condition,
+                previous = GetInitialState(initialState),
                 command = std::move(command)]() mutable {
     bool current = condition();
 
@@ -99,24 +102,25 @@ Trigger Trigger::OnFalse(CommandPtr&& command) {
   return *this;
 }
 
-Trigger Trigger::WhileTrue(Command* command) {
-  m_loop->Bind(
-      [condition = m_condition, previous = m_condition(), command]() mutable {
-        bool current = condition();
+Trigger Trigger::WhileTrue(Command* command, InitialState initialState) {
+  m_loop->Bind([condition = m_condition,
+                previous = GetInitialState(initialState), command]() mutable {
+    bool current = condition();
 
-        if (!previous && current) {
-          command->Schedule();
-        } else if (previous && !current) {
-          command->Cancel();
-        }
+    if (!previous && current) {
+      command->Schedule();
+    } else if (previous && !current) {
+      command->Cancel();
+    }
 
-        previous = current;
-      });
+    previous = current;
+  });
   return *this;
 }
 
-Trigger Trigger::WhileTrue(CommandPtr&& command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
+Trigger Trigger::WhileTrue(CommandPtr&& command, InitialState initialState) {
+  m_loop->Bind([condition = m_condition,
+                previous = GetInitialState(initialState),
                 command = std::move(command)]() mutable {
     bool current = condition();
 
@@ -131,24 +135,25 @@ Trigger Trigger::WhileTrue(CommandPtr&& command) {
   return *this;
 }
 
-Trigger Trigger::WhileFalse(Command* command) {
-  m_loop->Bind(
-      [condition = m_condition, previous = m_condition(), command]() mutable {
-        bool current = condition();
+Trigger Trigger::WhileFalse(Command* command, InitialState initialState) {
+  m_loop->Bind([condition = m_condition,
+                previous = GetInitialState(initialState), command]() mutable {
+    bool current = condition();
 
-        if (previous && !current) {
-          command->Schedule();
-        } else if (!previous && current) {
-          command->Cancel();
-        }
+    if (previous && !current) {
+      command->Schedule();
+    } else if (!previous && current) {
+      command->Cancel();
+    }
 
-        previous = current;
-      });
+    previous = current;
+  });
   return *this;
 }
 
-Trigger Trigger::WhileFalse(CommandPtr&& command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
+Trigger Trigger::WhileFalse(CommandPtr&& command, InitialState initialState) {
+  m_loop->Bind([condition = m_condition,
+                previous = GetInitialState(initialState),
                 command = std::move(command)]() mutable {
     bool current = condition();
 
@@ -163,8 +168,9 @@ Trigger Trigger::WhileFalse(CommandPtr&& command) {
   return *this;
 }
 
-Trigger Trigger::ToggleOnTrue(Command* command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
+Trigger Trigger::ToggleOnTrue(Command* command, InitialState initialState) {
+  m_loop->Bind([condition = m_condition,
+                previous = GetInitialState(initialState),
                 command = command]() mutable {
     bool current = condition();
 
@@ -181,8 +187,9 @@ Trigger Trigger::ToggleOnTrue(Command* command) {
   return *this;
 }
 
-Trigger Trigger::ToggleOnTrue(CommandPtr&& command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
+Trigger Trigger::ToggleOnTrue(CommandPtr&& command, InitialState initialState) {
+  m_loop->Bind([condition = m_condition,
+                previous = GetInitialState(initialState),
                 command = std::move(command)]() mutable {
     bool current = condition();
 
@@ -199,8 +206,9 @@ Trigger Trigger::ToggleOnTrue(CommandPtr&& command) {
   return *this;
 }
 
-Trigger Trigger::ToggleOnFalse(Command* command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
+Trigger Trigger::ToggleOnFalse(Command* command, InitialState initialState) {
+  m_loop->Bind([condition = m_condition,
+                previous = GetInitialState(initialState),
                 command = command]() mutable {
     bool current = condition();
 
@@ -217,8 +225,10 @@ Trigger Trigger::ToggleOnFalse(Command* command) {
   return *this;
 }
 
-Trigger Trigger::ToggleOnFalse(CommandPtr&& command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
+Trigger Trigger::ToggleOnFalse(CommandPtr&& command,
+                               InitialState initialState) {
+  m_loop->Bind([condition = m_condition,
+                previous = GetInitialState(initialState),
                 command = std::move(command)]() mutable {
     bool current = condition();
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
@@ -31,6 +31,21 @@ class Command;
 class Trigger {
  public:
   /**
+   * Enum specifying the initial state to use for a binding. This impacts
+   * whether or not the binding will be triggered immediately.
+   */
+  enum struct InitialState {
+    /** Indicates the binding should assume the condition starts as false. */
+    FALSE,
+    /** Indicates the binding should assume the condition starts as true. */
+    TRUE,
+    /** Indicates the binding should use the trigger's condition. */
+    CONDITION,
+    /** Indicates the binding should use the negated trigger's condition. */
+    NEG_CONDITION
+  };
+
+  /**
    * Creates a new trigger based on the given condition.
    *
    * <p>Polled by the default scheduler button loop.
@@ -61,18 +76,22 @@ class Trigger {
    * Starts the command when the condition changes.
    *
    * @param command the command to start
+   * @param initialState the initial state to use
    * @return this trigger, so calls can be chained
    */
-  Trigger OnChange(Command* command);
+  Trigger OnChange(Command* command,
+                   InitialState initialState = InitialState::CONDITION);
 
   /**
    * Starts the command when the condition changes. Moves command ownership to
    * the button scheduler.
    *
    * @param command the command to start
+   * @param initialState the initial state to use
    * @return this trigger, so calls can be chained
    */
-  Trigger OnChange(CommandPtr&& command);
+  Trigger OnChange(CommandPtr&& command,
+                   InitialState initialState = InitialState::CONDITION);
 
   /**
    * Starts the given command whenever the condition changes from `false` to
@@ -82,18 +101,22 @@ class Trigger {
    * lifespan of the command.
    *
    * @param command the command to start
+   * @param initialState the initial state to use
    * @return this trigger, so calls can be chained
    */
-  Trigger OnTrue(Command* command);
+  Trigger OnTrue(Command* command,
+                 InitialState initialState = InitialState::CONDITION);
 
   /**
    * Starts the given command whenever the condition changes from `false` to
    * `true`. Moves command ownership to the button scheduler.
    *
    * @param command The command to bind.
+   * @param initialState the initial state to use
    * @return The trigger, for chained calls.
    */
-  Trigger OnTrue(CommandPtr&& command);
+  Trigger OnTrue(CommandPtr&& command,
+                 InitialState initialState = InitialState::CONDITION);
 
   /**
    * Starts the given command whenever the condition changes from `true` to
@@ -103,18 +126,22 @@ class Trigger {
    * lifespan of the command.
    *
    * @param command the command to start
+   * @param initialState the initial state to use
    * @return this trigger, so calls can be chained
    */
-  Trigger OnFalse(Command* command);
+  Trigger OnFalse(Command* command,
+                  InitialState initialState = InitialState::CONDITION);
 
   /**
    * Starts the given command whenever the condition changes from `true` to
    * `false`.
    *
    * @param command The command to bind.
+   * @param initialState the initial state to use
    * @return The trigger, for chained calls.
    */
-  Trigger OnFalse(CommandPtr&& command);
+  Trigger OnFalse(CommandPtr&& command,
+                  InitialState initialState = InitialState::CONDITION);
 
   /**
    * Starts the given command when the condition changes to `true` and cancels
@@ -127,9 +154,11 @@ class Trigger {
    * lifespan of the command.
    *
    * @param command the command to start
+   * @param initialState the initial state to use
    * @return this trigger, so calls can be chained
    */
-  Trigger WhileTrue(Command* command);
+  Trigger WhileTrue(Command* command,
+                    InitialState initialState = InitialState::CONDITION);
 
   /**
    * Starts the given command when the condition changes to `true` and cancels
@@ -140,9 +169,11 @@ class Trigger {
    * `true`. If the command should restart, see RepeatCommand.
    *
    * @param command The command to bind.
+   * @param initialState the initial state to use
    * @return The trigger, for chained calls.
    */
-  Trigger WhileTrue(CommandPtr&& command);
+  Trigger WhileTrue(CommandPtr&& command,
+                    InitialState initialState = InitialState::CONDITION);
 
   /**
    * Starts the given command when the condition changes to `false` and cancels
@@ -155,9 +186,11 @@ class Trigger {
    * lifespan of the command.
    *
    * @param command the command to start
+   * @param initialState the initial state to use
    * @return this trigger, so calls can be chained
    */
-  Trigger WhileFalse(Command* command);
+  Trigger WhileFalse(Command* command,
+                     InitialState initialState = InitialState::CONDITION);
 
   /**
    * Starts the given command when the condition changes to `false` and cancels
@@ -168,9 +201,11 @@ class Trigger {
    * `false`. If the command should restart, see RepeatCommand.
    *
    * @param command The command to bind.
+   * @param initialState the initial state to use
    * @return The trigger, for chained calls.
    */
-  Trigger WhileFalse(CommandPtr&& command);
+  Trigger WhileFalse(CommandPtr&& command,
+                     InitialState initialState = InitialState::CONDITION);
 
   /**
    * Toggles a command when the condition changes from `false` to `true`.
@@ -179,9 +214,11 @@ class Trigger {
    * lifespan of the command.
    *
    * @param command the command to toggle
+   * @param initialState the initial state to use
    * @return this trigger, so calls can be chained
    */
-  Trigger ToggleOnTrue(Command* command);
+  Trigger ToggleOnTrue(Command* command,
+                       InitialState initialState = InitialState::CONDITION);
 
   /**
    * Toggles a command when the condition changes from `false` to `true`.
@@ -190,9 +227,11 @@ class Trigger {
    * lifespan of the command.
    *
    * @param command the command to toggle
+   * @param initialState the initial state to use
    * @return this trigger, so calls can be chained
    */
-  Trigger ToggleOnTrue(CommandPtr&& command);
+  Trigger ToggleOnTrue(CommandPtr&& command,
+                       InitialState initialState = InitialState::CONDITION);
 
   /**
    * Toggles a command when the condition changes from `true` to the low
@@ -202,9 +241,11 @@ class Trigger {
    * lifespan of the command.
    *
    * @param command the command to toggle
+   * @param initialState the initial state to use
    * @return this trigger, so calls can be chained
    */
-  Trigger ToggleOnFalse(Command* command);
+  Trigger ToggleOnFalse(Command* command,
+                        InitialState initialState = InitialState::CONDITION);
 
   /**
    * Toggles a command when the condition changes from `true` to `false`.
@@ -213,9 +254,11 @@ class Trigger {
    * lifespan of the command.
    *
    * @param command the command to toggle
+   * @param initialState the initial state to use
    * @return this trigger, so calls can be chained
    */
-  Trigger ToggleOnFalse(CommandPtr&& command);
+  Trigger ToggleOnFalse(CommandPtr&& command,
+                        InitialState initialState = InitialState::CONDITION);
 
   /**
    * Composes two triggers with logical AND.
@@ -291,6 +334,19 @@ class Trigger {
   bool Get() const;
 
  private:
+  bool GetInitialState(InitialState initialState) const {
+    switch (initialState) {
+      case InitialState::FALSE:
+        return false;
+      case InitialState::TRUE:
+        return true;
+      case InitialState::CONDITION:
+        return m_condition();
+      case InitialState::NEG_CONDITION:
+        return !m_condition();
+    }
+  }
+
   frc::EventLoop* m_loop;
   std::function<bool()> m_condition;
 };

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/TriggerTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/TriggerTest.java
@@ -7,21 +7,29 @@ package edu.wpi.first.wpilibj2.command.button;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import edu.wpi.first.wpilibj.simulation.SimHooks;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.CommandTestBase;
 import edu.wpi.first.wpilibj2.command.FunctionalCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.StartEndCommand;
 import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
+import edu.wpi.first.wpilibj2.command.button.Trigger.InitialState;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
 
 class TriggerTest extends CommandTestBase {
   @Test
@@ -43,6 +51,23 @@ class TriggerTest extends CommandTestBase {
     assertFalse(command1.isScheduled());
   }
 
+  @ParameterizedTest
+  @MethodSource("initialStates")
+  void onTrueInitialStateTest(InitialState initialState, boolean pressed, Map<String, Boolean> results) {
+    CommandScheduler scheduler = CommandScheduler.getInstance();
+    Command command1 = Commands.idle();
+    InternalButton button = new InternalButton();
+    boolean shouldBeScheduled = results.get("onTrue");
+
+    button.setPressed(pressed);
+    button.onTrue(command1, initialState);
+
+    assertFalse(command1.isScheduled());
+
+    scheduler.run();
+    assertEquals(shouldBeScheduled, command1.isScheduled());
+  }
+
   @Test
   void onFalseTest() {
     CommandScheduler scheduler = CommandScheduler.getInstance();
@@ -60,6 +85,23 @@ class TriggerTest extends CommandTestBase {
     finished.set(true);
     scheduler.run();
     assertFalse(command1.isScheduled());
+  }
+
+  @ParameterizedTest
+  @MethodSource("initialStates")
+  void onFalseInitialStateTest(InitialState initialState, boolean pressed, Map<String, Boolean> results) {
+    CommandScheduler scheduler = CommandScheduler.getInstance();
+    Command command1 = Commands.idle();
+    InternalButton button = new InternalButton();
+    boolean shouldBeScheduled = results.get("onFalse");
+
+    button.setPressed(pressed);
+    button.onFalse(command1, initialState);
+
+    assertFalse(command1.isScheduled());
+
+    scheduler.run();
+    assertEquals(shouldBeScheduled, command1.isScheduled());
   }
 
   @Test
@@ -86,6 +128,23 @@ class TriggerTest extends CommandTestBase {
     finished.set(true);
     scheduler.run();
     assertFalse(command1.isScheduled());
+  }
+
+  @ParameterizedTest
+  @MethodSource("initialStates")
+  void onChangeInitialStateTest(InitialState initialState, boolean pressed, Map<String, Boolean> results) {
+    CommandScheduler scheduler = CommandScheduler.getInstance();
+    Command command1 = Commands.idle();
+    InternalButton button = new InternalButton();
+    boolean shouldBeScheduled = results.get("onTrue") || results.get("onFalse");
+
+    button.setPressed(pressed);
+    button.onChange(command1, initialState);
+
+    assertFalse(command1.isScheduled());
+
+    scheduler.run();
+    assertEquals(shouldBeScheduled, command1.isScheduled());
   }
 
   @Test
@@ -195,6 +254,23 @@ class TriggerTest extends CommandTestBase {
     assertEquals(1, endCounter.get());
   }
 
+  @ParameterizedTest
+  @MethodSource("initialStates")
+  void toggleOnTrueInitialStateTest(InitialState initialState, boolean pressed, Map<String, Boolean> results) {
+    CommandScheduler scheduler = CommandScheduler.getInstance();
+    Command command1 = Commands.idle();
+    InternalButton button = new InternalButton();
+    boolean shouldBeScheduled = results.get("onTrue");
+
+    button.setPressed(pressed);
+    button.onTrue(command1, initialState);
+
+    assertFalse(command1.isScheduled());
+
+    scheduler.run();
+    assertEquals(shouldBeScheduled, command1.isScheduled());
+  }
+
   @Test
   void cancelWhenActiveTest() {
     CommandScheduler scheduler = CommandScheduler.getInstance();
@@ -274,5 +350,17 @@ class TriggerTest extends CommandTestBase {
     assertFalse(button.getAsBoolean());
     button.setPressed(true);
     assertTrue(button.getAsBoolean());
+  }
+
+  static Stream<Arguments> initialStates() {
+    return Stream.of(
+      arguments(InitialState.FALSE, true, Map.of("onTrue", true, "onFalse", false)),
+      arguments(InitialState.FALSE, false, Map.of("onTrue", false, "onFalse", false)),
+      arguments(InitialState.TRUE, true, Map.of("onTrue", false, "onFalse", false)),
+      arguments(InitialState.TRUE, false, Map.of("onTrue", false, "onFalse", true)),
+      arguments(InitialState.CONDITION, true, Map.of("onTrue", false, "onFalse", false)),
+      arguments(InitialState.CONDITION, false, Map.of("onTrue", false, "onFalse", false)),
+      arguments(InitialState.NEG_CONDITION, true, Map.of("onTrue", true, "onFalse", false)),
+      arguments(InitialState.NEG_CONDITION, false, Map.of("onTrue", false, "onFalse", true)));
   }
 }

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/button/TriggerTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/button/TriggerTest.cpp
@@ -18,6 +18,14 @@
 using namespace frc2;
 class TriggerTest : public CommandTestBase {};
 
+// Initial state, pressed, rising, falling
+using InitialStateTestData =
+    std::tuple<Trigger::InitialState, bool, bool, bool>;
+
+class TriggerInitialStateTest
+    : public TriggerTest,
+      public testing::WithParamInterface<InitialStateTestData> {};
+
 TEST_F(TriggerTest, OnTrue) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
@@ -36,6 +44,22 @@ TEST_F(TriggerTest, OnTrue) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
+TEST_P(TriggerInitialStateTest, OnTrue) {
+  auto [initialState, pressed, rising, falling] = GetParam();
+  auto& scheduler = CommandScheduler::GetInstance();
+  RunCommand command([] {});
+  bool shouldBeScheduled = rising;
+
+  Trigger([pressed = pressed] {
+    return pressed;
+  }).OnTrue(&command, initialState);
+
+  EXPECT_FALSE(scheduler.IsScheduled(&command));
+
+  scheduler.Run();
+  EXPECT_EQ(shouldBeScheduled, scheduler.IsScheduled(&command));
+}
+
 TEST_F(TriggerTest, OnFalse) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
@@ -52,6 +76,22 @@ TEST_F(TriggerTest, OnFalse) {
   finished = true;
   scheduler.Run();
   EXPECT_FALSE(scheduler.IsScheduled(&command));
+}
+
+TEST_P(TriggerInitialStateTest, OnFalse) {
+  auto [initialState, pressed, rising, falling] = GetParam();
+  auto& scheduler = CommandScheduler::GetInstance();
+  RunCommand command([] {});
+  bool shouldBeScheduled = falling;
+
+  Trigger([pressed = pressed] {
+    return pressed;
+  }).OnFalse(&command, initialState);
+
+  EXPECT_FALSE(scheduler.IsScheduled(&command));
+
+  scheduler.Run();
+  EXPECT_EQ(shouldBeScheduled, scheduler.IsScheduled(&command));
 }
 
 TEST_F(TriggerTest, OnChange) {
@@ -76,6 +116,22 @@ TEST_F(TriggerTest, OnChange) {
   finished = true;
   scheduler.Run();
   EXPECT_FALSE(command.IsScheduled());
+}
+
+TEST_P(TriggerInitialStateTest, OnChange) {
+  auto [initialState, pressed, rising, falling] = GetParam();
+  auto& scheduler = CommandScheduler::GetInstance();
+  RunCommand command([] {});
+  bool shouldBeScheduled = rising || falling;
+
+  Trigger([pressed = pressed] {
+    return pressed;
+  }).OnChange(&command, initialState);
+
+  EXPECT_FALSE(scheduler.IsScheduled(&command));
+
+  scheduler.Run();
+  EXPECT_EQ(shouldBeScheduled, scheduler.IsScheduled(&command));
 }
 
 TEST_F(TriggerTest, WhileTrueRepeatedly) {
@@ -175,6 +231,22 @@ TEST_F(TriggerTest, ToggleOnTrue) {
   EXPECT_EQ(1, endCounter);
 }
 
+TEST_P(TriggerInitialStateTest, ToggleOnTrue) {
+  auto [initialState, pressed, rising, falling] = GetParam();
+  auto& scheduler = CommandScheduler::GetInstance();
+  RunCommand command([] {});
+  bool shouldBeScheduled = rising;
+
+  Trigger([pressed = pressed] {
+    return pressed;
+  }).ToggleOnTrue(&command, initialState);
+
+  EXPECT_FALSE(scheduler.IsScheduled(&command));
+
+  scheduler.Run();
+  EXPECT_EQ(shouldBeScheduled, scheduler.IsScheduled(&command));
+}
+
 TEST_F(TriggerTest, And) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
@@ -247,3 +319,16 @@ TEST_F(TriggerTest, Debounce) {
   scheduler.Run();
   EXPECT_TRUE(scheduler.IsScheduled(&command));
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    InitialState, TriggerInitialStateTest,
+    testing::Values(
+        // Initial state, pressed, rising, falling
+        std::tuple{Trigger::InitialState::FALSE, false, false, false},
+        std::tuple{Trigger::InitialState::FALSE, true, true, false},
+        std::tuple{Trigger::InitialState::TRUE, false, false, true},
+        std::tuple{Trigger::InitialState::TRUE, true, false, false},
+        std::tuple{Trigger::InitialState::CONDITION, false, false, false},
+        std::tuple{Trigger::InitialState::CONDITION, true, false, false},
+        std::tuple{Trigger::InitialState::NEG_CONDITION, false, false, true},
+        std::tuple{Trigger::InitialState::NEG_CONDITION, true, true, false}));


### PR DESCRIPTION
If someone has a better name for `NEG_CONDITION`, please let me know!

Fixes #7413 and fixes #5608 by letting users specify `NEG_CONDITION` to force an initial edge or `FALSE` to force an initial edge if the condition is true.