### PR TITLE
[wpiutil] Add ManagedStatic

### DIFF
--- a/upstream_utils/llvm.py
+++ b/upstream_utils/llvm.py
@@ -62,6 +62,7 @@ def run_global_replacements(wpiutil_llvm_files):
         content = content.replace("LLVM_ADT_", "WPIUTIL_WPI_")
         content = content.replace("LLVM_SUPPORT_", "WPIUTIL_WPI_")
         content = content.replace("LLVM_DEFINED_HAS_FEATURE", "WPI_DEFINED_HAS_FEATURE")
+        content = content.replace("LLVM_USE_CONSTEXPR_CTOR", "WPI_USE_CONSTEXPR_CTOR")
 
         content = content.replace("const std::string_view &", "std::string_view ")
         content = content.replace("sys::fs::openFileForRead", "fs::OpenFileForRead")
@@ -73,6 +74,8 @@ def run_global_replacements(wpiutil_llvm_files):
 
         # Replace llvm_unreachable() with wpi_unreachable()
         content = content.replace("llvm_unreachable", "wpi_unreachable")
+        # Replace llvm_shutdown() with wpi_shutdown()
+        content = content.replace("llvm_shutdown", "wpi_shutdown")
 
         content = content.replace("llvm_is_multithreaded()", "1")
 

--- a/upstream_utils/llvm_patches/0001-Remove-StringRef-ArrayRef-and-Optional.patch
+++ b/upstream_utils/llvm_patches/0001-Remove-StringRef-ArrayRef-and-Optional.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:09:18 -0400
-Subject: [PATCH 01/37] Remove StringRef, ArrayRef, and Optional
+Subject: [PATCH 01/38] Remove StringRef, ArrayRef, and Optional
 
 ---
  llvm/include/llvm/ADT/PointerUnion.h          |   1 -

--- a/upstream_utils/llvm_patches/0002-Wrap-std-min-max-calls-in-parens-for-Windows-warning.patch
+++ b/upstream_utils/llvm_patches/0002-Wrap-std-min-max-calls-in-parens-for-Windows-warning.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:12:41 -0400
-Subject: [PATCH 02/37] Wrap std::min/max calls in parens, for Windows warnings
+Subject: [PATCH 02/38] Wrap std::min/max calls in parens, for Windows warnings
 
 ---
  llvm/include/llvm/ADT/DenseMap.h       |  4 ++--

--- a/upstream_utils/llvm_patches/0003-Change-unique_function-storage-size.patch
+++ b/upstream_utils/llvm_patches/0003-Change-unique_function-storage-size.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:13:55 -0400
-Subject: [PATCH 03/37] Change unique_function storage size
+Subject: [PATCH 03/38] Change unique_function storage size
 
 ---
  llvm/include/llvm/ADT/FunctionExtras.h | 4 ++--

--- a/upstream_utils/llvm_patches/0004-Threading-updates.patch
+++ b/upstream_utils/llvm_patches/0004-Threading-updates.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:17:19 -0400
-Subject: [PATCH 04/37] Threading updates
+Subject: [PATCH 04/38] Threading updates
 
 - Remove guards for threads and exception
 - Prefer scope gaurd over lock gaurd

--- a/upstream_utils/llvm_patches/0005-ifdef-guard-safety.patch
+++ b/upstream_utils/llvm_patches/0005-ifdef-guard-safety.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:28:13 -0400
-Subject: [PATCH 05/37] \#ifdef guard safety
+Subject: [PATCH 05/38] \#ifdef guard safety
 
 Prevents redefinition if someone is pulling in real LLVM, since the macros are in global namespace
 ---

--- a/upstream_utils/llvm_patches/0006-Explicitly-use-std.patch
+++ b/upstream_utils/llvm_patches/0006-Explicitly-use-std.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:37:34 -0400
-Subject: [PATCH 06/37] Explicitly use std::
+Subject: [PATCH 06/38] Explicitly use std::
 
 ---
  llvm/include/llvm/ADT/SmallSet.h       |  2 +-

