### PR TITLE
[wpiutil] use reinterpret_cast for kInvalidFile on Win32 via macro

### DIFF
--- a/wpiutil/src/main/native/cpp/DataLogBackgroundWriter.cpp
+++ b/wpiutil/src/main/native/cpp/DataLogBackgroundWriter.cpp
@@ -183,9 +183,9 @@ struct DataLogBackgroundWriter::WriterThreadState {
   ~WriterThreadState() { Close(); }
 
   void Close() {
-    if (f != fs::kInvalidFile) {
+    if (f != WPI_kInvalidFile) {
       fs::CloseFile(f);
-      f = fs::kInvalidFile;
+      f = WPI_kInvalidFile;
     }
   }
 
@@ -207,7 +207,7 @@ struct DataLogBackgroundWriter::WriterThreadState {
   std::string baseFilename;
   std::string filename;
   fs::path path;
-  fs::file_t f = fs::kInvalidFile;
+  fs::file_t f = WPI_kInvalidFile;
   uintmax_t freeSpace = UINTMAX_MAX;
   int segmentCount = 1;
 };
@@ -264,7 +264,7 @@ void DataLogBackgroundWriter::StartLogFile(WriterThreadState& state) {
       }
     }
 
-    if (state.f == fs::kInvalidFile) {
+    if (state.f == WPI_kInvalidFile) {
       WPI_ERROR(m_msglog, "Could not open log file, no log being saved");
     } else {
       WPI_INFO(m_msglog, "Logging to '{}' ({} free space)", state.path.string(),
@@ -273,7 +273,7 @@ void DataLogBackgroundWriter::StartLogFile(WriterThreadState& state) {
   }
 
   // start file
-  if (state.f != fs::kInvalidFile) {
+  if (state.f != WPI_kInvalidFile) {
     StartFile();
   }
 }
@@ -347,7 +347,7 @@ void DataLogBackgroundWriter::WriterThreadMain(std::string_view dir) {
       written = 0;
     }
 
-    if (!m_newFilename.empty() && state.f != fs::kInvalidFile) {
+    if (!m_newFilename.empty() && state.f != WPI_kInvalidFile) {
       auto newFilename = std::move(m_newFilename);
       m_newFilename.clear();
       // rename
@@ -374,7 +374,7 @@ void DataLogBackgroundWriter::WriterThreadMain(std::string_view dir) {
         continue;
       }
 
-      if (state.f != fs::kInvalidFile && !blocked) {
+      if (state.f != WPI_kInvalidFile && !blocked) {
         lock.unlock();
 
         // update free space every 10 flushes (in case other things are writing)

--- a/wpiutil/src/main/native/cpp/fs.cpp
+++ b/wpiutil/src/main/native/cpp/fs.cpp
@@ -205,8 +205,6 @@ void CloseFile(file_t& F) {
 
 #else  // _WIN32
 
-const file_t WPI_kInvalidFile = -1;
-
 static int nativeOpenFlags(CreationDisposition Disp, OpenFlags Flags,
                            FileAccess Access) {
   int Result = 0;

--- a/wpiutil/src/main/native/include/wpi/fs.h
+++ b/wpiutil/src/main/native/include/wpi/fs.h
@@ -28,7 +28,7 @@ using fstream = std::fstream;
 #if defined(_WIN32)
 // A Win32 HANDLE is a typedef of void*
 using file_t = void*;
-#define WPI_kInvalidFile reinterpret_cast<file_t>(-1)
+#define WPI_kInvalidFile reinterpret_cast<fs::file_t>(-1)
 #else
 using file_t = int;
 #define WPI_kInvalidFile -1

--- a/wpiutil/src/main/native/include/wpi/fs.h
+++ b/wpiutil/src/main/native/include/wpi/fs.h
@@ -28,7 +28,7 @@ using fstream = std::fstream;
 #if defined(_WIN32)
 // A Win32 HANDLE is a typedef of void*
 using file_t = void*;
-#define WPI_kInvalidFile reinterpret_cast<void*>(-1)
+#define WPI_kInvalidFile reinterpret_cast<file_t>(-1)
 #else
 using file_t = int;
 #define WPI_kInvalidFile -1

--- a/wpiutil/src/main/native/include/wpi/fs.h
+++ b/wpiutil/src/main/native/include/wpi/fs.h
@@ -28,11 +28,11 @@ using fstream = std::fstream;
 #if defined(_WIN32)
 // A Win32 HANDLE is a typedef of void*
 using file_t = void*;
+#define WPI_kInvalidFile reinterpret_cast<void*>(-1)
 #else
 using file_t = int;
+#define WPI_kInvalidFile -1
 #endif
-
-extern const file_t kInvalidFile;
 
 enum CreationDisposition : unsigned {
   /// CD_CreateAlways - When opening a file:
@@ -139,7 +139,7 @@ file_t OpenFile(const path& Path, std::error_code& EC, CreationDisposition Disp,
  *              opened in, for example, read-write or in write-only mode.
  * @param Mode The access permissions of the file, represented in octal.
  * @returns a platform-specific file descriptor if \a Name has been opened,
- *          otherwise kInvalidFile.
+ *          otherwise WPI_kInvalidFile.
  */
 inline file_t OpenFileForWrite(const path& Path, std::error_code& EC,
                                CreationDisposition Disp, OpenFlags Flags,
@@ -162,7 +162,7 @@ inline file_t OpenFileForWrite(const path& Path, std::error_code& EC,
  *              opened in, for example, read-write or in write-only mode.
  * @param Mode The access permissions of the file, represented in octal.
  * @return a platform-specific file descriptor if \a Name has been opened,
- *         otherwise kInvalidFile.
+ *         otherwise WPI_kInvalidFile.
  */
 inline file_t OpenFileForReadWrite(const path& Path, std::error_code& EC,
                                    CreationDisposition Disp, OpenFlags Flags,
@@ -181,7 +181,7 @@ inline file_t OpenFileForReadWrite(const path& Path, std::error_code& EC,
  * @param EC Error code output, set to non-zero on error
  * @param Flags Additional flags
  * @return a platform-specific file descriptor if \a Name has been opened,
- *         otherwise kInvalidFile.
+ *         otherwise WPI_kInvalidFile.
  */
 file_t OpenFileForRead(const path& Path, std::error_code& EC,
                        OpenFlags Flags = OF_None);
@@ -191,7 +191,7 @@ file_t OpenFileForRead(const path& Path, std::error_code& EC,
  * must be closed with ::close() instead of CloseFile().
  *
  * @param F On input, this is the file to convert to a file descriptor.
- *          On output, the file is set to kInvalidFile.
+ *          On output, the file is set to WPI_kInvalidFile.
  * @param EC Error code output, set to non-zero on error
  * @param Flags Flags passed to the OpenFile function that created file_t
  * @return file descriptor, or -1 on error
@@ -202,7 +202,7 @@ int FileToFd(file_t& F, std::error_code& EC, OpenFlags Flags);
  * Closes the file object.
  *
  * @param F On input, this is the file to close.  On output, the file is
- *          set to kInvalidFile.
+ *          set to WPI_kInvalidFile.
  */
 void CloseFile(file_t& F);
 


### PR DESCRIPTION
Prerequisite for #7641