### PR TITLE
Add missing -ldl when building libuv in bazel

### DIFF
--- a/wpinet/BUILD.bazel
+++ b/wpinet/BUILD.bazel
@@ -121,6 +121,10 @@ cc_library(
     ] + ["native-srcs"],
     hdrs = glob(["src/main/native/include/**/*"]),
     includes = ["src/main/native/include"],
+    linkopts = select({
+        "@bazel_tools//src/conditions:linux": ["-ldl"],
+        "//conditions:default": [],
+    }),
     strip_include_prefix = "src/main/native/include",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
I was getting:
external/arm_frc_linux_gnueabi_repo/bin/../arm-nilrt-linux-gnueabi/sysroot/usr/lib/gcc/arm-nilrt-linux-gnueabi/12/../../../../../../../arm-nilrt-linux-gnueabi/bin/ld: bazel-out/k8-opt--roborio/bin/external/com_github_wpilibsuite_allwpilib/wpinet/libwpinet.static.a(fs.o): undefined reference to symbol 'dlsym@@GLIBC_2.4' external/arm_frc_linux_gnueabi_repo/bin/../arm-nilrt-linux-gnueabi/sysroot/usr/lib/gcc/arm-nilrt-linux-gnueabi/12/../../../../../../../arm-nilrt-linux-gnueabi/bin/ld: external/arm_frc_linux_gnueabi_repo/bin/../arm-nilrt-linux-gnueabi/sysroot/lib/libdl.so.2: error adding symbols: DSO missing from command line collect2: error: ld returned 1 exit status

This fixes that error for me.