--- a/upstream_utils/llvm_patches/0007-Remove-format_provider.patch
+++ b/upstream_utils/llvm_patches/0007-Remove-format_provider.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:53:50 -0400
-Subject: [PATCH 07/37] Remove format_provider
+Subject: [PATCH 07/38] Remove format_provider
 
 ---
  llvm/include/llvm/Support/Chrono.h      | 114 ------------------------

--- a/upstream_utils/llvm_patches/0008-Add-compiler-warning-pragmas.patch
+++ b/upstream_utils/llvm_patches/0008-Add-compiler-warning-pragmas.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 13:34:07 -0400
-Subject: [PATCH 08/37] Add compiler warning pragmas
+Subject: [PATCH 08/38] Add compiler warning pragmas
 
 ---
  llvm/include/llvm/ADT/FunctionExtras.h | 11 +++++++++++

--- a/upstream_utils/llvm_patches/0009-Remove-unused-functions.patch
+++ b/upstream_utils/llvm_patches/0009-Remove-unused-functions.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 13:43:50 -0400
-Subject: [PATCH 09/37] Remove unused functions
+Subject: [PATCH 09/38] Remove unused functions
 
 ---
  llvm/include/llvm/ADT/SmallString.h      |  77 ------

--- a/upstream_utils/llvm_patches/0010-Detemplatize-SmallVectorBase.patch
+++ b/upstream_utils/llvm_patches/0010-Detemplatize-SmallVectorBase.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Thu, 5 May 2022 23:18:34 -0400
-Subject: [PATCH 10/37] Detemplatize SmallVectorBase
+Subject: [PATCH 10/38] Detemplatize SmallVectorBase
 
 ---
  llvm/include/llvm/ADT/SmallVector.h | 35 ++++++++++-----------------

--- a/upstream_utils/llvm_patches/0011-Add-vectors-to-raw_ostream.patch
+++ b/upstream_utils/llvm_patches/0011-Add-vectors-to-raw_ostream.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 13:48:59 -0400
-Subject: [PATCH 11/37] Add vectors to raw_ostream
+Subject: [PATCH 11/38] Add vectors to raw_ostream
 
 ---
  llvm/include/llvm/Support/raw_ostream.h | 115 ++++++++++++++++++++++++

--- a/upstream_utils/llvm_patches/0012-Extra-collections-features.patch
+++ b/upstream_utils/llvm_patches/0012-Extra-collections-features.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 3 May 2022 22:16:10 -0400
-Subject: [PATCH 12/37] Extra collections features
+Subject: [PATCH 12/38] Extra collections features
 
 ---
  llvm/lib/Support/raw_ostream.cpp | 8 ++++++++

--- a/upstream_utils/llvm_patches/0013-EpochTracker-ABI-macro.patch
+++ b/upstream_utils/llvm_patches/0013-EpochTracker-ABI-macro.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Wed, 4 May 2022 00:01:00 -0400
-Subject: [PATCH 13/37] EpochTracker ABI macro
+Subject: [PATCH 13/38] EpochTracker ABI macro
 
 ---
  llvm/include/llvm/ADT/EpochTracker.h | 2 +-

--- a/upstream_utils/llvm_patches/0014-Delete-numbers-from-MathExtras.patch
+++ b/upstream_utils/llvm_patches/0014-Delete-numbers-from-MathExtras.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Thu, 5 May 2022 18:09:45 -0400
-Subject: [PATCH 14/37] Delete numbers from MathExtras
+Subject: [PATCH 14/38] Delete numbers from MathExtras
 
 ---
  llvm/include/llvm/Support/MathExtras.h | 36 --------------------------

--- a/upstream_utils/llvm_patches/0015-Add-lerp-and-sgn.patch
+++ b/upstream_utils/llvm_patches/0015-Add-lerp-and-sgn.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 3 May 2022 22:50:24 -0400
-Subject: [PATCH 15/37] Add lerp and sgn
+Subject: [PATCH 15/38] Add lerp and sgn
 
 ---
  llvm/include/llvm/Support/MathExtras.h | 21 +++++++++++++++++++++

--- a/upstream_utils/llvm_patches/0016-Fixup-includes.patch
+++ b/upstream_utils/llvm_patches/0016-Fixup-includes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:38:11 -0400
-Subject: [PATCH 16/37] Fixup includes
+Subject: [PATCH 16/38] Fixup includes
 
 ---
  llvm/include/llvm/Support/PointerLikeTypeTraits.h |  1 +

