### PR TITLE
[wpiutil] DataLogWriter: Don't crash on file open error

### DIFF
--- a/wpiutil/src/main/native/cpp/DataLogWriter.cpp
+++ b/wpiutil/src/main/native/cpp/DataLogWriter.cpp
@@ -12,14 +12,22 @@
 
 using namespace wpi::log;
 
+static std::unique_ptr<wpi::raw_ostream> CheckOpen(std::string_view filename,
+                                                   std::error_code& ec) {
+  auto rv = std::make_unique<wpi::raw_fd_ostream>(filename, ec);
+  if (ec) {
+    return nullptr;
+  }
+  return rv;
+}
+
 DataLogWriter::DataLogWriter(std::string_view filename, std::error_code& ec,
                              std::string_view extraHeader)
     : DataLogWriter{s_defaultMessageLog, filename, ec, extraHeader} {}
 
 DataLogWriter::DataLogWriter(wpi::Logger& msglog, std::string_view filename,
                              std::error_code& ec, std::string_view extraHeader)
-    : DataLogWriter{msglog, std::make_unique<raw_fd_ostream>(filename, ec),
-                    extraHeader} {
+    : DataLogWriter{msglog, CheckOpen(filename, ec), extraHeader} {
   if (ec) {
     Stop();
   }


### PR DESCRIPTION
Fixes #7531.