### PR TITLE
update thridparty protobuf since ATOMIC_VAR_INT is deprecated

### DIFF
--- a/wpiutil/src/main/native/thirdparty/protobuf/src/stubs/common.cpp
+++ b/wpiutil/src/main/native/thirdparty/protobuf/src/stubs/common.cpp
@@ -178,7 +178,7 @@ void NullLogHandler(LogLevel /* level */, const char* /* filename */,
 }
 
 static LogHandler* log_handler_ = &DefaultLogHandler;
-static std::atomic<int> log_silencer_count_ = ATOMIC_VAR_INIT(0);
+static std::atomic<int> log_silencer_count_{0};
 
 LogMessage& LogMessage::operator<<(const std::string& value) {
   message_ += value;


### PR DESCRIPTION
https://github.com/wpilibsuite/allwpilib/issues/7576