### PR TITLE
Add back comment commands with a safer implementation

### DIFF
--- a/.github/workflows/comment-command.yml
+++ b/.github/workflows/comment-command.yml
@@ -1,0 +1,105 @@
+name: Comment Commands
+on:
+  issue_comment:
+    types: [ created ]
+
+jobs:
+  format:
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/format')
+    runs-on: ubuntu-latest
+    steps:
+      - name: React Rocket
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.issue
+            github.rest.reactions.createForIssueComment({
+              owner,
+              repo,
+              comment_id: context.payload.comment.id,
+              content: "rocket",
+            });
+      - uses: actions/checkout@v4
+          token: ${{ secrets.COMMENT_COMMAND_PAT_TOKEN }}
+      - name: Checkout PR
+        run: |
+          gh pr checkout ${{ github.event.issue.number }}
+        env:
+          GH_TOKEN: ${{ secrets.COMMENT_COMMAND_PAT_TOKEN }}
+      - name: Fetch patches
+        id: fetch-patches
+        uses: dawidd6/action-download-artifact@v7
+        with:
+          workflow: lint-format.yml
+          pr: ${{ github.event.issue.number }}
+          name: "fixes$"
+          name_is_regexp: true
+          workflow_conclusion: "failure" # Format failure -> patches available
+          if_no_artifact_found: warn
+          allow_forks: false
+      - name: Check found artifacts
+        id: check-found-artifacts
+        run: |
+          echo "found-artifacts=${{ steps.fetch-patches.outputs.artifacts &&
+            contains(fromJSON(steps.fetch-patches.outputs.artifacts).*.name, 'javaformat fixes') &&
+            contains(fromJSON(steps.fetch-patches.outputs.artifacts).*.name, 'wpiformat fixes') }}" >> "$GITHUB_OUTPUT"
+      - name: Apply patch
+        if: steps.check-found-artifacts.outputs.found-artifacts
+        run: |
+          git apply "wpiformat fixes/wpiformat-fixes.patch" --index
+          # Apply java format and prefer new changes
+          git apply "javaformat fixes/javaformat-fixes.patch" --3way --theirs
+      - name: Commit
+        if: steps.check-found-artifacts.outputs.found-artifacts
+        run: |
+          # Set credentials
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Commit
+          git commit -m "Formatting fixes"
+          git push
+
+  pregen:
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/pregen')
+    runs-on: ubuntu-latest
+    steps:
+      - name: React Rocket
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.issue
+            github.rest.reactions.createForIssueComment({
+              owner,
+              repo,
+              comment_id: context.payload.comment.id,
+              content: "rocket",
+            });
+      - uses: actions/checkout@v4
+          token: ${{ secrets.COMMENT_COMMAND_PAT_TOKEN }}
+      - name: Checkout PR
+        run: |
+          gh pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.COMMENT_COMMAND_PAT_TOKEN }}
+      - name: Fetch patches
+        id: fetch-patches
+        uses: dawidd6/action-download-artifact@v7
+        with:
+          workflow: pregenerate.yml
+          pr: ${{ github.event.issue.number }}
+          name: pregenerated-files-fixes
+          workflow_conclusion: "failure" # Pregen failure -> patches available
+          if_no_artifact_found: warn
+          allow_forks: false
+      - name: Apply patch
+        if: steps.fetch-patches.outputs.found_artifact == 'true' # need this because found_artifact seems to be a string
+        run: git apply pregenerated-files-fixes.patch --index
+      - name: Commit
+        if: steps.fetch-patches.outputs.found_artifact == 'true'
+        run: |
+          # Set credentials
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Commit
+          git commit -am "Regenerate pregenerated files"
+          git push


### PR DESCRIPTION
Instead of formatting in the workflow, it pulls the patches uploaded by the lint/pregen tasks. This does mean that those workflows have to run to completion before the formatter for the formatter to work.

Still needs to pull in buildifier. Would it be fine to move the buildifier lint in to the lint-format workflow? That would make this workflow simpler compared to pulling from multiple lint workflows.