--- a/upstream_utils/llvm_patches/0017-Use-std-is_trivially_copy_constructible.patch
+++ b/upstream_utils/llvm_patches/0017-Use-std-is_trivially_copy_constructible.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:42:09 -0400
-Subject: [PATCH 17/37] Use std::is_trivially_copy_constructible
+Subject: [PATCH 17/38] Use std::is_trivially_copy_constructible
 
 ---
  llvm/include/llvm/Support/type_traits.h | 16 ----------------

--- a/upstream_utils/llvm_patches/0018-Windows-support.patch
+++ b/upstream_utils/llvm_patches/0018-Windows-support.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 3 May 2022 20:22:38 -0400
-Subject: [PATCH 18/37] Windows support
+Subject: [PATCH 18/38] Windows support
 
 ---
  .../llvm/Support/Windows/WindowsSupport.h     | 45 +++++----

--- a/upstream_utils/llvm_patches/0019-Remove-call-to-RtlGetLastNtStatus.patch
+++ b/upstream_utils/llvm_patches/0019-Remove-call-to-RtlGetLastNtStatus.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Tue, 17 Sep 2024 21:19:52 -0700
-Subject: [PATCH 19/37] Remove call to RtlGetLastNtStatus()
+Subject: [PATCH 19/38] Remove call to RtlGetLastNtStatus()
 
 ---
  llvm/lib/Support/ErrorHandling.cpp | 23 -----------------------

--- a/upstream_utils/llvm_patches/0020-Prefer-fmtlib.patch
+++ b/upstream_utils/llvm_patches/0020-Prefer-fmtlib.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:46:20 -0400
-Subject: [PATCH 20/37] Prefer fmtlib
+Subject: [PATCH 20/38] Prefer fmtlib
 
 ---
  llvm/lib/Support/ErrorHandling.cpp | 20 ++++++--------------

--- a/upstream_utils/llvm_patches/0021-Prefer-wpi-s-fs.h.patch
+++ b/upstream_utils/llvm_patches/0021-Prefer-wpi-s-fs.h.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:49:36 -0400
-Subject: [PATCH 21/37] Prefer wpi's fs.h
+Subject: [PATCH 21/38] Prefer wpi's fs.h
 
 ---
  llvm/include/llvm/Support/raw_ostream.h | 7 ++-----

--- a/upstream_utils/llvm_patches/0022-Remove-unused-functions.patch
+++ b/upstream_utils/llvm_patches/0022-Remove-unused-functions.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 19:16:51 -0400
-Subject: [PATCH 22/37] Remove unused functions
+Subject: [PATCH 22/38] Remove unused functions
 
 ---
  llvm/include/llvm/Support/raw_ostream.h |  5 +-

--- a/upstream_utils/llvm_patches/0023-OS-specific-changes.patch
+++ b/upstream_utils/llvm_patches/0023-OS-specific-changes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 19:30:43 -0400
-Subject: [PATCH 23/37] OS-specific changes
+Subject: [PATCH 23/38] OS-specific changes
 
 ---
  llvm/lib/Support/ErrorHandling.cpp | 16 +++++++---------

--- a/upstream_utils/llvm_patches/0024-Use-SmallVector-for-UTF-conversion.patch
+++ b/upstream_utils/llvm_patches/0024-Use-SmallVector-for-UTF-conversion.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Mon, 9 May 2022 00:04:30 -0400
-Subject: [PATCH 24/37] Use SmallVector for UTF conversion
+Subject: [PATCH 24/38] Use SmallVector for UTF conversion
 
 ---
  llvm/include/llvm/Support/ConvertUTF.h    |  6 +++---

--- a/upstream_utils/llvm_patches/0025-Prefer-to-use-static-pointers-in-raw_ostream.patch
+++ b/upstream_utils/llvm_patches/0025-Prefer-to-use-static-pointers-in-raw_ostream.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Thu, 19 May 2022 00:58:36 -0400
-Subject: [PATCH 25/37] Prefer to use static pointers in raw_ostream
+Subject: [PATCH 25/38] Prefer to use static pointers in raw_ostream
 
 See #1401
 ---

