### PR TITLE
Fixed sendable logging in epilogue

### DIFF
--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/LogBackedSendableBuilder.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/LogBackedSendableBuilder.java
@@ -24,7 +24,8 @@ import java.util.function.Supplier;
 /** A sendable builder implementation that sends data to a {@link EpilogueBackend}. */
 @SuppressWarnings("PMD.CouplingBetweenObjects") // most methods simply delegate to the backend
 public class LogBackedSendableBuilder implements NTSendableBuilder {
-  private static final NetworkTable m_rootTable = NetworkTableInstance.getDefault().getTable("Robot");
+  private static final NetworkTable m_rootTable =
+      NetworkTableInstance.getDefault().getTable("Robot");
   private final EpilogueBackend m_backend;
   private final Collection<Runnable> m_updates = new ArrayList<>();
   private final NetworkTable m_networkTable;

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/LogBackedSendableBuilder.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/LogBackedSendableBuilder.java
@@ -24,8 +24,7 @@ import java.util.function.Supplier;
 /** A sendable builder implementation that sends data to a {@link EpilogueBackend}. */
 @SuppressWarnings("PMD.CouplingBetweenObjects") // most methods simply delegate to the backend
 public class LogBackedSendableBuilder implements NTSendableBuilder {
-  private static final NetworkTable rootTable =
-      NetworkTableInstance.getDefault().getTable("Robot");
+  private static final NetworkTable rootTable = NetworkTableInstance.getDefault().getTable("Robot");
   private final EpilogueBackend m_backend;
   private final Collection<Runnable> m_updates = new ArrayList<>();
   private final NetworkTable networkTable;
@@ -188,22 +187,22 @@ public class LogBackedSendableBuilder implements NTSendableBuilder {
   public void publishConstRaw(String key, String typeString, byte[] value) {
     m_backend.log(key, value);
   }
-  
+
   @Override
   public void setUpdateTable(Runnable func) {
     m_updates.add(func);
   }
-  
+
   @Override
   public Topic getTopic(String key) {
     return getTable().getTopic(key);
   }
-  
+
   @Override
   public NetworkTable getTable() {
     return networkTable;
   }
-  
+
   @Override
   public BackendKind getBackendKind() {
     return BackendKind.kUnknown;

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/LogBackedSendableBuilder.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/LogBackedSendableBuilder.java
@@ -24,10 +24,10 @@ import java.util.function.Supplier;
 /** A sendable builder implementation that sends data to a {@link EpilogueBackend}. */
 @SuppressWarnings("PMD.CouplingBetweenObjects") // most methods simply delegate to the backend
 public class LogBackedSendableBuilder implements NTSendableBuilder {
-  private static final NetworkTable rootTable = NetworkTableInstance.getDefault().getTable("Robot");
+  private static final NetworkTable m_rootTable = NetworkTableInstance.getDefault().getTable("Robot");
   private final EpilogueBackend m_backend;
   private final Collection<Runnable> m_updates = new ArrayList<>();
-  private final NetworkTable networkTable;
+  private final NetworkTable m_networkTable;
 
   /**
    * Creates a new sendable builder that delegates writes to an underlying backend.
@@ -37,9 +37,9 @@ public class LogBackedSendableBuilder implements NTSendableBuilder {
   public LogBackedSendableBuilder(EpilogueBackend backend) {
     this.m_backend = backend;
     if (backend instanceof NestedBackend nb) {
-      networkTable = rootTable.getSubTable(nb.getPrefix());
+      m_networkTable = m_rootTable.getSubTable(nb.getPrefix());
     } else {
-      networkTable = rootTable;
+      m_networkTable = m_rootTable;
     }
   }
 
@@ -200,7 +200,7 @@ public class LogBackedSendableBuilder implements NTSendableBuilder {
 
   @Override
   public NetworkTable getTable() {
-    return networkTable;
+    return m_networkTable;
   }
 
   @Override

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/NestedBackend.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/NestedBackend.java
@@ -37,9 +37,10 @@ public class NestedBackend implements EpilogueBackend {
   public EpilogueBackend getNested(String path) {
     return m_nestedBackends.computeIfAbsent(path, k -> new NestedBackend(k, this));
   }
-  
+
   /**
    * Gets the prefix of this nested backend.
+   *
    * @return the prefix of this nested backend
    */
   public String getPrefix() {

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/NestedBackend.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/NestedBackend.java
@@ -37,7 +37,11 @@ public class NestedBackend implements EpilogueBackend {
   public EpilogueBackend getNested(String path) {
     return m_nestedBackends.computeIfAbsent(path, k -> new NestedBackend(k, this));
   }
-
+  
+  /**
+   * Gets the prefix of this nested backend.
+   * @return the prefix of this nested backend
+   */
   public String getPrefix() {
     return m_prefix;
   }

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/NestedBackend.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/NestedBackend.java
@@ -37,7 +37,7 @@ public class NestedBackend implements EpilogueBackend {
   public EpilogueBackend getNested(String path) {
     return m_nestedBackends.computeIfAbsent(path, k -> new NestedBackend(k, this));
   }
-  
+
   public String getPrefix() {
     return m_prefix;
   }

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/NestedBackend.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/NestedBackend.java
@@ -37,6 +37,10 @@ public class NestedBackend implements EpilogueBackend {
   public EpilogueBackend getNested(String path) {
     return m_nestedBackends.computeIfAbsent(path, k -> new NestedBackend(k, this));
   }
+  
+  public String getPrefix() {
+    return m_prefix;
+  }
 
   @Override
   public void log(String identifier, int value) {


### PR DESCRIPTION
Fixed NT-only Sendables(Field2d, Mechanism2d, etc) not being logged with epilogue's @Logged annotation.