### PR TITLE
Remove roborio specializations from build system

### DIFF
--- a/cameraserver/multiCameraServer/build.gradle
+++ b/cameraserver/multiCameraServer/build.gradle
@@ -61,9 +61,6 @@ model {
                 lib project: ':cscore', library: 'cscore', linkage: 'static'
                 lib project: ':wpinet', library: 'wpinet', linkage: 'static'
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
-                if (binary.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                    nativeUtils.useRequiredLibrary(binary, 'ni_link_libraries', 'ni_runtime_libraries')
-                }
             }
         }
     }

--- a/crossConnIntegrationTests/build.gradle
+++ b/crossConnIntegrationTests/build.gradle
@@ -88,9 +88,6 @@ model {
                     lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
                     lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
                     lib project: ':thirdparty:googletest', library: 'googletest', linkage: 'static'
-                    if (binary.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        nativeUtils.useRequiredLibrary(binary, 'ni_link_libraries', 'ni_runtime_libraries')
-                    }
                 } else {
                     binary.sources {
                         simCpp(CppSourceSet) {

--- a/cscore/build.gradle
+++ b/cscore/build.gradle
@@ -22,7 +22,6 @@ model {
 
             enableCheckTask true
             javaCompileTasks << compileJava
-            jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.roborio)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.systemcore)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.linuxarm32)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.linuxarm64)
@@ -187,7 +186,7 @@ model {
                             lib project: ':wpigui', library: 'wpigui', linkage: 'static'
                             lib library: 'cscore', linkage: 'shared'
                             lib project: ':thirdparty:imgui_suite', library: 'imguiSuite', linkage: 'static'
-                            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                            if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                                 it.buildable = false
                                 return
                             }
@@ -200,9 +199,6 @@ model {
                                 if (it.targetPlatform.name.startsWith('linuxarm')) {
                                     it.linker.args << '-lGL'
                                 }
-                            }
-                            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                                nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
                             }
                         }
                         sources.cpp.source {
@@ -218,9 +214,6 @@ model {
                         lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
                         lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
                         lib library: 'cscore', linkage: 'shared'
-                        if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                            nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-                        }
                     }
                     sources.cpp.source {
                         srcDirs 'examples/' + "${key}"

--- a/datalogtool/build.gradle
+++ b/datalogtool/build.gradle
@@ -93,7 +93,7 @@ model {
                 }
             }
             binaries.all {
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                     it.buildable = false
                     return
                 }

--- a/glass/build.gradle
+++ b/glass/build.gradle
@@ -85,7 +85,7 @@ model {
                 }
             }
             binaries.all {
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                     it.buildable = false
                     return
                 }
@@ -112,7 +112,7 @@ model {
                 }
             }
             binaries.all {
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                     it.buildable = false
                     return
                 }
@@ -153,7 +153,7 @@ model {
                 }
             }
             binaries.all {
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                     it.buildable = false
                     return
                 }

--- a/hal/build.gradle
+++ b/hal/build.gradle
@@ -10,23 +10,9 @@ ext {
     nativeName = 'hal'
     setBaseName = 'wpiHal'
     devMain = 'edu.wpi.first.hal.DevMain'
-    niLibraries = true
     generatedHeaders = "src/generated/main/native/include"
     splitSetup = {
-        if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-            it.sources {
-                athenaCpp(CppSourceSet) {
-                    source {
-                        srcDirs = ['src/main/native/athena']
-                        include '**/*.cpp'
-                    }
-                    exportedHeaders {
-                        srcDir 'src/main/native/include'
-                        srcDir generatedHeaders
-                    }
-                }
-            }
-        } else if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+        if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
             it.sources {
                 systemCoreCpp(CppSourceSet) {
                     source {
@@ -69,9 +55,6 @@ ext {
         }
     }
     exeSplitSetup = {
-        if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-            nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-        }
     }
 }
 
@@ -108,17 +91,6 @@ nativeUtils.exportsConfigs {
     }
     halJNI {
         x64SymbolFilter = symbolFilter
-    }
-}
-
-model {
-    binaries {
-        all {
-            if (!(it instanceof NativeBinarySpec)) return
-                if (it.component.name != 'hal' && it.component.name != 'halBase') return
-                if (it.targetPlatform.name != nativeUtils.wpi.platforms.roborio) return
-                nativeUtils.useRequiredLibrary(it, 'ni_link_libraries')
-        }
     }
 }
 

