### PR TITLE
[commands] Fix C++ iterator invalidation bug

### DIFF
--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -55,14 +55,6 @@ class CommandScheduler::Impl {
   wpi::SmallVector<InterruptAction, 4> interruptActions;
   wpi::SmallVector<Action, 4> finishActions;
 
-  // Flag and queues for avoiding concurrent modification if commands are
-  // scheduled/canceled during run
-  bool inRunLoop = false;
-  wpi::SmallVector<Command*, 4> toSchedule;
-  wpi::SmallVector<Command*, 4> toCancelCommands;
-  wpi::SmallVector<std::optional<Command*>, 4> toCancelInterruptors;
-  wpi::SmallSet<Command*, 4> endingCommands;
-
   // Map of Command* -> CommandPtr for CommandPtrs transferred to the scheduler
   // via Schedule(CommandPtr&&). These are erased (destroyed) at the very end of
   // the loop cycle when the command lifecycle is complete.
@@ -118,11 +110,6 @@ frc::EventLoop* CommandScheduler::GetDefaultButtonLoop() const {
 }
 
 void CommandScheduler::Schedule(Command* command) {
-  if (m_impl->inRunLoop) {
-    m_impl->toSchedule.emplace_back(command);
-    return;
-  }
-
   RequireUngrouped(command);
 
   if (m_impl->disabled || m_impl->scheduledCommands.contains(command) ||
@@ -208,10 +195,13 @@ void CommandScheduler::Run() {
   loopCache->Poll();
   m_watchdog.AddEpoch("buttons.Run()");
 
-  m_impl->inRunLoop = true;
   bool isDisabled = frc::RobotState::IsDisabled();
   // create a new set to avoid iterator invalidation.
   for (Command* command : wpi::SmallSet(m_impl->scheduledCommands)) {
+    if (!IsScheduled(command)) {
+      continue;  // skip as the normal scheduledCommands was modified
+    }
+
     if (isDisabled && !command->RunsWhenDisabled()) {
       Cancel(command, std::nullopt);
       continue;
@@ -224,36 +214,22 @@ void CommandScheduler::Run() {
     m_watchdog.AddEpoch(command->GetName() + ".Execute()");
 
     if (command->IsFinished()) {
-      m_impl->endingCommands.insert(command);
+      m_impl->scheduledCommands.erase(command);
       command->End(false);
       for (auto&& action : m_impl->finishActions) {
         action(*command);
       }
-      m_impl->endingCommands.erase(command);
 
       for (auto&& requirement : command->GetRequirements()) {
         m_impl->requirements.erase(requirement);
       }
 
       m_watchdog.AddEpoch(command->GetName() + ".End(false)");
+
       // remove owned commands after everything else is done
       m_impl->ownedCommands.erase(command);
     }
   }
-
-  m_impl->inRunLoop = false;
-
-  for (Command* command : m_impl->toSchedule) {
-    Schedule(command);
-  }
-
-  for (size_t i = 0; i < m_impl->toCancelCommands.size(); i++) {
-    Cancel(m_impl->toCancelCommands[i], m_impl->toCancelInterruptors[i]);
-  }
-
-  m_impl->toSchedule.clear();
-  m_impl->toCancelCommands.clear();
-  m_impl->toCancelInterruptors.clear();
 
   // Add default commands for un-required registered subsystems.
   for (auto&& subsystem : m_impl->subsystems) {
@@ -346,24 +322,14 @@ void CommandScheduler::Cancel(Command* command,
   if (!m_impl) {
     return;
   }
-  if (m_impl->endingCommands.contains(command)) {
-    return;
-  }
-  if (m_impl->inRunLoop) {
-    m_impl->toCancelCommands.emplace_back(command);
-    m_impl->toCancelInterruptors.emplace_back(interruptor);
-    return;
-  }
   if (!IsScheduled(command)) {
     return;
   }
-  m_impl->endingCommands.insert(command);
+  m_impl->scheduledCommands.erase(command);
   command->End(true);
   for (auto&& action : m_impl->interruptActions) {
     action(*command, interruptor);
   }
-  m_impl->endingCommands.erase(command);
-  m_impl->scheduledCommands.erase(command);
   for (auto&& requirement : m_impl->requirements) {
     if (requirement.second == command) {
       m_impl->requirements.erase(requirement.first);

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -225,7 +225,6 @@ void CommandScheduler::Run() {
       }
 
       m_watchdog.AddEpoch(command->GetName() + ".End(false)");
-
       // remove owned commands after everything else is done
       m_impl->ownedCommands.erase(command);
     }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -210,8 +210,8 @@ void CommandScheduler::Run() {
 
   m_impl->inRunLoop = true;
   bool isDisabled = frc::RobotState::IsDisabled();
-  // Run scheduled commands, remove finished commands.
-  for (Command* command : m_impl->scheduledCommands) {
+  // create a new set to avoid iterator invalidation.
+  for (Command* command : wpi::SmallSet(m_impl->scheduledCommands)) {
     if (isDisabled && !command->RunsWhenDisabled()) {
       Cancel(command, std::nullopt);
       continue;
@@ -231,7 +231,6 @@ void CommandScheduler::Run() {
       }
       m_impl->endingCommands.erase(command);
 
-      m_impl->scheduledCommands.erase(command);
       for (auto&& requirement : command->GetRequirements()) {
         m_impl->requirements.erase(requirement);
       }
@@ -241,6 +240,7 @@ void CommandScheduler::Run() {
       m_impl->ownedCommands.erase(command);
     }
   }
+
   m_impl->inRunLoop = false;
 
   for (Command* command : m_impl->toSchedule) {

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandScheduleTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandScheduleTest.cpp
@@ -129,7 +129,8 @@ TEST_F(CommandScheduleTest, CancelNextCommand) {
   scheduler.Schedule(&command2);
   scheduler.Run();
 
-  EXPECT_EQ(*counterPtr, 1);
+  EXPECT_EQ(*counterPtr, 1)
+      << "Second command was run when it shouldn't have been";
 
   // only one of the commands should be canceled.
   EXPECT_FALSE(scheduler.IsScheduled(&command1) &&
@@ -143,6 +144,26 @@ TEST_F(CommandScheduleTest, CancelNextCommand) {
 
   scheduler.Run();
   EXPECT_EQ(*counterPtr, 2);
+}
+
+TEST_F(CommandScheduleTest, CommandKnowsWhenItEnded) {
+  CommandScheduler scheduler = GetScheduler();
+
+  frc2::FunctionalCommand* commandPtr = nullptr;
+  auto command = frc2::FunctionalCommand(
+      [] {}, [] {},
+      [&](auto isForced) {
+        EXPECT_FALSE(scheduler.IsScheduled(commandPtr))
+            << "Command shouldn't be scheduled when its end is called";
+      },
+      [] { return true; });
+  commandPtr = &command;
+
+  scheduler.Schedule(commandPtr);
+  scheduler.Run();
+  EXPECT_FALSE(scheduler.IsScheduled(commandPtr))
+      << "Command should be removed from scheduler when its isFinished() "
+         "returns true";
 }
 
 TEST_F(CommandScheduleTest, SmartDashboardCancel) {

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandScheduleTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandScheduleTest.cpp
@@ -101,45 +101,6 @@ TEST_F(CommandScheduleTest, SchedulerCancel) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(CommandScheduleTest, CancelNextCommand) {
-  CommandScheduler scheduler = GetScheduler();
-
-  frc2::RunCommand* command1Ptr = nullptr;
-  frc2::RunCommand* command2Ptr = nullptr;
-  int counter = 0;
-
-  auto command1 = frc2::RunCommand([&counter, &command2Ptr, &scheduler] {
-    scheduler.Cancel(command2Ptr);
-    counter++;
-  });
-  auto command2 = frc2::RunCommand([&counter, &command1Ptr, &scheduler] {
-    scheduler.Cancel(command1Ptr);
-    counter++;
-  });
-
-  command1Ptr = &command1;
-  command2Ptr = &command2;
-
-  scheduler.Schedule(&command1);
-  scheduler.Schedule(&command2);
-  scheduler.Run();
-
-  EXPECT_EQ(counter, 1) << "Second command was run when it shouldn't have been";
-
-  // only one of the commands should be canceled.
-  EXPECT_FALSE(scheduler.IsScheduled(&command1) &&
-               scheduler.IsScheduled(&command2))
-      << "Both commands are running when only one should be";
-  // one of the commands shouldn't be canceled because the other one is canceled
-  // first
-  EXPECT_TRUE(scheduler.IsScheduled(&command1) ||
-              scheduler.IsScheduled(&command2))
-      << "Both commands are canceled when only one should be";
-
-  scheduler.Run();
-  EXPECT_EQ(counter, 2);
-}
-
 TEST_F(CommandScheduleTest, CommandKnowsWhenItEnded) {
   CommandScheduler scheduler = GetScheduler();
 
@@ -169,7 +130,7 @@ TEST_F(CommandScheduleTest, ScheduleCommandInCommand) {
       frc2::RunCommand([&counter, &scheduler, &commandToGetScheduled] {
         scheduler.Schedule(&commandToGetScheduled);
         EXPECT_EQ(counter, 1)
-            << "Scheduled cmmand's init was not run immediately "
+            << "Scheduled command's init was not run immediately "
                "after getting scheduled";
       });
 

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandScheduleTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandScheduleTest.cpp
@@ -2,16 +2,13 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include <frc2/command/FunctionalCommand.h>
-#include <frc2/command/InstantCommand.h>
-#include <frc2/command/RunCommand.h>
-
-#include <memory>
-
 #include <frc/smartdashboard/SmartDashboard.h>
 #include <networktables/NetworkTableInstance.h>
 
 #include "CommandTestBase.h"
+#include "frc2/command/FunctionalCommand.h"
+#include "frc2/command/InstantCommand.h"
+#include "frc2/command/RunCommand.h"
 
 using namespace frc2;
 class CommandScheduleTest : public CommandTestBase {};

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandScheduleTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandScheduleTest.cpp
@@ -133,11 +133,13 @@ TEST_F(CommandScheduleTest, CancelNextCommand) {
 
   // only one of the commands should be canceled.
   EXPECT_FALSE(scheduler.IsScheduled(&command1) &&
-               scheduler.IsScheduled(&command2));
+               scheduler.IsScheduled(&command2))
+      << "Both commands are running when only one should be";
   // one of the commands shouldn't be canceled because the other one is canceled
   // first
   EXPECT_TRUE(scheduler.IsScheduled(&command1) ||
-              scheduler.IsScheduled(&command2));
+              scheduler.IsScheduled(&command2))
+      << "Both commands are canceled when only one should be";
 
   scheduler.Run();
   EXPECT_EQ(*counterPtr, 2);

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/SchedulingRecursionTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/SchedulingRecursionTest.cpp
@@ -339,6 +339,45 @@ TEST_F(SchedulingRecursionTest, CancelDefaultCommandFromEnd) {
   EXPECT_TRUE(scheduler.IsScheduled(&other));
 }
 
+TEST_F(SchedulingRecursionTest, CancelNextCommandFromCommand) {
+  CommandScheduler scheduler = GetScheduler();
+
+  frc2::RunCommand* command1Ptr = nullptr;
+  frc2::RunCommand* command2Ptr = nullptr;
+  int counter = 0;
+
+  auto command1 = frc2::RunCommand([&counter, &command2Ptr, &scheduler] {
+    scheduler.Cancel(command2Ptr);
+    counter++;
+  });
+  auto command2 = frc2::RunCommand([&counter, &command1Ptr, &scheduler] {
+    scheduler.Cancel(command1Ptr);
+    counter++;
+  });
+
+  command1Ptr = &command1;
+  command2Ptr = &command2;
+
+  scheduler.Schedule(&command1);
+  scheduler.Schedule(&command2);
+  scheduler.Run();
+
+  EXPECT_EQ(counter, 1) << "Second command was run when it shouldn't have been";
+
+  // only one of the commands should be canceled.
+  EXPECT_FALSE(scheduler.IsScheduled(&command1) &&
+               scheduler.IsScheduled(&command2))
+      << "Both commands are running when only one should be";
+  // one of the commands shouldn't be canceled because the other one is canceled
+  // first
+  EXPECT_TRUE(scheduler.IsScheduled(&command1) ||
+              scheduler.IsScheduled(&command2))
+      << "Both commands are canceled when only one should be";
+
+  scheduler.Run();
+  EXPECT_EQ(counter, 2);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     SchedulingRecursionTests, SchedulingRecursionTest,
     testing::Values(Command::InterruptionBehavior::kCancelSelf,


### PR DESCRIPTION
Because of the huge impact changing the Java `Command Scheduler` code has, this draft PR removes all the changes made to the Java side and only includes the changes made to C++ from the #6593 PR. 

This is still being [discussed in the FRC Discord server](https://discord.com/channels/176186766946992128/528555967827148801/1318255755677270056)