### PR TITLE
[wpimath] fix to acceleration getter for DCMotorSim

### DIFF
--- a/wpilibc/src/main/native/cpp/simulation/DCMotorSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/DCMotorSim.cpp
@@ -52,7 +52,7 @@ units::radians_per_second_t DCMotorSim::GetAngularVelocity() const {
 
 units::radians_per_second_squared_t DCMotorSim::GetAngularAcceleration() const {
   return units::radians_per_second_squared_t{
-      (m_plant.A() * m_x + m_plant.B() * m_u)(0, 0)};
+      (m_plant.A() * m_x + m_plant.B() * m_u)(1, 0)};
 }
 
 units::newton_meter_t DCMotorSim::GetTorque() const {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
@@ -184,7 +184,7 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
    */
   public double getAngularAccelerationRadPerSecSq() {
     var acceleration = (m_plant.getA().times(m_x)).plus(m_plant.getB().times(m_u));
-    return acceleration.get(0, 0);
+    return acceleration.get(1, 0);
   }
 
   /**


### PR DESCRIPTION
The matrix variable was extracting the wrong row. It should be row index 1 and was row index 0.

Fixes #7448.