### PR TITLE
Patch thirdparty protobuf to remove deprecated ATOMIC_VAR_INIT

### DIFF
--- a/upstream_utils/protobuf_patches/0001-Fix-sign-compare-warnings.patch
+++ b/upstream_utils/protobuf_patches/0001-Fix-sign-compare-warnings.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 10 Jun 2023 14:13:07 -0700
-Subject: [PATCH 01/13] Fix sign-compare warnings
+Subject: [PATCH 01/14] Fix sign-compare warnings
 
 ---
  src/google/protobuf/compiler/importer.cc                  | 2 +-

--- a/upstream_utils/protobuf_patches/0002-Remove-redundant-move.patch
+++ b/upstream_utils/protobuf_patches/0002-Remove-redundant-move.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 10 Jun 2023 14:41:39 -0700
-Subject: [PATCH 02/13] Remove redundant move
+Subject: [PATCH 02/14] Remove redundant move
 
 ---
  src/google/protobuf/extension_set.h | 2 +-

--- a/upstream_utils/protobuf_patches/0003-Fix-maybe-uninitialized-warnings.patch
+++ b/upstream_utils/protobuf_patches/0003-Fix-maybe-uninitialized-warnings.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 10 Jun 2023 15:00:20 -0700
-Subject: [PATCH 03/13] Fix maybe-uninitialized warnings
+Subject: [PATCH 03/14] Fix maybe-uninitialized warnings
 
 ---
  src/google/protobuf/arena.cc                     |  6 +++---

--- a/upstream_utils/protobuf_patches/0004-Fix-coded_stream-WriteRaw.patch
+++ b/upstream_utils/protobuf_patches/0004-Fix-coded_stream-WriteRaw.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 10 Jun 2023 15:03:38 -0700
-Subject: [PATCH 04/13] Fix coded_stream WriteRaw
+Subject: [PATCH 04/14] Fix coded_stream WriteRaw
 
 ---
  src/google/protobuf/implicit_weak_message.h | 2 +-

--- a/upstream_utils/protobuf_patches/0005-Suppress-enum-enum-conversion-warning.patch
+++ b/upstream_utils/protobuf_patches/0005-Suppress-enum-enum-conversion-warning.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 10 Jun 2023 15:13:45 -0700
-Subject: [PATCH 05/13] Suppress enum-enum conversion warning
+Subject: [PATCH 05/14] Suppress enum-enum conversion warning
 
 ---
  src/google/protobuf/generated_message_tctable_impl.h | 9 +++++++++

--- a/upstream_utils/protobuf_patches/0006-Fix-noreturn-function-returning.patch
+++ b/upstream_utils/protobuf_patches/0006-Fix-noreturn-function-returning.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 10 Jun 2023 15:16:46 -0700
-Subject: [PATCH 06/13] Fix noreturn function returning
+Subject: [PATCH 06/14] Fix noreturn function returning
 
 ---
  src/google/protobuf/generated_message_tctable_impl.h | 3 +++

--- a/upstream_utils/protobuf_patches/0007-Work-around-GCC-12-restrict-warning-compiler-bug.patch
+++ b/upstream_utils/protobuf_patches/0007-Work-around-GCC-12-restrict-warning-compiler-bug.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 10 Jun 2023 15:59:45 -0700
-Subject: [PATCH 07/13] Work around GCC 12 restrict warning compiler bug
+Subject: [PATCH 07/14] Work around GCC 12 restrict warning compiler bug
 
 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
 ---

--- a/upstream_utils/protobuf_patches/0008-Disable-MSVC-switch-warning.patch
+++ b/upstream_utils/protobuf_patches/0008-Disable-MSVC-switch-warning.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Tue, 13 Jun 2023 23:56:15 -0700
-Subject: [PATCH 08/13] Disable MSVC switch warning
+Subject: [PATCH 08/14] Disable MSVC switch warning
 
 ---
  src/google/protobuf/generated_message_reflection.cc | 4 ++++

--- a/upstream_utils/protobuf_patches/0009-Disable-unused-function-warning.patch
+++ b/upstream_utils/protobuf_patches/0009-Disable-unused-function-warning.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Tue, 13 Jun 2023 23:58:50 -0700
-Subject: [PATCH 09/13] Disable unused function warning
+Subject: [PATCH 09/14] Disable unused function warning
 
 ---
  src/google/protobuf/generated_message_tctable_lite.cc | 4 ++++

