### PR TITLE
[build] Restore Windows constexpr mutex define on wpiutil

### DIFF
--- a/wpiutil/build.gradle
+++ b/wpiutil/build.gradle
@@ -184,6 +184,12 @@ nativeUtils.exportsConfigs {
     }
 }
 
+nativeUtils.platformConfigs.each {
+    if (it.name.contains('windows')) {
+        it.cppCompiler.args.add("/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR")
+    }
+}
+
 cppHeadersZip {
     def thirdpartyIncDirs = [
         'src/main/native/thirdparty/argparse/include',


### PR DESCRIPTION
Replaces #7502 

We only need wpiutil to have the flag, as that will enable the msvc checks we added to work properly.