### PR TITLE
[wpilibc, wpilibh, cmd] Improve HID direction documentation (NFC)

### DIFF
--- a/wpilibNewCommands/src/generate/main/java/commandhid.java.jinja
+++ b/wpilibNewCommands/src/generate/main/java/commandhid.java.jinja
@@ -107,7 +107,7 @@ public class Command{{ ConsoleName }}Controller extends CommandGenericHID {
 {% endfor -%}
 {% for stick in sticks %}
   /**
-   * Get the {{ stick.NameParts[1] }} axis value of {{ stick.NameParts[0] }} side of the controller.
+   * Get the {{ stick.NameParts[1] }} axis value of {{ stick.NameParts[0] }} side of the controller. {{ stick.PositiveDirection }} is positive.
    *
    * @return The axis value.
    */

--- a/wpilibNewCommands/src/generate/main/native/include/frc2/command/button/commandhid.h.jinja
+++ b/wpilibNewCommands/src/generate/main/native/include/frc2/command/button/commandhid.h.jinja
@@ -71,7 +71,7 @@ class Command{{ ConsoleName }}Controller : public CommandGenericHID {
 {% endfor -%}
 {% for stick in sticks %}
   /**
-   * Get the {{ stick.NameParts[1] }} axis value of {{ stick.NameParts[0] }} side of the controller.
+   * Get the {{ stick.NameParts[1] }} axis value of {{ stick.NameParts[0] }} side of the controller. {{ stick.PositiveDirection }} is positive.
    *
    * @return The axis value.
    */

--- a/wpilibNewCommands/src/generated/main/java/edu/wpi/first/wpilibj2/command/button/CommandPS4Controller.java
+++ b/wpilibNewCommands/src/generated/main/java/edu/wpi/first/wpilibj2/command/button/CommandPS4Controller.java
@@ -348,7 +348,7 @@ public class CommandPS4Controller extends CommandGenericHID {
   }
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -357,7 +357,7 @@ public class CommandPS4Controller extends CommandGenericHID {
   }
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return The axis value.
    */
@@ -366,7 +366,7 @@ public class CommandPS4Controller extends CommandGenericHID {
   }
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -375,7 +375,7 @@ public class CommandPS4Controller extends CommandGenericHID {
   }
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return The axis value.
    */

--- a/wpilibNewCommands/src/generated/main/java/edu/wpi/first/wpilibj2/command/button/CommandPS5Controller.java
+++ b/wpilibNewCommands/src/generated/main/java/edu/wpi/first/wpilibj2/command/button/CommandPS5Controller.java
@@ -348,7 +348,7 @@ public class CommandPS5Controller extends CommandGenericHID {
   }
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -357,7 +357,7 @@ public class CommandPS5Controller extends CommandGenericHID {
   }
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return The axis value.
    */
@@ -366,7 +366,7 @@ public class CommandPS5Controller extends CommandGenericHID {
   }
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -375,7 +375,7 @@ public class CommandPS5Controller extends CommandGenericHID {
   }
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return The axis value.
    */

--- a/wpilibNewCommands/src/generated/main/java/edu/wpi/first/wpilibj2/command/button/CommandStadiaController.java
+++ b/wpilibNewCommands/src/generated/main/java/edu/wpi/first/wpilibj2/command/button/CommandStadiaController.java
@@ -370,7 +370,7 @@ public class CommandStadiaController extends CommandGenericHID {
   }
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -379,7 +379,7 @@ public class CommandStadiaController extends CommandGenericHID {
   }
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -388,7 +388,7 @@ public class CommandStadiaController extends CommandGenericHID {
   }
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return The axis value.
    */
@@ -397,7 +397,7 @@ public class CommandStadiaController extends CommandGenericHID {
   }
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return The axis value.
    */

--- a/wpilibNewCommands/src/generated/main/java/edu/wpi/first/wpilibj2/command/button/CommandXboxController.java
+++ b/wpilibNewCommands/src/generated/main/java/edu/wpi/first/wpilibj2/command/button/CommandXboxController.java
@@ -338,7 +338,7 @@ public class CommandXboxController extends CommandGenericHID {
   }
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -347,7 +347,7 @@ public class CommandXboxController extends CommandGenericHID {
   }
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -356,7 +356,7 @@ public class CommandXboxController extends CommandGenericHID {
   }
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return The axis value.
    */
@@ -365,7 +365,7 @@ public class CommandXboxController extends CommandGenericHID {
   }
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return The axis value.
    */

--- a/wpilibNewCommands/src/generated/main/native/include/frc2/command/button/CommandPS4Controller.h
+++ b/wpilibNewCommands/src/generated/main/native/include/frc2/command/button/CommandPS4Controller.h
@@ -204,28 +204,28 @@ class CommandPS4Controller : public CommandGenericHID {
                                                 .GetDefaultButtonLoop()) const;
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return The axis value.
    */
   double GetLeftX() const;
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return The axis value.
    */
   double GetLeftY() const;
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return The axis value.
    */
   double GetRightX() const;
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return The axis value.
    */

--- a/wpilibNewCommands/src/generated/main/native/include/frc2/command/button/CommandPS5Controller.h
+++ b/wpilibNewCommands/src/generated/main/native/include/frc2/command/button/CommandPS5Controller.h
@@ -204,28 +204,28 @@ class CommandPS5Controller : public CommandGenericHID {
                                                 .GetDefaultButtonLoop()) const;
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return The axis value.
    */
   double GetLeftX() const;
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return The axis value.
    */
   double GetLeftY() const;
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return The axis value.
    */
   double GetRightX() const;
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return The axis value.
    */

--- a/wpilibNewCommands/src/generated/main/native/include/frc2/command/button/CommandStadiaController.h
+++ b/wpilibNewCommands/src/generated/main/native/include/frc2/command/button/CommandStadiaController.h
@@ -216,28 +216,28 @@ class CommandStadiaController : public CommandGenericHID {
                                                 .GetDefaultButtonLoop()) const;
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return The axis value.
    */
   double GetLeftX() const;
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return The axis value.
    */
   double GetRightX() const;
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return The axis value.
    */
   double GetLeftY() const;
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return The axis value.
    */

--- a/wpilibNewCommands/src/generated/main/native/include/frc2/command/button/CommandXboxController.h
+++ b/wpilibNewCommands/src/generated/main/native/include/frc2/command/button/CommandXboxController.h
@@ -190,28 +190,28 @@ class CommandXboxController : public CommandGenericHID {
                                                  .GetDefaultButtonLoop()) const;
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return The axis value.
    */
   double GetLeftX() const;
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return The axis value.
    */
   double GetRightX() const;
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return The axis value.
    */
   double GetLeftY() const;
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return The axis value.
    */

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandJoystick.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandJoystick.java
@@ -241,8 +241,13 @@ public class CommandJoystick extends CommandGenericHID {
    */
   public double getDirectionRadians() {
     // https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html#joystick-and-controller-coordinate-system
-    // +X is right and +Y is back, so 0 radians is right and CW is positive. Rotate by 90 degrees
-    // CCW to make 0 radians forward and CW positive.
+    // A positive rotation around the X axis moves the joystick right, and a
+    // positive rotation around the Y axis moves the joystick backward. When
+    // treating them as translations, 0 radians is measured from the right
+    // direction, and angle increases clockwise.
+    //
+    // It's rotated 90 degrees CCW (y is negated and the arguments are reversed)
+    // so that 0 radians is forward.
     return m_hid.getDirectionRadians();
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandJoystick.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandJoystick.java
@@ -173,6 +173,9 @@ public class CommandJoystick extends CommandGenericHID {
   /**
    * Get the x position of the HID.
    *
+   * <p>This depends on the mapping of the joystick connected to the current port. On most
+   * joysticks, positive is to the right.
+   *
    * @return the x position
    */
   public double getX() {
@@ -181,6 +184,9 @@ public class CommandJoystick extends CommandGenericHID {
 
   /**
    * Get the y position of the HID.
+   *
+   * <p>This depends on the mapping of the joystick connected to the current port. On most
+   * joysticks, positive is to the back.
    *
    * @return the y position
    */
@@ -218,8 +224,8 @@ public class CommandJoystick extends CommandGenericHID {
   }
 
   /**
-   * Get the magnitude of the direction vector formed by the joystick's current position relative to
-   * its origin.
+   * Get the magnitude of the vector formed by the joystick's current position relative to its
+   * origin.
    *
    * @return The magnitude of the direction vector
    */
@@ -228,16 +234,21 @@ public class CommandJoystick extends CommandGenericHID {
   }
 
   /**
-   * Get the direction of the vector formed by the joystick and its origin in radians.
+   * Get the direction of the vector formed by the joystick and its origin in radians. 0 is forward
+   * and clockwise is positive. (Straight right is π/2.)
    *
    * @return The direction of the vector in radians
    */
   public double getDirectionRadians() {
+    // https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html#joystick-and-controller-coordinate-system
+    // +X is right and +Y is back, so 0 radians is right and CW is positive. Rotate by 90 degrees
+    // CCW to make 0 radians forward and CW positive.
     return m_hid.getDirectionRadians();
   }
 
   /**
-   * Get the direction of the vector formed by the joystick and its origin in degrees.
+   * Get the direction of the vector formed by the joystick and its origin in degrees. 0 is forward
+   * and clockwise is positive. (Straight right is 90.)
    *
    * @return The direction of the vector in degrees
    */

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/CommandJoystick.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/CommandJoystick.cpp
@@ -26,5 +26,8 @@ double CommandJoystick::GetMagnitude() const {
 }
 
 units::radian_t CommandJoystick::GetDirection() const {
+  // https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html#joystick-and-controller-coordinate-system
+  // +X is right and +Y is back, so 0 radians is right and CW is positive.
+  // Rotate by 90 degrees CCW to make 0 radians forward and CW positive.
   return m_hid.GetDirection();
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/CommandJoystick.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/CommandJoystick.cpp
@@ -27,7 +27,12 @@ double CommandJoystick::GetMagnitude() const {
 
 units::radian_t CommandJoystick::GetDirection() const {
   // https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html#joystick-and-controller-coordinate-system
-  // +X is right and +Y is back, so 0 radians is right and CW is positive.
-  // Rotate by 90 degrees CCW to make 0 radians forward and CW positive.
+  // A positive rotation around the X axis moves the joystick right, and a
+  // positive rotation around the Y axis moves the joystick backward. When
+  // treating them as translations, 0 radians is measured from the right
+  // direction, and angle increases clockwise.
+  //
+  // It's rotated 90 degrees CCW (y is negated and the arguments are reversed)
+  // so that 0 radians is forward.
   return m_hid.GetDirection();
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/CommandJoystick.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/CommandJoystick.h
@@ -56,7 +56,7 @@ class CommandJoystick : public CommandGenericHID {
   class Trigger Top(frc::EventLoop* loop = CommandScheduler::GetInstance()
                                                .GetDefaultButtonLoop()) const;
   /**
-   * Get the magnitude of the direction vector formed by the joystick's
+   * Get the magnitude of the vector formed by the joystick's
    * current position relative to its origin.
    *
    * @return The magnitude of the direction vector
@@ -64,7 +64,9 @@ class CommandJoystick : public CommandGenericHID {
   double GetMagnitude() const;
 
   /**
-   * Get the direction of the vector formed by the joystick and its origin.
+   * Get the direction of the vector formed by the joystick and its origin. 0 is
+   * forward and clockwise is positive. (Straight right is π/2 radians or 90
+   * degrees.)
    *
    * @return The direction of the vector.
    */

--- a/wpilibc/src/generate/main/native/include/frc/hid.h.jinja
+++ b/wpilibc/src/generate/main/native/include/frc/hid.h.jinja
@@ -47,7 +47,7 @@ class {{ ConsoleName }}Controller : public GenericHID,
   {{ ConsoleName }}Controller& operator=({{ ConsoleName }}Controller&&) = default;
 {% for stick in sticks %}
   /**
-   * Get the {{ stick.NameParts[1] }} axis value of {{ stick.NameParts[0] }} side of the controller.
+   * Get the {{ stick.NameParts[1] }} axis value of {{ stick.NameParts[0] }} side of the controller. {{ stick.PositiveDirection }} is positive.
    *
    * @return the axis value.
    */

--- a/wpilibc/src/generated/main/native/include/frc/PS4Controller.h
+++ b/wpilibc/src/generated/main/native/include/frc/PS4Controller.h
@@ -45,28 +45,28 @@ class PS4Controller : public GenericHID,
   PS4Controller& operator=(PS4Controller&&) = default;
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return the axis value.
    */
   double GetLeftX() const;
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return the axis value.
    */
   double GetLeftY() const;
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return the axis value.
    */
   double GetRightX() const;
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return the axis value.
    */

--- a/wpilibc/src/generated/main/native/include/frc/PS5Controller.h
+++ b/wpilibc/src/generated/main/native/include/frc/PS5Controller.h
@@ -45,28 +45,28 @@ class PS5Controller : public GenericHID,
   PS5Controller& operator=(PS5Controller&&) = default;
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return the axis value.
    */
   double GetLeftX() const;
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return the axis value.
    */
   double GetLeftY() const;
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return the axis value.
    */
   double GetRightX() const;
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return the axis value.
    */

--- a/wpilibc/src/generated/main/native/include/frc/StadiaController.h
+++ b/wpilibc/src/generated/main/native/include/frc/StadiaController.h
@@ -45,28 +45,28 @@ class StadiaController : public GenericHID,
   StadiaController& operator=(StadiaController&&) = default;
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return the axis value.
    */
   double GetLeftX() const;
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return the axis value.
    */
   double GetRightX() const;
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return the axis value.
    */
   double GetLeftY() const;
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return the axis value.
    */

--- a/wpilibc/src/generated/main/native/include/frc/XboxController.h
+++ b/wpilibc/src/generated/main/native/include/frc/XboxController.h
@@ -45,28 +45,28 @@ class XboxController : public GenericHID,
   XboxController& operator=(XboxController&&) = default;
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return the axis value.
    */
   double GetLeftX() const;
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return the axis value.
    */
   double GetRightX() const;
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return the axis value.
    */
   double GetLeftY() const;
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return the axis value.
    */

--- a/wpilibc/src/main/native/cpp/Joystick.cpp
+++ b/wpilibc/src/main/native/cpp/Joystick.cpp
@@ -120,7 +120,12 @@ double Joystick::GetMagnitude() const {
 
 units::radian_t Joystick::GetDirection() const {
   // https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html#joystick-and-controller-coordinate-system
-  // +X is right and +Y is back, so 0 radians is right and CW is positive.
-  // Rotate by 90 degrees CCW to make 0 radians forward and CW positive.
+  // A positive rotation around the X axis moves the joystick right, and a
+  // positive rotation around the Y axis moves the joystick backward. When
+  // treating them as translations, 0 radians is measured from the right
+  // direction, and angle increases clockwise.
+  //
+  // It's rotated 90 degrees CCW (y is negated and the arguments are reversed)
+  // so that 0 radians is forward.
   return units::radian_t{std::atan2(GetX(), -GetY())};
 }

--- a/wpilibc/src/main/native/cpp/Joystick.cpp
+++ b/wpilibc/src/main/native/cpp/Joystick.cpp
@@ -119,5 +119,8 @@ double Joystick::GetMagnitude() const {
 }
 
 units::radian_t Joystick::GetDirection() const {
+  // https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html#joystick-and-controller-coordinate-system
+  // +X is right and +Y is back, so 0 radians is right and CW is positive.
+  // Rotate by 90 degrees CCW to make 0 radians forward and CW positive.
   return units::radian_t{std::atan2(GetX(), -GetY())};
 }

--- a/wpilibc/src/main/native/include/frc/Joystick.h
+++ b/wpilibc/src/main/native/include/frc/Joystick.h
@@ -148,6 +148,7 @@ class Joystick : public GenericHID {
    * Get the X value of the current joystick.
    *
    * This depends on the mapping of the joystick connected to the current port.
+   * On most joysticks, positive is to the right.
    */
   double GetX() const;
 
@@ -155,6 +156,7 @@ class Joystick : public GenericHID {
    * Get the Y value of the current joystick.
    *
    * This depends on the mapping of the joystick connected to the current port.
+   * On most joysticks, positive is to the back.
    */
   double GetY() const;
 
@@ -244,7 +246,7 @@ class Joystick : public GenericHID {
   BooleanEvent Top(EventLoop* loop) const;
 
   /**
-   * Get the magnitude of the direction vector formed by the joystick's
+   * Get the magnitude of the vector formed by the joystick's
    * current position relative to its origin.
    *
    * @return The magnitude of the direction vector
@@ -252,7 +254,9 @@ class Joystick : public GenericHID {
   double GetMagnitude() const;
 
   /**
-   * Get the direction of the vector formed by the joystick and its origin.
+   * Get the direction of the vector formed by the joystick and its origin. 0 is
+   * forward and clockwise is positive. (Straight right is π/2 radians or 90
+   * degrees.)
    *
    * @return The direction of the vector.
    */

--- a/wpilibj/src/generate/hids.json
+++ b/wpilibj/src/generate/hids.json
@@ -60,28 +60,32 @@
           "left",
           "X"
         ],
-        "value": 0
+        "value": 0,
+        "PositiveDirection": "Right"
       },
       {
         "NameParts": [
           "right",
           "X"
         ],
-        "value": 4
+        "value": 4,
+        "PositiveDirection": "Right"
       },
       {
         "NameParts": [
           "left",
           "Y"
         ],
-        "value": 1
+        "value": 1,
+        "PositiveDirection": "Back"
       },
       {
         "NameParts": [
           "right",
           "Y"
         ],
-        "value": 5
+        "value": 5,
+        "PositiveDirection": "Back"
       }
     ],
     "triggers": [
@@ -175,28 +179,32 @@
           "left",
           "X"
         ],
-        "value": 0
+        "value": 0,
+        "PositiveDirection": "Right"
       },
       {
         "NameParts": [
           "left",
           "Y"
         ],
-        "value": 1
+        "value": 1,
+        "PositiveDirection": "Back"
       },
       {
         "NameParts": [
           "right",
           "X"
         ],
-        "value": 2
+        "value": 2,
+        "PositiveDirection": "Right"
       },
       {
         "NameParts": [
           "right",
           "Y"
         ],
-        "value": 5
+        "value": 5,
+        "PositiveDirection": "Back"
       }
     ],
     "triggers": [
@@ -290,28 +298,32 @@
           "left",
           "X"
         ],
-        "value": 0
+        "value": 0,
+        "PositiveDirection": "Right"
       },
       {
         "NameParts": [
           "left",
           "Y"
         ],
-        "value": 1
+        "value": 1,
+        "PositiveDirection": "Back"
       },
       {
         "NameParts": [
           "right",
           "X"
         ],
-        "value": 2
+        "value": 2,
+        "PositiveDirection": "Right"
       },
       {
         "NameParts": [
           "right",
           "Y"
         ],
-        "value": 5
+        "value": 5,
+        "PositiveDirection": "Back"
       }
     ],
     "triggers": [
@@ -412,28 +424,32 @@
           "left",
           "X"
         ],
-        "value": 0
+        "value": 0,
+        "PositiveDirection": "Right"
       },
       {
         "NameParts": [
           "right",
           "X"
         ],
-        "value": 3
+        "value": 3,
+        "PositiveDirection": "Right"
       },
       {
         "NameParts": [
           "left",
           "Y"
         ],
-        "value": 1
+        "value": 1,
+        "PositiveDirection": "Back"
       },
       {
         "NameParts": [
           "right",
           "Y"
         ],
-        "value": 4
+        "value": 4,
+        "PositiveDirection": "Back"
       }
     ]
   }

--- a/wpilibj/src/generate/hids.schema.json
+++ b/wpilibj/src/generate/hids.schema.json
@@ -66,7 +66,8 @@
           "type": "object",
           "required": [
             "NameParts",
-            "value"
+            "value",
+            "PositiveDirection"
           ],
           "properties": {
             "NameParts": {
@@ -80,6 +81,10 @@
             "value": {
               "description": "The axis value",
               "type": "integer"
+            },
+            "PositiveDirection": {
+              "description": "The positive direction of the axis.",
+              "type": "string"
             }
           }
         }

--- a/wpilibj/src/generate/main/java/hid.java.jinja
+++ b/wpilibj/src/generate/main/java/hid.java.jinja
@@ -103,7 +103,7 @@ public class {{ ConsoleName }}Controller extends GenericHID implements Sendable 
   }
 {% for stick in sticks %}
   /**
-   * Get the {{ stick.NameParts[1] }} axis value of {{ stick.NameParts[0] }} side of the controller.
+   * Get the {{ stick.NameParts[1] }} axis value of {{ stick.NameParts[0] }} side of the controller. {{ stick.PositiveDirection }} is positive.
    *
    * @return The axis value.
    */

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/PS4Controller.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/PS4Controller.java
@@ -129,7 +129,7 @@ public class PS4Controller extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -138,7 +138,7 @@ public class PS4Controller extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return The axis value.
    */
@@ -147,7 +147,7 @@ public class PS4Controller extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -156,7 +156,7 @@ public class PS4Controller extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return The axis value.
    */

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/PS5Controller.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/PS5Controller.java
@@ -129,7 +129,7 @@ public class PS5Controller extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -138,7 +138,7 @@ public class PS5Controller extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return The axis value.
    */
@@ -147,7 +147,7 @@ public class PS5Controller extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -156,7 +156,7 @@ public class PS5Controller extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return The axis value.
    */

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/StadiaController.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/StadiaController.java
@@ -127,7 +127,7 @@ public class StadiaController extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -136,7 +136,7 @@ public class StadiaController extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -145,7 +145,7 @@ public class StadiaController extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return The axis value.
    */
@@ -154,7 +154,7 @@ public class StadiaController extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return The axis value.
    */

--- a/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/XboxController.java
+++ b/wpilibj/src/generated/main/java/edu/wpi/first/wpilibj/XboxController.java
@@ -121,7 +121,7 @@ public class XboxController extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the X axis value of left side of the controller.
+   * Get the X axis value of left side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -130,7 +130,7 @@ public class XboxController extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Get the X axis value of right side of the controller. Right is positive.
    *
    * @return The axis value.
    */
@@ -139,7 +139,7 @@ public class XboxController extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Get the Y axis value of left side of the controller. Back is positive.
    *
    * @return The axis value.
    */
@@ -148,7 +148,7 @@ public class XboxController extends GenericHID implements Sendable {
   }
 
   /**
-   * Get the Y axis value of right side of the controller.
+   * Get the Y axis value of right side of the controller. Back is positive.
    *
    * @return The axis value.
    */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
@@ -320,8 +320,13 @@ public class Joystick extends GenericHID {
    */
   public double getDirectionRadians() {
     // https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html#joystick-and-controller-coordinate-system
-    // +X is right and +Y is back, so 0 radians is right and CW is positive. Rotate by 90 degrees
-    // CCW to make 0 radians forward and CW positive.
+    // A positive rotation around the X axis moves the joystick right, and a
+    // positive rotation around the Y axis moves the joystick backward. When
+    // treating them as translations, 0 radians is measured from the right
+    // direction, and angle increases clockwise.
+    //
+    // It's rotated 90 degrees CCW (y is negated and the arguments are reversed)
+    // so that 0 radians is forward.
     return Math.atan2(getX(), -getY());
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
@@ -179,7 +179,7 @@ public class Joystick extends GenericHID {
 
   /**
    * Get the X value of the joystick. This depends on the mapping of the joystick connected to the
-   * current port.
+   * current port. On most joysticks, positive is to the right.
    *
    * @return The X value of the joystick.
    */
@@ -189,7 +189,7 @@ public class Joystick extends GenericHID {
 
   /**
    * Get the Y value of the joystick. This depends on the mapping of the joystick connected to the
-   * current port.
+   * current port. On most joysticks, positive is to the back.
    *
    * @return The Y value of the joystick.
    */
@@ -303,8 +303,8 @@ public class Joystick extends GenericHID {
   }
 
   /**
-   * Get the magnitude of the direction vector formed by the joystick's current position relative to
-   * its origin.
+   * Get the magnitude of the vector formed by the joystick's current position relative to its
+   * origin.
    *
    * @return The magnitude of the direction vector
    */
@@ -313,16 +313,21 @@ public class Joystick extends GenericHID {
   }
 
   /**
-   * Get the direction of the vector formed by the joystick and its origin in radians.
+   * Get the direction of the vector formed by the joystick and its origin in radians. 0 is forward
+   * and clockwise is positive. (Straight right is π/2.)
    *
    * @return The direction of the vector in radians
    */
   public double getDirectionRadians() {
+    // https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html#joystick-and-controller-coordinate-system
+    // +X is right and +Y is back, so 0 radians is right and CW is positive. Rotate by 90 degrees
+    // CCW to make 0 radians forward and CW positive.
     return Math.atan2(getX(), -getY());
   }
 
   /**
-   * Get the direction of the vector formed by the joystick and its origin in degrees.
+   * Get the direction of the vector formed by the joystick and its origin in degrees. 0 is forward
+   * and clockwise is positive. (Straight right is 90.)
    *
    * @return The direction of the vector in degrees
    */


### PR DESCRIPTION
Closes #7611.

Not completely sure about whether the link to the WPILib docs page should stay there or if there's a better way to include it (that also plays nicely with formatting).

CommandJoystick.h doesn't have the `getX()` and `getY()` direction clarifications since it doesn't have them. 