### PR TITLE
Remove sources from ceres-cpp

### DIFF
--- a/shared/ceres.gradle
+++ b/shared/ceres.gradle
@@ -4,7 +4,6 @@ nativeUtils {
             groupId = "edu.wpi.first.thirdparty.frc2024.ceres"
             artifactId = "ceres-cpp"
             headerClassifier = "headers"
-            sourceClassifier = "sources"
             ext = "zip"
             version = '2.2-3'
             targetPlatforms.addAll(nativeUtils.wpi.platforms.desktopPlatforms)


### PR DESCRIPTION
Without this, generateVsCodeConfig doesn't work, as it can't find the sources artifact.