### PR TITLE
[sysid] allow selection of test runs if there are multiple per test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 # Set default build type to release with debug info (i.e. release mode optimizations
 # are performed, but debug info still exists).
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "" FORCE)
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "" FORCE)
 endif()
 
 cmake_minimum_required(VERSION 3.21)

--- a/sysid/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/sysid/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -6,6 +6,7 @@
 
 #include <cmath>
 #include <limits>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -15,8 +16,11 @@
 #include <wpi/StringExtras.h>
 #include <wpi/StringMap.h>
 
+#include "imgui.h"
 #include "sysid/analysis/FeedforwardAnalysis.h"
 #include "sysid/analysis/FilteringUtils.h"
+#include "sysid/analysis/Storage.h"
+#include "units/time.h"
 
 using namespace sysid;
 
@@ -55,10 +59,31 @@ static double Lerp(units::second_t time,
  *
  * @return A PreparedData vector
  */
-static std::vector<PreparedData> ConvertToPrepared(const MotorData& data) {
+static std::vector<PreparedData> ConvertToPrepared(const MotorData& data, std::string testName) {
   std::vector<PreparedData> prepared;
+  int selectedRun = 0;
+  // do we have just one run?
+  if (data.runs.size() > 1) {
+    // prompt the user to pick one
+    ImGui::OpenPopup("Test Run Selector");
+  }
+
+  if (ImGui::BeginPopupModal("Test Run Selector")) {
+    ImGui::Text("You have multiple runs of the %s test. Please select a run to use for analysis.", testName.c_str());
+    for (size_t i = 0; i < data.runs.size(); i++) {
+      ImGui::Separator();
+      units::second_t duration = data.runs[i].voltage.end()->time - data.runs[i].voltage.begin()->time;
+      ImGui::Text("Run %zu: Duration: %fs", i, duration.value());
+      if (ImGui::Button("Select Run")) {
+        selectedRun = i;
+        ImGui::CloseCurrentPopup();
+      }
+    }
+    ImGui::EndPopup(); 
+  }
+
   // assume we've selected down to a single contiguous run by this point
-  auto run = data.runs[0];
+  auto run = data.runs[selectedRun];
 
   for (int i = 0; i < static_cast<int>(run.voltage.size()) - 1; ++i) {
     const auto& currentVoltage = run.voltage[i];
@@ -127,7 +152,7 @@ void AnalysisManager::PrepareGeneralData() {
   // Convert data to PreparedData structs
   for (auto& it : m_data.motorData) {
     auto key = it.first;
-    preparedData[key] = ConvertToPrepared(m_data.motorData[key]);
+    preparedData[key] = ConvertToPrepared(m_data.motorData[key], key);
     WPI_INFO(m_logger, "SAMPLES {}", preparedData[key].size());
   }
 

--- a/sysid/src/main/native/cpp/view/Analyzer.cpp
+++ b/sysid/src/main/native/cpp/view/Analyzer.cpp
@@ -478,6 +478,7 @@ void Analyzer::DisplayFeedforwardParameters(float beginX, float beginY) {
       m_settings.stepTestDuration = units::second_t{m_stepTestDuration};
       PrepareData();
     }
+    CreateTooltip("Determines the duration of data considered for the dynamic tests.");
   }
 }
 

--- a/sysid/src/main/native/cpp/view/Analyzer.cpp
+++ b/sysid/src/main/native/cpp/view/Analyzer.cpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <numbers>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -25,6 +26,7 @@
 #include "sysid/analysis/AnalysisType.h"
 #include "sysid/analysis/FeedbackControllerPreset.h"
 #include "sysid/analysis/FilteringUtils.h"
+#include "sysid/analysis/Storage.h"
 #include "sysid/view/UILayout.h"
 
 using namespace sysid;
@@ -182,6 +184,45 @@ bool Analyzer::DisplayResetAndUnitOverride() {
   return false;
 }
 
+double Analyzer::GetRunDuration(MotorData::Run run) {
+  double voltsDuration = abs(run.voltage.begin()->time.value() - run.voltage.end()->time.value());
+  double posDuration = abs(run.position.begin()->time.value() - run.position.end()->time.value());
+  double velDuration = abs(run.position.begin()->time.value() - run.position.end()->time.value());
+  return std::max({voltsDuration, posDuration, velDuration});
+}
+
+void Analyzer::HandleMultipleRuns(std::string testName, MotorData data,
+                                  bool multipleRuns) {
+  if (multipleRuns) {
+    ImGui::OpenPopup("Test Run Selector");
+  }
+
+  ImGui::SetNextWindowSize(ImVec2(480.0, 360.0));
+  //ImGui::SetNextWindowPos(ImVec2)
+  if (ImGui::BeginPopupModal("Test Run Selector")) {
+    ImGui::Text(
+        "You have multiple runs of the %s test.\nPlease select a run to use "
+        "for analysis.",
+        testName.c_str());
+    ImGui::Spacing();
+    for (size_t i = 0; i < data.runs.size(); i++) {
+      ImGui::Separator();
+      double duration =
+          GetRunDuration(data.runs[i]);
+      ImGui::Text("Run %zu: Duration: %fs", i + 1, duration);
+      ImGui::Text("Samples: %zu Volt %zu Pos %zu Vel",
+                  data.runs[i].voltage.size(), data.runs[i].position.size(),
+                  data.runs[i].velocity.size());
+      if (ImGui::Button("Select Run")) {
+        m_manager->m_selectedRun = i;
+        ImGui::CloseCurrentPopup();
+        m_multipleRunsPopup = false;
+      }
+    }
+    ImGui::EndPopup();
+  }
+}
+
 void Analyzer::ConfigParamsOnFileSelect() {
   WPI_INFO(m_logger, "{}", "Configuring Params");
   m_stepTestDuration = m_settings.stepTestDuration.to<float>();
@@ -252,6 +293,13 @@ void Analyzer::Display() {
       }
       break;
     }
+    case AnalyzerState::kMultipleRuns: {
+      HandleMultipleRuns(m_currentTest, m_currentData, m_multipleRunsPopup);
+      if (!m_multipleRunsPopup) {
+        m_state = AnalyzerState::kNominalDisplay;
+      }
+      break;
+    }
     case AnalyzerState::kMissingTestsError: {
       CreateErrorPopup(m_errorPopup, m_exception);
       if (!m_errorPopup) {
@@ -295,6 +343,11 @@ void Analyzer::PrepareData() {
   } catch (const sysid::MissingTestsError& e) {
     m_state = AnalyzerState::kMissingTestsError;
     HandleError(e.what());
+  } catch (const AnalysisManager::MultipleRunsError& e) {
+    m_state = AnalyzerState::kMultipleRuns;
+    m_currentData = e.data;
+    m_currentTest = e.testName;
+    m_multipleRunsPopup = true;
   } catch (const AnalysisManager::FileReadingError& e) {
     m_state = AnalyzerState::kFileError;
     HandleError(e.what());
@@ -478,7 +531,8 @@ void Analyzer::DisplayFeedforwardParameters(float beginX, float beginY) {
       m_settings.stepTestDuration = units::second_t{m_stepTestDuration};
       PrepareData();
     }
-    CreateTooltip("Determines the duration of data considered for the dynamic tests.");
+    CreateTooltip(
+        "Determines the duration of data considered for the dynamic tests.");
   }
 }
 

--- a/sysid/src/main/native/cpp/view/DataSelector.cpp
+++ b/sysid/src/main/native/cpp/view/DataSelector.cpp
@@ -191,6 +191,13 @@ void DataSelector::Reset() {
 
 DataSelector::Tests DataSelector::LoadTests(
     const glass::DataLogReaderEntry& testStateEntry) {
+
+  // struct SysidTestTimeRange {
+  //   std::string state;
+  //   int64_t start;
+  //   int64_t end;
+  // };
+
   Tests tests;
   for (auto&& range : testStateEntry.ranges) {
     std::string_view prevState;

--- a/sysid/src/main/native/cpp/view/DataSelector.cpp
+++ b/sysid/src/main/native/cpp/view/DataSelector.cpp
@@ -5,6 +5,7 @@
 #include "sysid/view/DataSelector.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -20,6 +21,7 @@
 #include "sysid/Util.h"
 #include "sysid/analysis/AnalysisType.h"
 #include "sysid/analysis/Storage.h"
+#include "units/time.h"
 
 using namespace sysid;
 
@@ -48,9 +50,15 @@ static bool EmitEntryTarget(const char* name, bool isString,
   return rv;
 }
 
+double GetRunDuration(MotorData::Run run) {
+  double voltsDuration = abs(run.voltage.begin()->time.value() - run.voltage.end()->time.value());
+  double posDuration = abs(run.position.begin()->time.value() - run.position.end()->time.value());
+  double velDuration = abs(run.position.begin()->time.value() - run.position.end()->time.value());
+  return std::max({voltsDuration, posDuration, velDuration});
+}
+
 void DataSelector::Display() {
   using namespace std::chrono_literals;
-
   // building test data is modal (due to async access)
   if (m_testdataFuture.valid()) {
     if (m_testdataFuture.wait_for(0s) == std::future_status::ready) {
@@ -61,8 +69,8 @@ void DataSelector::Display() {
         int i = 0;
         for (auto&& run : motordata.second.runs) {
           m_testdataStats.emplace_back(fmt::format(
-              "  Run {} samples: {} Volt {} Pos {} Vel", ++i,
-              run.voltage.size(), run.position.size(), run.velocity.size()));
+              "  Run {} samples: {} Volt {} Pos {} Vel\n\t{:.1f} seconds", ++i,
+              run.voltage.size(), run.position.size(), run.velocity.size(), GetRunDuration(run)));
         }
       }
       if (testdata) {
@@ -72,6 +80,7 @@ void DataSelector::Display() {
     ImGui::Text("Loading data...");
     return;
   }
+
 
   if (!m_testdataStats.empty()) {
     for (auto&& line : m_testdataStats) {

--- a/sysid/src/main/native/include/sysid/analysis/AnalysisManager.h
+++ b/sysid/src/main/native/include/sysid/analysis/AnalysisManager.h
@@ -345,6 +345,7 @@ class AnalysisManager {
   units::second_t m_maxStepTime{std::numeric_limits<double>::infinity()};
   std::vector<units::second_t> m_positionDelays;
   std::vector<units::second_t> m_velocityDelays;
+  bool m_runSelector = false;
 
   void PrepareGeneralData();
 };

--- a/sysid/src/main/native/include/sysid/analysis/AnalysisManager.h
+++ b/sysid/src/main/native/include/sysid/analysis/AnalysisManager.h
@@ -11,6 +11,7 @@
 #include <numeric>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <units/time.h>
@@ -35,6 +36,7 @@ class AnalysisManager {
   // This contains data for each test (e.g. quasistatic-forward,
   // quasistatic-backward, etc) indexed by test name
   TestData m_data;
+  int m_selectedRun = 0;
   /**
    * Represents settings for an instance of the analysis manager. This contains
    * information about the feedback controller preset, loop type, velocity
@@ -327,6 +329,22 @@ class AnalysisManager {
 
   bool HasData() const { return !m_originalDataset.empty(); }
 
+  
+
+  /**
+ * Error for if a test contains multiple runs.
+ */
+class MultipleRunsError : public std::exception {
+  public:
+   explicit MultipleRunsError(std::string test, MotorData  data)
+       : testName(std::move(test)), data(std::move(data)) {
+        
+       }
+ 
+   std::string testName;
+   MotorData data;
+ };
+
  private:
   wpi::Logger& m_logger;
 
@@ -345,8 +363,8 @@ class AnalysisManager {
   units::second_t m_maxStepTime{std::numeric_limits<double>::infinity()};
   std::vector<units::second_t> m_positionDelays;
   std::vector<units::second_t> m_velocityDelays;
-  bool m_runSelector = false;
 
   void PrepareGeneralData();
+  std::vector<PreparedData> ConvertToPrepared(const MotorData& data, std::string testName);
 };
 }  // namespace sysid

--- a/sysid/src/main/native/include/sysid/view/Analyzer.h
+++ b/sysid/src/main/native/include/sysid/view/Analyzer.h
@@ -21,6 +21,7 @@
 #include "sysid/analysis/AnalysisManager.h"
 #include "sysid/analysis/FeedbackAnalysis.h"
 #include "sysid/analysis/FeedbackControllerPreset.h"
+#include "sysid/analysis/Storage.h"
 #include "sysid/view/AnalyzerPlot.h"
 
 struct ImPlotPoint;
@@ -48,7 +49,8 @@ class Analyzer : public glass::View {
     kTestDurationError,
     kGeneralDataError,
     kMissingTestsError,
-    kFileError
+    kFileError,
+    kMultipleRuns
   };
   /**
    * The different motor controller timing presets that can be used.
@@ -201,6 +203,10 @@ class Analyzer : public glass::View {
    */
   void HandleError(std::string_view msg);
 
+  void HandleMultipleRuns(std::string testName, MotorData data, bool multipleRuns);
+
+  double GetRunDuration(MotorData::Run run);
+
   // State of the Display GUI
   AnalyzerState m_state = AnalyzerState::kWaitingForData;
 
@@ -212,6 +218,9 @@ class Analyzer : public glass::View {
 
   // This is true if the error popup needs to be displayed
   bool m_errorPopup = false;
+  bool m_multipleRunsPopup = false;
+  MotorData m_currentData;
+  std::string m_currentTest;
 
   // Everything related to feedback controller calculations.
   AnalysisManager::Settings m_settings;


### PR DESCRIPTION
Currently SysId will choose the first run of each test regardless of sample count, duration, or order in the log. If a given test has multiple runs, this PR will open a popup to allow the user to select which run they want to use.