--- a/ntcoreffi/build.gradle
+++ b/ntcoreffi/build.gradle
@@ -74,9 +74,6 @@ model {
                 project(':ntcore').addNtcoreDependency(binary, 'static')
                 lib project: ':wpinet', library: 'wpinet', linkage: 'static'
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
-                if (binary.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                    nativeUtils.useRequiredLibrary(binary, 'netcomm', 'chipobject_headers')
-                }
             }
         }
     }

--- a/outlineviewer/build.gradle
+++ b/outlineviewer/build.gradle
@@ -91,7 +91,7 @@ model {
                 }
             }
             binaries.all {
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                     it.buildable = false
                     return
                 }

--- a/processstarter/build.gradle
+++ b/processstarter/build.gradle
@@ -33,7 +33,7 @@ model {
         "${nativeName}"(NativeExecutableSpec) {
             baseName = 'processstarter'
             binaries.all {
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                     it.buildable = false
                     return
                 }

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -14,7 +14,6 @@ nativeUtils {
     wpi {
         configureDependencies {
             opencvYear = "frc2025"
-            niLibVersion = "2025.0.0"
             opencvVersion = "4.10.0-3"
         }
     }

--- a/shared/javacpp/setupBuild.gradle
+++ b/shared/javacpp/setupBuild.gradle
@@ -82,9 +82,6 @@ model {
                 lib library: nativeName, linkage: 'shared'
                 if (!project.hasProperty('noWpiutil')) {
                     lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-                    if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-                    }
                 }
                 if (project.hasProperty('exeSplitSetup')) {
                     exeSplitSetup(it)
@@ -133,9 +130,6 @@ model {
             if (!project.hasProperty('noWpiutil')) {
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
                 lib project: ':wpiutil', library: 'wpiutilTestLib', linkage: 'shared'
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                    nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-                }
             }
             if (project.hasProperty('exeSplitSetup')) {
                 exeSplitSetup(it)

--- a/shared/jni/setupBuild.gradle
+++ b/shared/jni/setupBuild.gradle
@@ -110,7 +110,6 @@ model {
 
             enableCheckTask !project.hasProperty('skipJniCheck')
             javaCompileTasks << compileJava
-            jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.roborio)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.systemcore)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.linuxarm32)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.linuxarm64)
@@ -159,7 +158,6 @@ model {
 
             enableCheckTask !project.hasProperty('skipJniCheck')
             javaCompileTasks << compileJava
-            jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.roborio)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.systemcore)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.linuxarm32)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.linuxarm64)
@@ -218,9 +216,6 @@ model {
                 if (!project.hasProperty('noWpiutil')) {
                     lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
                     lib project: ':wpiutil', library: 'wpiutilJNIShared', linkage: 'shared'
-                    if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-                    }
                 }
                 if (project.hasProperty('exeSplitSetup')) {
                     exeSplitSetup(it)
@@ -271,9 +266,6 @@ model {
             if (!project.hasProperty('noWpiutil')) {
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
                 lib project: ':wpiutil', library: 'wpiutilTestLib', linkage: 'shared'
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                    nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-                }
             }
             if (project.hasProperty('exeSplitSetup')) {
                 exeSplitSetup(it)

--- a/shared/plugins/setupBuild.gradle
+++ b/shared/plugins/setupBuild.gradle
@@ -68,9 +68,6 @@ if (!project.hasProperty('onlylinuxathena') && !project.hasProperty('onlylinuxsy
                             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
                         }
                         lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-                        if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                            nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-                        }
                     } else {
                         it.buildable = false
                     }

--- a/simulation/halsim_ds_socket/build.gradle
+++ b/simulation/halsim_ds_socket/build.gradle
@@ -52,9 +52,6 @@ model {
             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
             lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
             lib library: pluginName, linkage: 'shared'
-            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-            }
         }
     }
 }

--- a/simulation/halsim_gui/build.gradle
+++ b/simulation/halsim_gui/build.gradle
@@ -32,7 +32,7 @@ model {
             lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
             lib project: ':fieldImages', library: 'fieldImages', linkage: 'static'
             lib project: ':thirdparty:imgui_suite', library: 'imguiSuite', linkage: 'static'
-            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                 it.buildable = false
                 return
             }

