### PR TITLE
feat: new method to set a ranged based contribution limits for `pidController`

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -345,6 +345,20 @@ public class PIDController implements Sendable, AutoCloseable {
   }
 
   /**
+   * Sets the minimum and maximum contributions of the integral term based on a range.
+   * 
+   * <p>The internal integrator is clamped so that the integral term's contribution to the output
+   * stays between minimumIntegral and maximumIntegral. This prevents integral windup.
+   * 
+   * @param intergralRaduis The distance above and bellow 0.0 that the maximum and minimum contribution will be set to.
+   */
+  public void setIntegratorRange( double intergralRange ) {
+    intergralRange = Math.abs( intergralRange );
+    m_maximumIntegral = intergralRange;
+    m_minimumIntegral = intergralRange;
+  }
+
+  /**
    * Sets the minimum and maximum contributions of the integral term.
    *
    * <p>The internal integrator is clamped so that the integral term's contribution to the output

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -355,7 +355,7 @@ public class PIDController implements Sendable, AutoCloseable {
   public void setIntegratorRange( double intergralRange ) {
     intergralRange = Math.abs( intergralRange );
     m_maximumIntegral = intergralRange;
-    m_minimumIntegral = intergralRange;
+    m_minimumIntegral = -intergralRange;
   }
 
   /**


### PR DESCRIPTION
This method adds a cleaner way to set the minimum and maximum contributions ( for the integral term ) for when an overall speed limit is all that is needed. This is done via a range, the maximum is set to the positive range, and the minimum is set to the negative range.

This is named the same as the existing function ( `setIntegratorRange` ) to set the minimum and maximum contributions separately.