--- a/upstream_utils/protobuf_patches/0010-Disable-pedantic-warning.patch
+++ b/upstream_utils/protobuf_patches/0010-Disable-pedantic-warning.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Wed, 14 Jun 2023 00:02:26 -0700
-Subject: [PATCH 10/13] Disable pedantic warning
+Subject: [PATCH 10/14] Disable pedantic warning
 
 ---
  src/google/protobuf/descriptor.h                    | 8 ++++++++

--- a/upstream_utils/protobuf_patches/0011-Avoid-use-of-sprintf.patch
+++ b/upstream_utils/protobuf_patches/0011-Avoid-use-of-sprintf.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Mon, 9 Oct 2023 19:28:08 -0700
-Subject: [PATCH 11/13] Avoid use of sprintf
+Subject: [PATCH 11/14] Avoid use of sprintf
 
 ---
  src/google/protobuf/stubs/strutil.cc | 14 +++++++++++---

--- a/upstream_utils/protobuf_patches/0012-Suppress-stringop-overflow-warning-false-positives.patch
+++ b/upstream_utils/protobuf_patches/0012-Suppress-stringop-overflow-warning-false-positives.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Fri, 10 Nov 2023 14:17:53 -0800
-Subject: [PATCH 12/13] Suppress stringop-overflow warning false positives
+Subject: [PATCH 12/14] Suppress stringop-overflow warning false positives
 
 ---
  src/google/protobuf/io/coded_stream.h    | 7 +++++++

--- a/upstream_utils/protobuf_patches/0013-Switch-descriptor-to-not-use-globals-from-header-inl.patch
+++ b/upstream_utils/protobuf_patches/0013-Switch-descriptor-to-not-use-globals-from-header-inl.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Thad House <thadhouse1@gmail.com>
 Date: Sun, 18 Aug 2024 22:43:37 -0700
-Subject: [PATCH 13/13] Switch descriptor to not use globals from header inline
+Subject: [PATCH 13/14] Switch descriptor to not use globals from header inline
  functions
 
 ---

--- a/upstream_utils/protobuf_patches/0014-Remove-deprecated-ATOMIC_VAR_INIT.patch
+++ b/upstream_utils/protobuf_patches/0014-Remove-deprecated-ATOMIC_VAR_INIT.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: braykoff <99614905+Braykoff@users.noreply.github.com>
 Date: Mon, 23 Dec 2024 15:12:02 -0500
-Subject: [PATCH 14/14] Remove deprecated ATOMIC_VAR_INT
+Subject: [PATCH 14/14] Remove deprecated ATOMIC_VAR_INIT
 
 ---
  src/google/protobuf/stubs/common.cc | 2 +-

--- a/upstream_utils/protobuf_patches/0014-Remove-deprecated-ATOMIC_VAR_INT.patch
+++ b/upstream_utils/protobuf_patches/0014-Remove-deprecated-ATOMIC_VAR_INT.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: braykoff <99614905+Braykoff@users.noreply.github.com>
+Date: Mon, 23 Dec 2024 15:12:02 -0500
+Subject: [PATCH 14/14] Remove deprecated ATOMIC_VAR_INT
+
+---
+ src/google/protobuf/stubs/common.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/google/protobuf/stubs/common.cc b/src/google/protobuf/stubs/common.cc
+index 1423021b846966eb02d36c10df488f8aa0082a64..a16668a5964398c85c0268d82f652cf3c6aa668e 100644
+--- a/src/google/protobuf/stubs/common.cc
++++ b/src/google/protobuf/stubs/common.cc
+@@ -178,7 +178,7 @@ void NullLogHandler(LogLevel /* level */, const char* /* filename */,
+ }
+ 
+ static LogHandler* log_handler_ = &DefaultLogHandler;
+-static std::atomic<int> log_silencer_count_ = ATOMIC_VAR_INIT(0);
++static std::atomic<int> log_silencer_count_{0};
+ 
+ LogMessage& LogMessage::operator<<(const std::string& value) {
+   message_ += value;

--- a/wpiutil/src/main/native/thirdparty/protobuf/src/stubs/common.cpp
+++ b/wpiutil/src/main/native/thirdparty/protobuf/src/stubs/common.cpp
@@ -178,7 +178,7 @@ void NullLogHandler(LogLevel /* level */, const char* /* filename */,
 }
 
 static LogHandler* log_handler_ = &DefaultLogHandler;
-static std::atomic<int> log_silencer_count_ = ATOMIC_VAR_INIT(0);
+static std::atomic<int> log_silencer_count_{0};
 
 LogMessage& LogMessage::operator<<(const std::string& value) {
   message_ += value;


### PR DESCRIPTION
Resolves #7576 
Supersedes PR #7577 by @horner