### PR TITLE
[wpimath] Fix UnscentedKalmanFilter and improve math docs

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MerweScaledSigmaPoints.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MerweScaledSigmaPoints.java
@@ -69,8 +69,8 @@ public class MerweScaledSigmaPoints<S extends Num> {
   }
 
   /**
-   * Computes the sigma points for an unscented Kalman filter given the mean
-   * (x) and square-root covariance (s) of the filter.
+   * Computes the sigma points for an unscented Kalman filter given the mean(x) and square-root
+   * covariance (s) of the filter.
    *
    * @param x An array of the means.
    * @param s Square-root covariance of the filter.

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MerweScaledSigmaPoints.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MerweScaledSigmaPoints.java
@@ -69,10 +69,8 @@ public class MerweScaledSigmaPoints<S extends Num> {
   }
 
   /**
-   * Computes the sigma points for an unscented Kalman filter given the mean (x) and square root covariance(s)
-   * of the filter.
-   * 
-   * (Eq. 17)
+   * Computes the sigma points for an unscented Kalman filter given the mean
+   * (x) and square-root covariance (s) of the filter.
    *
    * @param x An array of the means.
    * @param s Square-root covariance of the filter.
@@ -88,6 +86,8 @@ public class MerweScaledSigmaPoints<S extends Num> {
     // 2 * states + 1 by states
     Matrix<S, ?> sigmas =
         new Matrix<>(new SimpleMatrix(m_states.getNum(), 2 * m_states.getNum() + 1));
+
+    // equation (17)
     sigmas.setColumn(0, x);
     for (int k = 0; k < m_states.getNum(); k++) {
       var xPlusU = x.plus(U.extractColumnVector(k));

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MerweScaledSigmaPoints.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MerweScaledSigmaPoints.java
@@ -69,7 +69,7 @@ public class MerweScaledSigmaPoints<S extends Num> {
   }
 
   /**
-   * Computes the sigma points for an unscented Kalman filter given the mean(x) and square-root
+   * Computes the sigma points for an unscented Kalman filter given the mean (x) and square-root
    * covariance (s) of the filter.
    *
    * @param x An array of the means.

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MerweScaledSigmaPoints.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MerweScaledSigmaPoints.java
@@ -69,8 +69,10 @@ public class MerweScaledSigmaPoints<S extends Num> {
   }
 
   /**
-   * Computes the sigma points for an unscented Kalman filter given the mean (x) and covariance(P)
+   * Computes the sigma points for an unscented Kalman filter given the mean (x) and square root covariance(s)
    * of the filter.
+   * 
+   * (Eq. 17)
    *
    * @param x An array of the means.
    * @param s Square-root covariance of the filter.

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
@@ -228,7 +228,7 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
     // Compute the square-root covariance of the sigma points
     //
     // We transpose S⁻ first because we formed it by horizontally
-    // concatenating each part, it should be vertical so we can take
+    // concatenating each part; it should be vertical so we can take
     // the QR decomposition as defined in the "QR Decomposition" passage
     // of section 3. "EFFICIENT SQUARE-ROOT IMPLEMENTATION"
     //
@@ -505,7 +505,7 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
     //
     //   sigmas  = 𝒳
     //   sigmasH = 𝒴
-    // 
+    //
     // This differs from equation (22) which uses
     // the prior sigma points, regenerating them allows
     // multiple measurement updates per time update
@@ -517,7 +517,8 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
     }
 
     // Pass the predicted measurement sigmas through the Unscented Transform
-    // to compute the mean predicted measurement and square-root innovation covariance
+    // to compute the mean predicted measurement and square-root innovation
+    // covariance.
     //
     // equations (23) (24) and (25)
     var transRet =
@@ -533,7 +534,8 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
     var yHat = transRet.getFirst();
     var Sy = transRet.getSecond();
 
-    // Compute cross covariance of the predicted state and measurement sigma points given as:
+    // Compute cross covariance of the predicted state and measurement sigma
+    // points given as:
     //
     //           2n
     //   P_{xy} = Σ Wᵢ⁽ᶜ⁾[𝒳ᵢ - x̂][𝒴ᵢ - ŷ⁻]ᵀ
@@ -548,9 +550,9 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
       Pxy = Pxy.plus(dx.times(dy).times(m_pts.getWc(i)));
     }
 
-    // Compute the Kalman gain, to do this in Eigen we use QR
-    // decomposition to solve, this is equivalent to MATLAB's
-    // \ operator, so we need to rearrange to use that
+    // Compute the Kalman gain. We use Eigen's QR decomposition to solve. This
+    // is equivalent to MATLAB's \ operator, so we need to rearrange to use
+    // that.
     //
     //   K = (P_{xy} / S_{y}ᵀ) / S_{y}
     //   K = (S_{y} \ P_{xy})ᵀ / S_{y}

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
@@ -35,11 +35,9 @@ import org.ejml.simple.SimpleMatrix;
  * href="https://file.tavsys.net/control/controls-engineering-in-frc.pdf">https://file.tavsys.net/control/controls-engineering-in-frc.pdf</a>
  * chapter 9 "Stochastic control theory".
  *
- * <p>This class implements a square-root-form unscented Kalman filter
- * (SR-UKF). The main reason for this is to guarantee that the covariance
- * matrix remains positive definite.
- * For more information about the SR-UKF, see
- * https://www.researchgate.net/publication/3908304.
+ * <p>This class implements a square-root-form unscented Kalman filter (SR-UKF). The main reason for
+ * this is to guarantee that the covariance matrix remains positive definite. For more information
+ * about the SR-UKF, see https://www.researchgate.net/publication/3908304.
  *
  * @param <States> Number of states.
  * @param <Inputs> Number of inputs.
@@ -237,7 +235,7 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
     //
     // equations (20) and (24)
     Matrix<C, C> newS = new Matrix<>(new SimpleMatrix(qr.getR(null, true)).transpose());
-    
+
     // Update or downdate the square-root covariance with (𝒳₀-x̂)
     // depending on whether its weight (W₀⁽ᶜ⁾) is positive or negative.
     //

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
@@ -229,7 +229,8 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
     //
     // We transpose S⁻ first because we formed it by horizontally
     // concatenating each part, it should be vertical so we can take
-    // the QR decomposition.
+    // the QR decomposition as defined in the "QR Decomposition" passage
+    // of section 3. "EFFICIENT SQUARE-ROOT IMPLEMENTATION"
     //
     // The resulting matrix R is the square-root covariance S, but it
     // is upper triangular, so we need to transpose it.

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
@@ -35,9 +35,11 @@ import org.ejml.simple.SimpleMatrix;
  * href="https://file.tavsys.net/control/controls-engineering-in-frc.pdf">https://file.tavsys.net/control/controls-engineering-in-frc.pdf</a>
  * chapter 9 "Stochastic control theory".
  *
- * <p>This class implements a square-root-form unscented Kalman filter (SR-UKF). For more
- * information about the SR-UKF, see <a
- * href="https://www.researchgate.net/publication/3908304">https://www.researchgate.net/publication/3908304</a>.
+ * <p>This class implements a square-root-form unscented Kalman filter
+ * (SR-UKF). The main reason for this is to guarantee that the covariance
+ * matrix remain positive definite.
+ * For more information about the SR-UKF, see
+ * https://www.researchgate.net/publication/3908304.
  *
  * @param <States> Number of states.
  * @param <Inputs> Number of inputs.

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
@@ -37,7 +37,7 @@ import org.ejml.simple.SimpleMatrix;
  *
  * <p>This class implements a square-root-form unscented Kalman filter
  * (SR-UKF). The main reason for this is to guarantee that the covariance
- * matrix remain positive definite.
+ * matrix remains positive definite.
  * For more information about the SR-UKF, see
  * https://www.researchgate.net/publication/3908304.
  *

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
@@ -554,7 +554,7 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
     //
     //   K = (P_{xy} / S_{y}ᵀ) / S_{y}
     //   K = (S_{y} \ P_{xy})ᵀ / S_{y}
-    //   K = (S_{y}ᵀ \ (S_{y} \ P_{xu}ᵀ))ᵀ
+    //   K = (S_{y}ᵀ \ (S_{y} \ P_{xy}ᵀ))ᵀ
     //
     // equation (27)
     Matrix<States, R> K =

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
@@ -196,15 +196,19 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
     }
 
     // New mean is usually just the sum of the sigmas * weights:
+    //
     //      2n
     //   x̂ = Σ Wᵢ⁽ᵐ⁾𝒳ᵢ
     //      i=0
+    //
     // equations (19) and (23) show this
     // but we allow a custom function, usually for angle wrapping
     Matrix<C, N1> x = meanFunc.apply(sigmas, Wm);
 
     // Form an intermediate matrix S_bar as:
+    //
     //   [√{W₁⁽ᶜ⁾}*(𝒳_{1:2L} - x̂) √{Rᵛ}]
+    //
     // the part of equations (20) and (24) within the "qr{}"
     Matrix<C, ?> Sbar = new Matrix<>(new SimpleMatrix(dim.getNum(), 2 * s.getNum() + dim.getNum()));
     for (int i = 0; i < 2 * s.getNum(); i++) {
@@ -367,8 +371,10 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
 
     // Project each sigma point forward in time according to the
     // dynamics f(x, u)
-    // sigmas  = 𝒳ₖ₋₁
-    // sigmasF = 𝒳ₖ,ₖ₋₁ or just 𝒳 for readability
+    //
+    //   sigmas  = 𝒳ₖ₋₁
+    //   sigmasF = 𝒳ₖ,ₖ₋₁ or just 𝒳 for readability
+    //
     // equation (18)
     for (int i = 0; i < m_pts.getNumSigmas(); ++i) {
       Matrix<States, N1> x = sigmas.extractColumnVector(i);
@@ -516,9 +522,11 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
     var Sy = transRet.getSecond();
 
     // Compute cross covariance of the predicted state and measurement sigma points given as:
+    //
     //           2n
     //   P_{xy} = Σ Wᵢ⁽ᶜ⁾[𝒳ᵢ - x̂][𝒴ᵢ - ŷ⁻]ᵀ
     //           i=0
+    //
     // equation (26)
     Matrix<States, R> Pxy = new Matrix<>(m_states, rows);
     for (int i = 0; i < m_pts.getNumSigmas(); i++) {
@@ -531,9 +539,11 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
     // Compute the Kalman gain, to do this in Eigen we use QR
     // decomposition to solve, this is equivalent to MATLAB's
     // \ operator, so we need to rearrange to use that
-    // K = (P_{xy} / S_{y}ᵀ) / S_{y}
-    // K = (S_{y} \ P_{xy})ᵀ / S_{y}
-    // K = (S_{y}ᵀ \ (S_{y} \ P_{xu}ᵀ))ᵀ
+    //
+    //   K = (P_{xy} / S_{y}ᵀ) / S_{y}
+    //   K = (S_{y} \ P_{xy})ᵀ / S_{y}
+    //   K = (S_{y}ᵀ \ (S_{y} \ P_{xu}ᵀ))ᵀ
+    //
     // equation (27)
     Matrix<States, R> K =
         Sy.transpose()
@@ -541,7 +551,9 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
             .transpose();
 
     // Compute the posterior state mean
+    //
     // x̂ = x̂⁻ + K(y − ŷ⁻)
+    //
     // second part of equation (27)
     m_xHat = addFuncX.apply(m_xHat, K.times(residualFuncY.apply(y, yHat)));
 

--- a/wpimath/src/main/native/include/frc/estimator/MerweScaledSigmaPoints.h
+++ b/wpimath/src/main/native/include/frc/estimator/MerweScaledSigmaPoints.h
@@ -52,6 +52,8 @@ class MerweScaledSigmaPoints {
   /**
    * Computes the sigma points for an unscented Kalman filter given the mean
    * (x) and square-root covariance(S) of the filter.
+   * 
+   * (Eq. 17)
    *
    * @param x An array of the means.
    * @param S Square-root covariance of the filter.

--- a/wpimath/src/main/native/include/frc/estimator/MerweScaledSigmaPoints.h
+++ b/wpimath/src/main/native/include/frc/estimator/MerweScaledSigmaPoints.h
@@ -69,7 +69,7 @@ class MerweScaledSigmaPoints {
 
     Matrixd<States, 2 * States + 1> sigmas;
 
-    // (Eq. 17)
+    // equation (17)
     sigmas.template block<States, 1>(0, 0) = x;
     for (int k = 0; k < States; ++k) {
       sigmas.template block<States, 1>(0, k + 1) =

--- a/wpimath/src/main/native/include/frc/estimator/MerweScaledSigmaPoints.h
+++ b/wpimath/src/main/native/include/frc/estimator/MerweScaledSigmaPoints.h
@@ -51,9 +51,7 @@ class MerweScaledSigmaPoints {
 
   /**
    * Computes the sigma points for an unscented Kalman filter given the mean
-   * (x) and square-root covariance(S) of the filter.
-   * 
-   * (Eq. 17)
+   * (x) and square-root covariance (S) of the filter.
    *
    * @param x An array of the means.
    * @param S Square-root covariance of the filter.
@@ -70,6 +68,8 @@ class MerweScaledSigmaPoints {
     Matrixd<States, States> U = eta * S;
 
     Matrixd<States, 2 * States + 1> sigmas;
+
+    // (Eq. 17)
     sigmas.template block<States, 1>(0, 0) = x;
     for (int k = 0; k < States; ++k) {
       sigmas.template block<States, 1>(0, k + 1) =

--- a/wpimath/src/main/native/include/frc/estimator/UnscentedKalmanFilter.h
+++ b/wpimath/src/main/native/include/frc/estimator/UnscentedKalmanFilter.h
@@ -261,8 +261,10 @@ class UnscentedKalmanFilter {
 
     // Project each sigma point forward in time according to the
     // dynamics f(x, u)
-    // sigmas  = 𝒳ₖ₋₁
-    // sigmasF = 𝒳ₖ,ₖ₋₁ or just 𝒳 for readability
+    //
+    //   sigmas  = 𝒳ₖ₋₁
+    //   sigmasF = 𝒳ₖ,ₖ₋₁ or just 𝒳 for readability
+    //
     // equation (18)
     for (int i = 0; i < m_pts.NumSigmas(); ++i) {
       StateVector x = sigmas.template block<States, 1>(0, i);
@@ -404,9 +406,11 @@ class UnscentedKalmanFilter {
         discR.template triangularView<Eigen::Lower>());
 
     // Compute cross covariance of the predicted state and measurement sigma points given as:
+    //
     //           2n
     //   P_{xy} = Σ Wᵢ⁽ᶜ⁾[𝒳ᵢ - x̂][𝒴ᵢ - ŷ⁻]ᵀ
     //           i=0
+    //
     // equation (26)
     Matrixd<States, Rows> Pxy;
     Pxy.setZero();
@@ -421,9 +425,11 @@ class UnscentedKalmanFilter {
     // Compute the Kalman gain, to do this in Eigen we use QR
     // decomposition to solve, this is equivalent to MATLAB's
     // \ operator, so we need to rearrange to use that
-    // K = (P_{xy} / S_{y}ᵀ) / S_{y}
-    // K = (S_{y} \ P_{xy})ᵀ / S_{y}
-    // K = (S_{y}ᵀ \ (S_{y} \ P_{xu}ᵀ))ᵀ
+    //
+    //   K = (P_{xy} / S_{y}ᵀ) / S_{y}
+    //   K = (S_{y} \ P_{xy})ᵀ / S_{y}
+    //   K = (S_{y}ᵀ \ (S_{y} \ P_{xu}ᵀ))ᵀ
+    //
     // equation (27)
     Matrixd<States, Rows> K =
         Sy.transpose()
@@ -432,7 +438,9 @@ class UnscentedKalmanFilter {
             .transpose();
 
     // Compute the posterior state mean
-    // x̂ = x̂⁻ + K(y − ŷ⁻)
+    //
+    //   x̂ = x̂⁻ + K(y − ŷ⁻)
+    //
     // second part of equation (27)
     m_xHat = addFuncX(m_xHat, K * residualFuncY(y, yHat));
 

--- a/wpimath/src/main/native/include/frc/estimator/UnscentedKalmanFilter.h
+++ b/wpimath/src/main/native/include/frc/estimator/UnscentedKalmanFilter.h
@@ -43,7 +43,9 @@ namespace frc {
  * "Stochastic control theory".
  *
  * <p> This class implements a square-root-form unscented Kalman filter
- * (SR-UKF). For more information about the SR-UKF, see
+ * (SR-UKF). The main reason for this is to guarantee that the covariance
+ * matrix remain positive definite.
+ * For more information about the SR-UKF, see
  * https://www.researchgate.net/publication/3908304.
  *
  * @tparam States Number of states.

--- a/wpimath/src/main/native/include/frc/estimator/UnscentedKalmanFilter.h
+++ b/wpimath/src/main/native/include/frc/estimator/UnscentedKalmanFilter.h
@@ -433,7 +433,7 @@ class UnscentedKalmanFilter {
     //
     //   K = (P_{xy} / S_{y}ᵀ) / S_{y}
     //   K = (S_{y} \ P_{xy})ᵀ / S_{y}
-    //   K = (S_{y}ᵀ \ (S_{y} \ P_{xu}ᵀ))ᵀ
+    //   K = (S_{y}ᵀ \ (S_{y} \ P_{xy}ᵀ))ᵀ
     //
     // equation (27)
     Matrixd<States, Rows> K =

--- a/wpimath/src/main/native/include/frc/estimator/UnscentedKalmanFilter.h
+++ b/wpimath/src/main/native/include/frc/estimator/UnscentedKalmanFilter.h
@@ -388,7 +388,7 @@ class UnscentedKalmanFilter {
     //
     //   sigmas  = 𝒳
     //   sigmasH = 𝒴
-    // 
+    //
     // This differs from equation (22) which uses
     // the prior sigma points, regenerating them allows
     // multiple measurement updates per time update
@@ -401,14 +401,16 @@ class UnscentedKalmanFilter {
     }
 
     // Pass the predicted measurement sigmas through the Unscented Transform
-    // to compute the mean predicted measurement and square-root innovation covariance
+    // to compute the mean predicted measurement and square-root innovation
+    // covariance.
     //
     // equations (23) (24) and (25)
     auto [yHat, Sy] = SquareRootUnscentedTransform<Rows, States>(
         sigmasH, m_pts.Wm(), m_pts.Wc(), meanFuncY, residualFuncY,
         discR.template triangularView<Eigen::Lower>());
 
-    // Compute cross covariance of the predicted state and measurement sigma points given as:
+    // Compute cross covariance of the predicted state and measurement sigma
+    // points given as:
     //
     //           2n
     //   P_{xy} = Σ Wᵢ⁽ᶜ⁾[𝒳ᵢ - x̂][𝒴ᵢ - ŷ⁻]ᵀ
@@ -425,9 +427,9 @@ class UnscentedKalmanFilter {
               .transpose();
     }
 
-    // Compute the Kalman gain, to do this in Eigen we use QR
-    // decomposition to solve, this is equivalent to MATLAB's
-    // \ operator, so we need to rearrange to use that
+    // Compute the Kalman gain. We use Eigen's QR decomposition to solve. This
+    // is equivalent to MATLAB's \ operator, so we need to rearrange to use
+    // that.
     //
     //   K = (P_{xy} / S_{y}ᵀ) / S_{y}
     //   K = (S_{y} \ P_{xy})ᵀ / S_{y}

--- a/wpimath/src/main/native/include/frc/estimator/UnscentedKalmanFilter.h
+++ b/wpimath/src/main/native/include/frc/estimator/UnscentedKalmanFilter.h
@@ -255,6 +255,7 @@ class UnscentedKalmanFilter {
     Eigen::internal::llt_inplace<double, Eigen::Lower>::blocked(discQ);
 
     // Generate sigma points around the state mean
+    //
     // equation (17)
     Matrixd<States, 2 * States + 1> sigmas =
         m_pts.SquareRootSigmaPoints(m_xHat, m_S);
@@ -273,6 +274,7 @@ class UnscentedKalmanFilter {
 
     // Pass the predicted sigmas (𝒳) through the Unscented Transform
     // to compute the prior state mean and covariance
+    //
     // equations (18) (19) and (20)
     auto [xHat, S] = SquareRootUnscentedTransform<States, States>(
         m_sigmasF, m_pts.Wm(), m_pts.Wc(), m_meanFuncX, m_residualFuncX,
@@ -400,6 +402,7 @@ class UnscentedKalmanFilter {
 
     // Pass the predicted measurement sigmas through the Unscented Transform
     // to compute the mean predicted measurement and square-root innovation covariance
+    //
     // equations (23) (24) and (25)
     auto [yHat, Sy] = SquareRootUnscentedTransform<Rows, States>(
         sigmasH, m_pts.Wm(), m_pts.Wc(), meanFuncY, residualFuncY,
@@ -446,10 +449,12 @@ class UnscentedKalmanFilter {
 
     // Compute the intermediate matrix U for downdating
     // the square-root covariance
+    //
     // equation (28)
     Matrixd<States, Rows> U = K * Sy;
 
     // Downdate the posterior square-root state covariance
+    //
     // equation (29)
     for (int i = 0; i < Rows; i++) {
       Eigen::internal::llt_inplace<double, Eigen::Lower>::rankUpdate(

--- a/wpimath/src/main/native/include/frc/estimator/UnscentedTransform.h
+++ b/wpimath/src/main/native/include/frc/estimator/UnscentedTransform.h
@@ -48,15 +48,19 @@ SquareRootUnscentedTransform(
         residualFunc,
     const Matrixd<CovDim, CovDim>& squareRootR) {
   // New mean is usually just the sum of the sigmas * weights:
+  //
   //      2n
   //   x̂ = Σ Wᵢ⁽ᵐ⁾𝒳ᵢ
   //      i=0
+  //
   // equations (19) and (23) show this
   // but we allow a custom function, usually for angle wrapping
   Vectord<CovDim> x = meanFunc(sigmas, Wm);
 
   // Form an intermediate matrix S_bar as:
+  //
   //   [√{W₁⁽ᶜ⁾}*(𝒳_{1:2L} - x̂) √{Rᵛ}]
+  //
   // the part of equations (20) and (24) within the "qr{}"
   Matrixd<CovDim, States * 2 + CovDim> Sbar;
   for (int i = 0; i < States * 2; i++) {

--- a/wpimath/src/main/native/include/frc/estimator/UnscentedTransform.h
+++ b/wpimath/src/main/native/include/frc/estimator/UnscentedTransform.h
@@ -74,7 +74,9 @@ SquareRootUnscentedTransform(
   //
   // We transpose S⁻ first because we formed it by horizontally
   // concatenating each part, it should be vertical so we can take
-  // the QR decomposition.
+  // the QR decomposition as defined in the "QR Decomposition" passage
+  // of section 3. "EFFICIENT SQUARE-ROOT IMPLEMENTATION"
+  // 
   //
   // The resulting matrix R is the square-root covariance S, but it
   // is upper triangular, so we need to transpose it.

--- a/wpimath/src/main/native/include/frc/estimator/UnscentedTransform.h
+++ b/wpimath/src/main/native/include/frc/estimator/UnscentedTransform.h
@@ -70,13 +70,12 @@ SquareRootUnscentedTransform(
   }
   Sbar.template block<CovDim, CovDim>(0, States * 2) = squareRootR;
 
-  // Compute the square-root covariance of the sigma points
+  // Compute the square-root covariance of the sigma points.
   //
   // We transpose S⁻ first because we formed it by horizontally
-  // concatenating each part, it should be vertical so we can take
+  // concatenating each part; it should be vertical so we can take
   // the QR decomposition as defined in the "QR Decomposition" passage
   // of section 3. "EFFICIENT SQUARE-ROOT IMPLEMENTATION"
-  // 
   //
   // The resulting matrix R is the square-root covariance S, but it
   // is upper triangular, so we need to transpose it.

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
@@ -320,7 +320,7 @@ class UnscentedKalmanFilterTest {
 
     final double pos_stddev = 0.02;
     final double vel_stddev = 0.1;
-    final double cur_stddev = 0.1;
+    final double accel_stddev = 0.1;
 
     var true_states =
         new ArrayList<>(
@@ -347,7 +347,7 @@ class UnscentedKalmanFilterTest {
           motorMeasurementModel(true_states.get(i), control_inputs.get(i))
               .plus(
                   StateSpaceUtil.makeWhiteNoiseVector(
-                      VecBuilder.fill(pos_stddev, vel_stddev, cur_stddev))));
+                      VecBuilder.fill(pos_stddev, vel_stddev, accel_stddev))));
     }
 
     var P0 =
@@ -362,7 +362,7 @@ class UnscentedKalmanFilterTest {
             UnscentedKalmanFilterTest::motorDynamics,
             UnscentedKalmanFilterTest::motorMeasurementModel,
             VecBuilder.fill(0.1, 1.0, 1e-10, 1e-10),
-            VecBuilder.fill(pos_stddev, vel_stddev, cur_stddev),
+            VecBuilder.fill(pos_stddev, vel_stddev, accel_stddev),
             dtSeconds);
 
     observer.setXhat(MatBuilder.fill(Nat.N4(), Nat.N1(), 0.0, 0.0, 2.0, 2.0));

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
@@ -121,8 +121,8 @@ class UnscentedKalmanFilterTest {
 
   @Test
   void testDriveConvergence() {
-    double dtSeconds = 0.005;
-    double rbMeters = 0.8382 / 2.0; // Robot radius
+    final double dtSeconds = 0.005;
+    final double rbMeters = 0.8382 / 2.0; // Robot radius
 
     UnscentedKalmanFilter<N5, N2, N3> observer =
         new UnscentedKalmanFilter<>(
@@ -309,14 +309,14 @@ class UnscentedKalmanFilterTest {
 
   @Test
   void testMotorConvergence() {
-    double dtSeconds = 0.01;
-    int steps = 500;
-    double true_kV = 3;
-    double true_kA = 0.2;
+    final double dtSeconds = 0.01;
+    final int steps = 500;
+    final double true_kV = 3;
+    final double true_kA = 0.2;
 
-    double pos_stddev = 0.02;
-    double vel_stddev = 0.1;
-    double cur_stddev = 0.1;
+    final double pos_stddev = 0.02;
+    final double vel_stddev = 0.1;
+    final double cur_stddev = 0.1;
 
     var control_inputs =
         new ArrayList<>(Collections.nCopies(steps, MatBuilder.fill(Nat.N1(), Nat.N1(), 0.0)));

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
@@ -360,7 +360,7 @@ class UnscentedKalmanFilterTest {
     var discB = discABPair.getSecond();
 
     for (int i = 0; i < steps; ++i) {
-      inputs.set(i, motorControlInput(i * (dtSeconds / 1000)));
+      inputs.set(i, motorControlInput(i * dtSeconds));
       states.set(i + 1, discA.times(states.get(i)).plus(discB.times(inputs.get(i))));
       measurements.set(
           i,

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
@@ -364,7 +364,7 @@ class UnscentedKalmanFilterTest {
       states.set(i + 1, discA.times(states.get(i)).plus(discB.times(inputs.get(i))));
       measurements.set(
           i,
-          motorMeasurementModel(states.get(i), inputs.get(i))
+          motorMeasurementModel(states.get(i + 1), inputs.get(i))
               .plus(
                   StateSpaceUtil.makeWhiteNoiseVector(
                       VecBuilder.fill(pos_stddev, vel_stddev, accel_stddev))));

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
@@ -393,7 +393,7 @@ class UnscentedKalmanFilterTest {
       observer.correct(inputs.get(i), measurements.get(i));
     }
 
-    assertEquals(true_kV, observer.getXhat(2), 0.05);
-    assertEquals(true_kA, observer.getXhat(3), 0.05);
+    assertEquals(true_kV, observer.getXhat(2), true_kV * 0.5);
+    assertEquals(true_kA, observer.getXhat(3), true_kA * 0.5);
   }
 }

--- a/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
@@ -212,15 +212,10 @@ frc::Vectord<3> MotorMeasurementModel(const frc::Vectord<4>& x,
 }
 
 double MotorControlInput(const double& t) {
-  double u = 8 * std::sin(std::numbers::pi * std::sqrt(2.0) * t) +
-             6 * std::sin(std::numbers::pi * std::sqrt(3.0) * t) +
-             4 * std::sin(std::numbers::pi * std::sqrt(5.0) * t);
-
-  if (u > 12)
-    u = 12;
-  if (u < -12)
-    u = -12;
-  return u;
+  return std::clamp(8 * std::sin(std::numbers::pi * std::sqrt(2.0) * t) +
+                        6 * std::sin(std::numbers::pi * std::sqrt(3.0) * t) +
+                        4 * std::sin(std::numbers::pi * std::sqrt(5.0) * t),
+                    -12.0, 12.0);
 }
 
 TEST(UnscentedKalmanFilterTest, MotorConvergence) {

--- a/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
@@ -3,6 +3,7 @@
 // the WPILib BSD license file in the root directory of this project.
 
 #include <cmath>
+#include <numbers>
 #include <vector>
 
 #include <Eigen/QR>
@@ -20,7 +21,8 @@
 
 namespace {
 
-frc::Vectord<5> Dynamics(const frc::Vectord<5>& x, const frc::Vectord<2>& u) {
+// First test system, differential drive
+frc::Vectord<5> DriveDynamics(const frc::Vectord<5>& x, const frc::Vectord<2>& u) {
   auto motors = frc::DCMotor::CIM(2);
 
   // constexpr double Glow = 15.32;    // Low gear ratio
@@ -51,22 +53,22 @@ frc::Vectord<5> Dynamics(const frc::Vectord<5>& x, const frc::Vectord<2>& u) {
           k1.value() * ((C1 * vr).value() + (C2 * Vr).value())};
 }
 
-frc::Vectord<3> LocalMeasurementModel(
+frc::Vectord<3> DriveLocalMeasurementModel(
     const frc::Vectord<5>& x, [[maybe_unused]] const frc::Vectord<2>& u) {
   return frc::Vectord<3>{x(2), x(3), x(4)};
 }
 
-frc::Vectord<5> GlobalMeasurementModel(
+frc::Vectord<5> DriveGlobalMeasurementModel(
     const frc::Vectord<5>& x, [[maybe_unused]] const frc::Vectord<2>& u) {
   return frc::Vectord<5>{x(0), x(1), x(2), x(3), x(4)};
 }
-}  // namespace
 
-TEST(UnscentedKalmanFilterTest, Init) {
+
+TEST(UnscentedKalmanFilterTest, DriveInit) {
   constexpr auto dt = 5_ms;
 
-  frc::UnscentedKalmanFilter<5, 2, 3> observer{Dynamics,
-                                               LocalMeasurementModel,
+  frc::UnscentedKalmanFilter<5, 2, 3> observer{DriveDynamics,
+                                               DriveLocalMeasurementModel,
                                                {0.5, 0.5, 10.0, 1.0, 1.0},
                                                {0.0001, 0.01, 0.01},
                                                frc::AngleMean<5, 5>(2),
@@ -78,22 +80,22 @@ TEST(UnscentedKalmanFilterTest, Init) {
   frc::Vectord<2> u{12.0, 12.0};
   observer.Predict(u, dt);
 
-  auto localY = LocalMeasurementModel(observer.Xhat(), u);
+  auto localY = DriveLocalMeasurementModel(observer.Xhat(), u);
   observer.Correct(u, localY);
 
-  auto globalY = GlobalMeasurementModel(observer.Xhat(), u);
+  auto globalY = DriveGlobalMeasurementModel(observer.Xhat(), u);
   auto R = frc::MakeCovMatrix(0.01, 0.01, 0.0001, 0.01, 0.01);
-  observer.Correct<5>(u, globalY, GlobalMeasurementModel, R,
+  observer.Correct<5>(u, globalY, DriveGlobalMeasurementModel, R,
                       frc::AngleMean<5, 5>(2), frc::AngleResidual<5>(2),
                       frc::AngleResidual<5>(2), frc::AngleAdd<5>(2));
 }
 
-TEST(UnscentedKalmanFilterTest, Convergence) {
+TEST(UnscentedKalmanFilterTest, DriveConvergence) {
   constexpr auto dt = 5_ms;
   constexpr auto rb = 0.8382_m / 2.0;  // Robot radius
 
-  frc::UnscentedKalmanFilter<5, 2, 3> observer{Dynamics,
-                                               LocalMeasurementModel,
+  frc::UnscentedKalmanFilter<5, 2, 3> observer{DriveDynamics,
+                                               DriveLocalMeasurementModel,
                                                {0.5, 0.5, 10.0, 1.0, 1.0},
                                                {0.0001, 0.5, 0.5},
                                                frc::AngleMean<5, 5>(2),
@@ -112,7 +114,7 @@ TEST(UnscentedKalmanFilterTest, Convergence) {
   frc::Vectord<5> r = frc::Vectord<5>::Zero();
   frc::Vectord<2> u = frc::Vectord<2>::Zero();
 
-  auto B = frc::NumericalJacobianU<5, 5, 2>(Dynamics, frc::Vectord<5>::Zero(),
+  auto B = frc::NumericalJacobianU<5, 5, 2>(DriveDynamics, frc::Vectord<5>::Zero(),
                                             frc::Vectord<2>::Zero());
 
   observer.SetXhat(frc::Vectord<5>{
@@ -134,24 +136,24 @@ TEST(UnscentedKalmanFilterTest, Convergence) {
         ref.pose.Translation().X().value(), ref.pose.Translation().Y().value(),
         ref.pose.Rotation().Radians().value(), vl.value(), vr.value()};
 
-    auto localY = LocalMeasurementModel(trueXhat, frc::Vectord<2>::Zero());
+    auto localY = DriveLocalMeasurementModel(trueXhat, frc::Vectord<2>::Zero());
     observer.Correct(u, localY + frc::MakeWhiteNoiseVector(0.0001, 0.5, 0.5));
 
     frc::Vectord<5> rdot = (nextR - r) / dt.value();
-    u = B.householderQr().solve(rdot - Dynamics(r, frc::Vectord<2>::Zero()));
+    u = B.householderQr().solve(rdot - DriveDynamics(r, frc::Vectord<2>::Zero()));
 
     observer.Predict(u, dt);
 
     r = nextR;
-    trueXhat = frc::RK4(Dynamics, trueXhat, u, dt);
+    trueXhat = frc::RK4(DriveDynamics, trueXhat, u, dt);
   }
 
-  auto localY = LocalMeasurementModel(trueXhat, u);
+  auto localY = DriveLocalMeasurementModel(trueXhat, u);
   observer.Correct(u, localY);
 
-  auto globalY = GlobalMeasurementModel(trueXhat, u);
+  auto globalY = DriveGlobalMeasurementModel(trueXhat, u);
   auto R = frc::MakeCovMatrix(0.01, 0.01, 0.0001, 0.5, 0.5);
-  observer.Correct<5>(u, globalY, GlobalMeasurementModel, R,
+  observer.Correct<5>(u, globalY, DriveGlobalMeasurementModel, R,
                       frc::AngleMean<5, 5>(2), frc::AngleResidual<5>(2),
                       frc::AngleResidual<5>(2), frc::AngleAdd<5>(2)
 
@@ -183,3 +185,82 @@ TEST(UnscentedKalmanFilterTest, RoundTripP) {
 
   ASSERT_TRUE(observer.P().isApprox(P));
 }
+
+// Second system, single motor feedforward estimator
+frc::Vectord<4> MotorDynamics(const frc::Vectord<4>& x, const frc::Vectord<1>& u) {
+  const double p = x(0);
+  const double v = x(1);
+  const double kV = x(2);
+  const double kA = x(3);
+  const double V = u(0);
+
+  const double a = (V - kV * v) / kA;
+  return frc::Vectord<4>{v, a, 0, 0};
+}
+
+frc::Vectord<3> MotorMeasurementModel(const frc::Vectord<4>& x, const frc::Vectord<1>& u) {
+  const double p = x(0);
+  const double v = x(1);
+  const double kV = x(2);
+  const double kA = x(3);
+  const double V = u(0);
+
+  const double I = (V - kV * v) / kA;
+  return frc::Vectord<3>{p, v, I};
+}
+
+double MotorControlInput(const double& t) {
+  double u = 8 * std::sin(std::numbers::pi * std::sqrt(2.0) * t)
+           + 6 * std::sin(std::numbers::pi * std::sqrt(3.0) * t)
+           + 4 * std::sin(std::numbers::pi * std::sqrt(5.0) * t);
+  
+  if(u > 12) u = 12;
+  if(u < -12) u = -12;
+  return u;
+}
+
+TEST(UnscentedKalmanFilterTest, MotorConvergence) {
+  constexpr auto dt = 10_ms;
+  constexpr int steps = 500;
+  constexpr double true_kV = 3;
+  constexpr double true_kA = 0.2;
+
+  double pos_stddev = 0.02;
+  double vel_stddev = 0.1;
+  double cur_stddev = 0.1;
+
+  frc::UnscentedKalmanFilter<4, 1, 3> observer{MotorDynamics,
+                                               MotorMeasurementModel,
+                                               wpi::array<double, 4>{0.1, 1.0, 1e-10, 1e-10},
+                                               wpi::array<double, 3>{pos_stddev, vel_stddev, cur_stddev},
+                                               dt};
+
+  std::vector<frc::Vectord<1>> control_inputs(steps);
+  std::vector<frc::Vectord<4>> true_states(steps);
+  std::vector<frc::Vectord<3>> true_noisy_measurements(steps);
+  true_states[0] = frc::Vectord<4>{0.0, 0.0, true_kV, true_kA};
+
+  for (int i = 1; i < steps; i++) {
+    const frc::Vectord<1> u{MotorControlInput(i * (dt.value() / 1000))};
+    true_states[i] = frc::RK4(MotorDynamics, (true_states[i - 1]), u, dt);
+  }
+  for (int i = 0; i < steps; i++) {
+    control_inputs[i] = frc::Vectord<1>{MotorControlInput(i * (dt.value() / 1000))};
+    true_noisy_measurements[i] = MotorMeasurementModel(true_states[i], control_inputs[i]) + frc::MakeWhiteNoiseVector(pos_stddev, vel_stddev, cur_stddev);
+  }
+
+  frc::Vectord<4> P0{0.001, 0.001, 10, 10};
+
+  observer.SetXhat(frc::Vectord<4>{0.0, 0.0, 2.0, 2.0});
+  observer.SetP(P0.asDiagonal());
+
+  for (int i = 0; i < steps; i++) {
+    observer.Predict(control_inputs[i], dt);
+    observer.Correct(control_inputs[i], true_noisy_measurements[i]);
+  }
+
+  EXPECT_NEAR(true_kV, observer.Xhat(2), 0.05);
+  EXPECT_NEAR(true_kA, observer.Xhat(3), 0.05);
+}
+
+}  // namespace

--- a/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
@@ -188,7 +188,6 @@ TEST(UnscentedKalmanFilterTest, RoundTripP) {
 
 // Second system, single motor feedforward estimator
 frc::Vectord<4> MotorDynamics(const frc::Vectord<4>& x, const frc::Vectord<1>& u) {
-  const double p = x(0);
   const double v = x(1);
   const double kV = x(2);
   const double kA = x(3);

--- a/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
@@ -262,11 +262,6 @@ TEST(UnscentedKalmanFilterTest, MotorConvergence) {
   double vel_stddev = 0.1;
   double cur_stddev = 0.1;
 
-  frc::UnscentedKalmanFilter<4, 1, 3> observer{
-      MotorDynamics, MotorMeasurementModel,
-      wpi::array<double, 4>{0.1, 1.0, 1e-10, 1e-10},
-      wpi::array<double, 3>{pos_stddev, vel_stddev, cur_stddev}, dt};
-
   std::vector<frc::Vectord<1>> control_inputs(steps);
   std::vector<frc::Vectord<4>> true_states(steps);
   std::vector<frc::Vectord<3>> true_noisy_measurements(steps);
@@ -285,6 +280,11 @@ TEST(UnscentedKalmanFilterTest, MotorConvergence) {
   }
 
   frc::Vectord<4> P0{0.001, 0.001, 10, 10};
+
+  frc::UnscentedKalmanFilter<4, 1, 3> observer{
+      MotorDynamics, MotorMeasurementModel,
+      wpi::array<double, 4>{0.1, 1.0, 1e-10, 1e-10},
+      wpi::array<double, 3>{pos_stddev, vel_stddev, cur_stddev}, dt};
 
   observer.SetXhat(frc::Vectord<4>{0.0, 0.0, 2.0, 2.0});
   observer.SetP(P0.asDiagonal());

--- a/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
@@ -263,7 +263,7 @@ TEST(UnscentedKalmanFilterTest, MotorConvergence) {
 
   constexpr double pos_stddev = 0.02;
   constexpr double vel_stddev = 0.1;
-  constexpr double cur_stddev = 0.1;
+  constexpr double accel_stddev = 0.1;
 
   std::vector<frc::Vectord<4>> true_states(steps + 1);
   std::vector<frc::Vectord<1>> control_inputs(steps);
@@ -276,7 +276,7 @@ TEST(UnscentedKalmanFilterTest, MotorConvergence) {
         frc::RK4(MotorDynamics, true_states[i], control_inputs[i], dt);
     noisy_measurements[i] =
         MotorMeasurementModel(true_states[i], control_inputs[i]) +
-        frc::MakeWhiteNoiseVector(pos_stddev, vel_stddev, cur_stddev);
+        frc::MakeWhiteNoiseVector(pos_stddev, vel_stddev, accel_stddev);
   }
 
   frc::Vectord<4> P0{0.001, 0.001, 10, 10};
@@ -284,7 +284,7 @@ TEST(UnscentedKalmanFilterTest, MotorConvergence) {
   frc::UnscentedKalmanFilter<4, 1, 3> observer{
       MotorDynamics, MotorMeasurementModel,
       wpi::array<double, 4>{0.1, 1.0, 1e-10, 1e-10},
-      wpi::array<double, 3>{pos_stddev, vel_stddev, cur_stddev}, dt};
+      wpi::array<double, 3>{pos_stddev, vel_stddev, accel_stddev}, dt};
 
   observer.SetXhat(frc::Vectord<4>{0.0, 0.0, 2.0, 2.0});
   observer.SetP(P0.asDiagonal());

--- a/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
@@ -243,7 +243,7 @@ frc::Vectord<3> MotorMeasurementModel(const frc::Vectord<4>& x,
 
   double V = u(0);
 
-  double a = -kV / kA * v + 1 / kA * V;
+  double a = -kV / kA * v + 1.0 / kA * V;
   return frc::Vectord<3>{p, v, a};
 }
 

--- a/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
@@ -2,6 +2,7 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+#include <algorithm>
 #include <cmath>
 #include <numbers>
 #include <vector>

--- a/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
@@ -302,8 +302,8 @@ TEST(UnscentedKalmanFilterTest, MotorConvergence) {
     observer.Correct(inputs[i], measurements[i]);
   }
 
-  EXPECT_NEAR(true_kV, observer.Xhat(2), 0.05);
-  EXPECT_NEAR(true_kA, observer.Xhat(3), 0.05);
+  EXPECT_NEAR(true_kV, observer.Xhat(2), true_kV * 0.5);
+  EXPECT_NEAR(true_kA, observer.Xhat(3), true_kA * 0.5);
 }
 
 }  // namespace

--- a/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
@@ -212,7 +212,7 @@ double MotorControlInput(const double& t) {
   double u = 8 * std::sin(std::numbers::pi * std::sqrt(2.0) * t)
            + 6 * std::sin(std::numbers::pi * std::sqrt(3.0) * t)
            + 4 * std::sin(std::numbers::pi * std::sqrt(5.0) * t);
-  
+
   if(u > 12) u = 12;
   if(u < -12) u = -12;
   return u;

--- a/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
@@ -224,25 +224,27 @@ TEST(UnscentedKalmanFilterTest, RoundTripP) {
 // Second system, single motor feedforward estimator
 frc::Vectord<4> MotorDynamics(const frc::Vectord<4>& x,
                               const frc::Vectord<1>& u) {
-  const double v = x(1);
-  const double kV = x(2);
-  const double kA = x(3);
-  const double V = u(0);
+  double v = x(1);
+  double kV = x(2);
+  double kA = x(3);
 
-  const double a = (V - kV * v) / kA;
-  return frc::Vectord<4>{v, a, 0, 0};
+  double V = u(0);
+
+  double a = -kV / kA * v + 1.0 / kA * V;
+  return frc::Vectord<4>{v, a, 0.0, 0.0};
 }
 
 frc::Vectord<3> MotorMeasurementModel(const frc::Vectord<4>& x,
                                       const frc::Vectord<1>& u) {
-  const double p = x(0);
-  const double v = x(1);
-  const double kV = x(2);
-  const double kA = x(3);
-  const double V = u(0);
+  double p = x(0);
+  double v = x(1);
+  double kV = x(2);
+  double kA = x(3);
 
-  const double I = (V - kV * v) / kA;
-  return frc::Vectord<3>{p, v, I};
+  double V = u(0);
+
+  double a = -kV / kA * v + 1 / kA * V;
+  return frc::Vectord<3>{p, v, a};
 }
 
 frc::Vectord<1> MotorControlInput(double t) {

--- a/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
@@ -175,7 +175,7 @@ TEST(UnscentedKalmanFilterTest, DriveConvergence) {
 }
 
 TEST(UnscentedKalmanFilterTest, LinearUKF) {
-  constexpr auto dt = 20_ms;
+  constexpr units::second_t dt = 20_ms;
   auto plant = frc::LinearSystemId::IdentifyVelocitySystem<units::meters>(
       0.02_V / 1_mps, 0.006_V / 1_mps_sq);
   frc::UnscentedKalmanFilter<1, 1, 1> observer{
@@ -196,7 +196,7 @@ TEST(UnscentedKalmanFilterTest, LinearUKF) {
   frc::Vectord<1> ref{100.0};
   frc::Vectord<1> u{0.0};
 
-  for (int i = 0; i < (2.0 / units::second_t{dt}.value()); i++) {
+  for (int i = 0; i < 2.0 / dt.value(); i++) {
     observer.Predict(u, dt);
 
     u = discB.householderQr().solve(ref - discA * ref);
@@ -253,7 +253,7 @@ double MotorControlInput(const double& t) {
 }
 
 TEST(UnscentedKalmanFilterTest, MotorConvergence) {
-  constexpr auto dt = 10_ms;
+  constexpr units::second_t dt = 10_ms;
   constexpr int steps = 500;
   constexpr double true_kV = 3;
   constexpr double true_kA = 0.2;

--- a/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
@@ -281,7 +281,7 @@ TEST(UnscentedKalmanFilterTest, MotorConvergence) {
   frc::DiscretizeAB(A, B, dt, &discA, &discB);
 
   for (int i = 0; i < steps; ++i) {
-    inputs[i] = MotorControlInput(i * (dt.value() / 1000));
+    inputs[i] = MotorControlInput(i * dt.value());
     states[i + 1] = discA * states[i] + discB * inputs[i];
     measurements[i] =
         MotorMeasurementModel(states[i + 1], inputs[i]) +

--- a/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
@@ -258,9 +258,9 @@ TEST(UnscentedKalmanFilterTest, MotorConvergence) {
   constexpr double true_kV = 3;
   constexpr double true_kA = 0.2;
 
-  double pos_stddev = 0.02;
-  double vel_stddev = 0.1;
-  double cur_stddev = 0.1;
+  constexpr double pos_stddev = 0.02;
+  constexpr double vel_stddev = 0.1;
+  constexpr double cur_stddev = 0.1;
 
   std::vector<frc::Vectord<1>> control_inputs(steps);
   std::vector<frc::Vectord<4>> true_states(steps);


### PR DESCRIPTION
Throughout the code the state sqrt covariance S and innovation covariance Sy are maintained as upper triangular cholesky factors of those covariance matrices. [The original paper](https://www.researchgate.net/publication/3908304) defines P=S*S', so S should be lower triangular. The functions in the paper reflect this. In the code implementation, the sqrt covariance matrices are upper triangular, but the algorithm expects them to be lower triangular. 

This bug was likely missed because the incorrect version of the filter is able to converge for some systems where all the states are observed, and the test case is set up such that all states are observed. 

To fix the bug, a couple things needed to be changed:
all instances of rankUpdate() needed to be changed to use the lower triangular cholesky factor,
In the unscented transform, when S is found via QR decomposition, we need to take the transpose because R is upper triangular,
P() and SetP() functions need to be modified to be P=S*S' instead of P=S'*S, and P.llt().matrixL() instead of P.llt().matrixU() respectively.

Each part of the algorithm has also had the comments changed to clarify exactly which equation from the paper it implements.