### PR TITLE
[cmd] Extract common trigger binding logic

### DIFF
--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
@@ -15,159 +15,117 @@ using namespace frc2;
 
 Trigger::Trigger(const Trigger& other) = default;
 
+void Trigger::AddBinding(wpi::unique_function<void(bool, bool)>&& body) {
+  m_loop->Bind([condition = m_condition, previous = m_condition(),
+                body = std::move(body)]() mutable {
+    bool current = condition();
+
+    body(previous, current);
+
+    previous = current;
+  });
+}
+
 Trigger Trigger::OnChange(Command* command) {
-  m_loop->Bind(
-      [condition = m_condition, previous = m_condition(), command]() mutable {
-        bool current = condition();
-
-        if (previous != current) {
-          command->Schedule();
-        }
-
-        previous = current;
-      });
+  AddBinding([command](bool previous, bool current) {
+    if (previous != current) {
+      command->Schedule();
+    }
+  });
   return *this;
 }
 
 Trigger Trigger::OnChange(CommandPtr&& command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
-                command = std::move(command)]() mutable {
-    bool current = condition();
-
+  AddBinding([command = std::move(command)](bool previous, bool current) {
     if (previous != current) {
       command.Schedule();
     }
-
-    previous = current;
   });
   return *this;
 }
 
 Trigger Trigger::OnTrue(Command* command) {
-  m_loop->Bind(
-      [condition = m_condition, previous = m_condition(), command]() mutable {
-        bool current = condition();
-
-        if (!previous && current) {
-          command->Schedule();
-        }
-
-        previous = current;
-      });
+  AddBinding([command](bool previous, bool current) {
+    if (!previous && current) {
+      command->Schedule();
+    }
+  });
   return *this;
 }
 
 Trigger Trigger::OnTrue(CommandPtr&& command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
-                command = std::move(command)]() mutable {
-    bool current = condition();
-
+  AddBinding([command = std::move(command)](bool previous, bool current) {
     if (!previous && current) {
       command.Schedule();
     }
-
-    previous = current;
   });
   return *this;
 }
 
 Trigger Trigger::OnFalse(Command* command) {
-  m_loop->Bind(
-      [condition = m_condition, previous = m_condition(), command]() mutable {
-        bool current = condition();
-
-        if (previous && !current) {
-          command->Schedule();
-        }
-
-        previous = current;
-      });
+  AddBinding([command](bool previous, bool current) {
+    if (previous && !current) {
+      command->Schedule();
+    }
+  });
   return *this;
 }
 
 Trigger Trigger::OnFalse(CommandPtr&& command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
-                command = std::move(command)]() mutable {
-    bool current = condition();
-
+  AddBinding([command = std::move(command)](bool previous, bool current) {
     if (previous && !current) {
       command.Schedule();
     }
-
-    previous = current;
   });
   return *this;
 }
 
 Trigger Trigger::WhileTrue(Command* command) {
-  m_loop->Bind(
-      [condition = m_condition, previous = m_condition(), command]() mutable {
-        bool current = condition();
-
-        if (!previous && current) {
-          command->Schedule();
-        } else if (previous && !current) {
-          command->Cancel();
-        }
-
-        previous = current;
-      });
+  AddBinding([command](bool previous, bool current) {
+    if (!previous && current) {
+      command->Schedule();
+    } else if (previous && !current) {
+      command->Cancel();
+    }
+  });
   return *this;
 }
 
 Trigger Trigger::WhileTrue(CommandPtr&& command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
-                command = std::move(command)]() mutable {
-    bool current = condition();
-
+  AddBinding([command = std::move(command)](bool previous, bool current) {
     if (!previous && current) {
       command.Schedule();
     } else if (previous && !current) {
       command.Cancel();
     }
-
-    previous = current;
   });
   return *this;
 }
 
 Trigger Trigger::WhileFalse(Command* command) {
-  m_loop->Bind(
-      [condition = m_condition, previous = m_condition(), command]() mutable {
-        bool current = condition();
-
-        if (previous && !current) {
-          command->Schedule();
-        } else if (!previous && current) {
-          command->Cancel();
-        }
-
-        previous = current;
-      });
+  AddBinding([command](bool previous, bool current) {
+    if (previous && !current) {
+      command->Schedule();
+    } else if (!previous && current) {
+      command->Cancel();
+    }
+  });
   return *this;
 }
 
 Trigger Trigger::WhileFalse(CommandPtr&& command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
-                command = std::move(command)]() mutable {
-    bool current = condition();
-
+  AddBinding([command = std::move(command)](bool previous, bool current) {
     if (!previous && current) {
       command.Schedule();
     } else if (previous && !current) {
       command.Cancel();
     }
-
-    previous = current;
   });
   return *this;
 }
 
 Trigger Trigger::ToggleOnTrue(Command* command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
-                command = command]() mutable {
-    bool current = condition();
-
+  AddBinding([command](bool previous, bool current) {
     if (!previous && current) {
       if (command->IsScheduled()) {
         command->Cancel();
@@ -175,17 +133,12 @@ Trigger Trigger::ToggleOnTrue(Command* command) {
         command->Schedule();
       }
     }
-
-    previous = current;
   });
   return *this;
 }
 
 Trigger Trigger::ToggleOnTrue(CommandPtr&& command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
-                command = std::move(command)]() mutable {
-    bool current = condition();
-
+  AddBinding([command = std::move(command)](bool previous, bool current) {
     if (!previous && current) {
       if (command.IsScheduled()) {
         command.Cancel();
@@ -193,17 +146,12 @@ Trigger Trigger::ToggleOnTrue(CommandPtr&& command) {
         command.Schedule();
       }
     }
-
-    previous = current;
   });
   return *this;
 }
 
 Trigger Trigger::ToggleOnFalse(Command* command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
-                command = command]() mutable {
-    bool current = condition();
-
+  AddBinding([command](bool previous, bool current) {
     if (previous && !current) {
       if (command->IsScheduled()) {
         command->Cancel();
@@ -211,17 +159,12 @@ Trigger Trigger::ToggleOnFalse(Command* command) {
         command->Schedule();
       }
     }
-
-    previous = current;
   });
   return *this;
 }
 
 Trigger Trigger::ToggleOnFalse(CommandPtr&& command) {
-  m_loop->Bind([condition = m_condition, previous = m_condition(),
-                command = std::move(command)]() mutable {
-    bool current = condition();
-
+  AddBinding([command = std::move(command)](bool previous, bool current) {
     if (previous && !current) {
       if (command.IsScheduled()) {
         command.Cancel();
@@ -229,8 +172,6 @@ Trigger Trigger::ToggleOnFalse(CommandPtr&& command) {
         command.Schedule();
       }
     }
-
-    previous = current;
   });
   return *this;
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
@@ -11,6 +11,7 @@
 #include <frc/event/EventLoop.h>
 #include <frc/filter/Debouncer.h>
 #include <units/time.h>
+#include <wpi/FunctionExtras.h>
 
 #include "frc2/command/Command.h"
 #include "frc2/command/CommandScheduler.h"
@@ -291,6 +292,13 @@ class Trigger {
   bool Get() const;
 
  private:
+  /**
+   * Adds a binding to the EventLoop.
+   *
+   * @param body The body of the binding to add.
+   */
+  void AddBinding(wpi::unique_function<void(bool, bool)>&& body);
+
   frc::EventLoop* m_loop;
   std::function<bool()> m_condition;
 };


### PR DESCRIPTION
This makes the logic clearer in the actual binding methods and will hopefully make it less annoying to make changes such as allowing control over initial edges.

Also changes Java to use previous and current to match C++.