### PR TITLE
Record/Enum struct generation fix

### DIFF
--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/StructFetcher.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/StructFetcher.java
@@ -3,60 +3,59 @@ package edu.wpi.first.util.struct;
 import java.util.Optional;
 
 /**
- * A utility class for fetching the assigned struct of existing classes.
- * These are usually public, static, and final properties with
- * the Struct type.
+ * A utility class for fetching the assigned struct of existing classes. These are usually public,
+ * static, and final properties with the Struct type.
  */
 public final class StructFetcher {
-	private StructFetcher() {
-		throw new UnsupportedOperationException("This is a utility class!");
-	}
-	
-	/**
-	 * Returns a {@link Struct} for the given {@link StructSerializable} marked class. Due to the
-	 * non-contractual nature of the marker this can fail. If the {@code struct} field could not be
-	 * accessed for any reason, an empty {@link Optional} is returned.
-	 *
-	 * @param <T> The type of the class.
-	 * @param clazz The class object to extract the struct from.
-	 * @return An optional containing the struct if it could be extracted.
-	 */
-	@SuppressWarnings("unchecked")
-	public static <T extends StructSerializable> Optional<Struct<T>> fetchStruct(
-		Class<? extends T> clazz) {
-		try {
-			var possibleField = Optional.ofNullable(clazz.getDeclaredField("struct"));
-			return possibleField.flatMap(
-				field -> {
-					if (Struct.class.isAssignableFrom(field.getType())) {
-						try {
-							return Optional.ofNullable((Struct<T>) field.get(null));
-						} catch (IllegalAccessException e) {
-							return Optional.empty();
-						}
-					} else {
-						return Optional.empty();
-					}
-				});
-		} catch (NoSuchFieldException e) {
-			return Optional.empty();
-		}
-	}
-	
-	/**
-	 * Returns a {@link Struct} for the given class. This does not do compile time checking that the
-	 * class is a {@link StructSerializable}. Whenever possible it is reccomended to use {@link
-	 * #fetchStruct(Class)}.
-	 *
-	 * @param clazz The class object to extract the struct from.
-	 * @return An optional containing the struct if it could be extracted.
-	 */
-	@SuppressWarnings("unchecked")
-	public static Optional<Struct<?>> fetchStructDynamic(Class<?> clazz) {
-		if (StructSerializable.class.isAssignableFrom(clazz)) {
-			return fetchStruct((Class<? extends StructSerializable>) clazz).map(struct -> struct);
-		} else {
-			return Optional.empty();
-		}
-	}
+  private StructFetcher() {
+    throw new UnsupportedOperationException("This is a utility class!");
+  }
+
+  /**
+   * Returns a {@link Struct} for the given {@link StructSerializable} marked class. Due to the
+   * non-contractual nature of the marker this can fail. If the {@code struct} field could not be
+   * accessed for any reason, an empty {@link Optional} is returned.
+   *
+   * @param <T> The type of the class.
+   * @param clazz The class object to extract the struct from.
+   * @return An optional containing the struct if it could be extracted.
+   */
+  @SuppressWarnings("unchecked")
+  public static <T extends StructSerializable> Optional<Struct<T>> fetchStruct(
+      Class<? extends T> clazz) {
+    try {
+      var possibleField = Optional.ofNullable(clazz.getDeclaredField("struct"));
+      return possibleField.flatMap(
+          field -> {
+            if (Struct.class.isAssignableFrom(field.getType())) {
+              try {
+                return Optional.ofNullable((Struct<T>) field.get(null));
+              } catch (IllegalAccessException e) {
+                return Optional.empty();
+              }
+            } else {
+              return Optional.empty();
+            }
+          });
+    } catch (NoSuchFieldException e) {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Returns a {@link Struct} for the given class. This does not do compile time checking that the
+   * class is a {@link StructSerializable}. Whenever possible it is reccomended to use {@link
+   * #fetchStruct(Class)}.
+   *
+   * @param clazz The class object to extract the struct from.
+   * @return An optional containing the struct if it could be extracted.
+   */
+  @SuppressWarnings("unchecked")
+  public static Optional<Struct<?>> fetchStructDynamic(Class<?> clazz) {
+    if (StructSerializable.class.isAssignableFrom(clazz)) {
+      return fetchStruct((Class<? extends StructSerializable>) clazz).map(struct -> struct);
+    } else {
+      return Optional.empty();
+    }
+  }
 }

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/StructFetcher.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/StructFetcher.java
@@ -1,0 +1,62 @@
+package edu.wpi.first.util.struct;
+
+import java.util.Optional;
+
+/**
+ * A utility class for fetching the assigned struct of existing classes.
+ * These are usually public, static, and final properties with
+ * the Struct type.
+ */
+public final class StructFetcher {
+	private StructFetcher() {
+		throw new UnsupportedOperationException("This is a utility class!");
+	}
+	
+	/**
+	 * Returns a {@link Struct} for the given {@link StructSerializable} marked class. Due to the
+	 * non-contractual nature of the marker this can fail. If the {@code struct} field could not be
+	 * accessed for any reason, an empty {@link Optional} is returned.
+	 *
+	 * @param <T> The type of the class.
+	 * @param clazz The class object to extract the struct from.
+	 * @return An optional containing the struct if it could be extracted.
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T extends StructSerializable> Optional<Struct<T>> fetchStruct(
+		Class<? extends T> clazz) {
+		try {
+			var possibleField = Optional.ofNullable(clazz.getDeclaredField("struct"));
+			return possibleField.flatMap(
+				field -> {
+					if (Struct.class.isAssignableFrom(field.getType())) {
+						try {
+							return Optional.ofNullable((Struct<T>) field.get(null));
+						} catch (IllegalAccessException e) {
+							return Optional.empty();
+						}
+					} else {
+						return Optional.empty();
+					}
+				});
+		} catch (NoSuchFieldException e) {
+			return Optional.empty();
+		}
+	}
+	
+	/**
+	 * Returns a {@link Struct} for the given class. This does not do compile time checking that the
+	 * class is a {@link StructSerializable}. Whenever possible it is reccomended to use {@link
+	 * #fetchStruct(Class)}.
+	 *
+	 * @param clazz The class object to extract the struct from.
+	 * @return An optional containing the struct if it could be extracted.
+	 */
+	@SuppressWarnings("unchecked")
+	public static Optional<Struct<?>> fetchStructDynamic(Class<?> clazz) {
+		if (StructSerializable.class.isAssignableFrom(clazz)) {
+			return fetchStruct((Class<? extends StructSerializable>) clazz).map(struct -> struct);
+		} else {
+			return Optional.empty();
+		}
+	}
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/StructFetcher.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/StructFetcher.java
@@ -1,3 +1,7 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package edu.wpi.first.util.struct;
 
 import java.util.Optional;

--- a/wpiutil/src/test/java/edu/wpi/first/util/struct/StructGeneratorTest.java
+++ b/wpiutil/src/test/java/edu/wpi/first/util/struct/StructGeneratorTest.java
@@ -95,8 +95,7 @@ class StructGeneratorTest {
 
   @SuppressWarnings("unchecked")
   private <S extends StructSerializable> void testStructRoundTrip(S value) {
-    Struct<S> struct =
-        StructFetcher.fetchStruct((Class<S>) value.getClass()).get();
+    Struct<S> struct = StructFetcher.fetchStruct((Class<S>) value.getClass()).get();
     ByteBuffer buffer = ByteBuffer.allocate(struct.getSize());
     buffer.order(ByteOrder.LITTLE_ENDIAN);
     struct.pack(buffer, value);
@@ -108,8 +107,7 @@ class StructGeneratorTest {
 
   @SuppressWarnings("unchecked")
   private <S extends StructSerializable> void testStructDoublePack(S value) {
-    Struct<S> struct =
-        StructFetcher.fetchStruct((Class<S>) value.getClass()).get();
+    Struct<S> struct = StructFetcher.fetchStruct((Class<S>) value.getClass()).get();
     ByteBuffer buffer = ByteBuffer.allocate(struct.getSize());
     buffer.order(ByteOrder.LITTLE_ENDIAN);
     struct.pack(buffer, value);
@@ -123,8 +121,7 @@ class StructGeneratorTest {
 
   @SuppressWarnings("unchecked")
   private <S extends StructSerializable> void testStructDoubleUnpack(S value) {
-    Struct<S> struct =
-        StructFetcher.fetchStruct((Class<S>) value.getClass()).get();
+    Struct<S> struct = StructFetcher.fetchStruct((Class<S>) value.getClass()).get();
     ByteBuffer buffer = ByteBuffer.allocate(struct.getSize());
     buffer.order(ByteOrder.LITTLE_ENDIAN);
     struct.pack(buffer, value);

--- a/wpiutil/src/test/java/edu/wpi/first/util/struct/StructGeneratorTest.java
+++ b/wpiutil/src/test/java/edu/wpi/first/util/struct/StructGeneratorTest.java
@@ -4,15 +4,15 @@
 
 package edu.wpi.first.util.struct;
 
-import static edu.wpi.first.util.struct.ProceduralStructGenerator.genEnum;
-import static edu.wpi.first.util.struct.ProceduralStructGenerator.genRecord;
+import static edu.wpi.first.util.struct.StructGenerator.genEnum;
+import static edu.wpi.first.util.struct.StructGenerator.genRecord;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import org.junit.jupiter.api.Test;
 
-class ProceduralStructGeneratorTest {
+class StructGeneratorTest {
   public record CustomRecord(int int32, boolean bool, double float64, char character, short int16)
       implements StructSerializable {
     public static CustomRecord create() {
@@ -96,7 +96,7 @@ class ProceduralStructGeneratorTest {
   @SuppressWarnings("unchecked")
   private <S extends StructSerializable> void testStructRoundTrip(S value) {
     Struct<S> struct =
-        ProceduralStructGenerator.extractClassStruct((Class<S>) value.getClass()).get();
+        StructFetcher.fetchStruct((Class<S>) value.getClass()).get();
     ByteBuffer buffer = ByteBuffer.allocate(struct.getSize());
     buffer.order(ByteOrder.LITTLE_ENDIAN);
     struct.pack(buffer, value);
@@ -109,7 +109,7 @@ class ProceduralStructGeneratorTest {
   @SuppressWarnings("unchecked")
   private <S extends StructSerializable> void testStructDoublePack(S value) {
     Struct<S> struct =
-        ProceduralStructGenerator.extractClassStruct((Class<S>) value.getClass()).get();
+        StructFetcher.fetchStruct((Class<S>) value.getClass()).get();
     ByteBuffer buffer = ByteBuffer.allocate(struct.getSize());
     buffer.order(ByteOrder.LITTLE_ENDIAN);
     struct.pack(buffer, value);
@@ -124,7 +124,7 @@ class ProceduralStructGeneratorTest {
   @SuppressWarnings("unchecked")
   private <S extends StructSerializable> void testStructDoubleUnpack(S value) {
     Struct<S> struct =
-        ProceduralStructGenerator.extractClassStruct((Class<S>) value.getClass()).get();
+        StructFetcher.fetchStruct((Class<S>) value.getClass()).get();
     ByteBuffer buffer = ByteBuffer.allocate(struct.getSize());
     buffer.order(ByteOrder.LITTLE_ENDIAN);
     struct.pack(buffer, value);


### PR DESCRIPTION
ProceduralStructGenerator's genRecord and genEnum were package-private, and only extractClassStruct was made public.
However, this package private visibility rendered them unable to be used by the rest of wpilib(and advanced users). 

Here, ProceduralStructGenerator is split into 2 classes: StructGenerator(which generates structs) and StructFetcher(the new namespace for extractClassStruct). In addition, genRecord and genEnum have been made public methods.