### PR TITLE
Switch lint task to use base ubuntu image

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -51,7 +51,7 @@ jobs:
   tidy:
     name: "clang-tidy"
     runs-on: ubuntu-22.04
-    container: wpilib/roborio-cross-ubuntu:2025-22.04
+    container: wpilib/ubuntu-base:22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The 2027 branch cannot run lint with the roborio compiler. So switch the lint task to just not use it.