--- a/simulation/halsim_ws_client/build.gradle
+++ b/simulation/halsim_ws_client/build.gradle
@@ -23,7 +23,7 @@ apply from: "${rootDir}/shared/plugins/setupBuild.gradle"
 model {
     binaries {
         all {
-            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                 it.buildable = false
                 return
             }

--- a/simulation/halsim_ws_core/build.gradle
+++ b/simulation/halsim_ws_core/build.gradle
@@ -50,7 +50,7 @@ model {
     }
     binaries {
         all {
-            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                 it.buildable = false
                 return
             }

--- a/simulation/halsim_ws_server/build.gradle
+++ b/simulation/halsim_ws_server/build.gradle
@@ -44,7 +44,7 @@ model {
 
     binaries {
         all {
-            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                 it.buildable = false
                 return
             }
@@ -59,9 +59,6 @@ model {
             project(':ntcore').addNtcoreDependency(it, 'shared')
             lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
             lib library: pluginName, linkage: 'shared'
-            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-            }
         }
     }
 }

--- a/simulation/halsim_xrp/build.gradle
+++ b/simulation/halsim_xrp/build.gradle
@@ -23,7 +23,7 @@ apply from: "${rootDir}/shared/plugins/setupBuild.gradle"
 model {
     binaries {
         all {
-            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                 it.buildable = false
                 return
             }

--- a/sysid/build.gradle
+++ b/sysid/build.gradle
@@ -92,7 +92,7 @@ model {
                 }
             }
             binaries.all {
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                     it.buildable = false
                     return
                 }
@@ -131,7 +131,7 @@ model {
                 include "**/*.cpp"
             }
             binaries.all {
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                     it.buildable = false
                     return
                 }

--- a/thirdparty/imgui_suite/build.gradle
+++ b/thirdparty/imgui_suite/build.gradle
@@ -49,7 +49,7 @@ model {
                 }
             }
             binaries.all {
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                     it.buildable = false
                     return
                 }

--- a/wpical/build.gradle
+++ b/wpical/build.gradle
@@ -152,7 +152,7 @@ model {
                 }
             }
             binaries.all {
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore || it.targetPlatform.name.startsWith("linuxarm")) {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore || it.targetPlatform.name.startsWith("linuxarm")) {
                     it.buildable = false
                     return
                 }
@@ -203,7 +203,7 @@ model {
                 }
             }
             binaries.all {
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore || it.targetPlatform.name.startsWith("linuxarm")) {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore || it.targetPlatform.name.startsWith("linuxarm")) {
                     it.buildable = false
                     return
                 }

--- a/wpigui/build.gradle
+++ b/wpigui/build.gradle
@@ -36,7 +36,7 @@ model {
             }
             binaries.all {
                 lib project: ':thirdparty:imgui_suite', library: 'imguiSuite', linkage: 'static'
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                     it.buildable = false
                     return
                 }
@@ -105,7 +105,7 @@ model {
     }
     binaries {
         all {
-            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                 it.buildable = false
                 return
             }

--- a/wpilibNewCommands/build.gradle
+++ b/wpilibNewCommands/build.gradle
@@ -74,9 +74,6 @@ model {
                 nativeUtils.useRequiredLibrary(it, 'opencv_shared')
                 lib project: ':cscore', library: 'cscore', linkage: 'shared'
             }
-            if ((it instanceof NativeExecutableBinarySpec || it instanceof GoogleTestTestSuiteBinarySpec) && it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-            }
         }
     }
     tasks {

--- a/wpilibc/build.gradle
+++ b/wpilibc/build.gradle
@@ -171,9 +171,6 @@ model {
                 lib project: ':wpimath', library: 'wpimath', linkage: 'shared'
                 lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
                 nativeUtils.useRequiredLibrary(it, 'opencv_shared')
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                    nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-                }
             }
         }
     }
