### PR TITLE
[struct] Update StructSerializable contract (NFC)

### DIFF
--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/StructSerializable.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/StructSerializable.java
@@ -10,6 +10,7 @@ import edu.wpi.first.util.WPISerializable;
  * Marker interface to indicate a class is serializable using Struct serialization.
  *
  * <p>While this cannot be enforced by the interface, any class implementing this interface should
- * provide a public final static `struct` member variable.
+ * provide a public final static `struct` member variable, or a static final `getProto()` method if
+ * the class is generic.
  */
 public interface StructSerializable extends WPISerializable {}


### PR DESCRIPTION
I missed this in #5953, which updated  `ProtobufSerializable` to allow a static method instead of a static variable for templated types but forgot to do the same for `StructSerializable` when templated struct support was added to the PR.