### PR TITLE
[Epilogue] Backend refactoring and interface fixes

### DIFF
--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/AnnotationProcessor.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/AnnotationProcessor.java
@@ -143,12 +143,19 @@ public class AnnotationProcessor extends AbstractProcessor {
             annotatedElements.stream()
                 .filter(e -> e instanceof TypeElement)
                 .map(e -> (TypeElement) e),
-            // 2. All type elements containing a field or method with the @Logged annotation
+            // 2. All type elements containing a field or method with the @Logged annotation,
+            // or interfaces which have an implementing class with an @Logged annotation
             annotatedElements.stream()
                 .filter(e -> e instanceof VariableElement || e instanceof ExecutableElement)
                 .map(Element::getEnclosingElement)
                 .filter(e -> e instanceof TypeElement)
                 .map(e -> (TypeElement) e))
+        .flatMap(
+            e ->
+                Stream.concat(
+                    Stream.of(e),
+                    e.getInterfaces().stream()
+                        .map(i -> (TypeElement) ((DeclaredType) i).asElement())))
         .sorted(Comparator.comparing(e -> e.getSimpleName().toString()))
         .collect(
             Collectors.toCollection(LinkedHashSet::new)); // Collect to a set to avoid duplicates

--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
@@ -100,6 +100,61 @@ class AnnotationProcessorTest {
   }
 
   @Test