@@ -223,9 +220,6 @@ model {
             lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
             nativeUtils.useRequiredLibrary(it, 'opencv_shared')
             lib library: nativeName, linkage: 'shared'
-            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-            }
         }
     }
     tasks {

--- a/wpilibcExamples/build.gradle
+++ b/wpilibcExamples/build.gradle
@@ -102,9 +102,6 @@ model {
                     lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
                     lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
                     lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-                    if (binary.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        nativeUtils.useRequiredLibrary(binary, 'ni_link_libraries', 'ni_runtime_libraries')
-                    }
                     if (binary.targetPlatform.name == getCurrentArch()) {
                         simModules.each {
                             lib project: ":simulation:$it", library: it, linkage: 'shared'
@@ -153,9 +150,6 @@ model {
                     lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
                     lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
                     lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-                    if (binary.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        nativeUtils.useRequiredLibrary(binary, 'ni_link_libraries', 'ni_runtime_libraries')
-                    }
                 }
                 sources {
                     cpp {
@@ -221,9 +215,6 @@ model {
             lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
             lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-            }
             nativeUtils.useRequiredLibrary(it, 'opencv_shared')
 
             it.cppCompiler.define('RUNNING_FRC_TESTS')

--- a/wpilibcIntegrationTests/build.gradle
+++ b/wpilibcIntegrationTests/build.gradle
@@ -53,9 +53,6 @@ model {
                     lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
                     lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
                     lib project: ':thirdparty:googletest', library: 'googletest', linkage: 'static'
-                    if (binary.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        nativeUtils.useRequiredLibrary(binary, 'ni_link_libraries', 'ni_runtime_libraries')
-                    }
                 } else {
                     binary.sources {
                         simCpp(CppSourceSet) {

--- a/wpilibj/build.gradle
+++ b/wpilibj/build.gradle
@@ -119,9 +119,6 @@ model {
                 lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
                 project(':hal').addHalDependency(it, 'shared')
                 project(':hal').addHalJniDependency(it)
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                    nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-                }
             }
         }
     }

--- a/wpilibjExamples/build.gradle
+++ b/wpilibjExamples/build.gradle
@@ -110,14 +110,12 @@ model {
                 lib project: ':wpiutil', library: 'wpiutilJNIShared', linkage: 'shared'
                 lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
                 lib project: ':wpinet', library: 'wpinetJNIShared', linkage: 'shared'
-                if (binary.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                    nativeUtils.useRequiredLibrary(binary, 'ni_link_libraries', 'ni_runtime_libraries')
-                } else {
-                    def systemArch = getCurrentArch()
-                    if (binary.targetPlatform.name == systemArch) {
-                        lib project: ":simulation:halsim_gui", library: 'halsim_gui', linkage: 'shared'
-                    }
+
+                def systemArch = getCurrentArch()
+                if (binary.targetPlatform.name == systemArch) {
+                    lib project: ":simulation:halsim_gui", library: 'halsim_gui', linkage: 'shared'
                 }
+
                 nativeUtils.useRequiredLibrary(binary, 'opencv_shared')
             }
         }

--- a/wpinet/build.gradle
+++ b/wpinet/build.gradle
@@ -218,9 +218,6 @@ model {
                 binaries.all {
                     lib library: 'wpinet', linkage: 'shared'
                     lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-                    if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
-                    }
                 }
                 sources {
                     cpp {
@@ -246,9 +243,6 @@ model {
             binaries.all { binary ->
                 lib project: ':wpinet', library: 'wpinet', linkage: 'static'
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
-                if (binary.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                    nativeUtils.useRequiredLibrary(binary, 'ni_link_libraries', 'ni_runtime_libraries')
-                }
                 if (binary.targetPlatform.operatingSystem.isLinux()) {
                     linker.args "-lutil"
                 }
@@ -268,9 +262,6 @@ model {
             binaries.all { binary ->
                 lib project: ':wpinet', library: 'wpinet', linkage: 'static'
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
-                if (binary.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                    nativeUtils.useRequiredLibrary(binary, 'ni_link_libraries', 'ni_runtime_libraries')
-                }
             }
         }
     }

--- a/wpiutil/build.gradle
+++ b/wpiutil/build.gradle
@@ -293,17 +293,6 @@ model {
     }
 }
 
-model {
-    binaries {
-        all {
-            if (!(it instanceof NativeBinarySpec)) return
-                if (it.component.name != 'wpiutil' && it.component.name != 'wpiutilBase') return
-                if (it.targetPlatform.name != nativeUtils.wpi.platforms.roborio) return
-                nativeUtils.useRequiredLibrary(it, 'chipobject_headers')
-        }
-    }
-}
-
 sourceSets {
     printlog
 }


### PR DESCRIPTION
The integration tests and cross conn tests were left as is until I figure those out. Also rtns wasn't changed because its being removed in a separate PR.