### PR TITLE
roborioteamnumbersetter: capture exitCode from ssh_channel_get_exit_status

### DIFF
--- a/roborioteamnumbersetter/src/main/native/cpp/SshSession.cpp
+++ b/roborioteamnumbersetter/src/main/native/cpp/SshSession.cpp
@@ -146,7 +146,7 @@ std::string SshSession::ExecuteResult(std::string_view cmd, int* exitStatus) {
 #if LIBSSH_VERSION_MAJOR == 0 && LIBSSH_VERSION_MINOR >= 11
   ssh_channel_get_exit_state(channel, &exitCode, nullptr, nullptr);
 #else
-  ssh_channel_get_exit_status(channel);
+  exitCode = ssh_channel_get_exit_status(channel);
 #endif
   INFO("{} {}", exitCode, cmd);
 


### PR DESCRIPTION
This should fix https://github.com/wpilibsuite/2025Beta/issues/71. Unfortunately I don't have a way to test that it does, but it is clearly a bug and would cause the problem observed. 