### PR TITLE
Log path inference for epilogue

### DIFF
--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/util/InferLogPath.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/util/InferLogPath.java
@@ -1,0 +1,74 @@
+package edu.wpi.first.epilogue.util;
+
+import edu.wpi.first.epilogue.Logged;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * A utility interface that allows you to infer epilogue log paths for manual logging.
+ *
+ * <h5>InferLogPath.Parser.enable(this) must be called in your Robot class first before using this
+ * interface.</h5>
+ */
+public interface InferLogPath {
+  /**
+   * Computes the appropriate epilogue log path for a manually logged field.
+   *
+   * @param logUnder the name to log under. For instance, pivot/logUnder or arm/logUnder.
+   * @return An absolute log path that follows epilogue conventions.
+   */
+  default String logPath(String logUnder) {
+    return Parser.logPathMap.getOrDefault(this, Parser.DEFAULT_NAMESPACE) + "/" + logUnder;
+  }
+
+  class Parser {
+    static final Map<Object, String> logPathMap = new WeakHashMap<>();
+    static final String DEFAULT_NAMESPACE = "UNKNOWN";
+    static boolean enabled = false;
+    
+    /**
+     * Enables log path parsing. This must be called in your robot class to use this interface.
+     *
+     * @param robotInstance The TimedRobot instance
+     */
+    public static void enable(Object robotInstance) {
+      if (enabled) return;
+      enabled = true;
+      recurseLogPaths(robotInstance, "");
+    }
+
+    private Parser() {}
+
+    static void recurseLogPaths(Object obj, String currentPath) {
+      logPathMap.put(obj, currentPath);
+      var clazz = obj.getClass();
+      for (var field : clazz.getDeclaredFields()) {
+        try {
+          if (InferLogPath.class.isAssignableFrom(field.getType())) {
+            field.setAccessible(true);
+            recurseLogPaths(field.get(obj), currentPath + "/" + computeLogName(field));
+          } else {
+            var arraySubtype = field.getType().getComponentType();
+            if (arraySubtype == null || !InferLogPath.class.isAssignableFrom(arraySubtype))
+              continue;
+            field.setAccessible(true);
+            int index = 0;
+            var name = computeLogName(field);
+            for (Object value : (Object[]) field.get(obj)) {
+              recurseLogPaths(value, currentPath + "/" + name + "/" + index);
+              index++;
+            }
+          }
+        } catch (IllegalAccessException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+
+    private static String computeLogName(Field field) {
+      Logged logAnno = field.getAnnotation(Logged.class);
+      return logAnno == null || logAnno.name().isEmpty() ? field.getName() : logAnno.name();
+    }
+  }
+}

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/util/InferLogPath.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/util/InferLogPath.java
@@ -23,9 +23,9 @@ public interface InferLogPath {
   }
 
   class Parser {
-    static final Map<Object, String> logPathMap = new WeakHashMap<>();
-    static final String DEFAULT_NAMESPACE = "UNKNOWN";
-    static boolean enabled = false;
+    private static final Map<Object, String> logPathMap = new WeakHashMap<>();
+    private static final String DEFAULT_NAMESPACE = "UNKNOWN";
+    private static boolean enabled = false;
     
     /**
      * Enables log path parsing. This must be called in your robot class to use this interface.
@@ -40,7 +40,7 @@ public interface InferLogPath {
 
     private Parser() {}
 
-    static void recurseLogPaths(Object obj, String currentPath) {
+    private static void recurseLogPaths(Object obj, String currentPath) {
       logPathMap.put(obj, currentPath);
       var clazz = obj.getClass();
       for (var field : clazz.getDeclaredFields()) {

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/util/InferLogPath.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/util/InferLogPath.java
@@ -1,3 +1,7 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package edu.wpi.first.epilogue.util;
 
 import edu.wpi.first.epilogue.Logged;
@@ -26,7 +30,7 @@ public interface InferLogPath {
     private static final Map<Object, String> logPathMap = new WeakHashMap<>();
     private static final String DEFAULT_NAMESPACE = "UNKNOWN";
     private static boolean enabled = false;
-    
+
     /**
      * Enables log path parsing. This must be called in your robot class to use this interface.
      *

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/util/InferLogPath.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/util/InferLogPath.java
@@ -26,10 +26,11 @@ public interface InferLogPath {
     return Parser.logPathMap.getOrDefault(this, Parser.DEFAULT_NAMESPACE) + "/" + logUnder;
   }
 
-  class Parser {
+  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+  final class Parser {
     private static final Map<Object, String> logPathMap = new WeakHashMap<>();
     private static final String DEFAULT_NAMESPACE = "UNKNOWN";
-    private static boolean enabled = false;
+    private static boolean enabled;
 
     /**
      * Enables log path parsing. This must be called in your robot class to use this interface.
@@ -37,7 +38,9 @@ public interface InferLogPath {
      * @param robotInstance The TimedRobot instance
      */
     public static void enable(Object robotInstance) {
-      if (enabled) return;
+      if (enabled) {
+        return;
+      }
       enabled = true;
       recurseLogPaths(robotInstance, "");
     }
@@ -54,8 +57,9 @@ public interface InferLogPath {
             recurseLogPaths(field.get(obj), currentPath + "/" + computeLogName(field));
           } else {
             var arraySubtype = field.getType().getComponentType();
-            if (arraySubtype == null || !InferLogPath.class.isAssignableFrom(arraySubtype))
+            if (arraySubtype == null || !InferLogPath.class.isAssignableFrom(arraySubtype)) {
               continue;
+            }
             field.setAccessible(true);
             int index = 0;
             var name = computeLogName(field);

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/util/InferLogPath.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/util/InferLogPath.java
@@ -4,16 +4,10 @@
 
 package edu.wpi.first.epilogue.util;
 
-import edu.wpi.first.epilogue.Logged;
-import java.lang.reflect.Field;
-import java.util.Map;
-import java.util.WeakHashMap;
-
 /**
  * A utility interface that allows you to infer epilogue log paths for manual logging.
- *
- * <h5>InferLogPath.Parser.enable(this) must be called in your Robot class first before using this
- * interface.</h5>
+ * <code>LogPathInference.enable(this);</code> must be called within the constructor of
+ * your Robot class before using this interface.
  */
 public interface InferLogPath {
   /**
@@ -23,60 +17,8 @@ public interface InferLogPath {
    * @return An absolute log path that follows epilogue conventions.
    */
   default String logPath(String logUnder) {
-    return Parser.logPathMap.getOrDefault(this, Parser.DEFAULT_NAMESPACE) + "/" + logUnder;
-  }
-
-  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
-  final class Parser {
-    private static final Map<Object, String> logPathMap = new WeakHashMap<>();
-    private static final String DEFAULT_NAMESPACE = "UNKNOWN";
-    private static boolean enabled;
-
-    /**
-     * Enables log path parsing. This must be called in your robot class to use this interface.
-     *
-     * @param robotInstance The TimedRobot instance
-     */
-    public static void enable(Object robotInstance) {
-      if (enabled) {
-        return;
-      }
-      enabled = true;
-      recurseLogPaths(robotInstance, "");
-    }
-
-    private Parser() {}
-
-    private static void recurseLogPaths(Object obj, String currentPath) {
-      logPathMap.put(obj, currentPath);
-      var clazz = obj.getClass();
-      for (var field : clazz.getDeclaredFields()) {
-        try {
-          if (InferLogPath.class.isAssignableFrom(field.getType())) {
-            field.setAccessible(true);
-            recurseLogPaths(field.get(obj), currentPath + "/" + computeLogName(field));
-          } else {
-            var arraySubtype = field.getType().getComponentType();
-            if (arraySubtype == null || !InferLogPath.class.isAssignableFrom(arraySubtype)) {
-              continue;
-            }
-            field.setAccessible(true);
-            int index = 0;
-            var name = computeLogName(field);
-            for (Object value : (Object[]) field.get(obj)) {
-              recurseLogPaths(value, currentPath + "/" + name + "/" + index);
-              index++;
-            }
-          }
-        } catch (IllegalAccessException e) {
-          throw new RuntimeException(e);
-        }
-      }
-    }
-
-    private static String computeLogName(Field field) {
-      Logged logAnno = field.getAnnotation(Logged.class);
-      return logAnno == null || logAnno.name().isEmpty() ? field.getName() : logAnno.name();
-    }
+    return LogPathInference.logPathMap.getOrDefault(this, LogPathInference.DEFAULT_NAMESPACE)
+        + "/"
+        + logUnder;
   }
 }

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/util/LogPathInference.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/util/LogPathInference.java
@@ -1,0 +1,64 @@
+package edu.wpi.first.epilogue.util;
+
+import edu.wpi.first.epilogue.Logged;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * The parser for usage of the {@link InferLogPath} interface. To start, call <code>
+ * LogPathInference.start(this);</code> in your robot class.
+ */
+@SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+public final class LogPathInference {
+  static final Map<Object, String> logPathMap = new WeakHashMap<>();
+  static final String DEFAULT_NAMESPACE = "UNKNOWN";
+  private static boolean enabled;
+
+  /**
+   * Enables log path parsing. This must be called in your robot class to use this interface.
+   *
+   * @param robotInstance The TimedRobot instance
+   */
+  public static void enable(Object robotInstance) {
+    if (enabled) {
+      return;
+    }
+    enabled = true;
+    recurseLogPaths(robotInstance, "");
+  }
+
+  private LogPathInference() {}
+
+  private static void recurseLogPaths(Object obj, String currentPath) {
+    logPathMap.put(obj, currentPath);
+    var clazz = obj.getClass();
+    for (var field : clazz.getDeclaredFields()) {
+      try {
+        if (InferLogPath.class.isAssignableFrom(field.getType())) {
+          field.setAccessible(true);
+          recurseLogPaths(field.get(obj), currentPath + "/" + computeLogName(field));
+        } else {
+          var arraySubtype = field.getType().getComponentType();
+          if (arraySubtype == null || !InferLogPath.class.isAssignableFrom(arraySubtype)) {
+            continue;
+          }
+          field.setAccessible(true);
+          int index = 0;
+          var name = computeLogName(field);
+          for (Object value : (Object[]) field.get(obj)) {
+            recurseLogPaths(value, currentPath + "/" + name + "/" + index);
+            index++;
+          }
+        }
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  private static String computeLogName(Field field) {
+    Logged logAnno = field.getAnnotation(Logged.class);
+    return logAnno == null || logAnno.name().isEmpty() ? field.getName() : logAnno.name();
+  }
+}


### PR DESCRIPTION
Adds an InferLogPath interface that allows epilogue log paths to be fetched at runtime.
This way, you can use a manual logging solution(DogLog, SmartDashboard, DataLogManager) to log under the same namespace that epilogue does.

Even though it does use reflection, the runtime cost should be relatively small(as only a subset of classes will implement the InferLogPath interface anyways).
