### PR TITLE
Change Power Distribution Usage Reporting to Instances

### DIFF
--- a/hal/src/generate/Instances.txt
+++ b/hal/src/generate/Instances.txt
@@ -75,3 +75,6 @@ kLoggingFramework_Epilogue = 2
 kLoggingFramework_Monologue = 3
 kLoggingFramework_AdvantageKit = 4
 kLoggingFramework_DogLog = 5
+kPDP_CTRE = 1
+kPDP_REV = 2
+kPDP_Unknown = 3

--- a/hal/src/generated/main/java/edu/wpi/first/hal/FRCNetComm.java
+++ b/hal/src/generated/main/java/edu/wpi/first/hal/FRCNetComm.java
@@ -421,6 +421,12 @@ public final class FRCNetComm {
     public static final int kLoggingFramework_AdvantageKit = 4;
     /** kLoggingFramework_DogLog = 5. */
     public static final int kLoggingFramework_DogLog = 5;
+    /** kPDP_CTRE = 1. */
+    public static final int kPDP_CTRE = 1;
+    /** kPDP_REV = 2. */
+    public static final int kPDP_REV = 2;
+    /** kPDP_Unknown = 3. */
+    public static final int kPDP_Unknown = 3;
   }
 
   /** Utility class. */

--- a/hal/src/generated/main/native/include/hal/FRCUsageReporting.h
+++ b/hal/src/generated/main/native/include/hal/FRCUsageReporting.h
@@ -249,6 +249,9 @@ namespace HALUsageReporting {
     kLoggingFramework_Monologue = 3,
     kLoggingFramework_AdvantageKit = 4,
     kLoggingFramework_DogLog = 5,
+    kPDP_CTRE = 1,
+    kPDP_REV = 2,
+    kPDP_Unknown = 3,
   };
 }
 #endif

--- a/hal/src/generated/main/native/include/hal/UsageReporting.h
+++ b/hal/src/generated/main/native/include/hal/UsageReporting.h
@@ -222,6 +222,9 @@ typedef enum
     kLoggingFramework_Monologue = 3,
     kLoggingFramework_AdvantageKit = 4,
     kLoggingFramework_DogLog = 5,
+    kPDP_CTRE = 1,
+    kPDP_REV = 2,
+    kPDP_Unknown = 3,
 } tInstances;
 
 /**

--- a/wpilibc/src/main/native/cpp/PowerDistribution.cpp
+++ b/wpilibc/src/main/native/cpp/PowerDistribution.cpp
@@ -39,7 +39,14 @@ PowerDistribution::PowerDistribution() {
   m_module = HAL_GetPowerDistributionModuleNumber(m_handle, &status);
   FRC_ReportError(status, "Module {}", m_module);
 
-  HAL_Report(HALUsageReporting::kResourceType_PDP, m_module + 1);
+  if (HAL_GetPowerDistributionType(m_handle, &status) ==
+      HAL_PowerDistributionType::HAL_PowerDistributionType_kCTRE) {
+    HAL_Report(HALUsageReporting::kResourceType_PDP,
+               HALUsageReporting::kPDP_CTRE);
+  } else {
+    HAL_Report(HALUsageReporting::kResourceType_PDP,
+               HALUsageReporting::kPDP_REV);
+  }
   wpi::SendableRegistry::AddLW(this, "PowerDistribution", m_module);
 }
 
@@ -54,7 +61,13 @@ PowerDistribution::PowerDistribution(int module, ModuleType moduleType) {
   m_module = HAL_GetPowerDistributionModuleNumber(m_handle, &status);
   FRC_ReportError(status, "Module {}", module);
 
-  HAL_Report(HALUsageReporting::kResourceType_PDP, m_module + 1);
+  if (moduleType == ModuleType::kCTRE) {
+    HAL_Report(HALUsageReporting::kResourceType_PDP,
+               HALUsageReporting::kPDP_CTRE);
+  } else {
+    HAL_Report(HALUsageReporting::kResourceType_PDP,
+               HALUsageReporting::kPDP_REV);
+  }
   wpi::SendableRegistry::AddLW(this, "PowerDistribution", m_module);
 }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistribution.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistribution.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.wpilibj;
 
+import edu.wpi.first.hal.FRCNetComm.tInstances;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.PowerDistributionFaults;
@@ -51,7 +52,11 @@ public class PowerDistribution implements Sendable, AutoCloseable {
     m_handle = PowerDistributionJNI.initialize(module, moduleType.value);
     m_module = PowerDistributionJNI.getModuleNumber(m_handle);
 
-    HAL.report(tResourceType.kResourceType_PDP, m_module + 1);
+    if (moduleType == ModuleType.kCTRE) {
+      HAL.report(tResourceType.kResourceType_PDP, tInstances.kPDP_CTRE);
+    } else {
+      HAL.report(tResourceType.kResourceType_PDP, tInstances.kPDP_REV);
+    }
     SendableRegistry.addLW(this, "PowerDistribution", m_module);
   }
 
@@ -65,7 +70,12 @@ public class PowerDistribution implements Sendable, AutoCloseable {
     m_handle = PowerDistributionJNI.initialize(kDefaultModule, PowerDistributionJNI.AUTOMATIC_TYPE);
     m_module = PowerDistributionJNI.getModuleNumber(m_handle);
 
-    HAL.report(tResourceType.kResourceType_PDP, m_module + 1);
+    if (PowerDistributionJNI.getType(m_handle) == PowerDistributionJNI.CTRE_TYPE) {
+      HAL.report(tResourceType.kResourceType_PDP, tInstances.kPDP_CTRE);
+    } else {
+      HAL.report(tResourceType.kResourceType_PDP, tInstances.kPDP_REV);
+    }
+
     SendableRegistry.addLW(this, "PowerDistribution", m_module);
   }
 


### PR DESCRIPTION
LabVIEW doesn't appear to report PDP. This should reduce the number of Unknowns in the parsed UsageReporting.