### PR TITLE
[glass] Add NetworkTables view entry order setting

### DIFF
--- a/glass/src/lib/native/cpp/support/EnumSetting.cpp
+++ b/glass/src/lib/native/cpp/support/EnumSetting.cpp
@@ -41,6 +41,27 @@ bool EnumSetting::Combo(const char* label, int numOptions,
   return false;
 }
 
+bool EnumSetting::Menu(const char* label) {
+  if (m_value == -1) {
+    UpdateValue();
+  }
+
+  int i = 0;
+  bool change = false;
+  if (ImGui::BeginMenu(label)) {
+    for (auto choice : m_choices) {
+      if (ImGui::MenuItem(choice, nullptr, i == m_value)) {
+        SetValue(i);
+        change = true;
+      }
+      ++i;
+    }
+    ImGui::EndMenu();
+  }
+
+  return change;
+}
+
 void EnumSetting::UpdateValue() const {
   // override default value if str is one of the choices
   int i = 0;

--- a/glass/src/lib/native/include/glass/support/EnumSetting.h
+++ b/glass/src/lib/native/include/glass/support/EnumSetting.h
@@ -22,6 +22,8 @@ class EnumSetting {
   bool Combo(const char* label, int numOptions = -1,
              int popup_max_height_in_items = -1);
 
+  bool Menu(const char* label);
+
  private:
   void UpdateValue() const;
 

--- a/glass/src/libnt/native/include/glass/networktables/NetworkTables.h
+++ b/glass/src/libnt/native/include/glass/networktables/NetworkTables.h
@@ -26,6 +26,7 @@
 
 #include "glass/Model.h"
 #include "glass/View.h"
+#include "glass/support/EnumSetting.h"
 
 namespace glass {
 
@@ -201,9 +202,18 @@ class NetworkTablesModel : public Model {
 #endif
 };
 
+using NetworkTablesOrdering = int;
+
+enum NetworkTablesOrdering_ {
+  NetworkTablesOrdering_Combined = 0,
+  NetworkTablesOrdering_EntriesFirst,
+  NetworkTablesOrdering_SubtablesFirst,
+};
+
 using NetworkTablesFlags = int;
 
-static constexpr const int kNetworkTablesFlags_PrecisionBitShift = 9;
+static constexpr const int kNetworkTablesFlags_OrderingBitShift = 9;
+static constexpr const int kNetworkTablesFlags_PrecisionBitShift = 11;
 
 enum NetworkTablesFlags_ {
   NetworkTablesFlags_TreeView = 1 << 0,
@@ -214,6 +224,7 @@ enum NetworkTablesFlags_ {
   NetworkTablesFlags_ShowTimestamp = 1 << 5,
   NetworkTablesFlags_ShowServerTimestamp = 1 << 6,
   NetworkTablesFlags_CreateNoncanonicalKeys = 1 << 7,
+  NetworkTablesFlags_Ordering = 0b11 << kNetworkTablesFlags_OrderingBitShift,
   NetworkTablesFlags_Precision = 0xff << kNetworkTablesFlags_PrecisionBitShift,
   NetworkTablesFlags_Default = NetworkTablesFlags_TreeView |
                                (6 << kNetworkTablesFlags_PrecisionBitShift),
@@ -248,6 +259,7 @@ class NetworkTablesFlagsSettings {
   bool* m_pShowTimestamp = nullptr;
   bool* m_pShowServerTimestamp = nullptr;
   bool* m_pCreateNoncanonicalKeys = nullptr;
+  std::unique_ptr<EnumSetting> m_pOrdering;  // NetworkTablesOrdering
   int* m_pPrecision = nullptr;
   NetworkTablesFlags m_defaultFlags;  // NOLINT
   NetworkTablesFlags m_flags;         // NOLINT


### PR DESCRIPTION
This adds a setting to the NetworkTables window to group entries and subtables together, similar to how many IDEs organize the project file tree. For me, organizing the entries this way makes it easier to find what I'm looking for, and I think it likely would for other people as well. 

This adds 3 modes:
- `Combined` (default): Same behavior as previously, with all entries and subtables together in alphabetical order.
![combined](https://github.com/user-attachments/assets/3b1314a9-b44e-4a05-8847-22ea3c8ab5a9)
- `Entries First`: All entries are placed above subtables in the tree view
![entries first](https://github.com/user-attachments/assets/46c29f11-6ad8-4238-9e56-fb043e0638a2)
- `Subtables First`: All subtables are placed above entries in the tree view
![subtables first](https://github.com/user-attachments/assets/b00656ef-75e3-4922-b85a-64c0dc488165)
