### PR TITLE
[wpiunits] Add Measure.per overloads for all known unit types

### DIFF
--- a/wpiunits/src/generate/main/java/Measure-interface.java.jinja
+++ b/wpiunits/src/generate/main/java/Measure-interface.java.jinja
@@ -86,11 +86,6 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
   default {{ helpers['type_usage'](name) }} divide(double divisor) {
     return ({{ helpers['type_usage'](name) }}) div(divisor);
   }
-
-  @Override
-  default {{ config[name]['divide']['Time'] or "Velocity<{}>".format(helpers['mtou'](name)) }} per(TimeUnit period) {
-    return div(period.of(1));
-  }
 {% for unit in math_units -%}
 {% if unit == "Dimensionless" %}
   @Override
@@ -147,6 +142,15 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
   default {{ config[name]['divide'][unit] }} divide({{ unit }} divisor) {
     return div(divisor);
   }
+
+  @Override
+  default {{ config[name]['divide'][unit] }} per({{ helpers['mtou'](unit) }} divisorUnit) {
+{%- if unit == "Mult<?, ?>" or unit == "Per<?, ?>" %}
+    return div(divisorUnit.ofNative(1));
+{%- else %}
+    return div(divisorUnit.one());
+{%- endif %}
+  }
 {% elif unit == "Time" %}
   @Override
   default Velocity<{{ helpers['mtou'](name) }}> div({{ unit }} divisor) {
@@ -163,6 +167,15 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
   @Override
   default Velocity<{{ helpers['mtou'](name) }}> divide({{ unit }} divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Velocity<{{ helpers['mtou'](name) }}> per({{ helpers['mtou'](unit) }} divisorUnit) {
+{%- if unit == "Mult<?, ?>" or unit == "Per<?, ?>" %}
+    return div(divisorUnit.ofNative(1));
+{%- else %}
+    return div(divisorUnit.one());
+{%- endif %}
   }
 {% elif unit == name %}
   @Override
@@ -181,6 +194,11 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
   default Dimensionless divide({{ unit }} divisor) {
     return div(divisor);
   }
+
+  @Override
+  default Dimensionless per({{ helpers['mtou'](unit) }} divisorUnit) {
+    return div(divisorUnit.one());
+  }
 {% else %}
   @Override
   default Per<{{ helpers['mtou'](name) }}, {{ helpers['mtou'](unit) }}> div({{ unit }} divisor) {
@@ -197,6 +215,15 @@ public interface {{ helpers['type_decl'](name) }} extends Measure<{{ helpers['mt
   @Override
   default Per<{{ helpers['mtou'](name) }}, {{ helpers['mtou'](unit) }}> divide({{ unit }} divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<{{ helpers['mtou'](name) }}, {{ helpers['mtou'](unit) }}> per({{ helpers['mtou'](unit) }} divisorUnit) {
+{%- if unit == "Mult<?, ?>" or unit == "Per<?, ?>" %}
+    return div(divisorUnit.ofNative(1));
+{%- else %}
+    return div(divisorUnit.one());
+{%- endif %}
   }
 {% endif -%}
 {% endif -%}

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Acceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Acceleration.java
@@ -87,11 +87,6 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return (Acceleration<D>) div(divisor);
   }
 
-  @Override
-  default Velocity<AccelerationUnit<D>> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<AccelerationUnit<D>, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AccelerationUnit<D>, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return div(divisor);
   }
 
+  @Override
+  default Per<AccelerationUnit<D>, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AccelerationUnit<D>, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return div(divisor);
   }
 
+  @Override
+  default Per<AccelerationUnit<D>, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return div(divisor);
   }
 
+  @Override
+  default Per<AccelerationUnit<D>, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AccelerationUnit<D>, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return div(divisor);
   }
 
+  @Override
+  default Per<AccelerationUnit<D>, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AccelerationUnit<D>, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return div(divisor);
   }
 
+  @Override
+  default Per<AccelerationUnit<D>, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AccelerationUnit<D>, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return div(divisor);
   }
 
+  @Override
+  default Per<AccelerationUnit<D>, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AccelerationUnit<D>, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return div(divisor);
   }
 
+  @Override
+  default Per<AccelerationUnit<D>, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AccelerationUnit<D>, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return div(divisor);
   }
 
+  @Override
+  default Per<AccelerationUnit<D>, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AccelerationUnit<D>, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return div(divisor);
   }
 
+  @Override
+  default Per<AccelerationUnit<D>, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AccelerationUnit<D>, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return div(divisor);
   }
 
+  @Override
+  default Per<AccelerationUnit<D>, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AccelerationUnit<D>, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return div(divisor);
   }
 
+  @Override
+  default Velocity<AccelerationUnit<D>> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AccelerationUnit<D>, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
     return div(divisor);
   }
 
+  @Override
+  default Per<AccelerationUnit<D>, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AccelerationUnit<D>, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Acceleration<D extends Unit> extends Measure<AccelerationUnit<D
   @Override
   default Per<AccelerationUnit<D>, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AccelerationUnit<D>, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Angle.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Angle.java
@@ -87,11 +87,6 @@ public interface Angle extends Measure<AngleUnit> {
     return (Angle) div(divisor);
   }
 
