### PR TITLE
Restore and deprecate WPIUnits divide

### DIFF
--- a/wpiunits/src/generate/main/java/Measure-interface.java.jinja
+++ b/wpiunits/src/generate/main/java/Measure-interface.java.jinja
@@ -71,9 +71,9 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -94,9 +94,9 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -132,9 +132,9 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -149,9 +149,9 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -166,9 +166,9 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -183,9 +183,9 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generate/main/java/Measure-interface.java.jinja
+++ b/wpiunits/src/generate/main/java/Measure-interface.java.jinja
@@ -70,6 +70,18 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
     return ({{ helpers['type_usage'](name) }}) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default {{ helpers['type_usage'](name) }} divide(double divisor) {
+    return ({{ helpers['type_usage'](name) }}) div(divisor);
+  }
+
   @Override
   default {{ config[name]['divide']['Time'] or "Velocity<{}>".format(helpers['mtou'](name)) }} per(TimeUnit period) {
     return div(period.of(1));
@@ -79,6 +91,18 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
   @Override
   default {{ helpers['type_usage'](name) }} div({{ unit }} divisor) {
     return ({{ helpers['type_usage'](name) }}) {{ config[name]['base_unit'] }}.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default {{ helpers['type_usage'](name) }} divide({{ unit }} divisor) {
+    return ({{ helpers['type_usage'](name) }}) div(divisor);
   }
 
   @Override
@@ -106,20 +130,68 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
   default {{ config[name]['divide'][unit] }} div({{ unit }} divisor) {
     return {{ config[config[name]['divide'][unit]]['base_unit'] }}.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default {{ config[name]['divide'][unit] }} divide({{ unit }} divisor) {
+    return div(divisor);
+  }
 {% elif unit == "Time" %}
   @Override
   default Velocity<{{ helpers['mtou'](name) }}> div({{ unit }} divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<{{ helpers['mtou'](name) }}> divide({{ unit }} divisor) {
+    return div(divisor);
   }
 {% elif unit == name %}
   @Override
   default Dimensionless div({{ unit }} divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide({{ unit }} divisor) {
+    return div(divisor);
+  }
 {% else %}
   @Override
   default Per<{{ helpers['mtou'](name) }}, {{ helpers['mtou'](unit) }}> div({{ unit }} divisor) {
     return (Per<{{ helpers['mtou'](name) }}, {{ helpers['mtou'](unit) }}>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<{{ helpers['mtou'](name) }}, {{ helpers['mtou'](unit) }}> divide({{ unit }} divisor) {
+    return div(divisor);
   }
 {% endif -%}
 {% endif -%}

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Acceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Acceleration.java
@@ -70,6 +70,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return (Acceleration<D>) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Acceleration<D> divide(double divisor) {
+    return (Acceleration<D>) div(divisor);
+  }
+
   @Override
   default Velocity<AccelerationUnit<D>> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return (Per<AccelerationUnit<D>, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, AngleUnit> div(Angle divisor) {
     return (Per<AccelerationUnit<D>, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return (Per<AccelerationUnit<D>, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<AccelerationUnit<D>, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return (Per<AccelerationUnit<D>, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return (Per<AccelerationUnit<D>, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Acceleration<D> div(Dimensionless divisor) {
     return (Acceleration<D>) unit().of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Acceleration<D> divide(Dimensionless divisor) {
+    return (Acceleration<D>) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return (Per<AccelerationUnit<D>, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, EnergyUnit> div(Energy divisor) {
     return (Per<AccelerationUnit<D>, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return (Per<AccelerationUnit<D>, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, FrequencyUnit> div(Frequency divisor) {
     return (Per<AccelerationUnit<D>, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return (Per<AccelerationUnit<D>, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<AccelerationUnit<D>, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return (Per<AccelerationUnit<D>, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, MassUnit> div(Mass divisor) {
     return (Per<AccelerationUnit<D>, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return (Per<AccelerationUnit<D>, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<AccelerationUnit<D>, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return (Per<AccelerationUnit<D>, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, PowerUnit> div(Power divisor) {
     return (Per<AccelerationUnit<D>, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return (Per<AccelerationUnit<D>, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, TemperatureUnit> div(Temperature divisor) {
     return (Per<AccelerationUnit<D>, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<AccelerationUnit<D>> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, TorqueUnit> div(Torque divisor) {
     return (Per<AccelerationUnit<D>, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return (Per<AccelerationUnit<D>, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, VoltageUnit> div(Voltage divisor) {
     return (Per<AccelerationUnit<D>, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AccelerationUnit<D>, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Acceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Acceleration.java
@@ -71,9 +71,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Angle.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Angle.java
@@ -70,6 +70,18 @@ public interface Angle extends Measure<AngleUnit> {
     return (Angle) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Angle divide(double divisor) {
+    return (Angle) div(divisor);
+  }
+
   @Override
   default AngularVelocity per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Angle extends Measure<AngleUnit> {
     return (Per<AngleUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngleUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Dimensionless div(Angle divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Angle extends Measure<AngleUnit> {
     return (Per<AngleUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngleUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<AngleUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Angle extends Measure<AngleUnit> {
     return (Per<AngleUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngleUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Angle extends Measure<AngleUnit> {
     return (Per<AngleUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Angle div(Dimensionless divisor) {
     return (Angle) Radians.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Angle divide(Dimensionless divisor) {
+    return (Angle) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Angle extends Measure<AngleUnit> {
     return (Per<AngleUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngleUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, EnergyUnit> div(Energy divisor) {
     return (Per<AngleUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Angle extends Measure<AngleUnit> {
     return (Per<AngleUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default AngularVelocity times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<AngleUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Angle extends Measure<AngleUnit> {
     return (Per<AngleUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngleUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<AngleUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Angle extends Measure<AngleUnit> {
     return (Per<AngleUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngleUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, MassUnit> div(Mass divisor) {
     return (Per<AngleUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Angle extends Measure<AngleUnit> {
     return (Per<AngleUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngleUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<AngleUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Angle extends Measure<AngleUnit> {
     return (Per<AngleUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngleUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, PowerUnit> div(Power divisor) {
     return (Per<AngleUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Angle extends Measure<AngleUnit> {
     return (Per<AngleUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngleUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<AngleUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Angle extends Measure<AngleUnit> {
     return RadiansPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default AngularVelocity divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngleUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, TorqueUnit> div(Torque divisor) {
     return (Per<AngleUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Angle extends Measure<AngleUnit> {
     return (Per<AngleUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngleUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<AngleUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngleUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Angle.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Angle.java
@@ -71,9 +71,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -604,9 +604,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Angle extends Measure<AngleUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularAcceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularAcceleration.java
@@ -71,9 +71,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -351,9 +351,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularAcceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularAcceleration.java
@@ -70,6 +70,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return (AngularAcceleration) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default AngularAcceleration divide(double divisor) {
+    return (AngularAcceleration) div(divisor);
+  }
+
   @Override
   default Velocity<AngularAccelerationUnit> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return (Per<AngularAccelerationUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, AngleUnit> div(Angle divisor) {
     return (Per<AngularAccelerationUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<AngularAccelerationUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return (Per<AngularAccelerationUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return (Per<AngularAccelerationUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default AngularAcceleration div(Dimensionless divisor) {
     return (AngularAcceleration) RadiansPerSecondPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default AngularAcceleration divide(Dimensionless divisor) {
+    return (AngularAcceleration) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return (Per<AngularAccelerationUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, EnergyUnit> div(Energy divisor) {
     return (Per<AngularAccelerationUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return (Per<AngularAccelerationUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default AngularVelocity div(Frequency divisor) {
     return RadiansPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default AngularVelocity divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return (Per<AngularAccelerationUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<AngularAccelerationUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return (Per<AngularAccelerationUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, MassUnit> div(Mass divisor) {
     return (Per<AngularAccelerationUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return (Per<AngularAccelerationUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<AngularAccelerationUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return (Per<AngularAccelerationUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, PowerUnit> div(Power divisor) {
     return (Per<AngularAccelerationUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return (Per<AngularAccelerationUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<AngularAccelerationUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<AngularAccelerationUnit> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, TorqueUnit> div(Torque divisor) {
     return (Per<AngularAccelerationUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return (Per<AngularAccelerationUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<AngularAccelerationUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularAccelerationUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularMomentum.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularMomentum.java
@@ -70,6 +70,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return (AngularMomentum) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default AngularMomentum divide(double divisor) {
+    return (AngularMomentum) div(divisor);
+  }
+
   @Override
   default Velocity<AngularMomentumUnit> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return (Per<AngularMomentumUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, AngleUnit> div(Angle divisor) {
     return (Per<AngularMomentumUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return (Per<AngularMomentumUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Dimensionless div(AngularMomentum divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return KilogramSquareMeters.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default MomentOfInertia divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return (Per<AngularMomentumUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default AngularMomentum div(Dimensionless divisor) {
     return (AngularMomentum) KilogramMetersSquaredPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default AngularMomentum divide(Dimensionless divisor) {
+    return (AngularMomentum) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return (Per<AngularMomentumUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, EnergyUnit> div(Energy divisor) {
     return (Per<AngularMomentumUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return (Per<AngularMomentumUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<AngularMomentumUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return (Per<AngularMomentumUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<AngularMomentumUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return (Per<AngularMomentumUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, MassUnit> div(Mass divisor) {
     return (Per<AngularMomentumUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return (Per<AngularMomentumUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<AngularMomentumUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return (Per<AngularMomentumUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, PowerUnit> div(Power divisor) {
     return (Per<AngularMomentumUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return (Per<AngularMomentumUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<AngularMomentumUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<AngularMomentumUnit> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, TorqueUnit> div(Torque divisor) {
     return (Per<AngularMomentumUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return (Per<AngularMomentumUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<AngularMomentumUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularMomentumUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularMomentum.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularMomentum.java
@@ -71,9 +71,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -214,9 +214,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularVelocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularVelocity.java
@@ -71,9 +71,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -604,9 +604,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularVelocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularVelocity.java
@@ -70,6 +70,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return (AngularVelocity) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default AngularVelocity divide(double divisor) {
+    return (AngularVelocity) div(divisor);
+  }
+
   @Override
   default AngularAcceleration per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return (Per<AngularVelocityUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, AngleUnit> div(Angle divisor) {
     return (Per<AngularVelocityUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return (Per<AngularVelocityUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<AngularVelocityUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return (Per<AngularVelocityUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default AngularVelocity div(Dimensionless divisor) {
     return (AngularVelocity) RadiansPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default AngularVelocity divide(Dimensionless divisor) {
+    return (AngularVelocity) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return (Per<AngularVelocityUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, EnergyUnit> div(Energy divisor) {
     return (Per<AngularVelocityUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return (Per<AngularVelocityUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default AngularAcceleration times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<AngularVelocityUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return (Per<AngularVelocityUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<AngularVelocityUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return (Per<AngularVelocityUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, MassUnit> div(Mass divisor) {
     return (Per<AngularVelocityUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return (Per<AngularVelocityUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<AngularVelocityUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return (Per<AngularVelocityUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, PowerUnit> div(Power divisor) {
     return (Per<AngularVelocityUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return (Per<AngularVelocityUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<AngularVelocityUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return RadiansPerSecondPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default AngularAcceleration divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, TorqueUnit> div(Torque divisor) {
     return (Per<AngularVelocityUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return (Per<AngularVelocityUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<AngularVelocityUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<AngularVelocityUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 default Frequency asFrequency() { return Hertz.of(baseUnitMagnitude()); }
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Current.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Current.java
@@ -70,6 +70,18 @@ public interface Current extends Measure<CurrentUnit> {
     return (Current) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Current divide(double divisor) {
+    return (Current) div(divisor);
+  }
+
   @Override
   default Velocity<CurrentUnit> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Current extends Measure<CurrentUnit> {
     return (Per<CurrentUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<CurrentUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, AngleUnit> div(Angle divisor) {
     return (Per<CurrentUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Current extends Measure<CurrentUnit> {
     return (Per<CurrentUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<CurrentUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<CurrentUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Current extends Measure<CurrentUnit> {
     return (Per<CurrentUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<CurrentUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Current extends Measure<CurrentUnit> {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Current div(Dimensionless divisor) {
     return (Current) Amps.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Current divide(Dimensionless divisor) {
+    return (Current) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Current extends Measure<CurrentUnit> {
     return (Per<CurrentUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<CurrentUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, EnergyUnit> div(Energy divisor) {
     return (Per<CurrentUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Current extends Measure<CurrentUnit> {
     return (Per<CurrentUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<CurrentUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<CurrentUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Current extends Measure<CurrentUnit> {
     return (Per<CurrentUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<CurrentUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<CurrentUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Current extends Measure<CurrentUnit> {
     return (Per<CurrentUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<CurrentUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, MassUnit> div(Mass divisor) {
     return (Per<CurrentUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Current extends Measure<CurrentUnit> {
     return (Per<CurrentUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<CurrentUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<CurrentUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Current extends Measure<CurrentUnit> {
     return (Per<CurrentUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<CurrentUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, PowerUnit> div(Power divisor) {
     return (Per<CurrentUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Current extends Measure<CurrentUnit> {
     return (Per<CurrentUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<CurrentUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<CurrentUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Current extends Measure<CurrentUnit> {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<CurrentUnit> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<CurrentUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, TorqueUnit> div(Torque divisor) {
     return (Per<CurrentUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Current extends Measure<CurrentUnit> {
     return (Per<CurrentUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Power times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<CurrentUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<CurrentUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Current.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Current.java
@@ -71,9 +71,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Current extends Measure<CurrentUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Dimensionless.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Dimensionless.java
@@ -71,9 +71,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -604,9 +604,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Dimensionless.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Dimensionless.java
@@ -70,6 +70,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return (Dimensionless) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Dimensionless divide(double divisor) {
+    return (Dimensionless) div(divisor);
+  }
+
   @Override
   default Frequency per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return (Per<DimensionlessUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Angle times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, AngleUnit> div(Angle divisor) {
     return (Per<DimensionlessUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return (Per<DimensionlessUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default AngularMomentum times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<DimensionlessUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return (Per<DimensionlessUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Current times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return (Per<DimensionlessUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Dimensionless div(Dimensionless divisor) {
     return (Dimensionless) Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Dimensionless divide(Dimensionless divisor) {
+    return (Dimensionless) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return (Per<DimensionlessUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Energy times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, EnergyUnit> div(Energy divisor) {
     return (Per<DimensionlessUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return (Per<DimensionlessUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Frequency times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<DimensionlessUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return (Per<DimensionlessUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default LinearMomentum times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<DimensionlessUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return (Per<DimensionlessUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mass times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, MassUnit> div(Mass divisor) {
     return (Per<DimensionlessUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return (Per<DimensionlessUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<DimensionlessUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<DimensionlessUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return (Per<DimensionlessUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Power times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, PowerUnit> div(Power divisor) {
     return (Per<DimensionlessUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return (Per<DimensionlessUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Temperature times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<DimensionlessUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return Hertz.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Frequency divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Torque times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, TorqueUnit> div(Torque divisor) {
     return (Per<DimensionlessUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return (Per<DimensionlessUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Voltage times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<DimensionlessUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DimensionlessUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Distance.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Distance.java
@@ -71,9 +71,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -420,9 +420,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -604,9 +604,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Distance extends Measure<DistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Distance.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Distance.java
@@ -70,6 +70,18 @@ public interface Distance extends Measure<DistanceUnit> {
     return (Distance) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Distance divide(double divisor) {
+    return (Distance) div(divisor);
+  }
+
   @Override
   default LinearVelocity per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Distance extends Measure<DistanceUnit> {
     return (Per<DistanceUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<DistanceUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, AngleUnit> div(Angle divisor) {
     return (Per<DistanceUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Distance extends Measure<DistanceUnit> {
     return (Per<DistanceUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<DistanceUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<DistanceUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Distance extends Measure<DistanceUnit> {
     return (Per<DistanceUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<DistanceUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Distance extends Measure<DistanceUnit> {
     return (Per<DistanceUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Distance div(Dimensionless divisor) {
     return (Distance) Meters.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Distance divide(Dimensionless divisor) {
+    return (Distance) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Distance extends Measure<DistanceUnit> {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<DistanceUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, EnergyUnit> div(Energy divisor) {
     return (Per<DistanceUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Distance extends Measure<DistanceUnit> {
     return (Per<DistanceUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default LinearVelocity times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<DistanceUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Distance extends Measure<DistanceUnit> {
     return (Per<DistanceUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<DistanceUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<DistanceUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Distance extends Measure<DistanceUnit> {
     return Seconds.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Time divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<DistanceUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, MassUnit> div(Mass divisor) {
     return (Per<DistanceUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Distance extends Measure<DistanceUnit> {
     return (Per<DistanceUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<DistanceUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<DistanceUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Distance extends Measure<DistanceUnit> {
     return (Per<DistanceUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<DistanceUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, PowerUnit> div(Power divisor) {
     return (Per<DistanceUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Distance extends Measure<DistanceUnit> {
     return (Per<DistanceUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<DistanceUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<DistanceUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Distance extends Measure<DistanceUnit> {
     return MetersPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default LinearVelocity divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<DistanceUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, TorqueUnit> div(Torque divisor) {
     return (Per<DistanceUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Distance extends Measure<DistanceUnit> {
     return (Per<DistanceUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<DistanceUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<DistanceUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<DistanceUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Energy.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Energy.java
@@ -70,6 +70,18 @@ public interface Energy extends Measure<EnergyUnit> {
     return (Energy) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Energy divide(double divisor) {
+    return (Energy) div(divisor);
+  }
+
   @Override
   default Power per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Energy extends Measure<EnergyUnit> {
     return (Per<EnergyUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<EnergyUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, AngleUnit> div(Angle divisor) {
     return (Per<EnergyUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Energy extends Measure<EnergyUnit> {
     return (Per<EnergyUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<EnergyUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<EnergyUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Energy extends Measure<EnergyUnit> {
     return (Per<EnergyUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<EnergyUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Energy extends Measure<EnergyUnit> {
     return (Per<EnergyUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Energy div(Dimensionless divisor) {
     return (Energy) Joules.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Energy divide(Dimensionless divisor) {
+    return (Energy) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Energy extends Measure<EnergyUnit> {
     return (Per<EnergyUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<EnergyUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Dimensionless div(Energy divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Energy extends Measure<EnergyUnit> {
     return (Per<EnergyUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Power times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<EnergyUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Energy extends Measure<EnergyUnit> {
     return (Per<EnergyUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<EnergyUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<EnergyUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Energy extends Measure<EnergyUnit> {
     return (Per<EnergyUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<EnergyUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, MassUnit> div(Mass divisor) {
     return (Per<EnergyUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Energy extends Measure<EnergyUnit> {
     return (Per<EnergyUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<EnergyUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<EnergyUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Energy extends Measure<EnergyUnit> {
     return (Per<EnergyUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<EnergyUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, PowerUnit> div(Power divisor) {
     return (Per<EnergyUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Energy extends Measure<EnergyUnit> {
     return (Per<EnergyUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<EnergyUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<EnergyUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Energy extends Measure<EnergyUnit> {
     return Watts.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Power divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<EnergyUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, TorqueUnit> div(Torque divisor) {
     return (Per<EnergyUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Energy extends Measure<EnergyUnit> {
     return (Per<EnergyUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<EnergyUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<EnergyUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<EnergyUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Energy.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Energy.java
@@ -71,9 +71,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -604,9 +604,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Energy extends Measure<EnergyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Force.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Force.java
@@ -70,6 +70,18 @@ public interface Force extends Measure<ForceUnit> {
     return (Force) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Force divide(double divisor) {
+    return (Force) div(divisor);
+  }
+
   @Override
   default Velocity<ForceUnit> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Force extends Measure<ForceUnit> {
     return (Per<ForceUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ForceUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, AngleUnit> div(Angle divisor) {
     return (Per<ForceUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Force extends Measure<ForceUnit> {
     return (Per<ForceUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ForceUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<ForceUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Force extends Measure<ForceUnit> {
     return (Per<ForceUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ForceUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Force extends Measure<ForceUnit> {
     return (Per<ForceUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Force div(Dimensionless divisor) {
     return (Force) Newtons.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Force divide(Dimensionless divisor) {
+    return (Force) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Force extends Measure<ForceUnit> {
     return (Per<ForceUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ForceUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, EnergyUnit> div(Energy divisor) {
     return (Per<ForceUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Force extends Measure<ForceUnit> {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ForceUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<ForceUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Force extends Measure<ForceUnit> {
     return Kilograms.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Mass divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ForceUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<ForceUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Force extends Measure<ForceUnit> {
     return (Per<ForceUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ForceUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default LinearAcceleration div(Mass divisor) {
     return MetersPerSecondPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default LinearAcceleration divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Force extends Measure<ForceUnit> {
     return (Per<ForceUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ForceUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<ForceUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Force extends Measure<ForceUnit> {
     return (Per<ForceUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ForceUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, PowerUnit> div(Power divisor) {
     return (Per<ForceUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Force extends Measure<ForceUnit> {
     return (Per<ForceUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ForceUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<ForceUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Force extends Measure<ForceUnit> {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<ForceUnit> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ForceUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, TorqueUnit> div(Torque divisor) {
     return (Per<ForceUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Force extends Measure<ForceUnit> {
     return (Per<ForceUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ForceUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<ForceUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ForceUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Force.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Force.java
@@ -71,9 +71,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -374,9 +374,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -443,9 +443,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Force extends Measure<ForceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Frequency.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Frequency.java
@@ -70,6 +70,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return (Frequency) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Frequency divide(double divisor) {
+    return (Frequency) div(divisor);
+  }
+
   @Override
   default Velocity<FrequencyUnit> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return (Per<FrequencyUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default AngularVelocity times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, AngleUnit> div(Angle divisor) {
     return (Per<FrequencyUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return (Per<FrequencyUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<FrequencyUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<FrequencyUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return (Per<FrequencyUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<FrequencyUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return (Per<FrequencyUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Frequency div(Dimensionless divisor) {
     return (Frequency) Hertz.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Frequency divide(Dimensionless divisor) {
+    return (Frequency) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return (Per<FrequencyUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<FrequencyUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, EnergyUnit> div(Energy divisor) {
     return (Per<FrequencyUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return (Per<FrequencyUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<FrequencyUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Dimensionless div(Frequency divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return (Per<FrequencyUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<FrequencyUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<FrequencyUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return (Per<FrequencyUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<FrequencyUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, MassUnit> div(Mass divisor) {
     return (Per<FrequencyUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return (Per<FrequencyUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<FrequencyUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<FrequencyUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return (Per<FrequencyUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<FrequencyUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, PowerUnit> div(Power divisor) {
     return (Per<FrequencyUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return (Per<FrequencyUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<FrequencyUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<FrequencyUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<FrequencyUnit> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<FrequencyUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, TorqueUnit> div(Torque divisor) {
     return (Per<FrequencyUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return (Per<FrequencyUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<FrequencyUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<FrequencyUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<FrequencyUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 /** Converts this frequency to the time period between cycles. */
 default Time asPeriod() { return Seconds.of(1 / baseUnitMagnitude()); }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Frequency.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Frequency.java
@@ -71,9 +71,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Frequency extends Measure<FrequencyUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearAcceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearAcceleration.java
@@ -71,9 +71,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -351,9 +351,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearAcceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearAcceleration.java
@@ -70,6 +70,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return (LinearAcceleration) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default LinearAcceleration divide(double divisor) {
+    return (LinearAcceleration) div(divisor);
+  }
+
   @Override
   default Velocity<LinearAccelerationUnit> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return (Per<LinearAccelerationUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, AngleUnit> div(Angle divisor) {
     return (Per<LinearAccelerationUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return (Per<LinearAccelerationUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<LinearAccelerationUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return (Per<LinearAccelerationUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return (Per<LinearAccelerationUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default LinearAcceleration div(Dimensionless divisor) {
     return (LinearAcceleration) MetersPerSecondPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default LinearAcceleration divide(Dimensionless divisor) {
+    return (LinearAcceleration) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return (Per<LinearAccelerationUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, EnergyUnit> div(Energy divisor) {
     return (Per<LinearAccelerationUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return (Per<LinearAccelerationUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default LinearVelocity div(Frequency divisor) {
     return MetersPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default LinearVelocity divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<LinearAccelerationUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return (Per<LinearAccelerationUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, MassUnit> div(Mass divisor) {
     return (Per<LinearAccelerationUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return (Per<LinearAccelerationUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<LinearAccelerationUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return (Per<LinearAccelerationUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, PowerUnit> div(Power divisor) {
     return (Per<LinearAccelerationUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return (Per<LinearAccelerationUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<LinearAccelerationUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<LinearAccelerationUnit> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, TorqueUnit> div(Torque divisor) {
     return (Per<LinearAccelerationUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return (Per<LinearAccelerationUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<LinearAccelerationUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearAccelerationUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearMomentum.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearMomentum.java
@@ -71,9 +71,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -420,9 +420,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -443,9 +443,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -604,9 +604,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearMomentum.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearMomentum.java
@@ -70,6 +70,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return (LinearMomentum) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default LinearMomentum divide(double divisor) {
+    return (LinearMomentum) div(divisor);
+  }
+
   @Override
   default Force per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return (Per<LinearMomentumUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, AngleUnit> div(Angle divisor) {
     return (Per<LinearMomentumUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return (Per<LinearMomentumUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<LinearMomentumUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return (Per<LinearMomentumUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return (Per<LinearMomentumUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default LinearMomentum div(Dimensionless divisor) {
     return (LinearMomentum) KilogramMetersPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default LinearMomentum divide(Dimensionless divisor) {
+    return (LinearMomentum) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return (Per<LinearMomentumUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, EnergyUnit> div(Energy divisor) {
     return (Per<LinearMomentumUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return (Per<LinearMomentumUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Force times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<LinearMomentumUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return (Per<LinearMomentumUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Dimensionless div(LinearMomentum divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return Kilograms.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Mass divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default LinearVelocity div(Mass divisor) {
     return MetersPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default LinearVelocity divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return (Per<LinearMomentumUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<LinearMomentumUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return (Per<LinearMomentumUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, PowerUnit> div(Power divisor) {
     return (Per<LinearMomentumUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return (Per<LinearMomentumUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<LinearMomentumUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return Newtons.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Force divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, TorqueUnit> div(Torque divisor) {
     return (Per<LinearMomentumUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return (Per<LinearMomentumUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<LinearMomentumUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearMomentumUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearVelocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearVelocity.java
@@ -71,9 +71,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -604,9 +604,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearVelocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearVelocity.java
@@ -70,6 +70,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return (LinearVelocity) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default LinearVelocity divide(double divisor) {
+    return (LinearVelocity) div(divisor);
+  }
+
   @Override
   default LinearAcceleration per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return (Per<LinearVelocityUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, AngleUnit> div(Angle divisor) {
     return (Per<LinearVelocityUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return (Per<LinearVelocityUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<LinearVelocityUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return (Per<LinearVelocityUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return (Per<LinearVelocityUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default LinearVelocity div(Dimensionless divisor) {
     return (LinearVelocity) MetersPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default LinearVelocity divide(Dimensionless divisor) {
+    return (LinearVelocity) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return (Per<LinearVelocityUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, EnergyUnit> div(Energy divisor) {
     return (Per<LinearVelocityUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return (Per<LinearVelocityUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default LinearAcceleration times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<LinearVelocityUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return (Per<LinearVelocityUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<LinearVelocityUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, MassUnit> div(Mass divisor) {
     return (Per<LinearVelocityUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return (Per<LinearVelocityUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<LinearVelocityUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return (Per<LinearVelocityUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, PowerUnit> div(Power divisor) {
     return (Per<LinearVelocityUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return (Per<LinearVelocityUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<LinearVelocityUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return MetersPerSecondPerSecond.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default LinearAcceleration divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, TorqueUnit> div(Torque divisor) {
     return (Per<LinearVelocityUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return (Per<LinearVelocityUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<LinearVelocityUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<LinearVelocityUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mass.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mass.java
@@ -70,6 +70,18 @@ public interface Mass extends Measure<MassUnit> {
     return (Mass) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Mass divide(double divisor) {
+    return (Mass) div(divisor);
+  }
+
   @Override
   default Velocity<MassUnit> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Mass extends Measure<MassUnit> {
     return (Per<MassUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MassUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, AngleUnit> div(Angle divisor) {
     return (Per<MassUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Mass extends Measure<MassUnit> {
     return (Per<MassUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MassUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<MassUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Mass extends Measure<MassUnit> {
     return (Per<MassUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MassUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Mass extends Measure<MassUnit> {
     return (Per<MassUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Mass div(Dimensionless divisor) {
     return (Mass) Kilograms.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Mass divide(Dimensionless divisor) {
+    return (Mass) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Mass extends Measure<MassUnit> {
     return (Per<MassUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MassUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, EnergyUnit> div(Energy divisor) {
     return (Per<MassUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Mass extends Measure<MassUnit> {
     return (Per<MassUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MassUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<MassUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Mass extends Measure<MassUnit> {
     return (Per<MassUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MassUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<MassUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Mass extends Measure<MassUnit> {
     return (Per<MassUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MassUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Dimensionless div(Mass divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Mass extends Measure<MassUnit> {
     return (Per<MassUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MassUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<MassUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Mass extends Measure<MassUnit> {
     return (Per<MassUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MassUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, PowerUnit> div(Power divisor) {
     return (Per<MassUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Mass extends Measure<MassUnit> {
     return (Per<MassUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MassUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<MassUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Mass extends Measure<MassUnit> {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<MassUnit> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MassUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, TorqueUnit> div(Torque divisor) {
     return (Per<MassUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Mass extends Measure<MassUnit> {
     return (Per<MassUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MassUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<MassUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MassUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mass.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mass.java
@@ -71,9 +71,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Mass extends Measure<MassUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MomentOfInertia.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MomentOfInertia.java
@@ -71,9 +71,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MomentOfInertia.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MomentOfInertia.java
@@ -70,6 +70,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return (MomentOfInertia) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default MomentOfInertia divide(double divisor) {
+    return (MomentOfInertia) div(divisor);
+  }
+
   @Override
   default Velocity<MomentOfInertiaUnit> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return (Per<MomentOfInertiaUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, AngleUnit> div(Angle divisor) {
     return (Per<MomentOfInertiaUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return (Per<MomentOfInertiaUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<MomentOfInertiaUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return (Per<MomentOfInertiaUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return (Per<MomentOfInertiaUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default MomentOfInertia div(Dimensionless divisor) {
     return (MomentOfInertia) KilogramSquareMeters.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default MomentOfInertia divide(Dimensionless divisor) {
+    return (MomentOfInertia) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return (Per<MomentOfInertiaUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, EnergyUnit> div(Energy divisor) {
     return (Per<MomentOfInertiaUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return (Per<MomentOfInertiaUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<MomentOfInertiaUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return (Per<MomentOfInertiaUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<MomentOfInertiaUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return (Per<MomentOfInertiaUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, MassUnit> div(Mass divisor) {
     return (Per<MomentOfInertiaUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<MomentOfInertiaUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return (Per<MomentOfInertiaUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, PowerUnit> div(Power divisor) {
     return (Per<MomentOfInertiaUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return (Per<MomentOfInertiaUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<MomentOfInertiaUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<MomentOfInertiaUnit> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, TorqueUnit> div(Torque divisor) {
     return (Per<MomentOfInertiaUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return (Per<MomentOfInertiaUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<MomentOfInertiaUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MomentOfInertiaUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mult.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mult.java
@@ -70,6 +70,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return (Mult<A, B>) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Mult<A, B> divide(double divisor) {
+    return (Mult<A, B>) div(divisor);
+  }
+
   @Override
   default Velocity<MultUnit<A, B>> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return (Per<MultUnit<A, B>, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, AngleUnit> div(Angle divisor) {
     return (Per<MultUnit<A, B>, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return (Per<MultUnit<A, B>, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<MultUnit<A, B>, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return (Per<MultUnit<A, B>, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return (Per<MultUnit<A, B>, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Mult<A, B> div(Dimensionless divisor) {
     return (Mult<A, B>) unit().of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Mult<A, B> divide(Dimensionless divisor) {
+    return (Mult<A, B>) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return (Per<MultUnit<A, B>, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, EnergyUnit> div(Energy divisor) {
     return (Per<MultUnit<A, B>, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return (Per<MultUnit<A, B>, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, FrequencyUnit> div(Frequency divisor) {
     return (Per<MultUnit<A, B>, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return (Per<MultUnit<A, B>, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<MultUnit<A, B>, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return (Per<MultUnit<A, B>, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, MassUnit> div(Mass divisor) {
     return (Per<MultUnit<A, B>, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return (Per<MultUnit<A, B>, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<MultUnit<A, B>, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return (Per<MultUnit<A, B>, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, PowerUnit> div(Power divisor) {
     return (Per<MultUnit<A, B>, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return (Per<MultUnit<A, B>, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, TemperatureUnit> div(Temperature divisor) {
     return (Per<MultUnit<A, B>, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<MultUnit<A, B>> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, TorqueUnit> div(Torque divisor) {
     return (Per<MultUnit<A, B>, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return (Per<MultUnit<A, B>, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, VoltageUnit> div(Voltage divisor) {
     return (Per<MultUnit<A, B>, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<MultUnit<A, B>, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mult.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mult.java
@@ -71,9 +71,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Per.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Per.java
@@ -70,6 +70,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return (Per<Dividend, Divisor>) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Per<Dividend, Divisor> divide(double divisor) {
+    return (Per<Dividend, Divisor>) div(divisor);
+  }
+
   @Override
   default Velocity<PerUnit<Dividend, Divisor>> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return (Per<PerUnit<Dividend, Divisor>, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, AngleUnit> div(Angle divisor) {
     return (Per<PerUnit<Dividend, Divisor>, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return (Per<PerUnit<Dividend, Divisor>, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<PerUnit<Dividend, Divisor>, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return (Per<PerUnit<Dividend, Divisor>, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return (Per<PerUnit<Dividend, Divisor>, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Per<Dividend, Divisor> div(Dimensionless divisor) {
     return (Per<Dividend, Divisor>) unit().of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Per<Dividend, Divisor> divide(Dimensionless divisor) {
+    return (Per<Dividend, Divisor>) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return (Per<PerUnit<Dividend, Divisor>, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, EnergyUnit> div(Energy divisor) {
     return (Per<PerUnit<Dividend, Divisor>, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return (Per<PerUnit<Dividend, Divisor>, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, FrequencyUnit> div(Frequency divisor) {
     return (Per<PerUnit<Dividend, Divisor>, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return (Per<PerUnit<Dividend, Divisor>, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<PerUnit<Dividend, Divisor>, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return (Per<PerUnit<Dividend, Divisor>, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, MassUnit> div(Mass divisor) {
     return (Per<PerUnit<Dividend, Divisor>, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return (Per<PerUnit<Dividend, Divisor>, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<PerUnit<Dividend, Divisor>, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return (Per<PerUnit<Dividend, Divisor>, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, PowerUnit> div(Power divisor) {
     return (Per<PerUnit<Dividend, Divisor>, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return (Per<PerUnit<Dividend, Divisor>, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, TemperatureUnit> div(Temperature divisor) {
     return (Per<PerUnit<Dividend, Divisor>, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<PerUnit<Dividend, Divisor>> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, TorqueUnit> div(Torque divisor) {
     return (Per<PerUnit<Dividend, Divisor>, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return (Per<PerUnit<Dividend, Divisor>, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, VoltageUnit> div(Voltage divisor) {
     return (Per<PerUnit<Dividend, Divisor>, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 default Measure<Dividend> timesDivisor(Measure<? extends Divisor> multiplier) {
   return (Measure<Dividend>) baseUnit().numerator().ofBaseUnits(baseUnitMagnitude() * multiplier.baseUnitMagnitude());

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Per.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Per.java
@@ -71,9 +71,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Power.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Power.java
@@ -71,9 +71,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -231,9 +231,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -305,9 +305,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Power extends Measure<PowerUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Power.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Power.java
@@ -70,6 +70,18 @@ public interface Power extends Measure<PowerUnit> {
     return (Power) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Power divide(double divisor) {
+    return (Power) div(divisor);
+  }
+
   @Override
   default Velocity<PowerUnit> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Power extends Measure<PowerUnit> {
     return (Per<PowerUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PowerUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, AngleUnit> div(Angle divisor) {
     return (Per<PowerUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Power extends Measure<PowerUnit> {
     return (Per<PowerUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PowerUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<PowerUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Power extends Measure<PowerUnit> {
     return (Per<PowerUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PowerUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Power extends Measure<PowerUnit> {
     return Volts.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Voltage divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Power div(Dimensionless divisor) {
     return (Power) Watts.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Power divide(Dimensionless divisor) {
+    return (Power) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Power extends Measure<PowerUnit> {
     return (Per<PowerUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PowerUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Frequency div(Energy divisor) {
     return Hertz.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Frequency divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Power extends Measure<PowerUnit> {
     return (Per<PowerUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PowerUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<PowerUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Power extends Measure<PowerUnit> {
     return (Per<PowerUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PowerUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<PowerUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Power extends Measure<PowerUnit> {
     return (Per<PowerUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PowerUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, MassUnit> div(Mass divisor) {
     return (Per<PowerUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Power extends Measure<PowerUnit> {
     return (Per<PowerUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PowerUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<PowerUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Power extends Measure<PowerUnit> {
     return (Per<PowerUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PowerUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Dimensionless div(Power divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Power extends Measure<PowerUnit> {
     return (Per<PowerUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PowerUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<PowerUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Power extends Measure<PowerUnit> {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<PowerUnit> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PowerUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, TorqueUnit> div(Torque divisor) {
     return (Per<PowerUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Power extends Measure<PowerUnit> {
     return (Per<PowerUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<PowerUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<PowerUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Current div(Voltage divisor) {
     return Amps.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Current divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Resistance.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Resistance.java
@@ -71,9 +71,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Resistance extends Measure<ResistanceUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Resistance.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Resistance.java
@@ -70,6 +70,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return (Resistance) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Resistance divide(double divisor) {
+    return (Resistance) div(divisor);
+  }
+
   @Override
   default Velocity<ResistanceUnit> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return (Per<ResistanceUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ResistanceUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, AngleUnit> div(Angle divisor) {
     return (Per<ResistanceUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return (Per<ResistanceUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ResistanceUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<ResistanceUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return (Per<ResistanceUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Voltage times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return (Per<ResistanceUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Resistance div(Dimensionless divisor) {
     return (Resistance) Ohms.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Resistance divide(Dimensionless divisor) {
+    return (Resistance) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return (Per<ResistanceUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ResistanceUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, EnergyUnit> div(Energy divisor) {
     return (Per<ResistanceUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return (Per<ResistanceUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ResistanceUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<ResistanceUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return (Per<ResistanceUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ResistanceUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<ResistanceUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return (Per<ResistanceUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ResistanceUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, MassUnit> div(Mass divisor) {
     return (Per<ResistanceUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return (Per<ResistanceUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ResistanceUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<ResistanceUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return (Per<ResistanceUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ResistanceUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, PowerUnit> div(Power divisor) {
     return (Per<ResistanceUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ResistanceUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<ResistanceUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<ResistanceUnit> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ResistanceUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, TorqueUnit> div(Torque divisor) {
     return (Per<ResistanceUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return (Per<ResistanceUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<ResistanceUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<ResistanceUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<ResistanceUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Temperature.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Temperature.java
@@ -71,9 +71,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Temperature extends Measure<TemperatureUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Temperature.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Temperature.java
@@ -70,6 +70,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return (Temperature) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Temperature divide(double divisor) {
+    return (Temperature) div(divisor);
+  }
+
   @Override
   default Velocity<TemperatureUnit> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return (Per<TemperatureUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TemperatureUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, AngleUnit> div(Angle divisor) {
     return (Per<TemperatureUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return (Per<TemperatureUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TemperatureUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<TemperatureUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return (Per<TemperatureUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TemperatureUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return (Per<TemperatureUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Temperature div(Dimensionless divisor) {
     return (Temperature) Kelvin.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Temperature divide(Dimensionless divisor) {
+    return (Temperature) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return (Per<TemperatureUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TemperatureUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, EnergyUnit> div(Energy divisor) {
     return (Per<TemperatureUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return (Per<TemperatureUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TemperatureUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<TemperatureUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return (Per<TemperatureUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TemperatureUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<TemperatureUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return (Per<TemperatureUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TemperatureUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, MassUnit> div(Mass divisor) {
     return (Per<TemperatureUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return (Per<TemperatureUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TemperatureUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<TemperatureUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return (Per<TemperatureUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TemperatureUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, PowerUnit> div(Power divisor) {
     return (Per<TemperatureUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return (Per<TemperatureUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TemperatureUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Dimensionless div(Temperature divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<TemperatureUnit> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TemperatureUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, TorqueUnit> div(Torque divisor) {
     return (Per<TemperatureUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return (Per<TemperatureUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TemperatureUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<TemperatureUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TemperatureUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Time.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Time.java
@@ -71,9 +71,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -604,9 +604,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Time extends Measure<TimeUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Time.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Time.java
@@ -70,6 +70,18 @@ public interface Time extends Measure<TimeUnit> {
     return (Time) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Time divide(double divisor) {
+    return (Time) div(divisor);
+  }
+
   @Override
   default Dimensionless per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Time extends Measure<TimeUnit> {
     return (Per<TimeUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TimeUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, AngleUnit> div(Angle divisor) {
     return (Per<TimeUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Time extends Measure<TimeUnit> {
     return (Per<TimeUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TimeUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<TimeUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Time extends Measure<TimeUnit> {
     return (Per<TimeUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TimeUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Time extends Measure<TimeUnit> {
     return (Per<TimeUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Time div(Dimensionless divisor) {
     return (Time) Seconds.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Time divide(Dimensionless divisor) {
+    return (Time) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Time extends Measure<TimeUnit> {
     return (Per<TimeUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TimeUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, EnergyUnit> div(Energy divisor) {
     return (Per<TimeUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Time extends Measure<TimeUnit> {
     return (Per<TimeUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Dimensionless times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<TimeUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Time extends Measure<TimeUnit> {
     return (Per<TimeUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TimeUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<TimeUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Time extends Measure<TimeUnit> {
     return (Per<TimeUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TimeUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, MassUnit> div(Mass divisor) {
     return (Per<TimeUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Time extends Measure<TimeUnit> {
     return (Per<TimeUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TimeUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<TimeUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Time extends Measure<TimeUnit> {
     return (Per<TimeUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TimeUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, PowerUnit> div(Power divisor) {
     return (Per<TimeUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Time extends Measure<TimeUnit> {
     return (Per<TimeUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TimeUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<TimeUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Time extends Measure<TimeUnit> {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Dimensionless divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TimeUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, TorqueUnit> div(Torque divisor) {
     return (Per<TimeUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Time extends Measure<TimeUnit> {
     return (Per<TimeUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TimeUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<TimeUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TimeUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 default Frequency asFrequency() { return Hertz.of(1 / baseUnitMagnitude()); }
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Torque.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Torque.java
@@ -70,6 +70,18 @@ public interface Torque extends Measure<TorqueUnit> {
     return (Torque) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Torque divide(double divisor) {
+    return (Torque) div(divisor);
+  }
+
   @Override
   default Velocity<TorqueUnit> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Torque extends Measure<TorqueUnit> {
     return (Per<TorqueUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TorqueUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, AngleUnit> div(Angle divisor) {
     return (Per<TorqueUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Torque extends Measure<TorqueUnit> {
     return (Per<TorqueUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TorqueUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<TorqueUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Torque extends Measure<TorqueUnit> {
     return (Per<TorqueUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TorqueUnit, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Torque extends Measure<TorqueUnit> {
     return (Per<TorqueUnit, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Torque div(Dimensionless divisor) {
     return (Torque) NewtonMeters.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Torque divide(Dimensionless divisor) {
+    return (Torque) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Torque extends Measure<TorqueUnit> {
     return Newtons.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Force divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TorqueUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, EnergyUnit> div(Energy divisor) {
     return (Per<TorqueUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Torque extends Measure<TorqueUnit> {
     return Meters.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Distance divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TorqueUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<TorqueUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Torque extends Measure<TorqueUnit> {
     return (Per<TorqueUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TorqueUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<TorqueUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Torque extends Measure<TorqueUnit> {
     return (Per<TorqueUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TorqueUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, MassUnit> div(Mass divisor) {
     return (Per<TorqueUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Torque extends Measure<TorqueUnit> {
     return (Per<TorqueUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TorqueUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<TorqueUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Torque extends Measure<TorqueUnit> {
     return (Per<TorqueUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TorqueUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, PowerUnit> div(Power divisor) {
     return (Per<TorqueUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Torque extends Measure<TorqueUnit> {
     return (Per<TorqueUnit, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TorqueUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<TorqueUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Torque extends Measure<TorqueUnit> {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<TorqueUnit> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TorqueUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Dimensionless div(Torque divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Torque extends Measure<TorqueUnit> {
     return (Per<TorqueUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<TorqueUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, VoltageUnit> div(Voltage divisor) {
     return (Per<TorqueUnit, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<TorqueUnit, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Torque.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Torque.java
@@ -71,9 +71,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -282,9 +282,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -328,9 +328,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Torque extends Measure<TorqueUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Velocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Velocity.java
@@ -71,9 +71,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -231,9 +231,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -558,9 +558,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -580,9 +580,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -603,9 +603,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -626,9 +626,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -649,9 +649,9 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Velocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Velocity.java
@@ -70,6 +70,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Velocity<D>) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Velocity<D> divide(double divisor) {
+    return (Velocity<D>) div(divisor);
+  }
+
   @Override
   default Velocity<VelocityUnit<D>> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Per<VelocityUnit<D>, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, AngleUnit> div(Angle divisor) {
     return (Per<VelocityUnit<D>, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Per<VelocityUnit<D>, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<VelocityUnit<D>, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Per<VelocityUnit<D>, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, CurrentUnit> times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Per<VelocityUnit<D>, CurrentUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, CurrentUnit> divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Velocity<D> div(Dimensionless divisor) {
     return (Velocity<D>) unit().of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Velocity<D> divide(Dimensionless divisor) {
+    return (Velocity<D>) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Per<VelocityUnit<D>, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, EnergyUnit> div(Energy divisor) {
     return (Per<VelocityUnit<D>, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Per<VelocityUnit<D>, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, FrequencyUnit> div(Frequency divisor) {
     return (Per<VelocityUnit<D>, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Per<VelocityUnit<D>, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<VelocityUnit<D>, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Per<VelocityUnit<D>, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, MassUnit> div(Mass divisor) {
     return (Per<VelocityUnit<D>, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Per<VelocityUnit<D>, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<VelocityUnit<D>, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Per<VelocityUnit<D>, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, PowerUnit> div(Power divisor) {
     return (Per<VelocityUnit<D>, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Per<VelocityUnit<D>, ResistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, ResistanceUnit> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, TemperatureUnit> times(Temperature multiplier) {
@@ -305,6 +557,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Per<VelocityUnit<D>, TemperatureUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Measure<D> times(Time multiplier) {
     return (Measure<D>) unit().numerator().ofBaseUnits(baseUnitMagnitude() * multiplier.baseUnitMagnitude());
@@ -313,6 +577,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Velocity<VelocityUnit<D>> div(Time divisor) {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<VelocityUnit<D>> divide(Time divisor) {
+    return div(divisor);
   }
 
 
@@ -326,6 +602,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Per<VelocityUnit<D>, TorqueUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, VelocityUnit<?>> times(Velocity<?> multiplier) {
@@ -337,6 +625,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Per<VelocityUnit<D>, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, VoltageUnit> times(Voltage multiplier) {
@@ -346,6 +646,18 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, VoltageUnit> div(Voltage divisor) {
     return (Per<VelocityUnit<D>, VoltageUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VelocityUnit<D>, VoltageUnit> divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Voltage.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Voltage.java
@@ -71,9 +71,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -99,9 +99,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -122,9 +122,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -145,9 +145,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -168,9 +168,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -191,9 +191,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -214,9 +214,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -231,9 +231,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -259,9 +259,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -282,9 +282,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -305,9 +305,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -328,9 +328,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -351,9 +351,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -374,9 +374,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -397,9 +397,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -420,9 +420,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -443,9 +443,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -466,9 +466,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -489,9 +489,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -512,9 +512,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -535,9 +535,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Override
   @Deprecated(since = "2025", forRemoval = true)
@@ -558,9 +558,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -581,9 +581,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -604,9 +604,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -627,9 +627,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})
@@ -650,9 +650,9 @@ public interface Voltage extends Measure<VoltageUnit> {
   }
 
   /**
-  * {@InheritDoc}
+  * {@inheritDoc}
   *
-  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
   */
   @Deprecated(since = "2025", forRemoval = true)
   @SuppressWarnings({"deprecation", "removal"})

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Voltage.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Voltage.java
@@ -70,6 +70,18 @@ public interface Voltage extends Measure<VoltageUnit> {
     return (Voltage) unit().ofBaseUnits(baseUnitMagnitude() / divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Voltage divide(double divisor) {
+    return (Voltage) div(divisor);
+  }
+
   @Override
   default Velocity<VoltageUnit> per(TimeUnit period) {
     return div(period.of(1));
@@ -86,6 +98,18 @@ public interface Voltage extends Measure<VoltageUnit> {
     return (Per<VoltageUnit, AccelerationUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VoltageUnit, AngleUnit> times(Angle multiplier) {
@@ -95,6 +119,18 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, AngleUnit> div(Angle divisor) {
     return (Per<VoltageUnit, AngleUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, AngleUnit> divide(Angle divisor) {
+    return div(divisor);
   }
 
 
@@ -108,6 +144,18 @@ public interface Voltage extends Measure<VoltageUnit> {
     return (Per<VoltageUnit, AngularAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VoltageUnit, AngularMomentumUnit> times(AngularMomentum multiplier) {
@@ -117,6 +165,18 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, AngularMomentumUnit> div(AngularMomentum divisor) {
     return (Per<VoltageUnit, AngularMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, AngularMomentumUnit> divide(AngularMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -130,6 +190,18 @@ public interface Voltage extends Measure<VoltageUnit> {
     return (Per<VoltageUnit, AngularVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, AngularVelocityUnit> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Power times(Current multiplier) {
@@ -141,9 +213,33 @@ public interface Voltage extends Measure<VoltageUnit> {
     return Ohms.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Resistance divide(Current divisor) {
+    return div(divisor);
+  }
+
   @Override
   default Voltage div(Dimensionless divisor) {
     return (Voltage) Volts.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Voltage divide(Dimensionless divisor) {
+    return (Voltage) div(divisor);
   }
 
   @Override
@@ -162,6 +258,18 @@ public interface Voltage extends Measure<VoltageUnit> {
     return (Per<VoltageUnit, DistanceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, DistanceUnit> divide(Distance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VoltageUnit, EnergyUnit> times(Energy multiplier) {
@@ -171,6 +279,18 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, EnergyUnit> div(Energy divisor) {
     return (Per<VoltageUnit, EnergyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, EnergyUnit> divide(Energy divisor) {
+    return div(divisor);
   }
 
 
@@ -184,6 +304,18 @@ public interface Voltage extends Measure<VoltageUnit> {
     return (Per<VoltageUnit, ForceUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, ForceUnit> divide(Force divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VoltageUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -193,6 +325,18 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, FrequencyUnit> div(Frequency divisor) {
     return (Per<VoltageUnit, FrequencyUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, FrequencyUnit> divide(Frequency divisor) {
+    return div(divisor);
   }
 
 
@@ -206,6 +350,18 @@ public interface Voltage extends Measure<VoltageUnit> {
     return (Per<VoltageUnit, LinearAccelerationUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, LinearAccelerationUnit> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VoltageUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -215,6 +371,18 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, LinearMomentumUnit> div(LinearMomentum divisor) {
     return (Per<VoltageUnit, LinearMomentumUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
+    return div(divisor);
   }
 
 
@@ -228,6 +396,18 @@ public interface Voltage extends Measure<VoltageUnit> {
     return (Per<VoltageUnit, LinearVelocityUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, LinearVelocityUnit> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VoltageUnit, MassUnit> times(Mass multiplier) {
@@ -237,6 +417,18 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, MassUnit> div(Mass divisor) {
     return (Per<VoltageUnit, MassUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, MassUnit> divide(Mass divisor) {
+    return div(divisor);
   }
 
 
@@ -250,6 +442,18 @@ public interface Voltage extends Measure<VoltageUnit> {
     return (Per<VoltageUnit, MomentOfInertiaUnit>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, MomentOfInertiaUnit> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VoltageUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -259,6 +463,18 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, MultUnit<?, ?>> div(Mult<?, ?> divisor) {
     return (Per<VoltageUnit, MultUnit<?, ?>>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
+    return div(divisor);
   }
 
 
@@ -272,6 +488,18 @@ public interface Voltage extends Measure<VoltageUnit> {
     return (Per<VoltageUnit, PerUnit<?, ?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, PerUnit<?, ?>> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VoltageUnit, PowerUnit> times(Power multiplier) {
@@ -281,6 +509,18 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, PowerUnit> div(Power divisor) {
     return (Per<VoltageUnit, PowerUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, PowerUnit> divide(Power divisor) {
+    return div(divisor);
   }
 
 
@@ -294,6 +534,18 @@ public interface Voltage extends Measure<VoltageUnit> {
     return Amps.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Override
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  default Current divide(Resistance divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VoltageUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -303,6 +555,18 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, TemperatureUnit> div(Temperature divisor) {
     return (Per<VoltageUnit, TemperatureUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, TemperatureUnit> divide(Temperature divisor) {
+    return div(divisor);
   }
 
 
@@ -316,6 +580,18 @@ public interface Voltage extends Measure<VoltageUnit> {
     return VelocityUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitMagnitude() / divisor.baseUnitMagnitude());
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Velocity<VoltageUnit> divide(Time divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VoltageUnit, TorqueUnit> times(Torque multiplier) {
@@ -325,6 +601,18 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, TorqueUnit> div(Torque divisor) {
     return (Per<VoltageUnit, TorqueUnit>) Measure.super.div(divisor);
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, TorqueUnit> divide(Torque divisor) {
+    return div(divisor);
   }
 
 
@@ -338,6 +626,18 @@ public interface Voltage extends Measure<VoltageUnit> {
     return (Per<VoltageUnit, VelocityUnit<?>>) Measure.super.div(divisor);
   }
 
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Per<VoltageUnit, VelocityUnit<?>> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
 
   @Override
   default Mult<VoltageUnit, VoltageUnit> times(Voltage multiplier) {
@@ -347,6 +647,18 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Dimensionless div(Voltage divisor) {
     return Value.of(baseUnitMagnitude() / divisor.baseUnitMagnitude());
+  }
+
+  /**
+  * {@InheritDoc}
+  *
+  * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+  */
+  @Deprecated(since = "2025", forRemoval = true)
+  @SuppressWarnings({"deprecation", "removal"})
+  @Override
+  default Dimensionless divide(Voltage divisor) {
+    return div(divisor);
   }
 
 }

--- a/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
@@ -1022,6 +1022,341 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
   }
 
   /**
+   * Divides this measure by a unitless scalar and returns the result.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<U> divide(double divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a dimensionless scalar and returns the result.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<U> divide(Dimensionless divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measurement by another measure and performs some dimensional analysis to reduce
+   * the units.
+   *
+   * @param divisor the unit to divide by
+   * @return the resulting measure
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Measure<?> divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a generic acceleration and returns the result in the most appropriate
+   * unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Acceleration<?> divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by an angle and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Angle divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by an angular acceleration and returns the result in the most appropriate
+   * unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(AngularAcceleration divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by an angular momentum and returns the result in the most appropriate
+   * unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(AngularMomentum divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by an angular velocity and returns the result in the most appropriate
+   * unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(AngularVelocity divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by an electric current and returns the result in the most appropriate
+   * unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Current divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a distance and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Distance divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by an energy and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Energy divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a force and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Force divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a frequency and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Frequency divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a linear acceleration and returns the result in the most appropriate
+   * unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(LinearAcceleration divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a linear momentum and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(LinearMomentum divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a linear velocity and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(LinearVelocity divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a mass and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Mass divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a moment of inertia and returns the result in the most appropriate
+   * unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(MomentOfInertia divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a generic multiplication and returns the result in the most appropriate
+   * unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Mult<?, ?> divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a power and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Power divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a generic ratio and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Per<?, ?> divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a temperature and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Temperature divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a time and returns the result in the most appropriate unit. This will
+   * often - but not always - result in a {@link Per} type like {@link LinearVelocity} or {@link
+   * Acceleration}.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Time divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a torque and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Torque divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a generic velocity and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Velocity<?> divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a voltage and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Voltage divisor) {
+    return div(divisor);
+  }
+
+  /**
+   * Divides this measure by a resistance and returns the result in the most appropriate unit.
+   *
+   * @param divisor the measurement to divide by.
+   * @return the division result
+   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   */
+  @Deprecated(since = "2025", forRemoval = true)
+  default Measure<?> divide(Resistance divisor) {
+    return div(divisor);
+  }
+
+  /**
    * Divides this measure by a ratio in terms of this measurement's unit to another unit, returning
    * a measurement in terms of the other unit.
    *

--- a/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
@@ -152,7 +152,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    * equivalent to -10 Kelvin, and <i>not</i> -10° Celsius.
    *
    * @return a measure equal to zero minus this measure
-   * @deprecated use unaryMinus() instead. This was renamed for consistancy with other WPILib
+   * @deprecated use unaryMinus() instead. This was renamed for consistency with other WPILib
    *     classes like Rotation2d
    */
   @Deprecated(since = "2025", forRemoval = true)
@@ -1026,7 +1026,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<U> divide(double divisor) {
@@ -1038,7 +1038,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<U> divide(Dimensionless divisor) {
@@ -1051,7 +1051,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the unit to divide by
    * @return the resulting measure
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Measure<?> divisor) {
@@ -1064,7 +1064,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Acceleration<?> divisor) {
@@ -1076,7 +1076,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Angle divisor) {
@@ -1089,7 +1089,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(AngularAcceleration divisor) {
@@ -1102,7 +1102,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(AngularMomentum divisor) {
@@ -1115,7 +1115,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(AngularVelocity divisor) {
@@ -1128,7 +1128,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Current divisor) {
@@ -1140,7 +1140,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Distance divisor) {
@@ -1152,7 +1152,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Energy divisor) {
@@ -1164,7 +1164,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Force divisor) {
@@ -1176,7 +1176,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Frequency divisor) {
@@ -1189,7 +1189,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(LinearAcceleration divisor) {
@@ -1201,7 +1201,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(LinearMomentum divisor) {
@@ -1213,7 +1213,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(LinearVelocity divisor) {
@@ -1225,7 +1225,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Mass divisor) {
@@ -1238,7 +1238,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(MomentOfInertia divisor) {
@@ -1251,7 +1251,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Mult<?, ?> divisor) {
@@ -1263,7 +1263,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Power divisor) {
@@ -1275,7 +1275,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Per<?, ?> divisor) {
@@ -1287,7 +1287,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Temperature divisor) {
@@ -1301,7 +1301,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Time divisor) {
@@ -1313,7 +1313,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Torque divisor) {
@@ -1325,7 +1325,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Velocity<?> divisor) {
@@ -1337,7 +1337,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Voltage divisor) {
@@ -1349,7 +1349,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *
    * @param divisor the measurement to divide by.
    * @return the division result
-   * @deprecated use div instead. This was renamed for consistancy with other languages like Kotlin
+   * @deprecated use div instead. This was renamed for consistency with other languages like Kotlin
    */
   @Deprecated(since = "2025", forRemoval = true)
   default Measure<?> divide(Resistance divisor) {


### PR DESCRIPTION
It was changed to div in #7387, but 2024 used divide.