### PR TITLE
Make Field2D field picker show JSONs first

### DIFF
--- a/glass/src/lib/native/cpp/other/Field2D.cpp
+++ b/glass/src/lib/native/cpp/other/Field2D.cpp
@@ -373,13 +373,12 @@ void FieldInfo::DisplaySettings() {
     }
     ImGui::EndCombo();
   }
-  if (m_builtin.empty() && ImGui::Button("Load image...")) {
+  if (m_builtin.empty() && ImGui::Button("Load JSON/image...")) {
     m_fileOpener = std::make_unique<pfd::open_file>(
-        "Choose field image", "",
-        std::vector<std::string>{"Image File",
+        "Choose field JSON/image", "",
+        std::vector<std::string>{"PathWeaver JSON File", "*.json", "Image File",
                                  "*.jpg *.jpeg *.png *.bmp *.psd *.tga *.gif "
-                                 "*.hdr *.pic *.ppm *.pgm",
-                                 "PathWeaver JSON File", "*.json"});
+                                 "*.hdr *.pic *.ppm *.pgm"});
   }
   if (ImGui::Button("Reset image")) {
     Reset();


### PR DESCRIPTION
Too many people don't realize that glass/simgui field2d can load pathweaver JSON field files since it's hidden.