### PR TITLE
Build tools with systemcore image

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build WPILib with Gradle
         uses: addnab/docker-run-action@v3
         with:
-          image: wpilib/roborio-cross-ubuntu:2025-22.04
+          image: wpilib/systemcore-cross-ubuntu:2025-22.04
           options: -v ${{ github.workspace }}:/work -w /work -e GITHUB_REF -e CI -e DISPLAY
           run: df . && rm -f semicolon_delimited_script && ./gradlew :wpilibc:publish :wpilibj:publish :wpilibNewCommands:publish :hal:publish :cameraserver:publish :ntcore:publish :cscore:publish :wpimath:publish :wpinet:publish :wpiutil:publish :apriltag:publish :wpiunits:publish :simulation:halsim_gui:publish :simulation:halsim_ds_socket:publish :fieldImages:publish :epilogue-processor:publish :epilogue-runtime:publish :thirdparty:googletest:publish -x test -x Javadoc -x doxygen --build-cache && cp -r /root/releases/maven/development /work
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Roborio targets don't build anymore in 2027.