### PR TITLE
[bazel] Update toolchain to support systemcore

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,8 +16,14 @@ import shared/bazel/compiler_flags/base_linux_flags.rc
 import shared/bazel/compiler_flags/linux_flags.rc
 import shared/bazel/compiler_flags/osx_flags.rc
 import shared/bazel/compiler_flags/roborio_flags.rc
+import shared/bazel/compiler_flags/systemcore_flags.rc
 import shared/bazel/compiler_flags/windows_flags.rc
 import shared/bazel/compiler_flags/coverage_flags.rc
+
+# Alias toolchain names to what wpilibsuite uses for CI/Artifact naming
+build:athena --config=roborio
+build:linuxarm32 --config=raspibookworm32
+build:linuxarm64 --config=bookworm64
 
 build:build_java --test_tag_filters=allwpilib-build-java --build_tag_filters=allwpilib-build-java
 build:build_cpp --test_tag_filters=+allwpilib-build-cpp --build_tag_filters=+allwpilib-build-cpp

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -99,8 +99,8 @@ setup_legacy_bzlmodrio_ni_cpp_dependencies()
 
 http_archive(
     name = "bzlmodrio-opencv",
-    sha256 = "58c0069fc323259f3993750fe8245798f0db8b2fbf3772c5136253fa92912a16",
-    url = "https://github.com/wpilibsuite/bzlmodRio-opencv/releases/download/2025.4.10.0-3/bzlmodRio-opencv-2025.4.10.0-3.tar.gz",
+    sha256 = "ba3f4910ce9cc0e08abff732aeb5835b1bcfd864ca5296edeadcf2935f7e81b9",
+    url = "https://github.com/wpilibsuite/bzlmodRio-opencv/releases/download/2025.4.10.0-3.bcr1/bzlmodRio-opencv-2025.4.10.0-3.bcr1.tar.gz",
 )
 
 load("@bzlmodrio-opencv//:maven_cpp_deps.bzl", "setup_legacy_bzlmodrio_opencv_cpp_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,8 +35,8 @@ maven_install(
 # Download toolchains
 http_archive(
     name = "rules_bzlmodrio_toolchains",
-    sha256 = "fe267e2af53c1def1e962700a9aeda9e8fdfa9fb46b72167c615ec0e25447dd6",
-    url = "https://github.com/wpilibsuite/rules_bzlmodRio_toolchains/releases/download/2025-1/rules_bzlmodRio_toolchains-2025-1.tar.gz",
+    sha256 = "ff25b5f9445cbd43759be4c6582b987d1065cf817c593eedc7ada1a699298c84",
+    url = "https://github.com/wpilibsuite/rules_bzlmodRio_toolchains/releases/download/2025-1.bcr2/rules_bzlmodRio_toolchains-2025-1.bcr2.tar.gz",
 )
 
 load("@rules_bzlmodrio_toolchains//:maven_deps.bzl", "setup_legacy_setup_toolchains_dependencies")
@@ -50,8 +50,8 @@ load_toolchains()
 #
 http_archive(
     name = "rules_bzlmodrio_jdk",
-    sha256 = "a00d5fa971fbcad8a17b1968cdc5350688397035e90b0cb94e040d375ecd97b4",
-    url = "https://github.com/wpilibsuite/rules_bzlmodRio_jdk/releases/download/17.0.8.1-1/rules_bzlmodRio_jdk-17.0.8.1-1.tar.gz",
+    sha256 = "81869fe9860e39b17e4a9bc1d33c1ca2faede7e31d9538ed0712406f753a2163",
+    url = "https://github.com/wpilibsuite/rules_bzlmodRio_jdk/releases/download/17.0.12-7/rules_bzlmodRio_jdk-17.0.12-7.tar.gz",
 )
 
 load("@rules_bzlmodrio_jdk//:maven_deps.bzl", "setup_legacy_setup_jdk_dependencies")
@@ -62,9 +62,15 @@ register_toolchains(
     "@local_roborio//:macos",
     "@local_roborio//:linux",
     "@local_roborio//:windows",
-    "@local_raspi_32//:macos",
-    "@local_raspi_32//:linux",
-    "@local_raspi_32//:windows",
+    "@local_systemcore//:macos",
+    "@local_systemcore//:linux",
+    "@local_systemcore//:windows",
+    "@local_raspi_bullseye_32//:macos",
+    "@local_raspi_bullseye_32//:linux",
+    "@local_raspi_bullseye_32//:windows",
+    "@local_raspi_bookworm_32//:macos",
+    "@local_raspi_bookworm_32//:linux",
+    "@local_raspi_bookworm_32//:windows",
     "@local_bullseye_32//:macos",
     "@local_bullseye_32//:linux",
     "@local_bullseye_32//:windows",
@@ -83,8 +89,8 @@ setup_legacy_setup_jdk_dependencies()
 
 http_archive(
     name = "bzlmodrio-ni",
-    sha256 = "197fceac88bf44fb8427d5e000b0083118d3346172dd2ad31eccf83a5e61b3ce",
-    url = "https://github.com/wpilibsuite/bzlmodRio-ni/releases/download/2025.0.0/bzlmodRio-ni-2025.0.0.tar.gz",
+    sha256 = "fff62c3cb3e83f9a0d0a01f1739477c9ca5e9a6fac05be1ad59dafcd385801f7",
+    url = "https://github.com/wpilibsuite/bzlmodRio-ni/releases/download/2025.2.0/bzlmodRio-ni-2025.2.0.tar.gz",
 )
 
 load("@bzlmodrio-ni//:maven_cpp_deps.bzl", "setup_legacy_bzlmodrio_ni_cpp_dependencies")
@@ -93,8 +99,8 @@ setup_legacy_bzlmodrio_ni_cpp_dependencies()
 
 http_archive(
     name = "bzlmodrio-opencv",
-    sha256 = "4f4a607956ca8555618736c3058dd96e09d02df19e95088c1e352d2319fd70c7",
-    url = "https://github.com/wpilibsuite/bzlmodRio-opencv/releases/download/2025.4.10.0-2/bzlmodRio-opencv-2025.4.10.0-2.tar.gz",
+    sha256 = "58c0069fc323259f3993750fe8245798f0db8b2fbf3772c5136253fa92912a16",
+    url = "https://github.com/wpilibsuite/bzlmodRio-opencv/releases/download/2025.4.10.0-3/bzlmodRio-opencv-2025.4.10.0-3.tar.gz",
 )
 
 load("@bzlmodrio-opencv//:maven_cpp_deps.bzl", "setup_legacy_bzlmodrio_opencv_cpp_dependencies")

--- a/shared/bazel/compiler_flags/systemcore_flags.rc
+++ b/shared/bazel/compiler_flags/systemcore_flags.rc
@@ -8,4 +8,3 @@ build:systemcore --platform_suffix=systemcore
 build:systemcore --incompatible_enable_cc_toolchain_resolution
 
 build:systemcore --cxxopt=-Wno-error=deprecated-declarations
-

--- a/shared/bazel/compiler_flags/systemcore_flags.rc
+++ b/shared/bazel/compiler_flags/systemcore_flags.rc
@@ -1,0 +1,11 @@
+
+build:systemcore --config=base_linux
+
+build:systemcore --platforms=@rules_bzlmodrio_toolchains//platforms/systemcore
+build:systemcore --build_tag_filters=-no-bookworm
+build:systemcore --features=compiler_param_file
+build:systemcore --platform_suffix=systemcore
+build:systemcore --incompatible_enable_cc_toolchain_resolution
+
+build:systemcore --cxxopt=-Wno-error=deprecated-declarations
+


### PR DESCRIPTION
This updates the toolchains version to one that supports systemcore, mostly for the 2027 branch. Also bumps a couple of versions that were updated in gradle but not in bazel.

I have tested builds in a more bazl'ified version of the 2027 branch and can make that PR once this gets merged over there.