### PR TITLE
Remove unnecessary boxing

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticHub.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticHub.java
@@ -96,8 +96,7 @@ public class PneumaticHub implements PneumaticsBase {
 
   private static DataStore getForModule(int module) {
     synchronized (m_handleLock) {
-      Integer moduleBoxed = module;
-      DataStore pcm = m_handleMap.get(moduleBoxed);
+      DataStore pcm = m_handleMap.get(module);
       if (pcm == null) {
         pcm = new DataStore(module);
       }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticsControlModule.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticsControlModule.java
@@ -47,8 +47,7 @@ public class PneumaticsControlModule implements PneumaticsBase {
 
   private static DataStore getForModule(int module) {
     synchronized (m_handleLock) {
-      Integer moduleBoxed = module;
-      DataStore pcm = m_handleMap.get(moduleBoxed);
+      DataStore pcm = m_handleMap.get(module);
       if (pcm == null) {
         pcm = new DataStore(module);
       }

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/CounterTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/CounterTest.java
@@ -26,8 +26,8 @@ public class CounterTest extends AbstractComsSetup {
   private static FakeCounterFixture counter = null;
   private static final Logger logger = Logger.getLogger(CounterTest.class.getName());
 
-  Integer m_input;
-  Integer m_output;
+  int m_input;
+  int m_output;
 
   @Override
   protected Logger getClassLogger() {
@@ -40,10 +40,7 @@ public class CounterTest extends AbstractComsSetup {
    * @param input The input Port
    * @param output The output Port
    */
-  public CounterTest(Integer input, Integer output) {
-    assert input != null;
-    assert output != null;
-
+  public CounterTest(int input, int output) {
     m_input = input;
     m_output = output;
     // System.out.println("Counter Test: Input: " + input + " Output: " +

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/DIOCrossConnectTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/DIOCrossConnectTest.java
@@ -39,7 +39,7 @@ public class DIOCrossConnectTest extends AbstractInterruptTest {
    * @param input The port for the input wire
    * @param output The port for the output wire
    */
-  public DIOCrossConnectTest(Integer input, Integer output) {
+  public DIOCrossConnectTest(int input, int output) {
     if (dio != null) {
       dio.teardown();
     }

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/PDPTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/PDPTest.java
@@ -51,7 +51,7 @@ public class PDPTest extends AbstractComsSetup {
    * @param mef Motor encoder fixture.
    * @param expectedCurrentDraw Expected current draw in Amps.
    */
-  public PDPTest(MotorEncoderFixture<?> mef, Double expectedCurrentDraw) {
+  public PDPTest(MotorEncoderFixture<?> mef, double expectedCurrentDraw) {
     logger.fine("Constructor with: " + mef.getType());
     if (me != null && !me.equals(mef)) {
       me.teardown();

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/PIDTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/PIDTest.java
@@ -41,9 +41,9 @@ public class PIDTest extends AbstractComsSetup {
   private PIDController m_controller = null;
   private static MotorEncoderFixture<?> me = null;
 
-  private final Double m_p;
-  private final Double m_i;
-  private final Double m_d;
+  private final double m_p;
+  private final double m_i;
+  private final double m_d;
 
   @Override
   protected Logger getClassLogger() {
@@ -58,7 +58,7 @@ public class PIDTest extends AbstractComsSetup {
    * @param d D gain.
    * @param mef Motor encoder fixture.
    */
-  public PIDTest(Double p, Double i, Double d, MotorEncoderFixture<?> mef) {
+  public PIDTest(double p, double i, double d, MotorEncoderFixture<?> mef) {
     logger.fine("Constructor with: " + mef.getType());
     if (PIDTest.me != null && !PIDTest.me.equals(mef)) {
       PIDTest.me.teardown();

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/fixtures/DIOCrossConnectFixture.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/fixtures/DIOCrossConnectFixture.java
@@ -37,10 +37,8 @@ public class DIOCrossConnectFixture implements ITestFixture {
    * @param input The port of the {@link DigitalInput}
    * @param output The port of the {@link DigitalOutput}
    */
-  public DIOCrossConnectFixture(Integer input, Integer output) {
-    assert input != null;
-    assert output != null;
-    assert !input.equals(output);
+  public DIOCrossConnectFixture(int input, int output) {
+    assert input != output;
     m_input = new DigitalInput(input);
     m_output = new DigitalOutput(output);
     m_allocated = true;

--- a/wpimath/src/main/java/edu/wpi/first/math/system/NumericalIntegration.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/system/NumericalIntegration.java
@@ -25,7 +25,6 @@ public final class NumericalIntegration {
    * @param dtSeconds The time over which to integrate.
    * @return the integration of dx/dt = f(x) for dt.
    */
-  @SuppressWarnings("overloads")
   public static double rk4(DoubleFunction<Double> f, double x, double dtSeconds) {
     final var h = dtSeconds;
     final var k1 = f.apply(x);
@@ -45,9 +44,8 @@ public final class NumericalIntegration {
    * @param dtSeconds The time over which to integrate.
    * @return The result of Runge Kutta integration (4th order).
    */
-  @SuppressWarnings("overloads")
   public static double rk4(
-      BiFunction<Double, Double, Double> f, double x, Double u, double dtSeconds) {
+      BiFunction<Double, Double, Double> f, double x, double u, double dtSeconds) {
     final var h = dtSeconds;
 
     final var k1 = f.apply(x, u);
@@ -69,7 +67,6 @@ public final class NumericalIntegration {
    * @param dtSeconds The time over which to integrate.
    * @return the integration of dx/dt = f(x, u) for dt.
    */
-  @SuppressWarnings("overloads")
   public static <States extends Num, Inputs extends Num> Matrix<States, N1> rk4(
       BiFunction<Matrix<States, N1>, Matrix<Inputs, N1>, Matrix<States, N1>> f,
       Matrix<States, N1> x,
@@ -94,7 +91,6 @@ public final class NumericalIntegration {
    * @param dtSeconds The time over which to integrate.
    * @return 4th order Runge-Kutta integration of dx/dt = f(x) for dt.
    */
-  @SuppressWarnings("overloads")
   public static <States extends Num> Matrix<States, N1> rk4(
       Function<Matrix<States, N1>, Matrix<States, N1>> f, Matrix<States, N1> x, double dtSeconds) {
     final var h = dtSeconds;
@@ -145,7 +141,6 @@ public final class NumericalIntegration {
    * @param dtSeconds The time over which to integrate.
    * @return the integration of dx/dt = f(x, u) for dt.
    */
-  @SuppressWarnings("overloads")
   public static <States extends Num, Inputs extends Num> Matrix<States, N1> rkdp(
       BiFunction<Matrix<States, N1>, Matrix<Inputs, N1>, Matrix<States, N1>> f,
       Matrix<States, N1> x,
@@ -166,7 +161,6 @@ public final class NumericalIntegration {
    * @param maxError The maximum acceptable truncation error. Usually a small number like 1e-6.
    * @return the integration of dx/dt = f(x, u) for dt.
    */
-  @SuppressWarnings("overloads")
   public static <States extends Num, Inputs extends Num> Matrix<States, N1> rkdp(
       BiFunction<Matrix<States, N1>, Matrix<Inputs, N1>, Matrix<States, N1>> f,
       Matrix<States, N1> x,
@@ -291,7 +285,6 @@ public final class NumericalIntegration {
    * @param maxError The maximum acceptable truncation error. Usually a small number like 1e-6.
    * @return the integration of dx/dt = f(x, u) for dt.
    */
-  @SuppressWarnings("overloads")
   public static <Rows extends Num, Cols extends Num> Matrix<Rows, Cols> rkdp(
       BiFunction<Double, Matrix<Rows, Cols>, Matrix<Rows, Cols>> f,
       double t,

--- a/wpimath/src/main/java/edu/wpi/first/math/system/NumericalIntegration.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/system/NumericalIntegration.java
@@ -8,8 +8,9 @@ import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.Num;
 import edu.wpi.first.math.numbers.N1;
 import java.util.function.BiFunction;
-import java.util.function.DoubleFunction;
-import java.util.function.Function;
+import java.util.function.DoubleBinaryOperator;
+import java.util.function.DoubleUnaryOperator;
+import java.util.function.UnaryOperator;
 
 /** Numerical integration utilities. */
 public final class NumericalIntegration {
@@ -25,12 +26,12 @@ public final class NumericalIntegration {
    * @param dtSeconds The time over which to integrate.
    * @return the integration of dx/dt = f(x) for dt.
    */
-  public static double rk4(DoubleFunction<Double> f, double x, double dtSeconds) {
+  public static double rk4(DoubleUnaryOperator f, double x, double dtSeconds) {
     final var h = dtSeconds;
-    final var k1 = f.apply(x);
-    final var k2 = f.apply(x + h * k1 * 0.5);
-    final var k3 = f.apply(x + h * k2 * 0.5);
-    final var k4 = f.apply(x + h * k3);
+    final var k1 = f.applyAsDouble(x);
+    final var k2 = f.applyAsDouble(x + h * k1 * 0.5);
+    final var k3 = f.applyAsDouble(x + h * k2 * 0.5);
+    final var k4 = f.applyAsDouble(x + h * k3);
 
     return x + h / 6.0 * (k1 + 2.0 * k2 + 2.0 * k3 + k4);
   }
@@ -44,14 +45,13 @@ public final class NumericalIntegration {
    * @param dtSeconds The time over which to integrate.
    * @return The result of Runge Kutta integration (4th order).
    */
-  public static double rk4(
-      BiFunction<Double, Double, Double> f, double x, double u, double dtSeconds) {
+  public static double rk4(DoubleBinaryOperator f, double x, double u, double dtSeconds) {
     final var h = dtSeconds;
 
-    final var k1 = f.apply(x, u);
-    final var k2 = f.apply(x + h * k1 * 0.5, u);
-    final var k3 = f.apply(x + h * k2 * 0.5, u);
-    final var k4 = f.apply(x + h * k3, u);
+    final var k1 = f.applyAsDouble(x, u);
+    final var k2 = f.applyAsDouble(x + h * k1 * 0.5, u);
+    final var k3 = f.applyAsDouble(x + h * k2 * 0.5, u);
+    final var k4 = f.applyAsDouble(x + h * k3, u);
 
     return x + h / 6.0 * (k1 + 2.0 * k2 + 2.0 * k3 + k4);
   }
@@ -92,7 +92,7 @@ public final class NumericalIntegration {
    * @return 4th order Runge-Kutta integration of dx/dt = f(x) for dt.
    */
   public static <States extends Num> Matrix<States, N1> rk4(
-      Function<Matrix<States, N1>, Matrix<States, N1>> f, Matrix<States, N1> x, double dtSeconds) {
+      UnaryOperator<Matrix<States, N1>> f, Matrix<States, N1> x, double dtSeconds) {
     final var h = dtSeconds;
 
     Matrix<States, N1> k1 = f.apply(x);

--- a/wpiutil/src/main/java/edu/wpi/first/util/EventVector.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/EventVector.java
@@ -48,7 +48,7 @@ public class EventVector {
   public void wakeup() {
     m_lock.lock();
     try {
-      for (Integer eventHandle : m_events) {
+      for (int eventHandle : m_events) {
         WPIUtilJNI.setEvent(eventHandle);
       }
     } finally {


### PR DESCRIPTION
Also remove unnecessary `@SuppressWarnings("overloads")` in NumericalIntegration.java.

I'm not sure if the unboxing will mess with the [JUnit4 Parameterized tests](https://github.com/junit-team/junit4/wiki/Parameterized-tests), since it appears to use reflection so compiling does not necessarily mean there will not be an error when running. (I can't run `./gradlew wpilibjIntegrationTests:run` locally since it couldn't `wpiHaljni` in `java.library.path`) Given the more or less abandoned status of wpilibjIntegrationTests, I suspect it will be fine to merge this in and on the off chance we actually do use wpilibjIntegrationTests again and this PR does mess with it, we'll just revert the change then.