### PR TITLE
Add PI Radians Unit

### DIFF
--- a/wpimath/src/main/native/include/frc/MathUtil.h
+++ b/wpimath/src/main/native/include/frc/MathUtil.h
@@ -166,8 +166,8 @@ constexpr bool IsNear(T expected, T actual, T tolerance, T min, T max) {
 WPILIB_DLLEXPORT
 constexpr units::radian_t AngleModulus(units::radian_t angle) {
   return InputModulus<units::radian_t>(angle,
-                                       units::radian_t{-std::numbers::pi},
-                                       units::radian_t{std::numbers::pi});
+                                       -1_pi_rad,
+                                       1_pi_rad);
 }
 
 // floorDiv and floorMod algorithms taken from Java

--- a/wpimath/src/main/native/include/frc/MathUtil.h
+++ b/wpimath/src/main/native/include/frc/MathUtil.h
@@ -165,9 +165,7 @@ constexpr bool IsNear(T expected, T actual, T tolerance, T min, T max) {
  */
 WPILIB_DLLEXPORT
 constexpr units::radian_t AngleModulus(units::radian_t angle) {
-  return InputModulus<units::radian_t>(angle,
-                                       -1_pi_rad,
-                                       1_pi_rad);
+  return InputModulus<units::radian_t>(angle, -1_pi_rad, 1_pi_rad);
 }
 
 // floorDiv and floorMod algorithms taken from Java

--- a/wpimath/src/main/native/include/units/angle.h
+++ b/wpimath/src/main/native/include/units/angle.h
@@ -40,8 +40,9 @@ namespace units {
 #if !defined(DISABLE_PREDEFINED_UNITS) || defined(ENABLE_PREDEFINED_ANGLE_UNITS)
 UNIT_ADD_WITH_METRIC_PREFIXES(angle, radian, radians, rad,
                               unit<std::ratio<1>, units::category::angle_unit>)
-UNIT_ADD(angle, degree, degrees, deg,
-         unit<std::ratio<1, 180>, radians, std::ratio<1>>)
+UNIT_ADD(angle, pi_radian, pi_radians, pi_rad,
+         unit<std::ratio<1, 1>, radians, std::ratio<1>>)
+UNIT_ADD(angle, degree, degrees, deg, unit<std::ratio<1, 180>, pi_radians>)
 UNIT_ADD(angle, arcminute, arcminutes, arcmin, unit<std::ratio<1, 60>, degrees>)
 UNIT_ADD(angle, arcsecond, arcseconds, arcsec,
          unit<std::ratio<1, 60>, arcminutes>)

--- a/wpimath/src/main/native/include/units/angular_acceleration.h
+++ b/wpimath/src/main/native/include/units/angular_acceleration.h
@@ -22,6 +22,9 @@ namespace units {
 UNIT_ADD(angular_acceleration, radians_per_second_squared,
          radians_per_second_squared, rad_per_s_sq,
          unit<std::ratio<1>, units::category::angular_acceleration_unit>)
+UNIT_ADD(angular_acceleration, pi_radians_per_second_squared,
+         pi_radians_per_second_squared, pi_rad_per_s_sq,
+         compound_unit<angle::pi_radians, inverse<squared<time::seconds>>>)
 UNIT_ADD(angular_acceleration, degrees_per_second_squared,
          degrees_per_second_squared, deg_per_s_sq,
          compound_unit<angle::degrees, inverse<squared<time::seconds>>>)

--- a/wpimath/src/main/native/include/units/angular_jerk.h
+++ b/wpimath/src/main/native/include/units/angular_jerk.h
@@ -21,6 +21,9 @@ namespace units {
  */
 UNIT_ADD(angular_jerk, radians_per_second_cubed, radians_per_second_cubed,
          rad_per_s_cu, unit<std::ratio<1>, units::category::angular_jerk_unit>)
+UNIT_ADD(angular_jerk, pi_radians_per_second_cubed, pi_radians_per_second_cubed,
+         pi_rad_per_s_cu,
+         compound_unit<angle::pi_radians, inverse<cubed<time::seconds>>>)
 UNIT_ADD(angular_jerk, degrees_per_second_cubed, degrees_per_second_cubed,
          deg_per_s_cu,
          compound_unit<angle::degrees, inverse<cubed<time::seconds>>>)

--- a/wpimath/src/main/native/include/units/angular_velocity.h
+++ b/wpimath/src/main/native/include/units/angular_velocity.h
@@ -44,6 +44,8 @@ namespace units {
     defined(ENABLE_PREDEFINED_ANGULAR_VELOCITY_UNITS)
 UNIT_ADD(angular_velocity, radians_per_second, radians_per_second, rad_per_s,
          unit<std::ratio<1>, units::category::angular_velocity_unit>)
+UNIT_ADD(angular_velocity, pi_radians_per_second, pi_radians_per_second,
+         pi_rad_per_s, compound_unit<angle::pi_radians, inverse<time::seconds>>)
 UNIT_ADD(angular_velocity, degrees_per_second, degrees_per_second, deg_per_s,
          compound_unit<angle::degrees, inverse<time::seconds>>)
 UNIT_ADD(angular_velocity, turns_per_second, turns_per_second, tps,

--- a/wpiunits/src/main/java/edu/wpi/first/units/Units.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/Units.java
@@ -98,6 +98,13 @@ public final class Units {
    */
   public static final AngleUnit Radian = Radians; // alias
 
+  /** 1/2 of a turn around a circle. */
+  public static final AngleUnit PIRadians =
+      derive(Radians).aggregate(Math.PI).named("PI Radian").symbol("π rad").make();
+
+  /** 1/2 of a turn around a circle. */
+  public static final AngleUnit PIRadian = PIRadians; // alias
+
   /**
    * A single turn of an object around an external axis. Numerically equivalent to {@link
    * #Rotations}, but may be semantically more expressive in certain scenarios.
@@ -175,6 +182,12 @@ public final class Units {
   public static final AngularVelocityUnit RadiansPerSecond = Radians.per(Second);
 
   /**
+   * A unit of angular velocity, equivalent to spinning at a rate of one {@link #PIRadians π Radian}
+   * per {@link #Second}.
+   */
+  public static final AngularVelocityUnit PIRadiansPerSecond = PIRadians.per(Second);
+
+  /**
    * A unit of angular velocity equivalent to spinning at a rate of one {@link #Degrees Degree} per
    * {@link #Second}.
    */
@@ -216,6 +229,13 @@ public final class Units {
    */
   public static final AngularAccelerationUnit RadiansPerSecondPerSecond =
       RadiansPerSecond.per(Second);
+
+  /**
+   * A unit of angular acceleration, equivalent to accelerating at a rate of one {@link #PIRadians π
+   * Radian} per {@link #Second} every second.
+   */
+  public static final AngularAccelerationUnit PIRadiansPerSecondPerSecond =
+      PIRadiansPerSecond.per(Second);
 
   /**
    * A unit of angular acceleration equivalent to accelerating at a rate of one {@link #Degrees


### PR DESCRIPTION
Useful for reducing the number of imports necessary in files, and is cleaner than using std::numbers::pi every time in C++.