-  @Override
-  default AngularVelocity per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<AngleUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngleUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Angle extends Measure<AngleUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Dimensionless per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngleUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngleUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Angle extends Measure<AngleUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngleUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngleUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Angle extends Measure<AngleUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngleUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngleUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngleUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Angle extends Measure<AngleUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngleUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngleUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngleUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Angle extends Measure<AngleUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngleUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default AngularVelocity times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngleUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Angle extends Measure<AngleUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngleUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngleUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngleUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Angle extends Measure<AngleUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngleUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngleUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngleUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Angle extends Measure<AngleUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngleUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngleUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngleUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Angle extends Measure<AngleUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngleUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<AngleUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngleUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Angle extends Measure<AngleUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngleUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngleUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngleUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Angle extends Measure<AngleUnit> {
     return div(divisor);
   }
 
+  @Override
+  default AngularVelocity per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngleUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngleUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Angle extends Measure<AngleUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngleUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngleUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Angle extends Measure<AngleUnit> {
   @Override
   default Per<AngleUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngleUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularAcceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularAcceleration.java
@@ -87,11 +87,6 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return (AngularAcceleration) div(divisor);
   }
 
-  @Override
-  default Velocity<AngularAccelerationUnit> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<AngularAccelerationUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularAccelerationUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularAccelerationUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Dimensionless divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Dimensionless per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularAccelerationUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularAccelerationUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularAccelerationUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularAccelerationUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularAccelerationUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularAccelerationUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @SuppressWarnings({"deprecation", "removal"})
   default AngularVelocity divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default AngularVelocity per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularAccelerationUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularAccelerationUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularAccelerationUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularAccelerationUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularAccelerationUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularAccelerationUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularAccelerationUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularAccelerationUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularAccelerationUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularAccelerationUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Velocity<AngularAccelerationUnit> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularAccelerationUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularAccelerationUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularAccelerationUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface AngularAcceleration extends Measure<AngularAccelerationUnit> {
   @Override
   default Per<AngularAccelerationUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularAccelerationUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularMomentum.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularMomentum.java
@@ -87,11 +87,6 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return (AngularMomentum) div(divisor);
   }
 
-  @Override
-  default Velocity<AngularMomentumUnit> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<AngularMomentumUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularMomentumUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularMomentumUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularMomentumUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Dimensionless per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default MomentOfInertia per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularMomentumUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularMomentumUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularMomentumUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularMomentumUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularMomentumUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularMomentumUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularMomentumUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularMomentumUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularMomentumUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularMomentumUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularMomentumUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularMomentumUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularMomentumUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularMomentumUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularMomentumUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Velocity<AngularMomentumUnit> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularMomentumUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularMomentumUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularMomentumUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface AngularMomentum extends Measure<AngularMomentumUnit> {
   @Override
   default Per<AngularMomentumUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularMomentumUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularVelocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/AngularVelocity.java
@@ -87,11 +87,6 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return (AngularVelocity) div(divisor);
   }
 
