### PR TITLE
[cmd] Add CommandScheduler.getAllRegisteredSubsystems()

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -371,6 +371,13 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   }
 
   /**
+   * Get all registered subsystems as an immutable collection
+   */
+  public Set<Subsystem> getAllRegisteredSubsystems(){
+    return Collections.unmodifiableSet(m_subsystems.keySet());
+  }
+
+  /**
    * Un-registers all registered Subsystems with the scheduler. All currently registered subsystems
    * will no longer have their periodic block called, and will not have their default command
    * scheduled.

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -370,7 +370,11 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
     m_subsystems.keySet().removeAll(Set.of(subsystems));
   }
 
-  /** Get all registered subsystems as an immutable collection. */
+  /** 
+   * Get all registered subsystems.
+   * 
+   * @return Returns the list of registered subsystems as an immutable collection.
+  */
   public Set<Subsystem> getAllRegisteredSubsystems() {
     return Collections.unmodifiableSet(m_subsystems.keySet());
   }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -370,9 +370,9 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
     m_subsystems.keySet().removeAll(Set.of(subsystems));
   }
 
-  /** 
+  /**
    * Get all registered subsystems.
-   * 
+   *
    * @return Returns the list of registered subsystems as an immutable collection.
   */
   public Set<Subsystem> getAllRegisteredSubsystems() {

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -370,9 +370,7 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
     m_subsystems.keySet().removeAll(Set.of(subsystems));
   }
 
-  /**
-   * Get all registered subsystems as an immutable collection.
-   */
+  /** Get all registered subsystems as an immutable collection. */
   public Set<Subsystem> getAllRegisteredSubsystems() {
     return Collections.unmodifiableSet(m_subsystems.keySet());
   }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -371,9 +371,9 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   }
 
   /**
-   * Get all registered subsystems as an immutable collection
+   * Get all registered subsystems as an immutable collection.
    */
-  public Set<Subsystem> getAllRegisteredSubsystems(){
+  public Set<Subsystem> getAllRegisteredSubsystems() {
     return Collections.unmodifiableSet(m_subsystems.keySet());
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -374,7 +374,7 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
    * Get all registered subsystems.
    *
    * @return Returns the list of registered subsystems as an immutable collection.
-  */
+   */
   public Set<Subsystem> getAllRegisteredSubsystems() {
     return Collections.unmodifiableSet(m_subsystems.keySet());
   }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -376,7 +376,7 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
    * @return Returns the list of registered subsystems as an immutable collection.
    */
   public Set<Subsystem> getAllRegisteredSubsystems() {
-    return Collections.unmodifiableSet(m_subsystems.keySet());
+    return Set.copyOf(m_subsystems.keySet());
   }
 
   /**

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -288,6 +288,16 @@ void CommandScheduler::UnregisterSubsystem(
   }
 }
 
+std::vector<Subsystem*> CommandScheduler::GetAllRegisteredSubsystems(){
+  std::vector<frc2::Subsystem*> subsystems;
+  subsystems.reserve(m_impl->subsystems.size());
+  for(wpi::DenseMap<frc2::Subsystem*, std::unique_ptr<Command>>::iterator it = m_impl->subsystems.begin();
+  it != m_impl->subsystems.end(); ++it){
+    subsystems.push_back(it->first);
+  }
+  return subsystems;
+}
+
 void CommandScheduler::UnregisterAllSubsystems() {
   m_impl->subsystems.clear();
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -288,11 +288,12 @@ void CommandScheduler::UnregisterSubsystem(
   }
 }
 
-const std::vector<Subsystem*> CommandScheduler::GetAllRegisteredSubsystems(){
+const std::vector<Subsystem*> CommandScheduler::GetAllRegisteredSubsystems() {
   std::vector<frc2::Subsystem*> subsystems;
   subsystems.reserve(m_impl->subsystems.size());
-  for(wpi::DenseMap<frc2::Subsystem*, std::unique_ptr<Command>>::iterator it = m_impl->subsystems.begin();
-  it != m_impl->subsystems.end(); ++it){
+  for (wpi::DenseMap<frc2::Subsystem*, std::unique_ptr<Command>>::iterator it =
+           m_impl->subsystems.begin();
+       it != m_impl->subsystems.end(); ++it) {
     subsystems.push_back(it->first);
   }
   const std::vector<frc2::Subsystem*> ret = subsystems;

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -288,14 +288,15 @@ void CommandScheduler::UnregisterSubsystem(
   }
 }
 
-std::vector<Subsystem*> CommandScheduler::GetAllRegisteredSubsystems(){
+const std::vector<Subsystem*> CommandScheduler::GetAllRegisteredSubsystems(){
   std::vector<frc2::Subsystem*> subsystems;
   subsystems.reserve(m_impl->subsystems.size());
   for(wpi::DenseMap<frc2::Subsystem*, std::unique_ptr<Command>>::iterator it = m_impl->subsystems.begin();
   it != m_impl->subsystems.end(); ++it){
     subsystems.push_back(it->first);
   }
-  return subsystems;
+  const std::vector<frc2::Subsystem*> ret = subsystems;
+  return ret;
 }
 
 void CommandScheduler::UnregisterAllSubsystems() {

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <span>
 #include <utility>
+#include <vector>
 
 #include <frc/Errors.h>
 #include <frc/Watchdog.h>
@@ -190,6 +191,12 @@ class CommandScheduler final : public wpi::Sendable,
 
   void UnregisterSubsystem(std::initializer_list<Subsystem*> subsystems);
   void UnregisterSubsystem(std::span<Subsystem* const> subsystems);
+
+  /**
+   * @brief Get all registered subsytems as an immutable vector
+   * 
+   */
+  std::vector<Subsystem*> GetAllRegisteredSubsystems();
 
   /**
    * Un-registers all registered Subsystems with the scheduler. All currently

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -196,7 +196,7 @@ class CommandScheduler final : public wpi::Sendable,
    * @brief Get all registered subsytems as an immutable vector
    * 
    */
-  std::vector<Subsystem*> GetAllRegisteredSubsystems();
+  const std::vector<Subsystem*> GetAllRegisteredSubsystems();
 
   /**
    * Un-registers all registered Subsystems with the scheduler. All currently

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -194,7 +194,7 @@ class CommandScheduler final : public wpi::Sendable,
 
   /**
    * @brief Get all registered subsytems as an immutable vector
-   * 
+   *
    */
   const std::vector<Subsystem*> GetAllRegisteredSubsystems();
 


### PR DESCRIPTION
In java, the subsystems are returned as an immutable set and in c++ they are returned as a const vector. No tests for these as there isn't testing framework to create mock subsystems in wpilibNewCommands tests, at least not that I'm aware of.