### PR TITLE
[wpimath] Fix Debouncer type-changing behavior

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
@@ -114,6 +114,12 @@ public class Debouncer {
    */
   public void setDebounceType(DebounceType type) {
     m_debounceType = type;
+
+    m_baseline =
+        switch (m_debounceType) {
+          case kBoth, kRising -> false;
+          case kFalling -> true;
+        };
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
@@ -40,11 +40,7 @@ public class Debouncer {
 
     resetTimer();
 
-    m_baseline =
-        switch (m_debounceType) {
-          case kBoth, kRising -> false;
-          case kFalling -> true;
-        };
+    m_baseline = m_debounceType == DebounceType.kFalling;
   }
 
   /**
@@ -115,11 +111,7 @@ public class Debouncer {
   public void setDebounceType(DebounceType type) {
     m_debounceType = type;
 
-    m_baseline =
-        switch (m_debounceType) {
-          case kBoth, kRising -> false;
-          case kFalling -> true;
-        };
+    m_baseline = m_debounceType == DebounceType.kFalling;
   }
 
   /**

--- a/wpimath/src/main/native/cpp/filter/Debouncer.cpp
+++ b/wpimath/src/main/native/cpp/filter/Debouncer.cpp
@@ -10,15 +10,7 @@ using namespace frc;
 
 Debouncer::Debouncer(units::second_t debounceTime, DebounceType type)
     : m_debounceTime(debounceTime), m_debounceType(type) {
-  switch (type) {
-    case DebounceType::kBoth:  // fall-through
-    case DebounceType::kRising:
-      m_baseline = false;
-      break;
-    case DebounceType::kFalling:
-      m_baseline = true;
-      break;
-  }
+  m_baseline = m_debounceType == DebounceType::kFalling;
   ResetTimer();
 }
 

--- a/wpimath/src/main/native/include/frc/filter/Debouncer.h
+++ b/wpimath/src/main/native/include/frc/filter/Debouncer.h
@@ -71,7 +71,18 @@ class WPILIB_DLLEXPORT Debouncer {
    *
    * @param type Which type of state change the debouncing will be performed on.
    */
-  constexpr void SetDebounceType(DebounceType type) { m_debounceType = type; }
+  constexpr void SetDebounceType(DebounceType type) {
+    m_debounceType = type;
+    switch (type) {
+      case DebounceType::kBoth:  // fall-through
+      case DebounceType::kRising:
+        m_baseline = false;
+        break;
+      case DebounceType::kFalling:
+        m_baseline = true;
+        break;
+    }
+  }
 
   /**
    * Get the debounce type.

--- a/wpimath/src/main/native/include/frc/filter/Debouncer.h
+++ b/wpimath/src/main/native/include/frc/filter/Debouncer.h
@@ -73,15 +73,8 @@ class WPILIB_DLLEXPORT Debouncer {
    */
   constexpr void SetDebounceType(DebounceType type) {
     m_debounceType = type;
-    switch (type) {
-      case DebounceType::kBoth:  // fall-through
-      case DebounceType::kRising:
-        m_baseline = false;
-        break;
-      case DebounceType::kFalling:
-        m_baseline = true;
-        break;
-    }
+
+    m_baseline = m_debounceType == DebounceType::kFalling;
   }
 
   /**

--- a/wpimath/src/test/java/edu/wpi/first/math/filter/DebouncerTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/filter/DebouncerTest.java
@@ -84,5 +84,6 @@ class DebouncerTest {
     debouncer.setDebounceType(Debouncer.DebounceType.kFalling);
 
     assertSame(debouncer.getDebounceType(), Debouncer.DebounceType.kFalling);
+    assertTrue(debouncer.calculate(false));
   }
 }

--- a/wpimath/src/test/native/cpp/filter/DebouncerTest.cpp
+++ b/wpimath/src/test/native/cpp/filter/DebouncerTest.cpp
@@ -72,4 +72,6 @@ TEST_F(DebouncerTest, DebounceParams) {
 
   EXPECT_TRUE(debouncer.GetDebounceType() ==
               frc::Debouncer::DebounceType::kFalling);
+
+  EXPECT_TRUE(debouncer.Calculate(false));
 }


### PR DESCRIPTION
Closes #7867

Properly resets the baseline upon switching the debounce type, and adds
a test for such.

Signed-off-by: swurl <swurl@swurl.xyz>