--- a/upstream_utils/llvm_patches/0026-constexpr-endian-byte-swap.patch
+++ b/upstream_utils/llvm_patches/0026-constexpr-endian-byte-swap.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Fri, 1 Mar 2024 11:56:17 -0800
-Subject: [PATCH 26/37] constexpr endian byte swap
+Subject: [PATCH 26/38] constexpr endian byte swap
 
 ---
  llvm/include/llvm/Support/Endian.h | 4 +++-

--- a/upstream_utils/llvm_patches/0027-Copy-type-traits-from-STLExtras.h-into-PointerUnion..patch
+++ b/upstream_utils/llvm_patches/0027-Copy-type-traits-from-STLExtras.h-into-PointerUnion..patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Wed, 10 Aug 2022 17:07:52 -0700
-Subject: [PATCH 27/37] Copy type traits from STLExtras.h into PointerUnion.h
+Subject: [PATCH 27/38] Copy type traits from STLExtras.h into PointerUnion.h
 
 ---
  llvm/include/llvm/ADT/PointerUnion.h | 46 ++++++++++++++++++++++++++++

--- a/upstream_utils/llvm_patches/0028-Unused-variable-in-release-mode.patch
+++ b/upstream_utils/llvm_patches/0028-Unused-variable-in-release-mode.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Leander Schulten <Leander.Schulten@rwth-aachen.de>
 Date: Mon, 10 Jul 2023 00:53:43 +0200
-Subject: [PATCH 28/37] Unused variable in release mode
+Subject: [PATCH 28/38] Unused variable in release mode
 
 ---
  llvm/include/llvm/ADT/DenseMap.h | 2 +-

--- a/upstream_utils/llvm_patches/0029-Use-C-20-bit-header.patch
+++ b/upstream_utils/llvm_patches/0029-Use-C-20-bit-header.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Tue, 11 Jul 2023 22:56:09 -0700
-Subject: [PATCH 29/37] Use C++20 <bit> header
+Subject: [PATCH 29/38] Use C++20 <bit> header
 
 ---
  llvm/include/llvm/ADT/DenseMap.h       |   3 +-

--- a/upstream_utils/llvm_patches/0030-Remove-DenseMap-GTest-printer-test.patch
+++ b/upstream_utils/llvm_patches/0030-Remove-DenseMap-GTest-printer-test.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Sun, 30 Jul 2023 14:17:37 -0700
-Subject: [PATCH 30/37] Remove DenseMap GTest printer test
+Subject: [PATCH 30/38] Remove DenseMap GTest printer test
 
 LLVM modifies internal GTest headers to support it, which we can't do.
 ---

--- a/upstream_utils/llvm_patches/0031-raw_ostream-Add-SetNumBytesInBuffer.patch
+++ b/upstream_utils/llvm_patches/0031-raw_ostream-Add-SetNumBytesInBuffer.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sun, 29 Oct 2023 23:00:08 -0700
-Subject: [PATCH 31/37] raw_ostream: Add SetNumBytesInBuffer
+Subject: [PATCH 31/38] raw_ostream: Add SetNumBytesInBuffer
 
 ---
  llvm/include/llvm/Support/raw_ostream.h | 5 +++++

--- a/upstream_utils/llvm_patches/0032-raw_ostream-Replace-errnoAsErrorCode.patch
+++ b/upstream_utils/llvm_patches/0032-raw_ostream-Replace-errnoAsErrorCode.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Tue, 17 Sep 2024 15:30:31 -0700
-Subject: [PATCH 32/37] raw_ostream: Replace errnoAsErrorCode()
+Subject: [PATCH 32/38] raw_ostream: Replace errnoAsErrorCode()
 
 ---
  llvm/lib/Support/raw_ostream.cpp | 4 ++--

--- a/upstream_utils/llvm_patches/0033-type_traits.h-Add-is_constexpr.patch
+++ b/upstream_utils/llvm_patches/0033-type_traits.h-Add-is_constexpr.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 2 Dec 2023 15:21:32 -0800
-Subject: [PATCH 33/37] type_traits.h: Add is_constexpr()
+Subject: [PATCH 33/38] type_traits.h: Add is_constexpr()
 
 ---
  llvm/include/llvm/Support/type_traits.h | 5 +++++

