### PR TITLE
[sysid] Remove extra period from exception messages

### DIFF
--- a/sysid/src/main/native/include/sysid/analysis/FilteringUtils.h
+++ b/sysid/src/main/native/include/sysid/analysis/FilteringUtils.h
@@ -41,7 +41,7 @@ class InvalidDataError : public std::exception {
    */
   explicit InvalidDataError(std::string_view message) {
     m_message = fmt::format(
-        "{}. Please verify that your units and data is reasonable and then "
+        "{} Please verify that your units and data is reasonable and then "
         "adjust your velocity threshold, test duration, and/or window size to "
         "try to fix this issue.",
         message);


### PR DESCRIPTION
The first part of the message already has one.