### PR TITLE
Add limit setters to `SlewRateLimiter`

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
@@ -14,8 +14,8 @@ import edu.wpi.first.math.MathUtil;
  * edu.wpi.first.math.trajectory.TrapezoidProfile} instead.
  */
 public class SlewRateLimiter {
-  private final double m_positiveRateLimit;
-  private final double m_negativeRateLimit;
+  private double m_positiveRateLimit;
+  private double m_negativeRateLimit;
   private double m_prevVal;
   private double m_prevTime;
 
@@ -81,5 +81,29 @@ public class SlewRateLimiter {
   public void reset(double value) {
     m_prevVal = value;
     m_prevTime = MathSharedStore.getTimestamp();
+  }
+
+  /**
+   * Sets the rate-of-change limit.
+   *
+   * @param positiveRateLimit The rate-of-change limit in the positive direction, in units per
+   *     second. This is expected to be positive.
+   * @param negativeRateLimit The rate-of-change limit in the negative direction, in units per
+   *     second. This is expected to be negative.
+   */
+  public void setLimit(double positiveRateLimit, double negativeRateLimit) {
+    m_positiveRateLimit = positiveRateLimit;
+    m_negativeRateLimit = negativeRateLimit;
+  }
+
+  /**
+   * Sets the rate-of-change limit in both directions.
+   *
+   * @param rateLimit The rate-of-change limit in both directions, in units per second. This is
+   *     expected to be positive.
+   */
+  public void setLimit(double rateLimit) {
+    m_positiveRateLimit = rateLimit;
+    m_negativeRateLimit = rateLimit;
   }
 }

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -92,6 +92,30 @@ class SlewRateLimiter {
     m_prevTime = wpi::math::MathSharedStore::GetTimestamp();
   }
 
+  /**
+   * Sets the rate-of-change limit.
+   *
+   * @param positiveRateLimit The rate-of-change limit in the positive
+   * direction, in units per second. This is expected to be positive.
+   * @param negativeRateLimit The rate-of-change limit in the negative
+   * direction, in units per second. This is expected to be negative.
+   */
+  void SetLimit(Rate_t positiveRateLimit, Rate_t negativeRateLimit) {
+    m_positiveRateLimit = positiveRateLimit;
+    m_negativeRateLimit = negativeRateLimit;
+  }
+
+  /**
+   * Sets the rate-of-change limit in both directions.
+   *
+   * @param rateLimit The rate-of-change limit in both directions, in units per
+   * second. This is expected to be positive.
+   */
+  void SetLimit(Rate_t rateLimit) {
+    m_positiveRateLimit = rateLimit;
+    m_negativeRateLimit = rateLimit;
+  }
+
  private:
   Rate_t m_positiveRateLimit;
   Rate_t m_negativeRateLimit;


### PR DESCRIPTION
This helps when the rate limit needs to be dynamically changed, such as when the drivetrain's acceleration is limited based on an elevator's height.

Not sure if it should be a setter or `withLimit()` so you can chain it (`limiter.withLimit(newLimit).calculate(...)`). Not sure about the C++ implementation. Feedback appreciated.