### PR TITLE
[wpilibj] ADIS16470: Allow product ID of 16470

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16470_IMU.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16470_IMU.java
@@ -483,7 +483,8 @@ public class ADIS16470_IMU implements AutoCloseable, Sendable {
     }
     readRegister(PROD_ID); // Dummy read
     // Validate the product ID
-    if (readRegister(PROD_ID) != 16982) {
+    int prodId = readRegister(PROD_ID);
+    if (prodId != 16982 && prodId != 16470) {
       DriverStation.reportError("Could not find an ADIS16470", false);
       close();
       return false;


### PR DESCRIPTION
C++ allows either 16982 or 16470, do the same for Java.