-  @Override
-  default AngularAcceleration per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<AngularVelocityUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularVelocityUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularVelocityUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularVelocityUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularVelocityUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Dimensionless per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularVelocityUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularVelocityUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularVelocityUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularVelocityUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default AngularAcceleration times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularVelocityUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularVelocityUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularVelocityUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularVelocityUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularVelocityUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularVelocityUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularVelocityUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularVelocityUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularVelocityUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularVelocityUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularVelocityUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default AngularAcceleration per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularVelocityUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<AngularVelocityUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<AngularVelocityUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface AngularVelocity extends Measure<AngularVelocityUnit> {
   @Override
   default Per<AngularVelocityUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<AngularVelocityUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 default Frequency asFrequency() { return Hertz.of(baseUnitMagnitude()); }
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Current.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Current.java
@@ -87,11 +87,6 @@ public interface Current extends Measure<CurrentUnit> {
     return (Current) div(divisor);
   }
 
-  @Override
-  default Velocity<CurrentUnit> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<CurrentUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<CurrentUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Current extends Measure<CurrentUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<CurrentUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<CurrentUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<CurrentUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Current extends Measure<CurrentUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<CurrentUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<CurrentUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Current extends Measure<CurrentUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<CurrentUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<CurrentUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Dimensionless divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Dimensionless per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Current extends Measure<CurrentUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<CurrentUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<CurrentUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<CurrentUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Current extends Measure<CurrentUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<CurrentUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<CurrentUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<CurrentUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Current extends Measure<CurrentUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<CurrentUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<CurrentUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<CurrentUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Current extends Measure<CurrentUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<CurrentUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<CurrentUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<CurrentUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Current extends Measure<CurrentUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<CurrentUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<CurrentUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<CurrentUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Current extends Measure<CurrentUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<CurrentUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<CurrentUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<CurrentUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Current extends Measure<CurrentUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<CurrentUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<CurrentUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<CurrentUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Current extends Measure<CurrentUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Velocity<CurrentUnit> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<CurrentUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<CurrentUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Current extends Measure<CurrentUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<CurrentUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Power times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Current extends Measure<CurrentUnit> {
   @Override
   default Per<CurrentUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<CurrentUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Dimensionless.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Dimensionless.java
@@ -87,11 +87,6 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return (Dimensionless) div(divisor);
   }
 
-  @Override
-  default Frequency per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<DimensionlessUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DimensionlessUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DimensionlessUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default AngularAcceleration times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DimensionlessUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DimensionlessUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default AngularVelocity times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DimensionlessUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Current times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DimensionlessUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DimensionlessUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Energy times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DimensionlessUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DimensionlessUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Frequency times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DimensionlessUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DimensionlessUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default LinearMomentum times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DimensionlessUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DimensionlessUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mass times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DimensionlessUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DimensionlessUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<DimensionlessUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DimensionlessUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DimensionlessUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Power times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DimensionlessUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DimensionlessUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Temperature times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DimensionlessUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Frequency per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Torque times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DimensionlessUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DimensionlessUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Voltage times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Dimensionless extends Measure<DimensionlessUnit> {
   @Override
   default Per<DimensionlessUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DimensionlessUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Distance.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Distance.java
@@ -87,11 +87,6 @@ public interface Distance extends Measure<DistanceUnit> {
     return (Distance) div(divisor);
   }
 
-  @Override
-  default LinearVelocity per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<DistanceUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DistanceUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Distance extends Measure<DistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DistanceUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<DistanceUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DistanceUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Distance extends Measure<DistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DistanceUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<DistanceUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Distance extends Measure<DistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DistanceUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<DistanceUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DistanceUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Distance extends Measure<DistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Dimensionless per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<DistanceUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DistanceUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Distance extends Measure<DistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DistanceUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default LinearVelocity times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DistanceUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Distance extends Measure<DistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DistanceUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<DistanceUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DistanceUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Distance extends Measure<DistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Time per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<DistanceUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DistanceUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Distance extends Measure<DistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DistanceUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<DistanceUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DistanceUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Distance extends Measure<DistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DistanceUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<DistanceUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DistanceUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Distance extends Measure<DistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DistanceUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<DistanceUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DistanceUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Distance extends Measure<DistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default LinearVelocity per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<DistanceUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DistanceUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Distance extends Measure<DistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<DistanceUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<DistanceUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Distance extends Measure<DistanceUnit> {
   @Override
   default Per<DistanceUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<DistanceUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Energy.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Energy.java
@@ -87,11 +87,6 @@ public interface Energy extends Measure<EnergyUnit> {
     return (Energy) div(divisor);
   }
 
-  @Override
-  default Power per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<EnergyUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<EnergyUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Energy extends Measure<EnergyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<EnergyUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<EnergyUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<EnergyUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Energy extends Measure<EnergyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<EnergyUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<EnergyUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Energy extends Measure<EnergyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<EnergyUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<EnergyUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<EnergyUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Energy extends Measure<EnergyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<EnergyUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<EnergyUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Dimensionless divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Dimensionless per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Energy extends Measure<EnergyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<EnergyUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Power times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<EnergyUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Energy extends Measure<EnergyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<EnergyUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<EnergyUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<EnergyUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Energy extends Measure<EnergyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<EnergyUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<EnergyUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<EnergyUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Energy extends Measure<EnergyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<EnergyUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<EnergyUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<EnergyUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Energy extends Measure<EnergyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<EnergyUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<EnergyUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<EnergyUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Energy extends Measure<EnergyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<EnergyUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<EnergyUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<EnergyUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Energy extends Measure<EnergyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Power per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<EnergyUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<EnergyUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Energy extends Measure<EnergyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<EnergyUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<EnergyUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Energy extends Measure<EnergyUnit> {
   @Override
   default Per<EnergyUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<EnergyUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Force.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Force.java
@@ -87,11 +87,6 @@ public interface Force extends Measure<ForceUnit> {
     return (Force) div(divisor);
   }
 
-  @Override
-  default Velocity<ForceUnit> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<ForceUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ForceUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Force extends Measure<ForceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ForceUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ForceUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ForceUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Force extends Measure<ForceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ForceUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ForceUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Force extends Measure<ForceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ForceUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ForceUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ForceUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Force extends Measure<ForceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ForceUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ForceUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ForceUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Force extends Measure<ForceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Dimensionless per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ForceUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ForceUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Force extends Measure<ForceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Mass per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ForceUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ForceUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Force extends Measure<ForceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ForceUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ForceUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Force extends Measure<ForceUnit> {
   @SuppressWarnings({"deprecation", "removal"})
   default LinearAcceleration divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default LinearAcceleration per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Force extends Measure<ForceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ForceUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ForceUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ForceUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Force extends Measure<ForceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ForceUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<ForceUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ForceUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Force extends Measure<ForceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ForceUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ForceUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ForceUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Force extends Measure<ForceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Velocity<ForceUnit> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ForceUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ForceUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Force extends Measure<ForceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ForceUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ForceUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Force extends Measure<ForceUnit> {
   @Override
   default Per<ForceUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ForceUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Frequency.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Frequency.java
@@ -87,11 +87,6 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return (Frequency) div(divisor);
   }
 
-  @Override
-  default Velocity<FrequencyUnit> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<FrequencyUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<FrequencyUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<FrequencyUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<FrequencyUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<FrequencyUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<FrequencyUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default AngularAcceleration times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<FrequencyUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<FrequencyUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<FrequencyUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<FrequencyUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<FrequencyUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<FrequencyUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<FrequencyUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<FrequencyUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Dimensionless divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Dimensionless per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<FrequencyUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<FrequencyUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<FrequencyUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<FrequencyUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<FrequencyUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<FrequencyUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<FrequencyUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<FrequencyUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<FrequencyUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<FrequencyUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<FrequencyUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<FrequencyUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<FrequencyUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<FrequencyUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<FrequencyUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Velocity<FrequencyUnit> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<FrequencyUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<FrequencyUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<FrequencyUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<FrequencyUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Frequency extends Measure<FrequencyUnit> {
   @Override
   default Per<FrequencyUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<FrequencyUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 /** Converts this frequency to the time period between cycles. */
 default Time asPeriod() { return Seconds.of(1 / baseUnitMagnitude()); }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearAcceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearAcceleration.java
@@ -87,11 +87,6 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return (LinearAcceleration) div(divisor);
   }
 
-  @Override
-  default Velocity<LinearAccelerationUnit> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<LinearAccelerationUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearAccelerationUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearAccelerationUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearAccelerationUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearAccelerationUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearAccelerationUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearAccelerationUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearAccelerationUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearAccelerationUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearAccelerationUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @SuppressWarnings({"deprecation", "removal"})
   default LinearVelocity divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default LinearVelocity per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Dimensionless per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearAccelerationUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearAccelerationUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearAccelerationUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearAccelerationUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearAccelerationUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearAccelerationUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearAccelerationUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearAccelerationUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearAccelerationUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Velocity<LinearAccelerationUnit> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearAccelerationUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearAccelerationUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearAccelerationUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface LinearAcceleration extends Measure<LinearAccelerationUnit> {
   @Override
   default Per<LinearAccelerationUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearAccelerationUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearMomentum.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearMomentum.java
@@ -87,11 +87,6 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return (LinearMomentum) div(divisor);
   }
 
-  @Override
-  default Force per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<LinearMomentumUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearMomentumUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearMomentumUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearMomentumUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearMomentumUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearMomentumUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearMomentumUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearMomentumUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearMomentumUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearMomentumUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Force times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearMomentumUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearMomentumUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Dimensionless divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Dimensionless per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Mass per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @SuppressWarnings({"deprecation", "removal"})
   default LinearVelocity divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default LinearVelocity per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearMomentumUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearMomentumUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearMomentumUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearMomentumUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearMomentumUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearMomentumUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Force per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearMomentumUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearMomentumUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearMomentumUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface LinearMomentum extends Measure<LinearMomentumUnit> {
   @Override
   default Per<LinearMomentumUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearMomentumUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearVelocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/LinearVelocity.java
@@ -87,11 +87,6 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return (LinearVelocity) div(divisor);
   }
 
-  @Override
-  default LinearAcceleration per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<LinearVelocityUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearVelocityUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearVelocityUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearVelocityUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearVelocityUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearVelocityUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearVelocityUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearVelocityUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearVelocityUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearVelocityUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default LinearAcceleration times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearVelocityUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearVelocityUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearVelocityUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Dimensionless per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearVelocityUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearVelocityUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearVelocityUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearVelocityUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearVelocityUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearVelocityUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearVelocityUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default LinearAcceleration per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearVelocityUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<LinearVelocityUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<LinearVelocityUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface LinearVelocity extends Measure<LinearVelocityUnit> {
   @Override
   default Per<LinearVelocityUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<LinearVelocityUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mass.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mass.java
@@ -87,11 +87,6 @@ public interface Mass extends Measure<MassUnit> {
     return (Mass) div(divisor);
   }
 
-  @Override
-  default Velocity<MassUnit> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<MassUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MassUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Mass extends Measure<MassUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MassUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MassUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MassUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Mass extends Measure<MassUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MassUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MassUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Mass extends Measure<MassUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MassUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MassUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MassUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Mass extends Measure<MassUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MassUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MassUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MassUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Mass extends Measure<MassUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MassUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MassUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MassUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Mass extends Measure<MassUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MassUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MassUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MassUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Mass extends Measure<MassUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MassUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MassUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Dimensionless divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Dimensionless per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Mass extends Measure<MassUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MassUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MassUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MassUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Mass extends Measure<MassUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MassUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<MassUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MassUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Mass extends Measure<MassUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MassUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MassUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MassUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Mass extends Measure<MassUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Velocity<MassUnit> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MassUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MassUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Mass extends Measure<MassUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MassUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MassUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Mass extends Measure<MassUnit> {
   @Override
   default Per<MassUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MassUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MomentOfInertia.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MomentOfInertia.java
@@ -87,11 +87,6 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return (MomentOfInertia) div(divisor);
   }
 
-  @Override
-  default Velocity<MomentOfInertiaUnit> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<MomentOfInertiaUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MomentOfInertiaUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MomentOfInertiaUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MomentOfInertiaUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MomentOfInertiaUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default AngularMomentum times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MomentOfInertiaUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MomentOfInertiaUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MomentOfInertiaUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MomentOfInertiaUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MomentOfInertiaUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MomentOfInertiaUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MomentOfInertiaUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MomentOfInertiaUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MomentOfInertiaUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MomentOfInertiaUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Dimensionless per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MomentOfInertiaUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MomentOfInertiaUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MomentOfInertiaUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MomentOfInertiaUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MomentOfInertiaUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Velocity<MomentOfInertiaUnit> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MomentOfInertiaUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<MomentOfInertiaUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MomentOfInertiaUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface MomentOfInertia extends Measure<MomentOfInertiaUnit> {
   @Override
   default Per<MomentOfInertiaUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MomentOfInertiaUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mult.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Mult.java
@@ -87,11 +87,6 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return (Mult<A, B>) div(divisor);
   }
 
-  @Override
-  default Velocity<MultUnit<A, B>> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<MultUnit<A, B>, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MultUnit<A, B>, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return div(divisor);
   }
 
+  @Override
+  default Per<MultUnit<A, B>, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MultUnit<A, B>, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return div(divisor);
   }
 
+  @Override
+  default Per<MultUnit<A, B>, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return div(divisor);
   }
 
+  @Override
+  default Per<MultUnit<A, B>, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MultUnit<A, B>, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return div(divisor);
   }
 
+  @Override
+  default Per<MultUnit<A, B>, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MultUnit<A, B>, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return div(divisor);
   }
 
+  @Override
+  default Per<MultUnit<A, B>, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MultUnit<A, B>, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return div(divisor);
   }
 
