### PR TITLE
Improved kotlin support for Commands static factory

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -52,6 +52,17 @@ public final class Commands {
   }
 
   /**
+   * Constructs a command that runs an action once and finishes.
+   *
+   * @param action the action to run
+   * @return the command
+   * @see InstantCommand
+   */
+  public static Command runOnce(Runnable action) {
+    return new InstantCommand(action);
+  }
+
+  /**
    * Constructs a command that runs an action every iteration until interrupted.
    *
    * @param action the action to run
@@ -61,6 +72,17 @@ public final class Commands {
    */
   public static Command run(Runnable action, Subsystem... requirements) {
     return new RunCommand(action, requirements);
+  }
+
+  /**
+   * Constructs a command that runs an action every iteration until interrupted.
+   *
+   * @param action the action to run
+   * @return the command
+   * @see RunCommand
+   */
+  public static Command run(Runnable action) {
+    return new RunCommand(action);
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -57,6 +57,7 @@ public final class Commands {
    * @param action the action to run
    * @return the command
    * @see InstantCommand
+   * @see Commands#runOnce(Runnable, Subsystem...)
    */
   public static Command runOnce(Runnable action) {
     return new InstantCommand(action);
@@ -80,6 +81,7 @@ public final class Commands {
    * @param action the action to run
    * @return the command
    * @see RunCommand
+   * @see Commands#run(Runnable, Subsystem...)
    */
   public static Command run(Runnable action) {
     return new RunCommand(action);


### PR DESCRIPTION
Added an overload of the runOnce and run factories within the Commands namespace that only accepts a lambda argument(without the requirements vararg at the end). Kotlin allows you to "move" lambdas outside of the function body if the lambda is the last argument within the function args, but since it recognizes the vararg as the last argument, you cannot do this for the runOnce and run factories(while being able to for the until() decorator, the waitUntil() factory, and other components such as Triggers).

Before:
```
Commands.runOnce({
     // Do something here
})
```

Now:
```
Commands.runOnce {
   // Do something here
}
```