### PR TITLE
Add methods to get name of SendableChooser's selected value.

### DIFF
--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.h
@@ -37,7 +37,7 @@ template <class T>
   requires std::copy_constructible<T> && std::default_initializable<T>
 class SendableChooser : public SendableChooserBase {
   wpi::StringMap<T> m_choices;
-  std::function<void(std::string, T)> m_listener;
+  std::function<void(std::string_view, T)> m_listener;
   template <class U>
   static U _unwrap_smart_ptr(const U& value) {
     return value;
@@ -121,7 +121,7 @@ class SendableChooser : public SendableChooserBase {
    *  
    * @return The name of the option selected
    */
-  std::string GetSelectedName() const {
+  std::string_view GetSelectedName() const {
     std::scoped_lock lock(m_mutex);
     if (m_haveSelected) {
         return m_selected;
@@ -136,7 +136,7 @@ class SendableChooser : public SendableChooserBase {
    * previous listener.
    * @param listener The function to call that accepts the new name and new value
    */
-  void OnChange(std::function<void(std::string, T)> listener) {
+  void OnChange(std::function<void(std::string_view, T)> listener) {
     std::scoped_lock lock(m_mutex);
     m_listener = listener;
   }
@@ -148,7 +148,7 @@ class SendableChooser : public SendableChooserBase {
    * @param listener The function to call that accepts the new value
    */
   void OnChange(std::function<void(T)> listener) {
-    OnChange<T>([listener](std::string, T choice) {
+    OnChange<T>([listener](std::string_view, T choice) {
       listener(choice);
     });
   }
@@ -187,7 +187,7 @@ class SendableChooser : public SendableChooserBase {
     builder.AddStringProperty(kSelected, nullptr,
                               [=, this](std::string_view val) {
                                 T choice{};
-                                std::function<void(std::string, T)> listener;
+                                std::function<void(std::string_view, T)> listener;
                                 {
                                   std::scoped_lock lock(m_mutex);
                                   m_haveSelected = true;

--- a/wpilibc/src/test/native/cpp/smartdashboard/SendableChooserTest.cpp
+++ b/wpilibc/src/test/native/cpp/smartdashboard/SendableChooserTest.cpp
@@ -45,7 +45,7 @@ TEST(SendableChooserTest, DefaultIsReturnedOnNoSelect) {
   chooser.SetDefaultOption("4", 4);
 
   EXPECT_EQ(4, chooser.GetSelected());
-  EXPECT_EQ("4",, chooser.GetSelectedName());
+  EXPECT_EQ("4", chooser.GetSelectedName());
 }
 
 TEST(SendableChooserTest,
@@ -71,7 +71,7 @@ TEST(SendableChooserTest, ChangeListener) {
 
   std::string currentName = "";
   int currentVal = 0;
-  chooser.OnChange([&](std::string name, int val) { currentName = name; currentVal = val; });
+  chooser.OnChange([&](std::string_view name, int val) { currentName = std::string(name); currentVal = val; });
 
   frc::SmartDashboard::PutData("ChangeListenerChooser", &chooser);
   frc::SmartDashboard::UpdateValues();

--- a/wpilibc/src/test/native/cpp/smartdashboard/SendableChooserTest.cpp
+++ b/wpilibc/src/test/native/cpp/smartdashboard/SendableChooserTest.cpp
@@ -31,6 +31,7 @@ TEST_P(SendableChooserTest, ReturnsSelected) {
   chooserSim.SetSelected(std::to_string(GetParam()));
   frc::SmartDashboard::UpdateValues();
   EXPECT_EQ(GetParam(), chooser.GetSelected());
+  EXPECT_EQ(std::to_string(GetParam()), chooser.GetSelectedName());
 }
 
 TEST(SendableChooserTest, DefaultIsReturnedOnNoSelect) {
@@ -44,6 +45,7 @@ TEST(SendableChooserTest, DefaultIsReturnedOnNoSelect) {
   chooser.SetDefaultOption("4", 4);
 
   EXPECT_EQ(4, chooser.GetSelected());
+  EXPECT_EQ("4",, chooser.GetSelectedName());
 }
 
 TEST(SendableChooserTest,
@@ -55,6 +57,7 @@ TEST(SendableChooserTest,
   }
 
   EXPECT_EQ(0, chooser.GetSelected());
+  EXPECT_EQ("", chooser.GetSelectedName());
 }
 
 TEST(SendableChooserTest, ChangeListener) {
@@ -65,8 +68,10 @@ TEST(SendableChooserTest, ChangeListener) {
   for (int i = 1; i <= 3; i++) {
     chooser.AddOption(std::to_string(i), i);
   }
+
+  std::string currentName = "";
   int currentVal = 0;
-  chooser.OnChange([&](int val) { currentVal = val; });
+  chooser.OnChange([&](std::string name, int val) { currentName = name; currentVal = val; });
 
   frc::SmartDashboard::PutData("ChangeListenerChooser", &chooser);
   frc::SmartDashboard::UpdateValues();
@@ -74,6 +79,7 @@ TEST(SendableChooserTest, ChangeListener) {
   frc::SmartDashboard::UpdateValues();
 
   EXPECT_EQ(3, currentVal);
+  EXPECT_EQ("3", currentName);
 }
 
 INSTANTIATE_TEST_SUITE_P(SendableChooserTests, SendableChooserTest,

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooser.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooser.java
@@ -98,22 +98,13 @@ public class SendableChooser<V> implements Sendable, AutoCloseable {
    * @return the option selected
    */
   public V getSelected() {
-    m_mutex.lock();
-    try {
-      if (m_selected != null) {
-        return m_map.get(m_selected);
-      } else {
-        return m_map.get(m_defaultChoice);
-      }
-    } finally {
-      m_mutex.unlock();
-    }
+    return m_map.get(getSelectedName());
   }
 
   /**
    * Returns the name of the selected option. If there is none selected, it will return the default.
-   * If there is none selected and no default, it will return {@code null}.
-   * 
+   * If there is none selected and no default, it will return an empty String.
+   *
    * @return the name of the option selected
    */
   public String getSelectedName() {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooserTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooserTest.java
@@ -42,6 +42,7 @@ class SendableChooserTest {
       chooserSim.setSelected(String.valueOf(toSelect));
       SmartDashboard.updateValues();
       assertEquals(toSelect, chooser.getSelected());
+      assertEquals(String.valueOf(toSelect), chooser.getSelectedName());
     }
   }
 
@@ -54,6 +55,7 @@ class SendableChooserTest {
       chooser.setDefaultOption(String.valueOf(0), 0);
 
       assertEquals(0, chooser.getSelected());
+      assertEquals(String.valueOf(0), chooser.getSelectedName());
     }
   }
 
@@ -65,6 +67,7 @@ class SendableChooserTest {
       }
 
       assertNull(chooser.getSelected());
+      assertNull(chooser.getSelectedName());
     }
   }
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooserTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooserTest.java
@@ -67,7 +67,7 @@ class SendableChooserTest {
       }
 
       assertNull(chooser.getSelected());
-      assertNull(chooser.getSelectedName());
+      assertEquals("", chooser.getSelectedName());
     }
   }
 


### PR DESCRIPTION
In some cases, such as logging, it can be useful to get the name of a SendableChooser's currently selected option. This adds:
- `getSelectedName()`/`GetSelectedName()`, to get the name of the currently selected option
- `onChange(BiConsumer<String, V>)`/`OnChange(std::function<void(std::string_view, T)> listener)` to get the name when the currently selected option changes. The original onChange methods are kept for backward compatibility.