### PR TITLE
[epilogue] Fix epilogue generating incorrect packages for inner classes

### DIFF
--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/StringUtils.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/StringUtils.java
@@ -126,7 +126,7 @@ public final class StringUtils {
     if (config.name().isEmpty()) {
       className = String.join("$", nesting);
     } else {
-      className = config.name();
+      className = capitalize(config.name()).replaceAll(" ", "");
     }
 
     return packageName + "." + className + "Logger";

--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/StringUtils.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/StringUtils.java
@@ -5,9 +5,13 @@
 package edu.wpi.first.epilogue.processor;
 
 import edu.wpi.first.epilogue.Logged;
+import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 
 public final class StringUtils {
@@ -108,34 +112,24 @@ public final class StringUtils {
    */
   public static String loggerClassName(TypeElement clazz) {
     var config = clazz.getAnnotation(Logged.class);
-    var className = clazz.getQualifiedName().toString();
 
-    String packageName;
-    int lastDot = className.lastIndexOf('.');
-    if (lastDot <= 0) {
-      packageName = null;
+    Deque<String> nesting = new ArrayDeque<>();
+    Element enclosing = clazz.getEnclosingElement();
+    while (!(enclosing instanceof PackageElement p)) {
+      nesting.addFirst(enclosing.getSimpleName().toString());
+      enclosing = enclosing.getEnclosingElement();
+    }
+    nesting.addLast(clazz.getSimpleName().toString());
+    String packageName = p.getQualifiedName().toString();
+
+    String className;
+    if (config.name().isEmpty()) {
+      className = String.join("$", nesting);
     } else {
-      packageName = className.substring(0, lastDot);
+      className = config.name();
     }
 
-    String loggerClassName;
-
-    // Use the name on the class config to set the generated logger names
-    // This helps to avoid naming conflicts
-    if (config.name().isBlank()) {
-      loggerClassName = className + "Logger";
-    } else {
-      String cleaned = config.name().replaceAll(" ", "");
-
-      var loggerSimpleClassName = StringUtils.capitalize(cleaned) + "Logger";
-      if (packageName != null) {
-        loggerClassName = packageName + "." + loggerSimpleClassName;
-      } else {
-        loggerClassName = loggerSimpleClassName;
-      }
-    }
-
-    return loggerClassName;
+    return packageName + "." + className + "Logger";
   }
 
   /**

--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
@@ -1259,7 +1259,7 @@ class AnnotationProcessorTest {
         package edu.wpi.first.epilogue;
 
         class Outer {
-          @Logged(name = "CustomExample") // For the sake of testing, needs "Example" somewhere in the name
+          @Logged(name = "Custom Example") // For the sake of testing, needs "Example" somewhere in the name
           class Example {
             double x;
           }

--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
@@ -1167,6 +1167,132 @@ class AnnotationProcessorTest {
   }
 
   @Test
+  void innerClasses() {
+    String source =
+        """
+        package edu.wpi.first.epilogue;
+
+        class Outer {
+          @Logged
+          class Example { // Deliberately nonstatic
+            double x;
+          }
+        }
+        """;
+
+    String expectedRootLogger =
+        """
+        package edu.wpi.first.epilogue;
+
+        import edu.wpi.first.epilogue.Logged;
+        import edu.wpi.first.epilogue.Epilogue;
+        import edu.wpi.first.epilogue.logging.ClassSpecificLogger;
+        import edu.wpi.first.epilogue.logging.DataLogger;
+
+        public class Outer$ExampleLogger extends ClassSpecificLogger<Outer.Example> {
+          public Outer$ExampleLogger() {
+            super(Outer.Example.class);
+          }
+
+          @Override
+          public void update(DataLogger dataLogger, Outer.Example object) {
+            if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
+              dataLogger.log("x", object.x);
+            }
+          }
+        }
+        """;
+
+    assertLoggerGenerates(source, expectedRootLogger);
+  }
+
+  @Test
+  void highlyNestedInnerClasses() {
+    String source =
+        """
+        package edu.wpi.first.epilogue;
+
+        class A {
+          class B {
+            class C {
+              class D {
+                @Logged
+                class Example {
+                  double x;
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    String expectedRootLogger =
+        """
+        package edu.wpi.first.epilogue;
+
+        import edu.wpi.first.epilogue.Logged;
+        import edu.wpi.first.epilogue.Epilogue;
+        import edu.wpi.first.epilogue.logging.ClassSpecificLogger;
+        import edu.wpi.first.epilogue.logging.DataLogger;
+
+        public class A$B$C$D$ExampleLogger extends ClassSpecificLogger<A.B.C.D.Example> {
+          public A$B$C$D$ExampleLogger() {
+            super(A.B.C.D.Example.class);
+          }
+
+          @Override
+          public void update(DataLogger dataLogger, A.B.C.D.Example object) {
+            if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
+              dataLogger.log("x", object.x);
+            }
+          }
+        }
+        """;
+
+    assertLoggerGenerates(source, expectedRootLogger);
+  }
+
+  @Test
+  void renamedInnerClass() {
+    String source =
+        """
+        package edu.wpi.first.epilogue;
+
+        class Outer {
+          @Logged(name = "CustomExample") // For the sake of testing, needs "Example" somewhere in the name
+          class Example {
+            double x;
+          }
+        }
+        """;
+
+    String expectedRootLogger =
+        """
+        package edu.wpi.first.epilogue;
+
+        import edu.wpi.first.epilogue.Logged;
+        import edu.wpi.first.epilogue.Epilogue;
+        import edu.wpi.first.epilogue.logging.ClassSpecificLogger;
+        import edu.wpi.first.epilogue.logging.DataLogger;
+
+        public class CustomExampleLogger extends ClassSpecificLogger<Outer.Example> {
+          public CustomExampleLogger() {
+            super(Outer.Example.class);
+          }
+
+          @Override
+          public void update(DataLogger dataLogger, Outer.Example object) {
+            if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
+              dataLogger.log("x", object.x);
+            }
+          }
+        }
+        """;
+
+    assertLoggerGenerates(source, expectedRootLogger);
+  }
+
+  @Test
   void diamondInheritance() {
     String source =
         """


### PR DESCRIPTION
```java
package foo;

class Outer {
  @Logged
  static class Inner {}
}
```

would attempt to generate a `foo/Outer/InnerLogger.java` file, where the `Outer` package name in the generated output would conflict with the `Outer` _class_ name in the user source

This fixes the issue by generating files like`foo/Outer$InnerLogger.java`

Resolves https://github.com/wpilibsuite/2025Beta/issues/54