--- a/upstream_utils/llvm_patches/0034-Remove-auto-conversion-from-raw_ostream.patch
+++ b/upstream_utils/llvm_patches/0034-Remove-auto-conversion-from-raw_ostream.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Sun, 17 Mar 2024 14:51:11 -0700
-Subject: [PATCH 34/37] Remove auto-conversion from raw_ostream
+Subject: [PATCH 34/38] Remove auto-conversion from raw_ostream
 
 ---
  llvm/lib/Support/raw_ostream.cpp | 11 +----------

--- a/upstream_utils/llvm_patches/0035-Add-SmallVector-erase_if.patch
+++ b/upstream_utils/llvm_patches/0035-Add-SmallVector-erase_if.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Tue, 18 Jun 2024 09:07:33 -0700
-Subject: [PATCH 35/37] Add SmallVector erase_if()
+Subject: [PATCH 35/38] Add SmallVector erase_if()
 
 ---
  llvm/include/llvm/ADT/SmallVector.h | 8 ++++++++

--- a/upstream_utils/llvm_patches/0036-Fix-AlignedCharArrayUnion-for-C-23.patch
+++ b/upstream_utils/llvm_patches/0036-Fix-AlignedCharArrayUnion-for-C-23.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Sat, 13 Jul 2024 15:24:30 -0700
-Subject: [PATCH 36/37] Fix AlignedCharArrayUnion for C++23
+Subject: [PATCH 36/38] Fix AlignedCharArrayUnion for C++23
 
 ---
  llvm/include/llvm/Support/AlignOf.h | 14 +++++---------

--- a/upstream_utils/llvm_patches/0037-Fix-minIntN-and-maxIntN-assertions.patch
+++ b/upstream_utils/llvm_patches/0037-Fix-minIntN-and-maxIntN-assertions.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Mon, 23 Dec 2024 22:56:29 -0800
-Subject: [PATCH 37/37] Fix minIntN() and maxIntN() assertions
+Subject: [PATCH 37/38] Fix minIntN() and maxIntN() assertions
 
 ---
  llvm/include/llvm/Support/MathExtras.h | 4 ++--

--- a/wpilibc/src/main/native/cpp/DriverStation.cpp
+++ b/wpilibc/src/main/native/cpp/DriverStation.cpp
@@ -25,6 +25,7 @@
 #include <networktables/StringTopic.h>
 #include <wpi/DataLog.h>
 #include <wpi/EventVector.h>
+#include <wpi/ManagedStatic.h>
 #include <wpi/condition_variable.h>
 #include <wpi/json.h>
 #include <wpi/mutex.h>