+  void optInInheritance() {
+    String source =
+        """
+      package edu.wpi.first.epilogue;
+
+      class Example {
+        @Logged public ABC inst = new Base2();
+      }
+
+      class Base implements ABC {
+        double x;
+      }
+
+      class Base2 implements ABC {
+        @Logged double x;
+      }
+
+      interface ABC {
+        default double a() { return 2.0; }
+      }
+    """;
+
+    String expectedGeneratedSource =
+        """
+      package edu.wpi.first.epilogue;
+
+      import edu.wpi.first.epilogue.Logged;
+      import edu.wpi.first.epilogue.Epilogue;
+      import edu.wpi.first.epilogue.logging.ClassSpecificLogger;
+      import edu.wpi.first.epilogue.logging.EpilogueBackend;
+
+      public class ExampleLogger extends ClassSpecificLogger<Example> {
+        public ExampleLogger() {
+          super(Example.class);
+        }
+
+        @Override
+        public void update(EpilogueBackend backend, Example object) {
+          if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
+            var $$inst = object.inst;
+            if ($$inst instanceof edu.wpi.first.epilogue.Base2 edu_wpi_first_epilogue_Base2) {
+              Epilogue.base2Logger.tryUpdate(backend.getNested("inst"), edu_wpi_first_epilogue_Base2, Epilogue.getConfig().errorHandler);
+            } else {
+              // Base type edu.wpi.first.epilogue.ABC
+              Epilogue.abcLogger.tryUpdate(backend.getNested("inst"), $$inst, Epilogue.getConfig().errorHandler);
+            };
+          }
+        }
+      }
+      """;
+
+    assertLoggerGenerates(source, expectedGeneratedSource);
+  }
+
+  @Test
   void optInMethods() {
     String source =
         """

--- a/epilogue-runtime/build.gradle
+++ b/epilogue-runtime/build.gradle
@@ -13,4 +13,5 @@ dependencies {
     api(project(':ntcore'))
     api(project(':wpiutil'))
     api(project(':wpiunits'))
+    api(project(':wpilibj'))
 }

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/EpilogueConfiguration.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/EpilogueConfiguration.java
@@ -5,10 +5,9 @@
 package edu.wpi.first.epilogue;
 
 import edu.wpi.first.epilogue.logging.EpilogueBackend;
-import edu.wpi.first.epilogue.logging.NTEpilogueBackend;
+import edu.wpi.first.epilogue.logging.NTBackend;
 import edu.wpi.first.epilogue.logging.errors.ErrorHandler;
 import edu.wpi.first.epilogue.logging.errors.ErrorPrinter;
-import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.units.measure.Time;
 
 /**
@@ -22,7 +21,7 @@ public class EpilogueConfiguration {
    * NetworkTables. NetworkTable data can be mirrored to a log file on disk by calling {@code
    * DataLogManager.start()} in your {@code robotInit} method.
    */
-  public EpilogueBackend backend = new NTEpilogueBackend(NetworkTableInstance.getDefault());
+  public EpilogueBackend backend = new NTBackend();
 
   /**
    * The period Epilogue will log at. By default this is the period that the robot runs at. This is

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/FileBackend.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/FileBackend.java
@@ -22,6 +22,7 @@ import edu.wpi.first.util.datalog.StringLogEntry;
 import edu.wpi.first.util.datalog.StructArrayLogEntry;
 import edu.wpi.first.util.datalog.StructLogEntry;
 import edu.wpi.first.util.struct.Struct;
+import edu.wpi.first.wpilibj.DataLogManager;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -39,6 +40,11 @@ public class FileBackend implements EpilogueBackend {
    */
   public FileBackend(DataLog dataLog) {
     this.m_dataLog = requireNonNullParam(dataLog, "dataLog", "FileBackend");
+  }
+
+  /** Creates a new file-based backend. */
+  public FileBackend() {
+    this(DataLogManager.getLog());
   }
 
   @Override

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/NTBackend.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/NTBackend.java
@@ -22,13 +22,15 @@ import edu.wpi.first.networktables.StructPublisher;
 import edu.wpi.first.util.struct.Struct;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 
 /**
  * A backend implementation that sends data over network tables. Be careful when using this, since
  * sending too much data may cause bandwidth or CPU starvation.
  */
-public class NTEpilogueBackend implements EpilogueBackend {
+public class NTBackend implements EpilogueBackend {
   private final NetworkTableInstance m_nt;
+  private BooleanSupplier m_enabledSupplier;
 
   private final Map<String, Publisher> m_publishers = new HashMap<>();
   private final Map<String, NestedBackend> m_nestedBackends = new HashMap<>();
@@ -38,8 +40,23 @@ public class NTEpilogueBackend implements EpilogueBackend {
    *
    * @param nt the NetworkTable instance to use to send data to
    */
-  public NTEpilogueBackend(NetworkTableInstance nt) {
+  public NTBackend(NetworkTableInstance nt) {
     this.m_nt = nt;
+  }
+
+  /** Creates a logging backend that sends information to NetworkTables. */
+  public NTBackend() {
+    this.m_nt = NetworkTableInstance.getDefault();
+  }
+
+  /**
+   * Creates a logging backend that sends information to NetworkTables.
+   *
+   * @param enabledSupplier whether to enable networktables logging
+   */
+  public NTBackend(BooleanSupplier enabledSupplier) {
+    this.m_nt = NetworkTableInstance.getDefault();
+    this.m_enabledSupplier = enabledSupplier;
   }
 
   @Override
@@ -49,6 +66,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
 
   @Override
   public void log(String identifier, int value) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     ((IntegerPublisher)
             m_publishers.computeIfAbsent(identifier, k -> m_nt.getIntegerTopic(k).publish()))
         .set(value);
@@ -56,6 +76,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
 
   @Override
   public void log(String identifier, long value) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     ((IntegerPublisher)
             m_publishers.computeIfAbsent(identifier, k -> m_nt.getIntegerTopic(k).publish()))
         .set(value);
@@ -63,6 +86,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
 
   @Override
   public void log(String identifier, float value) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     ((FloatPublisher)
             m_publishers.computeIfAbsent(identifier, k -> m_nt.getFloatTopic(k).publish()))
         .set(value);
@@ -70,6 +96,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
 
   @Override
   public void log(String identifier, double value) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     ((DoublePublisher)
             m_publishers.computeIfAbsent(identifier, k -> m_nt.getDoubleTopic(k).publish()))
         .set(value);
@@ -77,6 +106,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
 
   @Override
   public void log(String identifier, boolean value) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     ((BooleanPublisher)
             m_publishers.computeIfAbsent(identifier, k -> m_nt.getBooleanTopic(k).publish()))
         .set(value);
@@ -84,6 +116,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
 
   @Override
   public void log(String identifier, byte[] value) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     ((RawPublisher)
             m_publishers.computeIfAbsent(identifier, k -> m_nt.getRawTopic(k).publish("raw")))
         .set(value);
@@ -92,6 +127,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
   @Override
   @SuppressWarnings("PMD.UnnecessaryCastRule")
   public void log(String identifier, int[] value) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     // NT backend only supports int64[], so we have to manually widen to 64 bits before sending
     long[] widened = new long[value.length];
 
@@ -106,6 +144,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
 
   @Override
   public void log(String identifier, long[] value) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     ((IntegerArrayPublisher)
             m_publishers.computeIfAbsent(identifier, k -> m_nt.getIntegerArrayTopic(k).publish()))
         .set(value);
@@ -113,6 +154,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
 
   @Override
   public void log(String identifier, float[] value) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     ((FloatArrayPublisher)
             m_publishers.computeIfAbsent(identifier, k -> m_nt.getFloatArrayTopic(k).publish()))
         .set(value);
@@ -120,6 +164,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
 
   @Override
   public void log(String identifier, double[] value) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     ((DoubleArrayPublisher)
             m_publishers.computeIfAbsent(identifier, k -> m_nt.getDoubleArrayTopic(k).publish()))
         .set(value);
@@ -127,6 +174,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
 
   @Override
   public void log(String identifier, boolean[] value) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     ((BooleanArrayPublisher)
             m_publishers.computeIfAbsent(identifier, k -> m_nt.getBooleanArrayTopic(k).publish()))
         .set(value);
@@ -134,6 +184,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
 
   @Override
   public void log(String identifier, String value) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     ((StringPublisher)
             m_publishers.computeIfAbsent(identifier, k -> m_nt.getStringTopic(k).publish()))
         .set(value);
@@ -141,6 +194,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
 
   @Override
   public void log(String identifier, String[] value) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     ((StringArrayPublisher)
             m_publishers.computeIfAbsent(identifier, k -> m_nt.getStringArrayTopic(k).publish()))
         .set(value);
@@ -149,6 +205,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
   @Override
   @SuppressWarnings("unchecked")
   public <S> void log(String identifier, S value, Struct<S> struct) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     m_nt.addSchema(struct);
     ((StructPublisher<S>)
             m_publishers.computeIfAbsent(identifier, k -> m_nt.getStructTopic(k, struct).publish()))
@@ -158,6 +217,9 @@ public class NTEpilogueBackend implements EpilogueBackend {
   @Override
   @SuppressWarnings("unchecked")
   public <S> void log(String identifier, S[] value, Struct<S> struct) {
+    if (m_enabledSupplier != null && !m_enabledSupplier.getAsBoolean()) {
+      return;
+    }
     m_nt.addSchema(struct);
     ((StructArrayPublisher<S>)
             m_publishers.computeIfAbsent(


### PR DESCRIPTION
This PR fixes a couple of things:
1. Interface inheritance is fixed. Previously, interfaces without the @Logged moniker would not be logged, regardless if any implementing members had an @Logged field or method. This fixes that.
2. NTEpilogueBackend was renamed to NTBackend for clarity; in addition, a no-args constructor(that uses the default NT instance) was added, and a constructor with a BooleanSupplier enabledSupplier was added to allow the disabling of NT logging dynamically(i.e when an fms is attached).
3. FileBackend gains a no-args constructor hat uses the default DataLogManager.getLog() instance.