### PR TITLE
[build] Remove statically linked JNI artifacts

### DIFF
--- a/MavenArtifacts.md
+++ b/MavenArtifacts.md
@@ -14,54 +14,27 @@ The development repository is where development releases of every commit to [mai
 ## Artifact classifiers
 We provide two base types of artifacts.
 
-The first types are Java artifacts. These are usually published as `jar` files. Usually, the actual jar file is published with no classifier. The sources are published with the `-sources` classifier, and the javadocs are published with the `-javadoc` classifier.
-
-The second types are native artifacts. These are usually published as `zip` files (except for the `JNI` artifact types, which are `jar` files. See below for information on this). The `-sources` and `-headers` classifiers contain the sources and headers respectively for the library. Each artifact also contains a classifier for each platform we publish. This platform is in the format `{os}{arch}`. The platform artifact only contains the binaries for a specific platform. In addition, we provide a `-all` classifier. This classifier combines all of the platform artifacts into a single artifact. This is useful for tools that cannot determine what version to use during builds. However, we recommend using the platform specific classifier when possible. Note that the binary artifacts never contain the headers, you always need the `-headers` classifier to get those.
-
-## Artifact Names
-
-WPILib builds four different types of artifacts.
-
-##### C++ Only Libraries
-When we publish C++ only libraries, they are published with the base artifact name as their artifact name, with a `-cpp` extension. All dependencies for the library are linked as shared libraries to the binary.
-
-
-Example:
-```
-edu.wpi.first.wpilibc:wpilibc-cpp:version:classifier@zip
-```
-
-#### Java Only Libraries
-When we publish Java only libraries, they are published with the base artifact name as their artifact name, with a `-java` extension.
+The first types are Java artifacts. These are usually published as `jar` files. Usually, the actual jar file is published with no classifier. The sources are published with the `-sources` classifier, and the javadocs are published with the `-javadoc` classifier. These artifacts are published with the base artifact name as their artifact ID, with a `-java` extension.
 
 Example:
 ```
 edu.wpi.first.wpilibj:wpilibj-java:version
 ```
 
-#### C++/Java Libraries without JNI
-For libraries that are both C++ and Java, but without a JNI component, the C++ component is published with the `basename-cpp` artifact name, and the Java component is published with the `basename-java` artifact name.
+The second types are native artifacts. These are usually published as `zip` files. The `-sources` and `-headers` classifiers contain the sources and headers respectively for the library. Each artifact also contains a classifier for each platform we publish. This platform is in the format `{os}{arch}`. The full list of supported platforms can be found in [native-utils](https://github.com/wpilibsuite/native-utils/blob/main/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java#L94). If the library is built statically, it will have `static` appended to the classifier. Additionally, if the library was built in debug mode, `debug` will be appended to the classifier. The platform artifact only contains the binaries for a specific platform. Note that the binary artifacts never contain the headers, you always need the `-headers` classifier to get those.
+
+If the library is Java and C++ and has a JNI component, the native artifact will have a shared library containing JNI entrypoints alongside the C++ shared library. This JNI shared library will have a `jni` suffix in the file name.
+
+Native artifacts are published with the base artifact name as their artifact ID, with a `-cpp` extension.
 
 Example:
 ```
-edu.wpi.first.wpiutil:wpiutil-cpp:version:classifier@zip (C++)
-edu.wpi.first.wpiutil:wpiutil-java:version (Java)
-```
-
-#### C++/Java Libraries with JNI
-For libraries that are both C++ and Java with a JNI component there are three different artifact names. For Java, the component is published as `basename-java`. For C++, the `basename-cpp` artifact contains the C++ artifacts with all dependencies linked as shared libraries to the binary. These binaries DO contain the JNI entry points. The `basename-jni` artifact contains identical C++ binaries to the `-cpp` artifact, however all of its dependencies are statically linked, and only the JNI and C entry points are exported.
-
-The `-jni` artifact should only be used in cases where you want to create a self contained Java application where the native artifacts are embedded in the jar. Note in an extraction scenario, extending off of the library is never supported, which is why the C++ entry points are not exposed. The name of the library is randomly generated during extraction. For pretty much all cases, and if you ever want to extend from a native library, you should use the `-cpp` artifacts. GradleRIO uses the `-cpp` artifacts for all platforms, even desktop, for this reason.
-
-Example:
-```
-edu.wpi.first.ntcore:ntcore-cpp:version:classifier@zip (C++)
-edu.wpi.first.ntcore:ntcore-jni:version:classifier (JNI jar library)
-edu.wpi.first.ntcore:ntcore-java:version (Java)
+edu.wpi.first.wpimath:wpimath-cpp:version:classifier@zip
+edu.wpi.first.wpimath:wpimath-cpp:version:windowsx86-64staticdebug@zip
 ```
 
 ## Provided Artifacts
-This repository provides the following artifacts. Below each artifact is its dependencies. Note if ever using the `-jni` artifacts, no dependencies are needed for native binaries.
+This repository provides the following artifacts. Below each artifact is its dependencies.
 
 For C++, if building with static dependencies, the listed order should be the link order in your linker.
 

--- a/apriltag/build.gradle
+++ b/apriltag/build.gradle
@@ -103,14 +103,8 @@ model {
                 return
             }
             it.cppCompiler.define 'WPILIB_EXPORTS'
-
-            if (it.component.name == "${nativeName}JNI") {
-                lib project: ':wpimath', library: 'wpimath', linkage: 'static'
-                lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
-            } else {
-                lib project: ':wpimath', library: 'wpimath', linkage: 'shared'
-                lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-            }
+            lib project: ':wpimath', library: 'wpimath', linkage: 'shared'
+            lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
         }
     }
     tasks {

--- a/cscore/build.gradle
+++ b/cscore/build.gradle
@@ -60,13 +60,8 @@ model {
             if (!it.buildable || !(it instanceof NativeBinarySpec)) {
                 return
             }
-            if (it.component.name == "${nativeName}JNI") {
-                lib project: ':wpinet', library: 'wpinet', linkage: 'static'
-                lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
-            } else {
-                lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
-                lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-            }
+            lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
+            lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
         }
     }
 }

