### PR TITLE
[wpical] Add support for new Apriltags (ID 16-22)

### DIFF
--- a/wpical/src/main/native/cpp/WPIcal.cpp
+++ b/wpical/src/main/native/cpp/WPIcal.cpp
@@ -189,17 +189,10 @@ static void DisplayGui() {
   ImGui::SetNextItemWidth(ImGui::GetFontSize() * 12);
   ImGui::InputInt("Pinned Tag", &pinnedTag);
 
-  if (pinnedTag < 1) {
-    pinnedTag = 1;
-  } else if (pinnedTag > maxFRCTag) {
-    pinnedTag = maxFRCTag;
-  }
-
   // calibrate button
   if (ImGui::Button("Calibrate!!!")) {
     if (!selected_field_calibration_directory.empty() &&
-        !selected_camera_intrinsics.empty() && !selected_field_map.empty() &&
-        pinnedTag > 0 && pinnedTag <= maxFRCTag) {
+        !selected_camera_intrinsics.empty() && !selected_field_map.empty()) {
       download_directory_selector =
           std::make_unique<pfd::select_folder>("Select Download Folder", "");
       if (download_directory_selector) {
@@ -218,7 +211,7 @@ static void DisplayGui() {
           showDebug);
 
       if (calibrationOutput == 1) {
-        ImGui::OpenPopup("Fmap Conversion failed");
+        ImGui::OpenPopup("Field Calibration Error");
       } else if (calibrationOutput == 0) {
         std::ifstream caljsonpath(calibration_json_path);
         try {
@@ -229,7 +222,7 @@ static void DisplayGui() {
           ImGui::SetNextWindowSize(ImVec2(600, 400), ImGuiCond_Always);
           ImGui::OpenPopup("Visualize Calibration");
         } catch (...) {
-          ImGui::OpenPopup("Field Calibration Error");
+          ImGui::OpenPopup("Fmap Conversion Error");
         }
       }
     }
@@ -244,7 +237,9 @@ static void DisplayGui() {
         "Some inputs are empty! please enter your camera calibration video, "
         "field map, and field calibration directory");
   } else if (!(pinnedTag > 0 && pinnedTag <= maxFRCTag)) {
-    ImGui::TextWrapped("Make sure the pinned tag is a valid april tag (1-22)");
+    ImGui::TextWrapped(
+        "The pinned tag is not within the normal range for FRC fields (1-22), "
+        "If you proceed, You may experience a bad calibration.");
   } else {
     ImGui::TextWrapped("Calibration Ready");
   }
@@ -271,7 +266,7 @@ static void DisplayGui() {
     ImGui::EndPopup();
   }
 
-  if (ImGui::BeginPopupModal("Fmap Conversion failed", NULL,
+  if (ImGui::BeginPopupModal("Fmap Conversion Error", NULL,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
     ImGui::TextWrapped(
         "Fmap conversion failed - you can still use the calibration output on "
@@ -481,18 +476,6 @@ static void DisplayGui() {
     ImGui::InputInt("Focused Tag", &focusedTag);
     ImGui::SetNextItemWidth(ImGui::GetFontSize() * 12);
     ImGui::InputInt("Reference Tag", &referenceTag);
-
-    if (focusedTag < 1) {
-      focusedTag = 1;
-    } else if (focusedTag > maxFRCTag) {
-      focusedTag = maxFRCTag;
-    }
-
-    if (referenceTag < 1) {
-      referenceTag = 1;
-    } else if (referenceTag > maxFRCTag) {
-      referenceTag = maxFRCTag;
-    }
 
     if (!calibration_json_path.empty() && !selected_field_map.empty()) {
       std::ifstream calJson(calibration_json_path);

--- a/wpical/src/main/native/cpp/WPIcal.cpp
+++ b/wpical/src/main/native/cpp/WPIcal.cpp
@@ -244,7 +244,7 @@ static void DisplayGui() {
         "Some inputs are empty! please enter your camera calibration video, "
         "field map, and field calibration directory");
   } else if (!(pinnedTag > 0 && pinnedTag <= maxFRCTag)) {
-    ImGui::TextWrapped("Make sure the pinned tag is a valid april tag (1-16)");
+    ImGui::TextWrapped("Make sure the pinned tag is a valid april tag (1-22)");
   } else {
     ImGui::TextWrapped("Calibration Ready");
   }

--- a/wpical/src/main/native/cpp/WPIcal.cpp
+++ b/wpical/src/main/native/cpp/WPIcal.cpp
@@ -114,6 +114,8 @@ static void DisplayGui() {
   static int focusedTag = 1;
   static int referenceTag = 1;
 
+  static int maxFRCTag = 22;
+
   static Fieldmap currentCalibrationMap;
   static Fieldmap currentReferenceMap;
 
@@ -189,15 +191,15 @@ static void DisplayGui() {
 
   if (pinnedTag < 1) {
     pinnedTag = 1;
-  } else if (pinnedTag > 16) {
-    pinnedTag = 16;
+  } else if (pinnedTag > maxFRCTag) {
+    pinnedTag = maxFRCTag;
   }
 
   // calibrate button
   if (ImGui::Button("Calibrate!!!")) {
     if (!selected_field_calibration_directory.empty() &&
         !selected_camera_intrinsics.empty() && !selected_field_map.empty() &&
-        pinnedTag > 0 && pinnedTag <= 16) {
+        pinnedTag > 0 && pinnedTag <= maxFRCTag) {
       download_directory_selector =
           std::make_unique<pfd::select_folder>("Select Download Folder", "");
       if (download_directory_selector) {
@@ -241,7 +243,7 @@ static void DisplayGui() {
     ImGui::TextWrapped(
         "Some inputs are empty! please enter your camera calibration video, "
         "field map, and field calibration directory");
-  } else if (!(pinnedTag > 0 && pinnedTag <= 16)) {
+  } else if (!(pinnedTag > 0 && pinnedTag <= maxFRCTag)) {
     ImGui::TextWrapped("Make sure the pinned tag is a valid april tag (1-16)");
   } else {
     ImGui::TextWrapped("Calibration Ready");
@@ -482,14 +484,14 @@ static void DisplayGui() {
 
     if (focusedTag < 1) {
       focusedTag = 1;
-    } else if (focusedTag > 16) {
-      focusedTag = 16;
+    } else if (focusedTag > maxFRCTag) {
+      focusedTag = maxFRCTag;
     }
 
     if (referenceTag < 1) {
       referenceTag = 1;
-    } else if (referenceTag > 16) {
-      referenceTag = 16;
+    } else if (referenceTag > maxFRCTag) {
+      referenceTag = maxFRCTag;
     }
 
     if (!calibration_json_path.empty() && !selected_field_map.empty()) {

--- a/wpical/src/main/native/cpp/fieldcalibration.cpp
+++ b/wpical/src/main/native/cpp/fieldcalibration.cpp
@@ -466,6 +466,19 @@ int fieldcalibration::calibrate(std::string input_dir_path,
     return 1;
   }
 
+  bool pinned_tag_found = false;
+  // Check if pinned tag is in ideal map
+  for (const auto& [tag_id, tag_json] : ideal_map) {
+    if (tag_id == pinned_tag_id) {
+      pinned_tag_found = true;
+      break;
+    }
+  }
+
+  if (!pinned_tag_found) {
+    return 1;
+  }
+
   // Apriltag detector
   apriltag_detector_t* tag_detector = apriltag_detector_create();
   tag_detector->nthreads = 8;

--- a/wpical/src/test/native/cpp/test_calibrate.cpp
+++ b/wpical/src/test/native/cpp/test_calibrate.cpp
@@ -87,3 +87,19 @@ TEST(Field_CalibrationTest, Atypical_Bad_Input_Directory) {
       projectRootPath + "/2024-crescendo.json", 3, false);
   EXPECT_EQ(ret, 1);
 }
+
+TEST(Field_CalibrationTest, Atypical_Bad_Pinned_Tag) {
+  int ret = fieldcalibration::calibrate(
+      projectRootPath + videoLocation, calSavePath,
+      calSavePath + "/cameracalibration.json",
+      projectRootPath + "/2024-crescendo.json", 42, false);
+  EXPECT_EQ(ret, 1);
+}
+
+TEST(Field_CalibrationTest, Atypical_Bad_Pinned_Tag_Negative) {
+  int ret = fieldcalibration::calibrate(
+      projectRootPath + videoLocation, calSavePath,
+      calSavePath + "/cameracalibration.json",
+      projectRootPath + "/2024-crescendo.json", -1, false);
+  EXPECT_EQ(ret, 1);
+}


### PR DESCRIPTION
This fixes WPIcal's issue with a fixed tag range and allows for teams to have custom maps with no tag maximum. This also adds checks and warnings for users who have selected a pinned tag ID that isn't in their initial map JSON.