### PR TITLE
[ci] Re-enable Artifactory cleaner cron job

### DIFF
--- a/.github/workflows/aql/wpilib-mvn-development_unused.aql
+++ b/.github/workflows/aql/wpilib-mvn-development_unused.aql
@@ -3,7 +3,7 @@
     {
       "aql": {
         "items.find": {
-          "repo": "wpilib-mvn-development",
+          "repo": "wpilib-mvn-development-local",
           "path": { "$nmatch":"*edu/wpi/first/thirdparty*" },
           "$or":[
             {

--- a/.github/workflows/artifactory-nightly-cleanup.yml
+++ b/.github/workflows/artifactory-nightly-cleanup.yml
@@ -2,6 +2,8 @@ name: Artifactory Nightly Cleanup
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '15 2 * * *'
 
 jobs:
   wpilib-mvn-development_unused_cleanup:


### PR DESCRIPTION
Now that we've recovered from the Great Artifactory Purge and reorganized the repos, we can turn this back on. The query targets the local repo for extra safety.