### PR TITLE
Refactor MomentOfInertiaUnit constructor to use MomentOfInertiaUnit instead of PerUnit

### DIFF
--- a/wpiunits/src/main/java/edu/wpi/first/units/MomentOfInertiaUnit.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/MomentOfInertiaUnit.java
@@ -28,7 +28,7 @@ public final class MomentOfInertiaUnit extends PerUnit<AngularMomentumUnit, Angu
   }
 
   MomentOfInertiaUnit(
-      PerUnit<AngularMomentumUnit, AngularVelocityUnit> baseUnit,
+      MomentOfInertiaUnit baseUnit,
       UnaryFunction toBaseConverter,
       UnaryFunction fromBaseConverter,
       String name,


### PR DESCRIPTION
`MomentOfInertiaUnit`'s constructor uses a `PerUnit` which causes issues when trying to make new units in the `MomentOfInertia` dimension. This should fix it