+  @Override
+  default Per<MultUnit<A, B>, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MultUnit<A, B>, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return div(divisor);
   }
 
+  @Override
+  default Per<MultUnit<A, B>, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MultUnit<A, B>, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return div(divisor);
   }
 
+  @Override
+  default Per<MultUnit<A, B>, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MultUnit<A, B>, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return div(divisor);
   }
 
+  @Override
+  default Per<MultUnit<A, B>, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MultUnit<A, B>, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return div(divisor);
   }
 
+  @Override
+  default Per<MultUnit<A, B>, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MultUnit<A, B>, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return div(divisor);
   }
 
+  @Override
+  default Velocity<MultUnit<A, B>> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MultUnit<A, B>, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
     return div(divisor);
   }
 
+  @Override
+  default Per<MultUnit<A, B>, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<MultUnit<A, B>, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Mult<A extends Unit, B extends Unit> extends Measure<MultUnit<A
   @Override
   default Per<MultUnit<A, B>, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<MultUnit<A, B>, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Per.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Per.java
@@ -87,11 +87,6 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return (Per<Dividend, Divisor>) div(divisor);
   }
 
-  @Override
-  default Velocity<PerUnit<Dividend, Divisor>> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return div(divisor);
   }
 
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return div(divisor);
   }
 
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return div(divisor);
   }
 
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return div(divisor);
   }
 
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return div(divisor);
   }
 
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return div(divisor);
   }
 
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return div(divisor);
   }
 
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return div(divisor);
   }
 
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return div(divisor);
   }
 
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return div(divisor);
   }
 
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return div(divisor);
   }
 
