### PR TITLE
[epilogue] Allow custom loggers for generic types

### DIFF
--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/AnnotationProcessor.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/AnnotationProcessor.java
@@ -86,7 +86,7 @@ public class AnnotationProcessor extends AbstractProcessor {
                   .getMessager()
                   .printMessage(
                       Diagnostic.Kind.ERROR,
-                      "Custom logger classes should have a @CustomLoggerFor annotation",
+                      "[EPILOGUE] Custom logger classes should have a @CustomLoggerFor annotation",
                       e);
             });
 
@@ -284,7 +284,7 @@ public class AnnotationProcessor extends AbstractProcessor {
             .getMessager()
             .printMessage(
                 Diagnostic.Kind.ERROR,
-                "Logger classes must have a public no-argument constructor",
+                "[EPILOGUE] Logger classes must have a public no-argument constructor",
                 annotatedElement);
         continue;
       }
@@ -306,7 +306,7 @@ public class AnnotationProcessor extends AbstractProcessor {
               .getMessager()
               .printMessage(
                   Diagnostic.Kind.ERROR,
-                  "Multiple custom loggers detected for type " + targetType,
+                  "[EPILOGUE] Multiple custom loggers detected for type " + targetType,
                   annotatedElement);
           continue;
         }
@@ -328,7 +328,7 @@ public class AnnotationProcessor extends AbstractProcessor {
               .getMessager()
               .printMessage(
                   Diagnostic.Kind.ERROR,
-                  "Not a subclass of ClassSpecificLogger<" + targetType + ">",
+                  "[EPILOGUE] Not a subclass of ClassSpecificLogger<" + targetType + ">",
                   annotatedElement);
           continue;
         }
@@ -378,7 +378,7 @@ public class AnnotationProcessor extends AbstractProcessor {
             .getMessager()
             .printMessage(
                 Diagnostic.Kind.ERROR,
-                "Could not write logger file for " + clazz.getQualifiedName(),
+                "[EPILOGUE] Could not write logger file for " + clazz.getQualifiedName(),
                 clazz);
         e.printStackTrace(System.err);
       }

--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/AnnotationProcessor.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/AnnotationProcessor.java
@@ -311,6 +311,16 @@ public class AnnotationProcessor extends AbstractProcessor {
           continue;
         }
 
+        if (annotatedElement instanceof TypeElement t && !t.getTypeParameters().isEmpty()) {
+          processingEnv
+              .getMessager()
+              .printMessage(
+                  Diagnostic.Kind.ERROR,
+                  "[EPILOGUE] Custom logger classes cannot take generic type arguments",
+                  annotatedElement);
+          continue;
+        }
+
         if (!processingEnv
             .getTypeUtils()
             .isAssignable(annotatedElement.asType(), requiredSuperClass)) {

--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/ConfiguredLoggerHandler.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/ConfiguredLoggerHandler.java
@@ -22,13 +22,22 @@ public class ConfiguredLoggerHandler extends ElementHandler {
 
   @Override
   public boolean isLoggable(Element element) {
-    return m_customLoggers.containsKey(dataType(element));
+    return m_customLoggers.keySet().stream()
+        .anyMatch(m -> m_processingEnv.getTypeUtils().isAssignable(dataType(element), m));
   }
 
   @Override
   public String logInvocation(Element element) {
     var dataType = dataType(element);
-    var loggerType = m_customLoggers.get(dataType);
+    var loggerType =
+        m_customLoggers.entrySet().stream()
+            .filter(
+                e -> {
+                  return m_processingEnv.getTypeUtils().isAssignable(dataType, e.getKey());
+                })
+            .findFirst()
+            .orElseThrow()
+            .getValue();
 
     return "Epilogue."
         + StringUtils.lowerCamelCase(loggerType.asElement().getSimpleName())


### PR DESCRIPTION
This allows for custom loggers to be defined for generic types such as `Vector<?>`, and improves error messaging for generic logger types