### PR TITLE
[wpimath] Fix macro name typo

### DIFF
--- a/wpimath/src/main/native/include/units/base.h
+++ b/wpimath/src/main/native/include/units/base.h
@@ -1759,7 +1759,7 @@ namespace units
 
 	namespace traits
 	{
-#ifdef FOR_DOXYGEN_PURPOSOES_ONLY
+#ifdef FOR_DOXYGEN_PURPOSES_ONLY
 		/**
 		* @ingroup		TypeTraits
 		* @brief		Trait for accessing the publicly defined types of `units::unit_t`


### PR DESCRIPTION
Self explanatory. Found this while trying to understand how the units worked.