@@ -150,9 +151,10 @@ struct Instance {
 
 static constexpr auto kJoystickUnpluggedMessageInterval = 1_s;
 
-static Instance& GetInstance() {
-  static Instance instance;
-  return instance;
+static wpi::ManagedStatic<Instance> gInst;
+
+static inline Instance& GetInstance() {
+  return *gInst;
 }
 
 static void SendMatchData();

--- a/wpilibc/src/main/native/cpp/Preferences.cpp
+++ b/wpilibc/src/main/native/cpp/Preferences.cpp
@@ -15,6 +15,7 @@
 #include <networktables/NetworkTableInstance.h>
 #include <networktables/NetworkTableListener.h>
 #include <networktables/StringTopic.h>
+#include <wpi/ManagedStatic.h>
 #include <wpi/json.h>
 
 using namespace frc;
@@ -36,18 +37,11 @@ struct Instance {
 };
 }  // namespace
 
-static Instance& GetInstance() {
-  static Instance instance;
-  return instance;
-}
+static wpi::ManagedStatic<Instance> gInst;
 
-#ifndef __FRC_ROBORIO__
-namespace frc::impl {
-void ResetPreferencesInstance() {
-  GetInstance() = Instance();
+static inline Instance& GetInstance() {
+  return *gInst;
 }
-}  // namespace frc::impl
-#endif
 
 std::vector<std::string> Preferences::GetKeys() {
   return ::GetInstance().table->GetKeys();

--- a/wpilibc/src/main/native/cpp/Watchdog.cpp
+++ b/wpilibc/src/main/native/cpp/Watchdog.cpp
@@ -11,6 +11,7 @@
 
 #include <fmt/format.h>
 #include <hal/Notifier.h>
+#include <wpi/ManagedStatic.h>
 #include <wpi/mutex.h>
 #include <wpi/priority_queue.h>
 
@@ -237,6 +238,6 @@ bool Watchdog::operator>(const Watchdog& rhs) const {
 }
 
 Watchdog::Impl* Watchdog::GetImpl() {
-  static Impl inst;
-  return &inst;
+  static wpi::ManagedStatic<Watchdog::Impl> inst;
+  return &*inst;
 }

--- a/wpilibc/src/main/native/include/frc/RobotBase.h
+++ b/wpilibc/src/main/native/include/frc/RobotBase.h
@@ -4,13 +4,13 @@
 
 #pragma once
 
-#include <chrono>
 #include <thread>
 
 #include <hal/DriverStation.h>
 #include <hal/HALBase.h>
 #include <hal/Main.h>
 #include <networktables/NetworkTable.h>
+#include <wpi/ManagedStatic.h>
 #include <wpi/RuntimeCheck.h>
 #include <wpi/condition_variable.h>
 #include <wpi/mutex.h>
@@ -24,10 +24,6 @@ namespace frc {
 int RunHALInitialization();
 
 namespace impl {
-#ifndef __FRC_ROBORIO__
-void ResetMotorSafety();
-#endif
-
 template <class Robot>
 void RunRobot(wpi::mutex& m, Robot** robot) {
   try {
@@ -51,7 +47,6 @@ void RunRobot(wpi::mutex& m, Robot** robot) {
     throw;
   }
 }
-
 }  // namespace impl
 
 template <class Robot>
@@ -124,9 +119,7 @@ int StartRobot() {
     impl::RunRobot<Robot>(m, &robot);
   }
 
-#ifndef __FRC_ROBORIO__
-  frc::impl::ResetMotorSafety();
-#endif
+  wpi::wpi_shutdown();
   HAL_Shutdown();
 
   return 0;

--- a/wpilibc/src/test/native/cpp/main.cpp
+++ b/wpilibc/src/test/native/cpp/main.cpp
@@ -4,19 +4,12 @@
 
 #include <gtest/gtest.h>
 #include <hal/HALBase.h>
-
-#ifndef __FRC_ROBORIO__
-namespace frc::impl {
-void ResetMotorSafety();
-}
-#endif
+#include <wpi/ManagedStatic.h>
 
 int main(int argc, char** argv) {
   HAL_Initialize(500, 0);
   ::testing::InitGoogleTest(&argc, argv);
   int ret = RUN_ALL_TESTS();
-#ifndef __FRC_ROBORIO__
-  frc::impl::ResetMotorSafety();
-#endif
+  wpi::wpi_shutdown();
   return ret;
 }

--- a/wpiutil/src/main/native/cpp/sendable/SendableRegistry.cpp
+++ b/wpiutil/src/main/native/cpp/sendable/SendableRegistry.cpp
@@ -62,9 +62,10 @@ Component& SendableRegistryInst::GetOrAdd(void* sendable,
   return *components[compUid - 1];
 }
 
-static SendableRegistryInst& GetInstance() {
-  wpi::ManagedStatic<SendableRegistryInst> inst;
-  return *inst;
+static wpi::ManagedStatic<SendableRegistryInst> gInst;
+
+static inline SendableRegistryInst& GetInstance() {
+  return *gInst;
 }
 
 void SendableRegistry::EnsureInitialized() {

--- a/wpiutil/src/main/native/cpp/sendable/SendableRegistry.cpp
+++ b/wpiutil/src/main/native/cpp/sendable/SendableRegistry.cpp
@@ -11,6 +11,7 @@
 #include <fmt/format.h>
 
 #include "wpi/DenseMap.h"
+#include "wpi/ManagedStatic.h"
 #include "wpi/SmallVector.h"
 #include "wpi/UidVector.h"
 #include "wpi/mutex.h"
@@ -61,23 +62,10 @@ Component& SendableRegistryInst::GetOrAdd(void* sendable,
   return *components[compUid - 1];
 }
 
-static std::unique_ptr<SendableRegistryInst>& GetInstanceHolder() {
-  static std::unique_ptr<SendableRegistryInst> instance =
-      std::make_unique<SendableRegistryInst>();
-  return instance;
-}
-
 static SendableRegistryInst& GetInstance() {
-  return *GetInstanceHolder();
+  wpi::ManagedStatic<SendableRegistryInst> inst;
+  return *inst;
 }
-
-#ifndef __FRC_ROBORIO__
-namespace wpi::impl {
-void ResetSendableRegistry() {
-  std::make_unique<SendableRegistryInst>().swap(GetInstanceHolder());
-}
-}  // namespace wpi::impl
-#endif
 
 void SendableRegistry::EnsureInitialized() {
   GetInstance();

--- a/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/ManagedStatic.cpp
+++ b/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/ManagedStatic.cpp
@@ -1,0 +1,78 @@
+//===-- ManagedStatic.cpp - Static Global wrapper -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the ManagedStatic class and wpi_shutdown().
+//
+//===----------------------------------------------------------------------===//
+
+#include "wpi/ManagedStatic.h"
+#include "wpi/mutex.h"
+#include <cassert>
+#include <mutex>
+using namespace wpi;
+
+static const ManagedStaticBase *StaticList = nullptr;
+
+static wpi::mutex *getManagedStaticMutex() {
+  static wpi::mutex m;
+  return &m;
+}
+
+void ManagedStaticBase::RegisterManagedStatic(void *(*Creator)(),
+                                              void (*Deleter)(void*)) const {
+  assert(Creator);
+  if (1) {
+    std::scoped_lock Lock(*getManagedStaticMutex());
+
+    if (!Ptr.load(std::memory_order_relaxed)) {
+      void *Tmp = Creator();
+
+      Ptr.store(Tmp, std::memory_order_release);
+      DeleterFn = Deleter;
+
+      // Add to list of managed statics.
+      Next = StaticList;
+      StaticList = this;
+    }
+  } else {
+    assert(!Ptr && !DeleterFn && !Next &&
+           "Partially initialized ManagedStatic!?");
+    Ptr = Creator();
+    DeleterFn = Deleter;
+
+    // Add to list of managed statics.
+    Next = StaticList;
+    StaticList = this;
+  }
+}
+
+void ManagedStaticBase::destroy() const {
+  assert(DeleterFn && "ManagedStatic not initialized correctly!");
+  assert(StaticList == this &&
+         "Not destroyed in reverse order of construction?");
+  // Unlink from list.
+  StaticList = Next;
+  Next = nullptr;
+
+  // Destroy memory.
+  DeleterFn(Ptr);
+
+  // Cleanup.
+  Ptr = nullptr;
+  DeleterFn = nullptr;
+}
+
+/// wpi_shutdown - Deallocate and destroy all ManagedStatic variables.
+/// IMPORTANT: it's only safe to call wpi_shutdown() in single thread,
+/// without any other threads executing LLVM APIs.
+/// wpi_shutdown() should be the last use of LLVM APIs.
+void wpi::wpi_shutdown() {
+  std::scoped_lock Lock(*getManagedStaticMutex());
+  while (StaticList)
+    StaticList->destroy();
+}

--- a/wpiutil/src/main/native/thirdparty/llvm/include/wpi/ManagedStatic.h
+++ b/wpiutil/src/main/native/thirdparty/llvm/include/wpi/ManagedStatic.h
@@ -1,0 +1,125 @@
+//===-- llvm/Support/ManagedStatic.h - Static Global wrapper ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the ManagedStatic class and the wpi_shutdown() function.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef WPIUTIL_WPI_MANAGEDSTATIC_H
+#define WPIUTIL_WPI_MANAGEDSTATIC_H
+
+#include <atomic>
+#include <cstddef>
+
+namespace wpi {
+
+/// object_creator - Helper method for ManagedStatic.
+template <class C> struct object_creator {
+  static void *call() { return new C(); }
+};
+
+/// object_deleter - Helper method for ManagedStatic.
+///
+template <typename T> struct object_deleter {
+  static void call(void *Ptr) { delete (T *)Ptr; }
+};
+template <typename T, size_t N> struct object_deleter<T[N]> {
+  static void call(void *Ptr) { delete[](T *)Ptr; }
+};
+
+// ManagedStatic must be initialized to zero, and it must *not* have a dynamic
+// initializer because managed statics are often created while running other
+// dynamic initializers. In standard C++11, the best way to accomplish this is
+// with a constexpr default constructor. However, different versions of the
+// Visual C++ compiler have had bugs where, even though the constructor may be
+// constexpr, a dynamic initializer may be emitted depending on optimization
+// settings. For the affected versions of MSVC, use the old linker
+// initialization pattern of not providing a constructor and leaving the fields
+// uninitialized. See http://llvm.org/PR41367 for details.
+#if !defined(_MSC_VER) || (_MSC_VER >= 1925) || defined(__clang__)
+#define WPI_USE_CONSTEXPR_CTOR
+#endif
+
+/// ManagedStaticBase - Common base class for ManagedStatic instances.
+class ManagedStaticBase {
+protected:
+#ifdef WPI_USE_CONSTEXPR_CTOR
+  mutable std::atomic<void *> Ptr{};
+  mutable void (*DeleterFn)(void *) = nullptr;
+  mutable const ManagedStaticBase *Next = nullptr;
+#else
+  // This should only be used as a static variable, which guarantees that this
+  // will be zero initialized.
+  mutable std::atomic<void *> Ptr;
+  mutable void (*DeleterFn)(void *);
+  mutable const ManagedStaticBase *Next;
+#endif
+
+  void RegisterManagedStatic(void *(*creator)(), void (*deleter)(void*)) const;
+
+public:
+#ifdef WPI_USE_CONSTEXPR_CTOR
+  constexpr ManagedStaticBase() = default;
+#endif
+
+  /// isConstructed - Return true if this object has not been created yet.
+  bool isConstructed() const { return Ptr != nullptr; }
+
+  void destroy() const;
+};
+
+/// ManagedStatic - This transparently changes the behavior of global statics to
+/// be lazily constructed on demand (good for reducing startup times of dynamic
+/// libraries that link in LLVM components) and for making destruction be
+/// explicit through the wpi_shutdown() function call.
+///
+template <class C, class Creator = object_creator<C>,
+          class Deleter = object_deleter<C>>
+class ManagedStatic : public ManagedStaticBase {
+public:
+  // Accessors.
+  C &operator*() {
+    void *Tmp = Ptr.load(std::memory_order_acquire);
+    if (!Tmp)
+      RegisterManagedStatic(Creator::call, Deleter::call);
+
+    return *static_cast<C *>(Ptr.load(std::memory_order_relaxed));
+  }
+
+  C *operator->() { return &**this; }
+
+  const C &operator*() const {
+    void *Tmp = Ptr.load(std::memory_order_acquire);
+    if (!Tmp)
+      RegisterManagedStatic(Creator::call, Deleter::call);
+
+    return *static_cast<C *>(Ptr.load(std::memory_order_relaxed));
+  }
+
+  const C *operator->() const { return &**this; }
+
+  // Extract the instance, leaving the ManagedStatic uninitialized. The
+  // user is then responsible for the lifetime of the returned instance.
+  C *claim() {
+    return static_cast<C *>(Ptr.exchange(nullptr));
+  }
+};
+
+/// wpi_shutdown - Deallocate and destroy all ManagedStatic variables.
+void wpi_shutdown();
+
+/// wpi_shutdown_obj - This is a simple helper class that calls
+/// wpi_shutdown() when it is destroyed.
+struct wpi_shutdown_obj {
+  wpi_shutdown_obj() = default;
+  ~wpi_shutdown_obj() { wpi_shutdown(); }
+};
+
+} // end namespace wpi
+
+#endif // WPIUTIL_WPI_MANAGEDSTATIC_H


### PR DESCRIPTION
This import from LLVM adds a wpi_shutdown() function to explicitly destroy all managed static instances.