### PR TITLE
[commands] Mark CommandPtr class as [[nodiscard]]

### DIFF
--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -192,8 +192,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param duration the timeout duration
    * @return the command with the timeout added
    */
-  [[nodiscard]]
-  CommandPtr WithTimeout(units::second_t duration) &&;
+    CommandPtr WithTimeout(units::second_t duration) &&;
 
   /**
    * Decorates this command with an interrupt condition. If the specified
@@ -203,8 +202,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param condition the interrupt condition
    * @return the command with the interrupt condition added
    */
-  [[nodiscard]]
-  CommandPtr Until(std::function<bool()> condition) &&;
+    CommandPtr Until(std::function<bool()> condition) &&;
 
   /**
    * Decorates this command with a run condition. If the specified condition
@@ -214,8 +212,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param condition the run condition
    * @return the command with the run condition added
    */
-  [[nodiscard]]
-  CommandPtr OnlyWhile(std::function<bool()> condition) &&;
+    CommandPtr OnlyWhile(std::function<bool()> condition) &&;
 
   /**
    * Decorates this command with a runnable to run before this command starts.
@@ -224,8 +221,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param requirements the required subsystems
    * @return the decorated command
    */
-  [[nodiscard]]
-  CommandPtr BeforeStarting(std::function<void()> toRun,
+    CommandPtr BeforeStarting(std::function<void()> toRun,
                             Requirements requirements = {}) &&;
 
   /**
@@ -235,8 +231,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param before the command to run before this one
    * @return the decorated command
    */
-  [[nodiscard]]
-  CommandPtr BeforeStarting(CommandPtr&& before) &&;
+    CommandPtr BeforeStarting(CommandPtr&& before) &&;
 
   /**
    * Decorates this command with a runnable to run after the command finishes.
@@ -245,8 +240,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param requirements the required subsystems
    * @return the decorated command
    */
-  [[nodiscard]]
-  CommandPtr AndThen(std::function<void()> toRun,
+    CommandPtr AndThen(std::function<void()> toRun,
                      Requirements requirements = {}) &&;
 
   /**
@@ -257,8 +251,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param next the commands to run next
    * @return the decorated command
    */
-  [[nodiscard]]
-  CommandPtr AndThen(CommandPtr&& next) &&;
+    CommandPtr AndThen(CommandPtr&& next) &&;
 
   /**
    * Decorates this command to run repeatedly, restarting it when it ends, until
@@ -266,8 +259,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    *
    * @return the decorated command
    */
-  [[nodiscard]]
-  CommandPtr Repeatedly() &&;
+    CommandPtr Repeatedly() &&;
 
   /**
    * Decorates this command to run "by proxy" by wrapping it in a ProxyCommand.
@@ -282,8 +274,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @return the decorated command
    * @see ProxyCommand
    */
-  [[nodiscard]]
-  CommandPtr AsProxy() &&;
+    CommandPtr AsProxy() &&;
 
   /**
    * Decorates this command to only run if this condition is not met. If the
@@ -294,8 +285,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param condition the condition that will prevent the command from running
    * @return the decorated command
    */
-  [[nodiscard]]
-  CommandPtr Unless(std::function<bool()> condition) &&;
+    CommandPtr Unless(std::function<bool()> condition) &&;
 
   /**
    * Decorates this command to only run if this condition is met. If the command
@@ -306,8 +296,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param condition the condition that will allow the command to run
    * @return the decorated command
    */
-  [[nodiscard]]
-  CommandPtr OnlyIf(std::function<bool()> condition) &&;
+    CommandPtr OnlyIf(std::function<bool()> condition) &&;
 
   /**
    * Creates a new command that runs this command and the deadline in parallel,
@@ -330,8 +319,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @return the decorated command
    * @see WithDeadline
    */
-  [[nodiscard]]
-  CommandPtr DeadlineFor(CommandPtr&& parallel) &&;
+    CommandPtr DeadlineFor(CommandPtr&& parallel) &&;
 
   /**
    * Decorates this command with a set of commands to run parallel to it, ending
@@ -341,8 +329,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param parallel the commands to run in parallel
    * @return the decorated command
    */
-  [[nodiscard]]
-  CommandPtr AlongWith(CommandPtr&& parallel) &&;
+    CommandPtr AlongWith(CommandPtr&& parallel) &&;
 
   /**
    * Decorates this command with a set of commands to run parallel to it, ending
@@ -352,8 +339,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param parallel the commands to run in parallel
    * @return the decorated command
    */
-  [[nodiscard]]
-  CommandPtr RaceWith(CommandPtr&& parallel) &&;
+    CommandPtr RaceWith(CommandPtr&& parallel) &&;
 
   /**
    * Decorates this command to run or stop when disabled.
@@ -361,8 +347,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param doesRunWhenDisabled true to run when disabled.
    * @return the decorated command
    */
-  [[nodiscard]]
-  CommandPtr IgnoringDisable(bool doesRunWhenDisabled) &&;
+    CommandPtr IgnoringDisable(bool doesRunWhenDisabled) &&;
 
   /**
    * Decorates this command to have a different interrupt behavior.
@@ -370,8 +355,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param interruptBehavior the desired interrupt behavior
    * @return the decorated command
    */
-  [[nodiscard]]
-  CommandPtr WithInterruptBehavior(
+    CommandPtr WithInterruptBehavior(
       Command::InterruptionBehavior interruptBehavior) &&;
 
   /**
@@ -382,8 +366,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * command was interrupted.
    * @return the decorated command
    */
-  [[nodiscard]]
-  CommandPtr FinallyDo(std::function<void(bool)> end) &&;
+    CommandPtr FinallyDo(std::function<void(bool)> end) &&;
 
   /**
    * Decorates this command with a lambda to call on interrupt or end, following
@@ -394,8 +377,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * interrupted.
    * @return the decorated command
    */
-  [[nodiscard]]
-  CommandPtr FinallyDo(std::function<void()> end) &&;
+    CommandPtr FinallyDo(std::function<void()> end) &&;
 
   /**
    * Decorates this command with a lambda to call on interrupt, following the
@@ -404,8 +386,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param handler a lambda to run when the command is interrupted
    * @return the decorated command
    */
-  [[nodiscard]]
-  CommandPtr HandleInterrupt(std::function<void()> handler) &&;
+    CommandPtr HandleInterrupt(std::function<void()> handler) &&;
 
   /**
    * Decorates this Command with a name.
@@ -413,8 +394,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param name name
    * @return the decorated Command
    */
-  [[nodiscard]]
-  CommandPtr WithName(std::string_view name) &&;
+    CommandPtr WithName(std::string_view name) &&;
 
   /**
    * Schedules this command.

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -192,7 +192,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param duration the timeout duration
    * @return the command with the timeout added
    */
-    CommandPtr WithTimeout(units::second_t duration) &&;
+  CommandPtr WithTimeout(units::second_t duration) &&;
 
   /**
    * Decorates this command with an interrupt condition. If the specified
@@ -202,7 +202,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param condition the interrupt condition
    * @return the command with the interrupt condition added
    */
-    CommandPtr Until(std::function<bool()> condition) &&;
+  CommandPtr Until(std::function<bool()> condition) &&;
 
   /**
    * Decorates this command with a run condition. If the specified condition
@@ -212,7 +212,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param condition the run condition
    * @return the command with the run condition added
    */
-    CommandPtr OnlyWhile(std::function<bool()> condition) &&;
+  CommandPtr OnlyWhile(std::function<bool()> condition) &&;
 
   /**
    * Decorates this command with a runnable to run before this command starts.
@@ -221,7 +221,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param requirements the required subsystems
    * @return the decorated command
    */
-    CommandPtr BeforeStarting(std::function<void()> toRun,
+  CommandPtr BeforeStarting(std::function<void()> toRun,
                             Requirements requirements = {}) &&;
 
   /**
@@ -231,7 +231,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param before the command to run before this one
    * @return the decorated command
    */
-    CommandPtr BeforeStarting(CommandPtr&& before) &&;
+  CommandPtr BeforeStarting(CommandPtr&& before) &&;
 
   /**
    * Decorates this command with a runnable to run after the command finishes.
@@ -240,7 +240,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param requirements the required subsystems
    * @return the decorated command
    */
-    CommandPtr AndThen(std::function<void()> toRun,
+  CommandPtr AndThen(std::function<void()> toRun,
                      Requirements requirements = {}) &&;
 
   /**
@@ -251,7 +251,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param next the commands to run next
    * @return the decorated command
    */
-    CommandPtr AndThen(CommandPtr&& next) &&;
+  CommandPtr AndThen(CommandPtr&& next) &&;
 
   /**
    * Decorates this command to run repeatedly, restarting it when it ends, until
@@ -259,7 +259,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    *
    * @return the decorated command
    */
-    CommandPtr Repeatedly() &&;
+  CommandPtr Repeatedly() &&;
 
   /**
    * Decorates this command to run "by proxy" by wrapping it in a ProxyCommand.
@@ -274,7 +274,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @return the decorated command
    * @see ProxyCommand
    */
-    CommandPtr AsProxy() &&;
+  CommandPtr AsProxy() &&;
 
   /**
    * Decorates this command to only run if this condition is not met. If the
@@ -285,7 +285,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param condition the condition that will prevent the command from running
    * @return the decorated command
    */
-    CommandPtr Unless(std::function<bool()> condition) &&;
+  CommandPtr Unless(std::function<bool()> condition) &&;
 
   /**
    * Decorates this command to only run if this condition is met. If the command
@@ -296,7 +296,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param condition the condition that will allow the command to run
    * @return the decorated command
    */
-    CommandPtr OnlyIf(std::function<bool()> condition) &&;
+  CommandPtr OnlyIf(std::function<bool()> condition) &&;
 
   /**
    * Creates a new command that runs this command and the deadline in parallel,
@@ -319,7 +319,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @return the decorated command
    * @see WithDeadline
    */
-    CommandPtr DeadlineFor(CommandPtr&& parallel) &&;
+  CommandPtr DeadlineFor(CommandPtr&& parallel) &&;
 
   /**
    * Decorates this command with a set of commands to run parallel to it, ending
@@ -329,7 +329,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param parallel the commands to run in parallel
    * @return the decorated command
    */
-    CommandPtr AlongWith(CommandPtr&& parallel) &&;
+  CommandPtr AlongWith(CommandPtr&& parallel) &&;
 
   /**
    * Decorates this command with a set of commands to run parallel to it, ending
@@ -339,7 +339,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param parallel the commands to run in parallel
    * @return the decorated command
    */
-    CommandPtr RaceWith(CommandPtr&& parallel) &&;
+  CommandPtr RaceWith(CommandPtr&& parallel) &&;
 
   /**
    * Decorates this command to run or stop when disabled.
@@ -347,7 +347,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param doesRunWhenDisabled true to run when disabled.
    * @return the decorated command
    */
-    CommandPtr IgnoringDisable(bool doesRunWhenDisabled) &&;
+  CommandPtr IgnoringDisable(bool doesRunWhenDisabled) &&;
 
   /**
    * Decorates this command to have a different interrupt behavior.
@@ -355,7 +355,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param interruptBehavior the desired interrupt behavior
    * @return the decorated command
    */
-    CommandPtr WithInterruptBehavior(
+  CommandPtr WithInterruptBehavior(
       Command::InterruptionBehavior interruptBehavior) &&;
 
   /**
@@ -366,7 +366,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * command was interrupted.
    * @return the decorated command
    */
-    CommandPtr FinallyDo(std::function<void(bool)> end) &&;
+  CommandPtr FinallyDo(std::function<void(bool)> end) &&;
 
   /**
    * Decorates this command with a lambda to call on interrupt or end, following
@@ -377,7 +377,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * interrupted.
    * @return the decorated command
    */
-    CommandPtr FinallyDo(std::function<void()> end) &&;
+  CommandPtr FinallyDo(std::function<void()> end) &&;
 
   /**
    * Decorates this command with a lambda to call on interrupt, following the
@@ -386,7 +386,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param handler a lambda to run when the command is interrupted
    * @return the decorated command
    */
-    CommandPtr HandleInterrupt(std::function<void()> handler) &&;
+  CommandPtr HandleInterrupt(std::function<void()> handler) &&;
 
   /**
    * Decorates this Command with a name.
@@ -394,7 +394,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * @param name name
    * @return the decorated Command
    */
-    CommandPtr WithName(std::string_view name) &&;
+  CommandPtr WithName(std::string_view name) &&;
 
   /**
    * Schedules this command.

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
@@ -25,7 +25,7 @@ namespace frc2 {
  * std::unique_ptr<Command>, use CommandPtr::Unwrap to convert.
  * CommandPtr::UnwrapVector does the same for vectors.
  */
-class CommandPtr final {
+class [[nodiscard]] CommandPtr final {
  public:
   explicit CommandPtr(std::unique_ptr<Command>&& command);
 
@@ -46,7 +46,6 @@ class CommandPtr final {
    *
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr Repeatedly() &&;
 
   /**
@@ -60,7 +59,6 @@ class CommandPtr final {
    * @return the decorated command
    * @see ProxyCommand
    */
-  [[nodiscard]]
   CommandPtr AsProxy() &&;
 
   /**
@@ -69,7 +67,6 @@ class CommandPtr final {
    * @param doesRunWhenDisabled true to run when disabled
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr IgnoringDisable(bool doesRunWhenDisabled) &&;
 
   /**
@@ -78,7 +75,6 @@ class CommandPtr final {
    * @param interruptBehavior the desired interrupt behavior
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr WithInterruptBehavior(
       Command::InterruptionBehavior interruptBehavior) &&;
 
@@ -89,7 +85,6 @@ class CommandPtr final {
    * @param requirements the required subsystems
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr AndThen(std::function<void()> toRun,
                      Requirements requirements = {}) &&;
 
@@ -101,7 +96,6 @@ class CommandPtr final {
    * @param next the commands to run next
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr AndThen(CommandPtr&& next) &&;
 
   /**
@@ -111,7 +105,6 @@ class CommandPtr final {
    * @param requirements the required subsystems
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr BeforeStarting(std::function<void()> toRun,
                             Requirements requirements = {}) &&;
 
@@ -122,7 +115,6 @@ class CommandPtr final {
    * @param before the command to run before this one
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr BeforeStarting(CommandPtr&& before) &&;
 
   /**
@@ -133,7 +125,6 @@ class CommandPtr final {
    * @param duration the timeout duration
    * @return the command with the timeout added
    */
-  [[nodiscard]]
   CommandPtr WithTimeout(units::second_t duration) &&;
 
   /**
@@ -144,7 +135,6 @@ class CommandPtr final {
    * @param condition the interrupt condition
    * @return the command with the interrupt condition added
    */
-  [[nodiscard]]
   CommandPtr Until(std::function<bool()> condition) &&;
 
   /**
@@ -155,7 +145,6 @@ class CommandPtr final {
    * @param condition the run condition
    * @return the command with the run condition added
    */
-  [[nodiscard]]
   CommandPtr OnlyWhile(std::function<bool()> condition) &&;
 
   /**
@@ -167,7 +156,6 @@ class CommandPtr final {
    * @param condition the condition that will prevent the command from running
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr Unless(std::function<bool()> condition) &&;
 
   /**
@@ -179,7 +167,6 @@ class CommandPtr final {
    * @param condition the condition that will allow the command to run
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr OnlyIf(std::function<bool()> condition) &&;
 
   /**
@@ -201,7 +188,7 @@ class CommandPtr final {
    * @param parallel the commands to run in parallel
    * @return the decorated command
    */
-  [[nodiscard]] [[deprecated("Replace with DeadlineFor")]]
+  [[deprecated("Replace with DeadlineFor")]]
   CommandPtr DeadlineWith(CommandPtr&& parallel) &&;
 
   /**
@@ -214,7 +201,6 @@ class CommandPtr final {
    * will be interupted when the deadline command ends
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr DeadlineFor(CommandPtr&& parallel) &&;
   /**
    * Decorates this command with a set of commands to run parallel to it, ending
@@ -224,7 +210,6 @@ class CommandPtr final {
    * @param parallel the commands to run in parallel
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr AlongWith(CommandPtr&& parallel) &&;
 
   /**
@@ -235,7 +220,6 @@ class CommandPtr final {
    * @param parallel the commands to run in parallel
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr RaceWith(CommandPtr&& parallel) &&;
 
   /**
@@ -246,7 +230,6 @@ class CommandPtr final {
    * command was interrupted
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr FinallyDo(std::function<void(bool)> end) &&;
 
   /**
@@ -258,7 +241,6 @@ class CommandPtr final {
    * interrupted.
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr FinallyDo(std::function<void()> end) &&;
 
   /**
@@ -268,7 +250,6 @@ class CommandPtr final {
    * @param handler a lambda to run when the command is interrupted
    * @return the decorated command
    */
-  [[nodiscard]]
   CommandPtr HandleInterrupt(std::function<void()> handler) &&;
 
   /**
@@ -278,7 +259,6 @@ class CommandPtr final {
    * @param name name
    * @return the decorated Command
    */
-  [[nodiscard]]
   CommandPtr WithName(std::string_view name) &&;
 
   /**

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
@@ -25,7 +25,8 @@ namespace frc2 {
  * std::unique_ptr<Command>, use CommandPtr::Unwrap to convert.
  * CommandPtr::UnwrapVector does the same for vectors.
  */
-class [[nodiscard]] CommandPtr final {
+class [[nodiscard]]
+CommandPtr final {
  public:
   explicit CommandPtr(std::unique_ptr<Command>&& command);
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
@@ -29,7 +29,6 @@ namespace cmd {
 /**
  * Constructs a command that does nothing, finishing immediately.
  */
-[[nodiscard]]
 CommandPtr None();
 
 /**
@@ -38,7 +37,6 @@ CommandPtr None();
  * @param requirements Subsystems to require
  * @return the command
  */
-[[nodiscard]]
 CommandPtr Idle(Requirements requirements = {});
 
 // Action Commands
@@ -49,7 +47,6 @@ CommandPtr Idle(Requirements requirements = {});
  * @param action the action to run
  * @param requirements subsystems the action requires
  */
-[[nodiscard]]
 CommandPtr RunOnce(std::function<void()> action,
                    Requirements requirements = {});
 
@@ -59,7 +56,6 @@ CommandPtr RunOnce(std::function<void()> action,
  * @param action the action to run
  * @param requirements subsystems the action requires
  */
-[[nodiscard]]
 CommandPtr Run(std::function<void()> action, Requirements requirements = {});
 
 /**
@@ -70,7 +66,6 @@ CommandPtr Run(std::function<void()> action, Requirements requirements = {});
  * @param end the action to run on interrupt
  * @param requirements subsystems the action requires
  */
-[[nodiscard]]
 CommandPtr StartEnd(std::function<void()> start, std::function<void()> end,
                     Requirements requirements = {});
 
@@ -82,7 +77,6 @@ CommandPtr StartEnd(std::function<void()> start, std::function<void()> end,
  * @param end the action to run on interrupt
  * @param requirements subsystems the action requires
  */
-[[nodiscard]]
 CommandPtr RunEnd(std::function<void()> run, std::function<void()> end,
                   Requirements requirements = {});
 
@@ -94,7 +88,6 @@ CommandPtr RunEnd(std::function<void()> run, std::function<void()> end,
  * @param run the action to run every iteration
  * @param requirements subsystems the action requires
  */
-[[nodiscard]]
 CommandPtr StartRun(std::function<void()> start, std::function<void()> run,
                     Requirements requirements = {});
 
@@ -103,7 +96,6 @@ CommandPtr StartRun(std::function<void()> start, std::function<void()> run,
  *
  * @param msg the message to print
  */
-[[nodiscard]]
 CommandPtr Print(std::string_view msg);
 
 // Idling Commands
@@ -113,7 +105,6 @@ CommandPtr Print(std::string_view msg);
  *
  * @param duration after how long the command finishes
  */
-[[nodiscard]]
 CommandPtr Wait(units::second_t duration);
 
 /**
@@ -122,7 +113,6 @@ CommandPtr Wait(units::second_t duration);
  *
  * @param condition the condition
  */
-[[nodiscard]]
 CommandPtr WaitUntil(std::function<bool()> condition);
 
 // Selector Commands
@@ -134,7 +124,6 @@ CommandPtr WaitUntil(std::function<bool()> condition);
  * @param onFalse the command to run if the selector function returns false
  * @param selector the selector function
  */
-[[nodiscard]]
 CommandPtr Either(CommandPtr&& onTrue, CommandPtr&& onFalse,
                   std::function<bool()> selector);
 
@@ -145,7 +134,6 @@ CommandPtr Either(CommandPtr&& onTrue, CommandPtr&& onFalse,
  * @param commands map of commands to select from
  */
 template <typename Key, std::convertible_to<CommandPtr>... CommandPtrs>
-[[nodiscard]]
 CommandPtr Select(std::function<Key()> selector,
                   std::pair<Key, CommandPtrs>&&... commands) {
   std::vector<std::pair<Key, std::unique_ptr<Command>>> vec;
@@ -162,7 +150,6 @@ CommandPtr Select(std::function<Key()> selector,
  * @param supplier the command supplier
  * @param requirements the set of requirements for this command
  */
-[[nodiscard]]
 CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier,
                  Requirements requirements);
 
@@ -173,7 +160,6 @@ CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier,
  *
  * @param supplier the command supplier
  */
-[[nodiscard]]
 CommandPtr DeferredProxy(wpi::unique_function<Command*()> supplier);
 
 /**
@@ -183,7 +169,6 @@ CommandPtr DeferredProxy(wpi::unique_function<Command*()> supplier);
  *
  * @param supplier the command supplier
  */
-[[nodiscard]]
 CommandPtr DeferredProxy(wpi::unique_function<CommandPtr()> supplier);
 // Command Groups
 
@@ -205,14 +190,12 @@ std::vector<CommandPtr> MakeVector(Args&&... args) {
 /**
  * Runs a group of commands in series, one after the other.
  */
-[[nodiscard]]
 CommandPtr Sequence(std::vector<CommandPtr>&& commands);
 
 /**
  * Runs a group of commands in series, one after the other.
  */
 template <std::convertible_to<CommandPtr>... CommandPtrs>
-[[nodiscard]]
 CommandPtr Sequence(CommandPtrs&&... commands) {
   return Sequence(impl::MakeVector(std::forward<CommandPtrs>(commands)...));
 }
@@ -221,7 +204,6 @@ CommandPtr Sequence(CommandPtrs&&... commands) {
  * Runs a group of commands in series, one after the other. Once the last
  * command ends, the group is restarted.
  */
-[[nodiscard]]
 CommandPtr RepeatingSequence(std::vector<CommandPtr>&& commands);
 
 /**
@@ -229,7 +211,6 @@ CommandPtr RepeatingSequence(std::vector<CommandPtr>&& commands);
  * command ends, the group is restarted.
  */
 template <std::convertible_to<CommandPtr>... CommandPtrs>
-[[nodiscard]]
 CommandPtr RepeatingSequence(CommandPtrs&&... commands) {
   return RepeatingSequence(
       impl::MakeVector(std::forward<CommandPtrs>(commands)...));
@@ -239,7 +220,6 @@ CommandPtr RepeatingSequence(CommandPtrs&&... commands) {
  * Runs a group of commands at the same time. Ends once all commands in the
  * group finish.
  */
-[[nodiscard]]
 CommandPtr Parallel(std::vector<CommandPtr>&& commands);
 
 /**
@@ -247,7 +227,6 @@ CommandPtr Parallel(std::vector<CommandPtr>&& commands);
  * group finish.
  */
 template <std::convertible_to<CommandPtr>... CommandPtrs>
-[[nodiscard]]
 CommandPtr Parallel(CommandPtrs&&... commands) {
   return Parallel(impl::MakeVector(std::forward<CommandPtrs>(commands)...));
 }
@@ -256,7 +235,6 @@ CommandPtr Parallel(CommandPtrs&&... commands) {
  * Runs a group of commands at the same time. Ends once any command in the group
  * finishes, and cancels the others.
  */
-[[nodiscard]]
 CommandPtr Race(std::vector<CommandPtr>&& commands);
 
 /**
@@ -264,7 +242,6 @@ CommandPtr Race(std::vector<CommandPtr>&& commands);
  * finishes, and cancels the others.
  */
 template <std::convertible_to<CommandPtr>... CommandPtrs>
-[[nodiscard]]
 CommandPtr Race(CommandPtrs&&... commands) {
   return Race(impl::MakeVector(std::forward<CommandPtrs>(commands)...));
 }
@@ -273,7 +250,6 @@ CommandPtr Race(CommandPtrs&&... commands) {
  * Runs a group of commands at the same time. Ends once a specific command
  * finishes, and cancels the others.
  */
-[[nodiscard]]
 CommandPtr Deadline(CommandPtr&& deadline, std::vector<CommandPtr>&& others);
 
 /**
@@ -281,7 +257,6 @@ CommandPtr Deadline(CommandPtr&& deadline, std::vector<CommandPtr>&& others);
  * finishes, and cancels the others.
  */
 template <std::convertible_to<CommandPtr>... CommandPtrs>
-[[nodiscard]]
 CommandPtr Deadline(CommandPtr&& deadline, CommandPtrs&&... commands) {
   return Deadline(std::move(deadline),
                   impl::MakeVector(std::forward<CommandPtrs>(commands)...));

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
@@ -127,7 +127,6 @@ class Subsystem {
    *
    * @param action the action to run
    */
-  [[nodiscard]]
   CommandPtr RunOnce(std::function<void()> action);
 
   /**
@@ -136,7 +135,6 @@ class Subsystem {
    *
    * @param action the action to run
    */
-  [[nodiscard]]
   CommandPtr Run(std::function<void()> action);
 
   /**
@@ -146,7 +144,6 @@ class Subsystem {
    * @param start the action to run on start
    * @param end the action to run on interrupt
    */
-  [[nodiscard]]
   CommandPtr StartEnd(std::function<void()> start, std::function<void()> end);
 
   /**
@@ -156,7 +153,6 @@ class Subsystem {
    * @param run the action to run every iteration
    * @param end the action to run on interrupt
    */
-  [[nodiscard]]
   CommandPtr RunEnd(std::function<void()> run, std::function<void()> end);
 
   /**
@@ -166,7 +162,6 @@ class Subsystem {
    * @param start the action to run on start
    * @param run the action to run every iteration
    */
-  [[nodiscard]]
   CommandPtr StartRun(std::function<void()> start, std::function<void()> run);
 
   /**
@@ -176,7 +171,6 @@ class Subsystem {
    * @param supplier the command supplier.
    * @return the command.
    */
-  [[nodiscard]]
   CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier);
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandPtrTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandPtrTest.cpp
@@ -38,5 +38,5 @@ TEST_F(CommandPtrTest, MovedFrom) {
 }
 
 TEST_F(CommandPtrTest, NullInitialization) {
-  EXPECT_THROW(CommandPtr{std::unique_ptr<Command>{}}, frc::RuntimeError);
+  EXPECT_THROW(auto cmd = CommandPtr{std::unique_ptr<Command>{}}, frc::RuntimeError);
 }

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandPtrTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandPtrTest.cpp
@@ -38,5 +38,6 @@ TEST_F(CommandPtrTest, MovedFrom) {
 }
 
 TEST_F(CommandPtrTest, NullInitialization) {
-  EXPECT_THROW(auto cmd = CommandPtr{std::unique_ptr<Command>{}}, frc::RuntimeError);
+  EXPECT_THROW(auto cmd = CommandPtr{std::unique_ptr<Command>{}},
+               frc::RuntimeError);
 }

--- a/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/include/subsystems/DriveSubsystem.h
+++ b/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/include/subsystems/DriveSubsystem.h
@@ -82,7 +82,7 @@ class DriveSubsystem : public frc2::SubsystemBase {
    * @param distance The distance to drive forward.
    * @return A command.
    */
-    frc2::CommandPtr ProfiledDriveDistance(units::meter_t distance);
+  frc2::CommandPtr ProfiledDriveDistance(units::meter_t distance);
 
   /**
    * Creates a command to drive forward a specified distance using a motion
@@ -91,7 +91,7 @@ class DriveSubsystem : public frc2::SubsystemBase {
    * @param distance The distance to drive forward.
    * @return A command.
    */
-    frc2::CommandPtr DynamicProfiledDriveDistance(units::meter_t distance);
+  frc2::CommandPtr DynamicProfiledDriveDistance(units::meter_t distance);
 
  private:
   frc::TrapezoidProfile<units::meters> m_profile{

--- a/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/include/subsystems/DriveSubsystem.h
+++ b/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/include/subsystems/DriveSubsystem.h
@@ -82,8 +82,7 @@ class DriveSubsystem : public frc2::SubsystemBase {
    * @param distance The distance to drive forward.
    * @return A command.
    */
-  [[nodiscard]]
-  frc2::CommandPtr ProfiledDriveDistance(units::meter_t distance);
+    frc2::CommandPtr ProfiledDriveDistance(units::meter_t distance);
 
   /**
    * Creates a command to drive forward a specified distance using a motion
@@ -92,8 +91,7 @@ class DriveSubsystem : public frc2::SubsystemBase {
    * @param distance The distance to drive forward.
    * @return A command.
    */
-  [[nodiscard]]
-  frc2::CommandPtr DynamicProfiledDriveDistance(units::meter_t distance);
+    frc2::CommandPtr DynamicProfiledDriveDistance(units::meter_t distance);
 
  private:
   frc::TrapezoidProfile<units::meters> m_profile{

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Drive.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Drive.h
@@ -28,8 +28,7 @@ class Drive : public frc2::SubsystemBase {
    * @param fwd the commanded forward movement
    * @param rot the commanded rotation
    */
-  [[nodiscard]]
-  frc2::CommandPtr ArcadeDriveCommand(std::function<double()> fwd,
+    frc2::CommandPtr ArcadeDriveCommand(std::function<double()> fwd,
                                       std::function<double()> rot);
 
   /**
@@ -39,8 +38,7 @@ class Drive : public frc2::SubsystemBase {
    * @param distance The distance to drive forward in meters
    * @param speed The fraction of max speed at which to drive
    */
-  [[nodiscard]]
-  frc2::CommandPtr DriveDistanceCommand(units::meter_t distance, double speed);
+    frc2::CommandPtr DriveDistanceCommand(units::meter_t distance, double speed);
 
   /**
    * Returns a command that turns to robot to the specified angle using a motion
@@ -48,8 +46,7 @@ class Drive : public frc2::SubsystemBase {
    *
    * @param angle The angle to turn to
    */
-  [[nodiscard]]
-  frc2::CommandPtr TurnToAngleCommand(units::degree_t angle);
+    frc2::CommandPtr TurnToAngleCommand(units::degree_t angle);
 
  private:
   frc::PWMSparkMax m_leftLeader{DriveConstants::kLeftMotor1Port};

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Drive.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Drive.h
@@ -28,7 +28,7 @@ class Drive : public frc2::SubsystemBase {
    * @param fwd the commanded forward movement
    * @param rot the commanded rotation
    */
-    frc2::CommandPtr ArcadeDriveCommand(std::function<double()> fwd,
+  frc2::CommandPtr ArcadeDriveCommand(std::function<double()> fwd,
                                       std::function<double()> rot);
 
   /**
@@ -38,7 +38,7 @@ class Drive : public frc2::SubsystemBase {
    * @param distance The distance to drive forward in meters
    * @param speed The fraction of max speed at which to drive
    */
-    frc2::CommandPtr DriveDistanceCommand(units::meter_t distance, double speed);
+  frc2::CommandPtr DriveDistanceCommand(units::meter_t distance, double speed);
 
   /**
    * Returns a command that turns to robot to the specified angle using a motion
@@ -46,7 +46,7 @@ class Drive : public frc2::SubsystemBase {
    *
    * @param angle The angle to turn to
    */
-    frc2::CommandPtr TurnToAngleCommand(units::degree_t angle);
+  frc2::CommandPtr TurnToAngleCommand(units::degree_t angle);
 
  private:
   frc::PWMSparkMax m_leftLeader{DriveConstants::kLeftMotor1Port};

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Intake.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Intake.h
@@ -19,10 +19,10 @@ class Intake : public frc2::SubsystemBase {
 
   /** Returns a command that deploys the intake, and then runs the intake motor
    * indefinitely. */
-    frc2::CommandPtr IntakeCommand();
+  frc2::CommandPtr IntakeCommand();
 
   /** Returns a command that turns off and retracts the intake. */
-    frc2::CommandPtr RetractCommand();
+  frc2::CommandPtr RetractCommand();
 
  private:
   frc::PWMSparkMax m_motor{IntakeConstants::kMotorPort};

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Intake.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Intake.h
@@ -19,12 +19,10 @@ class Intake : public frc2::SubsystemBase {
 
   /** Returns a command that deploys the intake, and then runs the intake motor
    * indefinitely. */
-  [[nodiscard]]
-  frc2::CommandPtr IntakeCommand();
+    frc2::CommandPtr IntakeCommand();
 
   /** Returns a command that turns off and retracts the intake. */
-  [[nodiscard]]
-  frc2::CommandPtr RetractCommand();
+    frc2::CommandPtr RetractCommand();
 
  private:
   frc::PWMSparkMax m_motor{IntakeConstants::kMotorPort};

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Pneumatics.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Pneumatics.h
@@ -17,8 +17,7 @@ class Pneumatics : frc2::SubsystemBase {
  public:
   Pneumatics();
   /** Returns a command that disables the compressor indefinitely. */
-  [[nodiscard]]
-  frc2::CommandPtr DisableCompressorCommand();
+    frc2::CommandPtr DisableCompressorCommand();
 
   /**
    * Query the analog pressure sensor.

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Pneumatics.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Pneumatics.h
@@ -17,7 +17,7 @@ class Pneumatics : frc2::SubsystemBase {
  public:
   Pneumatics();
   /** Returns a command that disables the compressor indefinitely. */
-    frc2::CommandPtr DisableCompressorCommand();
+  frc2::CommandPtr DisableCompressorCommand();
 
   /**
    * Query the analog pressure sensor.

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Shooter.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Shooter.h
@@ -28,7 +28,7 @@ class Shooter : public frc2::SubsystemBase {
    *
    * @param setpointRotationsPerSecond The desired shooter velocity
    */
-    frc2::CommandPtr ShootCommand(units::turns_per_second_t setpoint);
+  frc2::CommandPtr ShootCommand(units::turns_per_second_t setpoint);
 
  private:
   frc::PWMSparkMax m_shooterMotor{ShooterConstants::kShooterMotorPort};

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Shooter.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Shooter.h
@@ -28,8 +28,7 @@ class Shooter : public frc2::SubsystemBase {
    *
    * @param setpointRotationsPerSecond The desired shooter velocity
    */
-  [[nodiscard]]
-  frc2::CommandPtr ShootCommand(units::turns_per_second_t setpoint);
+    frc2::CommandPtr ShootCommand(units::turns_per_second_t setpoint);
 
  private:
   frc::PWMSparkMax m_shooterMotor{ShooterConstants::kShooterMotorPort};

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Storage.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Storage.h
@@ -16,7 +16,7 @@ class Storage : frc2::SubsystemBase {
  public:
   Storage();
   /** Returns a command that runs the storage motor indefinitely. */
-    frc2::CommandPtr RunCommand();
+  frc2::CommandPtr RunCommand();
 
   /** Whether the ball storage is full. */
   frc2::Trigger HasCargo{[this] { return m_ballSensor.Get(); }};

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Storage.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Storage.h
@@ -16,8 +16,7 @@ class Storage : frc2::SubsystemBase {
  public:
   Storage();
   /** Returns a command that runs the storage motor indefinitely. */
-  [[nodiscard]]
-  frc2::CommandPtr RunCommand();
+    frc2::CommandPtr RunCommand();
 
   /** Whether the ball storage is full. */
   frc2::Trigger HasCargo{[this] { return m_ballSensor.Get(); }};


### PR DESCRIPTION
Classes can be marked as [[nodiscard]] such that if they are ever returned from a method its as if that method has the [[nodiscard]] attribute. (https://en.cppreference.com/w/cpp/language/attributes/nodiscard)

Seeing as all the CommandPtr decorators were marked as [[nodiscard]], I thought this would achieve the goal more succinctly.
This has the added benefit of also making user created CommandPtr factories benefit as well.

What motivated this is that I've seen student code like the following several times

```cpp

CommandPtr ActivateIntake() {
  return RunEnd(
    [this] {SetIntakeSpeed(0.5);},
    [this] {SetIntakeSpeed(0.0);});
}

CommandPtr IntakeCoral() {
  return Run([this] {ActivateIntake();})
    .Until([this] {return CoralDetected();});
}
```

This code currently happily compiles without warnings and looks correct to someone unfamiliar with lambdas, async programming, or wpilib command semantics. (It says Run ActivateIntake until CoralDetected, sounds good to me!)
Essentially, students often get confused between methods which run "instantly" and methods which return commands.

This change makes it a warning, (which can be made an error with -Werror as I've set up our project to do and I recommend to everyone, especially with new programmers).