### PR TITLE
Convert static ChassisSpeeds factories to use instance methods and remove deprecation

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/ChassisSpeeds.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/ChassisSpeeds.java
@@ -189,8 +189,9 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    * swerve drivetrain.
    *
    * @param dtSeconds The duration of the timestep the speeds should be applied for.
+   * @return Reference to itself
    */
-  public void discretize(double dtSeconds) {
+  public ChassisSpeeds discretize(double dtSeconds) {
     var desiredDeltaPose =
         new Pose2d(
             vxMetersPerSecond * dtSeconds,
@@ -205,6 +206,8 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
     vxMetersPerSecond = twist.dx / dtSeconds;
     vyMetersPerSecond = twist.dy / dtSeconds;
     omegaRadiansPerSecond = twist.dtheta / dtSeconds;
+
+    return this;
   }
 
   /**
@@ -285,13 +288,16 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    * @param robotAngle The angle of the robot as measured by a gyroscope. The robot's angle is
    *     considered to be zero when it is facing directly away from your alliance station wall.
    *     Remember that this should be CCW positive.
+   * @return Reference to itself
    */
-  public void toRobotRelativeSpeeds(Rotation2d robotAngle) {
+  public ChassisSpeeds toRobotRelativeSpeeds(Rotation2d robotAngle) {
     // CW rotation into chassis frame
     var rotated =
         new Translation2d(vxMetersPerSecond, vyMetersPerSecond).rotateBy(robotAngle.unaryMinus());
     vxMetersPerSecond = rotated.getX();
     vyMetersPerSecond = rotated.getY();
+
+    return this;
   }
 
   /**
@@ -371,12 +377,15 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    * @param robotAngle The angle of the robot as measured by a gyroscope. The robot's angle is
    *     considered to be zero when it is facing directly away from your alliance station wall.
    *     Remember that this should be CCW positive.
+   * @return Reference to itself
    */
-  public void toFieldRelativeSpeeds(Rotation2d robotAngle) {
+  public ChassisSpeeds toFieldRelativeSpeeds(Rotation2d robotAngle) {
     // CCW rotation out of chassis frame
     var rotated = new Translation2d(vxMetersPerSecond, vyMetersPerSecond).rotateBy(robotAngle);
     vxMetersPerSecond = rotated.getX();
     vyMetersPerSecond = rotated.getY();
+
+    return this;
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/ChassisSpeeds.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/ChassisSpeeds.java
@@ -189,9 +189,8 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    * swerve drivetrain.
    *
    * @param dtSeconds The duration of the timestep the speeds should be applied for.
-   * @return Reference to itself
    */
-  public ChassisSpeeds discretize(double dtSeconds) {
+  public void discretize(double dtSeconds) {
     var desiredDeltaPose =
         new Pose2d(
             vxMetersPerSecond * dtSeconds,
@@ -206,8 +205,6 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
     vxMetersPerSecond = twist.dx / dtSeconds;
     vyMetersPerSecond = twist.dy / dtSeconds;
     omegaRadiansPerSecond = twist.dtheta / dtSeconds;
-
-    return this;
   }
 
   /**
@@ -288,16 +285,13 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    * @param robotAngle The angle of the robot as measured by a gyroscope. The robot's angle is
    *     considered to be zero when it is facing directly away from your alliance station wall.
    *     Remember that this should be CCW positive.
-   * @return Reference to itself
    */
-  public ChassisSpeeds toRobotRelativeSpeeds(Rotation2d robotAngle) {
+  public void toRobotRelativeSpeeds(Rotation2d robotAngle) {
     // CW rotation into chassis frame
     var rotated =
         new Translation2d(vxMetersPerSecond, vyMetersPerSecond).rotateBy(robotAngle.unaryMinus());
     vxMetersPerSecond = rotated.getX();
     vyMetersPerSecond = rotated.getY();
-
-    return this;
   }
 
   /**
@@ -377,15 +371,12 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    * @param robotAngle The angle of the robot as measured by a gyroscope. The robot's angle is
    *     considered to be zero when it is facing directly away from your alliance station wall.
    *     Remember that this should be CCW positive.
-   * @return Reference to itself
    */
-  public ChassisSpeeds toFieldRelativeSpeeds(Rotation2d robotAngle) {
+  public void toFieldRelativeSpeeds(Rotation2d robotAngle) {
     // CCW rotation out of chassis frame
     var rotated = new Translation2d(vxMetersPerSecond, vyMetersPerSecond).rotateBy(robotAngle);
     vxMetersPerSecond = rotated.getX();
     vyMetersPerSecond = rotated.getY();
-
-    return this;
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/ChassisSpeeds.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/ChassisSpeeds.java
@@ -98,33 +98,23 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    * <p>This is useful for compensating for translational skew when translating and rotating a
    * swerve drivetrain.
    *
+   * <p>This will create a new ChassisSpeeds object. To modify an existing ChassisSpeeds object
+   * without creating a new one, use the instance method instead.
+   *
    * @param vxMetersPerSecond Forward velocity.
    * @param vyMetersPerSecond Sideways velocity.
    * @param omegaRadiansPerSecond Angular velocity.
    * @param dtSeconds The duration of the timestep the speeds should be applied for.
    * @return Discretized ChassisSpeeds.
-   * @deprecated Use instance method instead.
    */
-  @Deprecated(forRemoval = true, since = "2025")
   public static ChassisSpeeds discretize(
       double vxMetersPerSecond,
       double vyMetersPerSecond,
       double omegaRadiansPerSecond,
       double dtSeconds) {
-    // Construct the desired pose after a timestep, relative to the current pose. The desired pose
-    // has decoupled translation and rotation.
-    var desiredDeltaPose =
-        new Pose2d(
-            vxMetersPerSecond * dtSeconds,
-            vyMetersPerSecond * dtSeconds,
-            new Rotation2d(omegaRadiansPerSecond * dtSeconds));
-
-    // Find the chassis translation/rotation deltas in the robot frame that move the robot from its
-    // current pose to the desired pose
-    var twist = Pose2d.kZero.log(desiredDeltaPose);
-
-    // Turn the chassis translation/rotation deltas into average velocities
-    return new ChassisSpeeds(twist.dx / dtSeconds, twist.dy / dtSeconds, twist.dtheta / dtSeconds);
+    var speeds = new ChassisSpeeds(vxMetersPerSecond, vyMetersPerSecond, omegaRadiansPerSecond);
+    speeds.discretize(dtSeconds);
+    return speeds;
   }
 
   /**
@@ -138,14 +128,15 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    * <p>This is useful for compensating for translational skew when translating and rotating a
    * swerve drivetrain.
    *
+   * <p>This will create a new ChassisSpeeds object. To modify an existing ChassisSpeeds object
+   * without creating a new one, use the instance method instead.
+   *
    * @param vx Forward velocity.
    * @param vy Sideways velocity.
    * @param omega Angular velocity.
    * @param dt The duration of the timestep the speeds should be applied for.
    * @return Discretized ChassisSpeeds.
-   * @deprecated Use instance method instead.
    */
-  @Deprecated(forRemoval = true, since = "2025")
   public static ChassisSpeeds discretize(
       LinearVelocity vx, LinearVelocity vy, AngularVelocity omega, Time dt) {
     return discretize(
@@ -163,12 +154,13 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    * <p>This is useful for compensating for translational skew when translating and rotating a
    * swerve drivetrain.
    *
+   * <p>This will create a new ChassisSpeeds object. To modify an existing ChassisSpeeds object
+   * without creating a new one, use the instance method instead.
+   *
    * @param continuousSpeeds The continuous speeds.
    * @param dtSeconds The duration of the timestep the speeds should be applied for.
    * @return Discretized ChassisSpeeds.
-   * @deprecated Use instance method instead.
    */
-  @Deprecated(forRemoval = true, since = "2025")
   public static ChassisSpeeds discretize(ChassisSpeeds continuousSpeeds, double dtSeconds) {
     return discretize(
         continuousSpeeds.vxMetersPerSecond,
@@ -211,6 +203,9 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    * Converts a user provided field-relative set of speeds into a robot-relative ChassisSpeeds
    * object.
    *
+   * <p>This will create a new ChassisSpeeds object. To modify an existing ChassisSpeeds object
+   * without creating a new one, use the instance method instead.
+   *
    * @param vxMetersPerSecond The component of speed in the x direction relative to the field.
    *     Positive x is away from your alliance wall.
    * @param vyMetersPerSecond The component of speed in the y direction relative to the field.
@@ -220,23 +215,23 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    *     considered to be zero when it is facing directly away from your alliance station wall.
    *     Remember that this should be CCW positive.
    * @return ChassisSpeeds object representing the speeds in the robot's frame of reference.
-   * @deprecated Use toRobotRelativeSpeeds instead.
    */
-  @Deprecated(forRemoval = true, since = "2025")
   public static ChassisSpeeds fromFieldRelativeSpeeds(
       double vxMetersPerSecond,
       double vyMetersPerSecond,
       double omegaRadiansPerSecond,
       Rotation2d robotAngle) {
-    // CW rotation into chassis frame
-    var rotated =
-        new Translation2d(vxMetersPerSecond, vyMetersPerSecond).rotateBy(robotAngle.unaryMinus());
-    return new ChassisSpeeds(rotated.getX(), rotated.getY(), omegaRadiansPerSecond);
+    var speeds = new ChassisSpeeds(vxMetersPerSecond, vyMetersPerSecond, omegaRadiansPerSecond);
+    speeds.toRobotRelativeSpeeds(robotAngle);
+    return speeds;
   }
 
   /**
    * Converts a user provided field-relative set of speeds into a robot-relative ChassisSpeeds
    * object.
+   *
+   * <p>This will create a new ChassisSpeeds object. To modify an existing ChassisSpeeds object
+   * without creating a new one, use the instance method instead.
    *
    * @param vx The component of speed in the x direction relative to the field. Positive x is away
    *     from your alliance wall.
@@ -247,9 +242,7 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    *     considered to be zero when it is facing directly away from your alliance station wall.
    *     Remember that this should be CCW positive.
    * @return ChassisSpeeds object representing the speeds in the robot's frame of reference.
-   * @deprecated Use toRobotRelativeSpeeds instead.
    */
-  @Deprecated(forRemoval = true, since = "2025")
   public static ChassisSpeeds fromFieldRelativeSpeeds(
       LinearVelocity vx, LinearVelocity vy, AngularVelocity omega, Rotation2d robotAngle) {
     return fromFieldRelativeSpeeds(
@@ -260,6 +253,9 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    * Converts a user provided field-relative ChassisSpeeds object into a robot-relative
    * ChassisSpeeds object.
    *
+   * <p>This will create a new ChassisSpeeds object. To modify an existing ChassisSpeeds object
+   * without creating a new one, use the instance method instead.
+   *
    * @param fieldRelativeSpeeds The ChassisSpeeds object representing the speeds in the field frame
    *     of reference. Positive x is away from your alliance wall. Positive y is to your left when
    *     standing behind the alliance wall.
@@ -267,9 +263,7 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    *     considered to be zero when it is facing directly away from your alliance station wall.
    *     Remember that this should be CCW positive.
    * @return ChassisSpeeds object representing the speeds in the robot's frame of reference.
-   * @deprecated Use toRobotRelativeSpeeds instead.
    */
-  @Deprecated(forRemoval = true, since = "2025")
   public static ChassisSpeeds fromFieldRelativeSpeeds(
       ChassisSpeeds fieldRelativeSpeeds, Rotation2d robotAngle) {
     return fromFieldRelativeSpeeds(
@@ -298,6 +292,9 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    * Converts a user provided robot-relative set of speeds into a field-relative ChassisSpeeds
    * object.
    *
+   * <p>This will create a new ChassisSpeeds object. To modify an existing ChassisSpeeds object
+   * without creating a new one, use the instance method instead.
+   *
    * @param vxMetersPerSecond The component of speed in the x direction relative to the robot.
    *     Positive x is towards the robot's front.
    * @param vyMetersPerSecond The component of speed in the y direction relative to the robot.
@@ -307,22 +304,23 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    *     considered to be zero when it is facing directly away from your alliance station wall.
    *     Remember that this should be CCW positive.
    * @return ChassisSpeeds object representing the speeds in the field's frame of reference.
-   * @deprecated Use toFieldRelativeSpeeds instead.
    */
-  @Deprecated(forRemoval = true, since = "2025")
   public static ChassisSpeeds fromRobotRelativeSpeeds(
       double vxMetersPerSecond,
       double vyMetersPerSecond,
       double omegaRadiansPerSecond,
       Rotation2d robotAngle) {
-    // CCW rotation out of chassis frame
-    var rotated = new Translation2d(vxMetersPerSecond, vyMetersPerSecond).rotateBy(robotAngle);
-    return new ChassisSpeeds(rotated.getX(), rotated.getY(), omegaRadiansPerSecond);
+    var speeds = new ChassisSpeeds(vxMetersPerSecond, vyMetersPerSecond, omegaRadiansPerSecond);
+    speeds.toFieldRelativeSpeeds(robotAngle);
+    return speeds;
   }
 
   /**
    * Converts a user provided robot-relative set of speeds into a field-relative ChassisSpeeds
    * object.
+   *
+   * <p>This will create a new ChassisSpeeds object. To modify an existing ChassisSpeeds object
+   * without creating a new one, use the instance method instead.
    *
    * @param vx The component of speed in the x direction relative to the robot. Positive x is
    *     towards the robot's front.
@@ -333,9 +331,7 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    *     considered to be zero when it is facing directly away from your alliance station wall.
    *     Remember that this should be CCW positive.
    * @return ChassisSpeeds object representing the speeds in the field's frame of reference.
-   * @deprecated Use toFieldRelativeSpeeds instead.
    */
-  @Deprecated(forRemoval = true, since = "2025")
   public static ChassisSpeeds fromRobotRelativeSpeeds(
       LinearVelocity vx, LinearVelocity vy, AngularVelocity omega, Rotation2d robotAngle) {
     return fromRobotRelativeSpeeds(
@@ -346,6 +342,9 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    * Converts a user provided robot-relative ChassisSpeeds object into a field-relative
    * ChassisSpeeds object.
    *
+   * <p>This will create a new ChassisSpeeds object. To modify an existing ChassisSpeeds object
+   * without creating a new one, use the instance method instead.
+   *
    * @param robotRelativeSpeeds The ChassisSpeeds object representing the speeds in the robot frame
    *     of reference. Positive x is towards the robot's front. Positive y is towards the robot's
    *     left.
@@ -353,9 +352,7 @@ public class ChassisSpeeds implements ProtobufSerializable, StructSerializable {
    *     considered to be zero when it is facing directly away from your alliance station wall.
    *     Remember that this should be CCW positive.
    * @return ChassisSpeeds object representing the speeds in the field's frame of reference.
-   * @deprecated Use toFieldRelativeSpeeds instead.
    */
-  @Deprecated(forRemoval = true, since = "2025")
   public static ChassisSpeeds fromRobotRelativeSpeeds(
       ChassisSpeeds robotRelativeSpeeds, Rotation2d robotAngle) {
     return fromRobotRelativeSpeeds(


### PR DESCRIPTION
This PR is basically identical to #7418, which allows chaining of the `toFieldRelativeSpeeds`, `toRobotRelativeSpeeds`, and `discretize` methods. I'm not exactly sure why that PR was closed, but I think the current implementation makes things a bit more verbose, especially when converting usage of the deprecated static methods to the new instance methods.

For example, a common usage of the static methods could look something like this:
```Java
swerve.driveRobotRelative(ChassisSpeeds.fromFieldRelativeSpeeds(
    someXValue,
    someYValue,
    someOmegaValue,
    robotRotation
));
```

The current implementation that returns void would require the above example to be converted like this:
```Java
ChassisSpeeds speeds = new ChassisSpeeds(someXValue, someYValue, someOmegaValue);
speeds.toRobotRelativeSpeeds(robotRotation);
swerve.driveRobotRelative(speeds);
```

Returning a self reference from these methods allows this conversion to be simplified back down to:
```Java
swerve.driveRobotRelative(new ChassisSpeeds(someXValue, someYValue, someOmegaValue)
    .toRobotRelativeSpeeds(robotRotation));
```

This also has the added benefit of allowing method chaining, but I'm mainly concerned about being able to directly pass the result of these methods to another method without having to create a variable and call a method as an intermediate step.

EDIT:
This PR has been reworked to instead remove the deprecation from the static factory methods, and remove their deprecation. This is a better solution overall than the previous iteration of this PR, as it allows the user to choose whether they want to create a new ChassisSpeeds object or modify the original.