--- a/ntcore/build.gradle
+++ b/ntcore/build.gradle
@@ -31,13 +31,8 @@ model {
             if (!it.buildable || !(it instanceof NativeBinarySpec)) {
                 return
             }
-            if (it.component.name == "${nativeName}JNI") {
-                lib project: ':wpinet', library: 'wpinet', linkage: 'static'
-                lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
-            } else {
-                lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
-                lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-            }
+            lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
+            lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
         }
     }
 }

--- a/shared/jni/publish.gradle
+++ b/shared/jni/publish.gradle
@@ -7,7 +7,6 @@ def baseArtifactId = nativeName
 def artifactGroupId = "edu.wpi.first.${nativeName}"
 def zipBaseName = "_GROUP_edu_wpi_first_${nativeName}_ID_${nativeName}-cpp_CLS"
 ext.zipBaseName = zipBaseName
-def jniBaseName = "_GROUP_edu_wpi_first_${nativeName}_ID_${nativeName}-jni_CLS"
 def jniCvStaticBaseName = "_GROUP_edu_wpi_first_${nativeName}_ID_${nativeName}-jnicvstatic_CLS"
 
 def licenseFile = file("$rootDir/license.md")
@@ -77,28 +76,6 @@ model {
             "${nativeName}JNIShared"
         ], zipBaseName, Zip, project, includeStandardZipFormat)
 
-        def jniTaskList = createComponentZipTasks($.components, ["${nativeName}JNI"], jniBaseName, Jar, project, { task, value ->
-            value.each { binary ->
-                if (binary.buildable) {
-                    if (binary instanceof SharedLibraryBinarySpec) {
-                        task.dependsOn binary.tasks.link
-                        def hashFile = new File(binary.sharedLibraryFile.parentFile.absolutePath, "${binary.component.baseName}.hash")
-                        task.outputs.file(hashFile)
-                        task.inputs.file(binary.sharedLibraryFile)
-                        task.from(hashFile) {
-                            into nativeUtils.getPlatformPath(binary)
-                        }
-                        task.doFirst {
-                            hashFile.text = MessageDigest.getInstance("MD5").digest(binary.sharedLibraryFile.bytes).encodeHex().toString()
-                        }
-                        task.from(binary.sharedLibraryFile) {
-                            into nativeUtils.getPlatformPath(binary)
-                        }
-                    }
-                }
-            }
-        })
-
         publications {
             cpp(MavenPublication) {
                 taskList.each {
@@ -108,15 +85,6 @@ model {
                 artifact cppSourcesZip
 
                 artifactId = "${baseArtifactId}-cpp"
-                groupId artifactGroupId
-                version wpilibVersioning.version.get()
-            }
-            jni(MavenPublication) {
-                jniTaskList.each {
-                    artifact it
-                }
-
-                artifactId = "${baseArtifactId}-jni"
                 groupId artifactGroupId
                 version wpilibVersioning.version.get()
             }

--- a/shared/jni/setupBuild.gradle
+++ b/shared/jni/setupBuild.gradle
@@ -145,53 +145,6 @@ model {
                 }
             }
         }
-        "${nativeName}JNI"(JniNativeLibrarySpec) {
-            if (project.hasProperty('setBaseName')) {
-                baseName = setBaseName + 'jni'
-            } else {
-                baseName = nativeName + 'jni'
-            }
-
-            if (project.hasProperty('skipJniSymbols')) {
-                checkSkipSymbols = skipJniSymbols
-            }
-
-            enableCheckTask !project.hasProperty('skipJniCheck')
-            javaCompileTasks << compileJava
-            jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.roborio)
-            jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.linuxarm32)
-            jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.linuxarm64)
-            sources {
-                cpp {
-                    source {
-                        srcDirs 'src/main/native/cpp'
-                        if (project.hasProperty('generatedSources')) {
-                            srcDir generatedSources
-                        }
-                        include '**/jni/**/*.cpp'
-                    }
-                    exportedHeaders {
-                        srcDir 'src/main/native/include'
-                        if (project.hasProperty('generatedHeaders')) {
-                            srcDir generatedHeaders
-                        }
-                        include '**/*.h'
-                    }
-                }
-            }
-            binaries.all {
-                if (it instanceof StaticLibraryBinarySpec) {
-                    it.buildable = false
-                    return
-                }
-                if (!project.hasProperty('noWpiutil')) {
-                    lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
-                }
-                if (project.hasProperty('jniSplitSetup')) {
-                    jniSplitSetup(it)
-                }
-            }
-        }
         // By default, a development executable will be generated. This is to help the case of
         // testing specific functionality of the library.
         "${nativeName}Dev"(NativeExecutableSpec) {


### PR DESCRIPTION
The loading framework for the `-jni` artifacts was removed in #6600, so these just don't work anymore. We can remove them to reduce the amount of space used when building and save some time as well (although the gains seem to be marginal).

Reference for CI build times and space savings: https://github.com/Gold856/allwpilib/actions/runs/12348391056