### PR TITLE
Pid controller range based min max

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -343,23 +343,23 @@ public class PIDController implements Sendable, AutoCloseable {
   public boolean isContinuousInputEnabled() {
     return m_continuous;
   }
-  
+
   /**
    * Sets an absolute limit on the integral term's contribution to the controller output.
-   * 
-   * <p>This method constrains the integral term so that its effect on the output 
-   * remains within the range [-integralLimit, integralLimit], preventing integral windup.
-   * 
-   * @param integralLimit The absolute value of the maximum allowable contribution 
-   *                      of the integral term to the output. The integral term will be 
-   *                      constrained between -integralLimit and +integralLimit.
+   *
+   * <p>This method constrains the integral term so that its effect on the output remains within
+   * the range [-integralLimit, integralLimit], preventing integral windup.
+   *
+   * @param integralLimit the absolute value of the maximum allowable contribution of the integral
+   *     term to the output. The integral term will be constrained between -integralLimit and
+   *     +integralLimit.
    */
   public void setIntegratorAbsoluteLimit(double integralLimit) {
     integralLimit = Math.abs(integralLimit);
     m_maximumIntegral = integralLimit;
     m_minimumIntegral = -integralLimit;
   }
-  
+
   /**
    * Sets the minimum and maximum contributions of the integral term.
    *

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -345,17 +345,17 @@ public class PIDController implements Sendable, AutoCloseable {
   }
 
   /**
-   * Sets symmetric limits on the integral term's contribution to the controller output.
+   * Sets an abosolute limit on the integral term's contribution to the controller output.
    * 
    * <p>This method constrains the integral term so that its effect on the output 
    * remains within the range [-integralRange, integralRange], preventing integral windup.
    * 
-   * @param integralRange The absolute value of the maximum allowable contribution of the integral term to the output. The integral term will be limited between -integralRange and +integralRange.
+   * @param integralLimit The absolute value of the maximum allowable contribution of the integral term to the output. The integral term will be limited between -integralRange and +integralRange.
    */
-  public void setIntegratorRange(double integralRange) {
-    integralRange = Math.abs(integralRange);
-    m_maximumIntegral = integralRange;
-    m_minimumIntegral = -integralRange;
+  public void setAbsoluteIntegratorLimit(double integralLimit) {
+    integralLimit = Math.abs(integralLimit);
+    m_maximumIntegral = integralLimit;
+    m_minimumIntegral = -integralLimit;
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -345,6 +345,20 @@ public class PIDController implements Sendable, AutoCloseable {
   }
 
   /**
+   * Sets the minimum and maximum contributions of the integral term based on a range.
+   * 
+   * <p>The internal integrator is clamped so that the integral term's contribution to the output
+   * stays between minimumIntegral and maximumIntegral. This prevents integral windup.
+   * 
+   * @param intergralRaduis The distance above and bellow 0.0 that the maximum and minimum contribution will be set to.
+   */
+  public void setIntegratorRange( double intergralRange ) {
+    intergralRange = Math.abs( intergralRange );
+    m_maximumIntegral = intergralRange;
+    m_minimumIntegral = intergralRange;
+  }
+
+  /**
    * Sets the minimum and maximum contributions of the integral term.
    *
    * <p>The internal integrator is clamped so that the integral term's contribution to the output

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -345,17 +345,17 @@ public class PIDController implements Sendable, AutoCloseable {
   }
 
   /**
-   * Sets the minimum and maximum contributions of the integral term based on a range.
+   * Sets symmetric limits on the integral term's contribution to the controller output.
    * 
-   * <p>The internal integrator is clamped so that the integral term's contribution to the output
-   * stays between minimumIntegral and maximumIntegral. This prevents integral windup.
+   * <p>This method constrains the integral term so that its effect on the output 
+   * remains within the range [-integralRange, integralRange], preventing integral windup.
    * 
-   * @param intergralRaduis The distance above and bellow 0.0 that the maximum and minimum contribution will be set to.
+   * @param integralRange The absolute value of the maximum allowable contribution of the integral term to the output. The integral term will be limited between -integralRange and +integralRange.
    */
-  public void setIntegratorRange( double intergralRange ) {
-    intergralRange = Math.abs( intergralRange );
-    m_maximumIntegral = intergralRange;
-    m_minimumIntegral = -intergralRange;
+  public void setIntegratorRange(double integralRange) {
+    integralRange = Math.abs(integralRange);
+    m_maximumIntegral = integralRange;
+    m_minimumIntegral = -integralRange;
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -355,7 +355,7 @@ public class PIDController implements Sendable, AutoCloseable {
   public void setIntegratorRange( double intergralRange ) {
     intergralRange = Math.abs( intergralRange );
     m_maximumIntegral = intergralRange;
-    m_minimumIntegral = intergralRange;
+    m_minimumIntegral = -intergralRange;
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -343,21 +343,23 @@ public class PIDController implements Sendable, AutoCloseable {
   public boolean isContinuousInputEnabled() {
     return m_continuous;
   }
-
+  
   /**
-   * Sets an abosolute limit on the integral term's contribution to the controller output.
+   * Sets an absolute limit on the integral term's contribution to the controller output.
    * 
    * <p>This method constrains the integral term so that its effect on the output 
-   * remains within the range [-integralRange, integralRange], preventing integral windup.
+   * remains within the range [-integralLimit, integralLimit], preventing integral windup.
    * 
-   * @param integralLimit The absolute value of the maximum allowable contribution of the integral term to the output. The integral term will be limited between -integralRange and +integralRange.
+   * @param integralLimit The absolute value of the maximum allowable contribution 
+   *                      of the integral term to the output. The integral term will be 
+   *                      constrained between -integralLimit and +integralLimit.
    */
-  public void setAbsoluteIntegratorLimit(double integralLimit) {
+  public void setIntegratorAbsoluteLimit(double integralLimit) {
     integralLimit = Math.abs(integralLimit);
     m_maximumIntegral = integralLimit;
     m_minimumIntegral = -integralLimit;
   }
-
+  
   /**
    * Sets the minimum and maximum contributions of the integral term.
    *

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -347,8 +347,8 @@ public class PIDController implements Sendable, AutoCloseable {
   /**
    * Sets an absolute limit on the integral term's contribution to the controller output.
    *
-   * <p>This method constrains the integral term so that its effect on the output remains within
-   * the range [-integralLimit, integralLimit], preventing integral windup.
+   * <p>This method constrains the integral term so that its effect on the output remains within the
+   * range [-integralLimit, integralLimit], preventing integral windup.
    *
    * @param integralLimit the absolute value of the maximum allowable contribution of the integral
    *     term to the output. The integral term will be constrained between -integralLimit and


### PR DESCRIPTION
This method adds a cleaner way to set the minimum and maximum contributions ( for the integral term ) for when an overall speed limit is all that is needed. This is done via a range, the maximum is set to the positive range, and the minimum is set to the negative range.

This is named the same as the existing function ( `setIntegratorRange` ) to set the minimum and maximum contributions separately.

Sorry calcmogul this is a second pull request. Can't reopen the first pull request. The changes requested are present in this one.