### PR TITLE
CMake: Reproducible Output Dir For Generated Field Images Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,6 @@ bazel_auth.rc
 
 # ctest
 /Testing/
+
+# Meson
+.meson-subproject*

--- a/fieldImages/CMakeLists.txt
+++ b/fieldImages/CMakeLists.txt
@@ -42,7 +42,7 @@ generate_resources(
     field_images_resources_src
 )
 
-add_library(fieldImages ${field_images_resources_src} src/main/native/cpp/fields.cpp )
+add_library(fieldImages ${field_images_resources_src} src/main/native/cpp/fields.cpp)
 set_target_properties(fieldImages PROPERTIES DEBUG_POSTFIX "d")
 
 set_property(TARGET fieldImages PROPERTY FOLDER "libraries")

--- a/fieldImages/CMakeLists.txt
+++ b/fieldImages/CMakeLists.txt
@@ -36,13 +36,13 @@ endif()
 
 generate_resources(
     src/main/native/resources/edu/wpi/first/fields
-    generated/main/cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/generated/main/cpp
     FIELDS
     fields
     field_images_resources_src
 )
 
-add_library(fieldImages src/main/native/cpp/fields.cpp ${field_images_resources_src})
+add_library(fieldImages ${field_images_resources_src} src/main/native/cpp/fields.cpp )
 set_target_properties(fieldImages PROPERTIES DEBUG_POSTFIX "d")
 
 set_property(TARGET fieldImages PROPERTY FOLDER "libraries")


### PR DESCRIPTION
By pre-pending the current build/binary directory to the generated output dir, it ensures the files are still found when allwpilib is used a subproject (cmake or meson).  Without doing this, the generated files are not found, do not compile, which ultimately leads to missing symbols when linking libfieldImages.