+  @Override
+  default Velocity<PerUnit<Dividend, Divisor>> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
     return div(divisor);
   }
 
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PerUnit<Dividend, Divisor>, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Per<Dividend extends Unit, Divisor extends Unit> extends Measur
   @Override
   default Per<PerUnit<Dividend, Divisor>, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PerUnit<Dividend, Divisor>, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 default Measure<Dividend> timesDivisor(Measure<? extends Divisor> multiplier) {
   return (Measure<Dividend>) baseUnit().numerator().ofBaseUnits(baseUnitMagnitude() * multiplier.baseUnitMagnitude());

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Power.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Power.java
@@ -87,11 +87,6 @@ public interface Power extends Measure<PowerUnit> {
     return (Power) div(divisor);
   }
 
-  @Override
-  default Velocity<PowerUnit> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<PowerUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PowerUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Power extends Measure<PowerUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<PowerUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PowerUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PowerUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Power extends Measure<PowerUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<PowerUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PowerUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Power extends Measure<PowerUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<PowerUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PowerUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Power extends Measure<PowerUnit> {
   @SuppressWarnings({"deprecation", "removal"})
   default Voltage divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Voltage per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Power extends Measure<PowerUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<PowerUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PowerUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Power extends Measure<PowerUnit> {
   @SuppressWarnings({"deprecation", "removal"})
   default Frequency divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Frequency per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Power extends Measure<PowerUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<PowerUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PowerUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PowerUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Power extends Measure<PowerUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<PowerUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PowerUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PowerUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Power extends Measure<PowerUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<PowerUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PowerUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PowerUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Power extends Measure<PowerUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<PowerUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PowerUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PowerUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Power extends Measure<PowerUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<PowerUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<PowerUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Dimensionless divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Dimensionless per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Power extends Measure<PowerUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<PowerUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PowerUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PowerUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Power extends Measure<PowerUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Velocity<PowerUnit> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PowerUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Power extends Measure<PowerUnit> {
   @Override
   default Per<PowerUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<PowerUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Power extends Measure<PowerUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<PowerUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<PowerUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Power extends Measure<PowerUnit> {
   @SuppressWarnings({"deprecation", "removal"})
   default Current divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Current per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Resistance.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Resistance.java
@@ -87,11 +87,6 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return (Resistance) div(divisor);
   }
 
-  @Override
-  default Velocity<ResistanceUnit> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<ResistanceUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ResistanceUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ResistanceUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ResistanceUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ResistanceUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ResistanceUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ResistanceUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ResistanceUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Voltage times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ResistanceUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ResistanceUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ResistanceUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ResistanceUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ResistanceUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ResistanceUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ResistanceUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ResistanceUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ResistanceUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ResistanceUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ResistanceUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ResistanceUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ResistanceUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ResistanceUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ResistanceUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ResistanceUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ResistanceUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<ResistanceUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ResistanceUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Dimensionless per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ResistanceUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ResistanceUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Velocity<ResistanceUnit> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ResistanceUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ResistanceUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<ResistanceUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<ResistanceUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Resistance extends Measure<ResistanceUnit> {
   @Override
   default Per<ResistanceUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<ResistanceUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Temperature.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Temperature.java
@@ -87,11 +87,6 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return (Temperature) div(divisor);
   }
 
-  @Override
-  default Velocity<TemperatureUnit> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<TemperatureUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TemperatureUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TemperatureUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TemperatureUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TemperatureUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TemperatureUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TemperatureUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TemperatureUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TemperatureUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TemperatureUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TemperatureUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TemperatureUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TemperatureUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TemperatureUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TemperatureUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TemperatureUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TemperatureUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TemperatureUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TemperatureUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TemperatureUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TemperatureUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TemperatureUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TemperatureUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TemperatureUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TemperatureUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TemperatureUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<TemperatureUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TemperatureUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TemperatureUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TemperatureUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Dimensionless divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Dimensionless per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Velocity<TemperatureUnit> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TemperatureUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TemperatureUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TemperatureUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TemperatureUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Temperature extends Measure<TemperatureUnit> {
   @Override
   default Per<TemperatureUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TemperatureUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Time.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Time.java
@@ -87,11 +87,6 @@ public interface Time extends Measure<TimeUnit> {
     return (Time) div(divisor);
   }
 
-  @Override
-  default Dimensionless per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<TimeUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TimeUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Time extends Measure<TimeUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TimeUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default AngularVelocity times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TimeUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Time extends Measure<TimeUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TimeUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Angle times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Time extends Measure<TimeUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TimeUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TimeUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TimeUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Time extends Measure<TimeUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TimeUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TimeUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TimeUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Time extends Measure<TimeUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TimeUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Dimensionless times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TimeUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Time extends Measure<TimeUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TimeUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TimeUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TimeUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Time extends Measure<TimeUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TimeUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TimeUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TimeUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Time extends Measure<TimeUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TimeUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TimeUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TimeUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Time extends Measure<TimeUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TimeUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<TimeUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TimeUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Time extends Measure<TimeUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TimeUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TimeUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TimeUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Time extends Measure<TimeUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Dimensionless per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TimeUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TimeUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Time extends Measure<TimeUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TimeUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TimeUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Time extends Measure<TimeUnit> {
   @Override
   default Per<TimeUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TimeUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 default Frequency asFrequency() { return Hertz.of(1 / baseUnitMagnitude()); }
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Torque.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Torque.java
@@ -87,11 +87,6 @@ public interface Torque extends Measure<TorqueUnit> {
     return (Torque) div(divisor);
   }
 
-  @Override
-  default Velocity<TorqueUnit> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<TorqueUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TorqueUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Torque extends Measure<TorqueUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TorqueUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TorqueUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TorqueUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Torque extends Measure<TorqueUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TorqueUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TorqueUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Torque extends Measure<TorqueUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TorqueUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TorqueUnit, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TorqueUnit, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Torque extends Measure<TorqueUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Force per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TorqueUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TorqueUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Torque extends Measure<TorqueUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Distance per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TorqueUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TorqueUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Torque extends Measure<TorqueUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TorqueUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TorqueUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TorqueUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Torque extends Measure<TorqueUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TorqueUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TorqueUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TorqueUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Torque extends Measure<TorqueUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TorqueUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TorqueUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TorqueUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Torque extends Measure<TorqueUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TorqueUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<TorqueUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TorqueUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Torque extends Measure<TorqueUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TorqueUnit, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TorqueUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TorqueUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Torque extends Measure<TorqueUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Velocity<TorqueUnit> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TorqueUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Dimensionless divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Dimensionless per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Torque extends Measure<TorqueUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<TorqueUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<TorqueUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Torque extends Measure<TorqueUnit> {
   @Override
   default Per<TorqueUnit, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<TorqueUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Velocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Velocity.java
@@ -87,11 +87,6 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return (Velocity<D>) div(divisor);
   }
 
-  @Override
-  default Velocity<VelocityUnit<D>> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<VelocityUnit<D>, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VelocityUnit<D>, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VelocityUnit<D>, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VelocityUnit<D>, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VelocityUnit<D>, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VelocityUnit<D>, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, CurrentUnit> times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, CurrentUnit> divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VelocityUnit<D>, CurrentUnit> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VelocityUnit<D>, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VelocityUnit<D>, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VelocityUnit<D>, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VelocityUnit<D>, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VelocityUnit<D>, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VelocityUnit<D>, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VelocityUnit<D>, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VelocityUnit<D>, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VelocityUnit<D>, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VelocityUnit<D>, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VelocityUnit<D>, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, PowerUnit> times(Power multiplier) {
@@ -528,6 +608,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VelocityUnit<D>, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, ResistanceUnit> times(Resistance multiplier) {
@@ -549,6 +634,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, ResistanceUnit> divide(Resistance divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VelocityUnit<D>, ResistanceUnit> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -575,6 +665,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   }
 
   @Override
+  default Per<VelocityUnit<D>, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  @Override
   default Measure<D> times(Time multiplier) {
     return (Measure<D>) unit().numerator().ofBaseUnits(baseUnitMagnitude() * multiplier.baseUnitMagnitude());
   }
@@ -594,6 +689,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Velocity<VelocityUnit<D>> divide(Time divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Velocity<VelocityUnit<D>> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -619,6 +719,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VelocityUnit<D>, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, VelocityUnit<?>> times(Velocity<?> multiplier) {
@@ -642,6 +747,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VelocityUnit<D>, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VelocityUnit<D>, VoltageUnit> times(Voltage multiplier) {
@@ -663,6 +773,11 @@ public interface Velocity<D extends Unit> extends Measure<VelocityUnit<D>> {
   @Override
   default Per<VelocityUnit<D>, VoltageUnit> divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VelocityUnit<D>, VoltageUnit> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Voltage.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Voltage.java
@@ -87,11 +87,6 @@ public interface Voltage extends Measure<VoltageUnit> {
     return (Voltage) div(divisor);
   }
 
-  @Override
-  default Velocity<VoltageUnit> per(TimeUnit period) {
-    return div(period.of(1));
-  }
-
 
   @Override
   default Mult<VoltageUnit, AccelerationUnit<?>> times(Acceleration<?> multiplier) {
@@ -113,6 +108,11 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, AccelerationUnit<?>> divide(Acceleration<?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VoltageUnit, AccelerationUnit<?>> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -138,6 +138,11 @@ public interface Voltage extends Measure<VoltageUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VoltageUnit, AngleUnit> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VoltageUnit, AngularAccelerationUnit> times(AngularAcceleration multiplier) {
@@ -159,6 +164,11 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, AngularAccelerationUnit> divide(AngularAcceleration divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VoltageUnit, AngularAccelerationUnit> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -184,6 +194,11 @@ public interface Voltage extends Measure<VoltageUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VoltageUnit, AngularMomentumUnit> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VoltageUnit, AngularVelocityUnit> times(AngularVelocity multiplier) {
@@ -207,6 +222,11 @@ public interface Voltage extends Measure<VoltageUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VoltageUnit, AngularVelocityUnit> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Power times(Current multiplier) {
@@ -228,6 +248,11 @@ public interface Voltage extends Measure<VoltageUnit> {
   @SuppressWarnings({"deprecation", "removal"})
   default Resistance divide(Current divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Resistance per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
   @Override
@@ -275,6 +300,11 @@ public interface Voltage extends Measure<VoltageUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VoltageUnit, DistanceUnit> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VoltageUnit, EnergyUnit> times(Energy multiplier) {
@@ -296,6 +326,11 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, EnergyUnit> divide(Energy divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VoltageUnit, EnergyUnit> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -321,6 +356,11 @@ public interface Voltage extends Measure<VoltageUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VoltageUnit, ForceUnit> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VoltageUnit, FrequencyUnit> times(Frequency multiplier) {
@@ -342,6 +382,11 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, FrequencyUnit> divide(Frequency divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VoltageUnit, FrequencyUnit> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -367,6 +412,11 @@ public interface Voltage extends Measure<VoltageUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VoltageUnit, LinearAccelerationUnit> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VoltageUnit, LinearMomentumUnit> times(LinearMomentum multiplier) {
@@ -388,6 +438,11 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, LinearMomentumUnit> divide(LinearMomentum divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VoltageUnit, LinearMomentumUnit> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -413,6 +468,11 @@ public interface Voltage extends Measure<VoltageUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VoltageUnit, LinearVelocityUnit> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VoltageUnit, MassUnit> times(Mass multiplier) {
@@ -434,6 +494,11 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, MassUnit> divide(Mass divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VoltageUnit, MassUnit> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -459,6 +524,11 @@ public interface Voltage extends Measure<VoltageUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VoltageUnit, MomentOfInertiaUnit> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VoltageUnit, MultUnit<?, ?>> times(Mult<?, ?> multiplier) {
@@ -480,6 +550,11 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, MultUnit<?, ?>> divide(Mult<?, ?> divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VoltageUnit, MultUnit<?, ?>> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
   }
 
 
@@ -505,6 +580,11 @@ public interface Voltage extends Measure<VoltageUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VoltageUnit, PerUnit<?, ?>> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.ofNative(1));
+  }
+
 
   @Override
   default Mult<VoltageUnit, PowerUnit> times(Power multiplier) {
@@ -526,6 +606,11 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, PowerUnit> divide(Power divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VoltageUnit, PowerUnit> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -551,6 +636,11 @@ public interface Voltage extends Measure<VoltageUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Current per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VoltageUnit, TemperatureUnit> times(Temperature multiplier) {
@@ -572,6 +662,11 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, TemperatureUnit> divide(Temperature divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VoltageUnit, TemperatureUnit> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -597,6 +692,11 @@ public interface Voltage extends Measure<VoltageUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Velocity<VoltageUnit> per(TimeUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VoltageUnit, TorqueUnit> times(Torque multiplier) {
@@ -618,6 +718,11 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Per<VoltageUnit, TorqueUnit> divide(Torque divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Per<VoltageUnit, TorqueUnit> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 
@@ -643,6 +748,11 @@ public interface Voltage extends Measure<VoltageUnit> {
     return div(divisor);
   }
 
+  @Override
+  default Per<VoltageUnit, VelocityUnit<?>> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
 
   @Override
   default Mult<VoltageUnit, VoltageUnit> times(Voltage multiplier) {
@@ -664,6 +774,11 @@ public interface Voltage extends Measure<VoltageUnit> {
   @Override
   default Dimensionless divide(Voltage divisor) {
     return div(divisor);
+  }
+
+  @Override
+  default Dimensionless per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
   }
 
 }

--- a/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
@@ -1022,6 +1022,270 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
   }
 
   /**
+   * Divides this measure by an acceleration unit and returns the result in the most appropriate
+   * unit. This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(AccelerationUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by an angle unit and returns the result in the most appropriate unit. This
+   * is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(AngleUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by an angular acceleration unit and returns the result in the most
+   * appropriate unit. This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(AngularAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by an angular momentum unit and returns the result in the most appropriate
+   * unit. This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(AngularMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by an angular velocity unit and returns the result in the most appropriate
+   * unit. This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(AngularVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a unit of electric current and returns the result in the most
+   * appropriate unit. This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(CurrentUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a distance unit and returns the result in the most appropriate unit.
+   * This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(DistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by an energy unit and returns the result in the most appropriate unit.
+   * This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(EnergyUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a force unit and returns the result in the most appropriate unit. This
+   * is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(ForceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a frequency unit and returns the result in the most appropriate unit.
+   * This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(FrequencyUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a linear acceleration unit and returns the result in the most
+   * appropriate unit. This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(LinearAccelerationUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a linear momentum unit and returns the result in the most appropriate
+   * unit. This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(LinearMomentumUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a linear velocity unit and returns the result in the most appropriate
+   * unit. This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(LinearVelocityUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a mass unit and returns the result in the most appropriate unit. This
+   * is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(MassUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a moment of inertia unit and returns the result in the most appropriate
+   * unit. This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(MomentOfInertiaUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a generic compound unit and returns the result in the most appropriate
+   * unit. This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(MultUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a power unit and returns the result in the most appropriate unit. This
+   * is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(PowerUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a generic ratio unit and returns the result in the most appropriate
+   * unit. This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(PerUnit<?, ?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a temperature unit and returns the result in the most appropriate unit.
+   * This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(TemperatureUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a time period and returns the result in the most appropriate unit. This
+   * is equivalent to {@code div(period.of(1))}.
+   *
+   * @param period the time period measurement to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(TimeUnit period) {
+    return div(period.of(1));
+  }
+
+  /**
+   * Divides this measure by a torque unit and returns the result in the most appropriate unit. This
+   * is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(TorqueUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a velocity unit and returns the result in the most appropriate unit.
+   * This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(VelocityUnit<?> divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a voltage unit and returns the result in the most appropriate unit.
+   * This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(VoltageUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
+   * Divides this measure by a resistance unit and returns the result in the most appropriate unit.
+   * This is equivalent to {@code div(divisorUnit.of(1))}.
+   *
+   * @param divisorUnit the unit to divide by.
+   * @return the division result
+   */
+  default Measure<?> per(ResistanceUnit divisorUnit) {
+    return div(divisorUnit.one());
+  }
+
+  /**
    * Divides this measure by a unitless scalar and returns the result.
    *
    * @param divisor the measurement to divide by.
@@ -1369,17 +1633,6 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
       Measure<? extends PerUnit<? extends U, Other>> divisor) {
     return ImmutableMeasure.ofBaseUnits(
         baseUnitMagnitude() / divisor.baseUnitMagnitude(), divisor.unit().denominator());
-  }
-
-  /**
-   * Divides this measure by a time period and returns the result in the most appropriate unit. This
-   * is equivalent to {@code div(period.of(1))}.
-   *
-   * @param period the time period measurement to divide by.
-   * @return the division result
-   */
-  default Measure<?> per(TimeUnit period) {
-    return div(period.of(1));
   }
 
   /**

--- a/wpiunits/src/main/java/edu/wpi/first/units/VelocityUnit.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/VelocityUnit.java
@@ -90,14 +90,14 @@ public final class VelocityUnit<D extends Unit> extends PerUnit<D, TimeUnit> {
 
   @Override
   @SuppressWarnings("unchecked")
-  public Measure<? extends VelocityUnit<D>> zero() {
-    return (Measure<? extends VelocityUnit<D>>) super.zero();
+  public Velocity<D> zero() {
+    return (Velocity<D>) super.zero();
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public Measure<? extends VelocityUnit<D>> one() {
-    return (Measure<? extends VelocityUnit<D>>) super.one();
+  public Velocity<D> one() {
+    return (Velocity<D>) super.one();
   }
 
   @Override


### PR DESCRIPTION
Instead of only providing per(TimeUnit)

Useful for making conversion factors easier, eg `Inches.of(10).per(Rotation)` vs `Inches.of(10).per(Rotation.one())`

Update VelocityUnit.one() and VelocityUnit.zero() to return Velocity objects instead of generic `Measure<? extends VelocityUnit<D>>`; VelocityUnit is final, so the wildcard generic is unnecessary, and this makes the generated `per` functions possible for this type