### PR TITLE
[wpilib, commands] Add warnWhenDisconnected() to HIDs

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandGenericHID.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandGenericHID.java
@@ -46,6 +46,21 @@ public class CommandGenericHID {
   }
 
   /**
+   * Specifies whether warnings should be printed to the console when this joystick is disconnected
+   * and a button, axis, or POV is read. This is intended to be used for test controllers that do
+   * not need to be plugged in during a match.
+   *
+   * <p>Unlike {@link edu.wpi.first.wpilibj.DriverStation#silenceJoystickConnectionWarning}, this
+   * only applies to this joystick, is NOT ignored when the FMS is connected, and does not affect
+   * warnings when reading a non-existent button, axis, or POV on a connected joystick.
+   *
+   * @param warn Whether warning messages should be printed.
+   */
+  public void warnWhenDisconnected(boolean warn) {
+    m_hid.warnWhenDisconnected(warn);
+  }
+
+  /**
    * Constructs an event instance around this button's digital signal.
    *
    * @param button the button index

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/CommandGenericHID.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/CommandGenericHID.cpp
@@ -12,6 +12,10 @@ frc::GenericHID& CommandGenericHID::GetHID() {
   return m_hid;
 }
 
+void CommandGenericHID::WarnWhenDisconnected(bool warn) {
+  m_hid.WarnWhenDisconnected(warn);
+}
+
 Trigger CommandGenericHID::Button(int button, frc::EventLoop* loop) const {
   return Trigger(loop, [this, button] { return m_hid.GetRawButton(button); });
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/CommandGenericHID.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/CommandGenericHID.h
@@ -27,6 +27,21 @@ class CommandGenericHID {
   explicit CommandGenericHID(int port);
 
   /**
+   * Specifies whether warnings should be printed to the console when this
+   * joystick is disconnected and a button, axis, or POV is read. This is
+   * intended to be used for test controllers that do not need to be plugged in
+   * during a match.
+   *
+   * <p>Unlike DriverStation::SilenceJoystickConnectionWarning(), this only
+   * applies to this joystick, is NOT ignored when the FMS is connected, and
+   * does not affect warnings when reading a non-existent button, axis, or POV
+   * on a connected joystick.
+   *
+   * @param warn Whether warning messages should be printed.
+   */
+  void WarnWhenDisconnected(bool warn);
+
+  /**
    * Get the underlying GenericHID object.
    *
    * @return the wrapped GenericHID object

--- a/wpilibc/src/main/native/cpp/GenericHID.cpp
+++ b/wpilibc/src/main/native/cpp/GenericHID.cpp
@@ -21,15 +21,28 @@ GenericHID::GenericHID(int port) {
   m_port = port;
 }
 
+void GenericHID::WarnWhenDisconnected(bool warn) {
+  m_warnWhenDisconnected = warn;
+}
+
 bool GenericHID::GetRawButton(int button) const {
+  if (!m_warnWhenDisconnected && !IsConnected()) {
+    return false;
+  }
   return DriverStation::GetStickButton(m_port, button);
 }
 
 bool GenericHID::GetRawButtonPressed(int button) {
+  if (!m_warnWhenDisconnected && !IsConnected()) {
+    return false;
+  }
   return DriverStation::GetStickButtonPressed(m_port, button);
 }
 
 bool GenericHID::GetRawButtonReleased(int button) {
+  if (!m_warnWhenDisconnected && !IsConnected()) {
+    return false;
+  }
   return DriverStation::GetStickButtonReleased(m_port, button);
 }
 
@@ -39,10 +52,16 @@ BooleanEvent GenericHID::Button(int button, EventLoop* loop) const {
 }
 
 double GenericHID::GetRawAxis(int axis) const {
+  if (!m_warnWhenDisconnected && !IsConnected()) {
+    return 0.0;
+  }
   return DriverStation::GetStickAxis(m_port, axis);
 }
 
 int GenericHID::GetPOV(int pov) const {
+  if (!m_warnWhenDisconnected && !IsConnected()) {
+    return -1;
+  }
   return DriverStation::GetStickPOV(m_port, pov);
 }
 

--- a/wpilibc/src/main/native/include/frc/GenericHID.h
+++ b/wpilibc/src/main/native/include/frc/GenericHID.h
@@ -82,6 +82,21 @@ class GenericHID {
   GenericHID& operator=(GenericHID&&) = default;
 
   /**
+   * Specifies whether warnings should be printed to the console when this
+   * joystick is disconnected and a button, axis, or POV is read. This is
+   * intended to be used for test controllers that do not need to be plugged in
+   * during a match.
+   *
+   * <p>Unlike DriverStation::SilenceJoystickConnectionWarning(), this only
+   * applies to this joystick, is NOT ignored when the FMS is connected, and
+   * does not affect warnings when reading a non-existent button, axis, or POV
+   * on a connected joystick.
+   *
+   * @param warn Whether warning messages should be printed.
+   */
+  void WarnWhenDisconnected(bool warn);
+
+  /**
    * Get the button value (starting at button 1).
    *
    * The buttons are returned in a single 16 bit value with one bit representing
@@ -372,6 +387,7 @@ class GenericHID {
   int m_outputs = 0;
   uint16_t m_leftRumble = 0;
   uint16_t m_rightRumble = 0;
+  bool m_warnWhenDisconnected = true;
 };
 
 }  // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/GenericHID.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/GenericHID.java
@@ -98,6 +98,7 @@ public class GenericHID {
   private int m_outputs;
   private int m_leftRumble;
   private int m_rightRumble;
+  private boolean m_warnWhenDisconnected = true;
   private final Map<EventLoop, Map<Integer, BooleanEvent>> m_buttonCache = new HashMap<>();
   private final Map<EventLoop, Map<Pair<Integer, Double>, BooleanEvent>> m_axisLessThanCache =
       new HashMap<>();
@@ -115,6 +116,21 @@ public class GenericHID {
   }
 
   /**
+   * Specifies whether warnings should be printed to the console when this joystick is disconnected
+   * and a button, axis, or POV is read. This is intended to be used for test controllers that do
+   * not need to be plugged in during a match.
+   *
+   * <p>Unlike {@link DriverStation#silenceJoystickConnectionWarning}, this only applies to this
+   * joystick, is NOT ignored when the FMS is connected, and does not affect warnings when reading a
+   * non-existent button, axis, or POV on a connected joystick.
+   *
+   * @param warn Whether warning messages should be printed.
+   */
+  public void warnWhenDisconnected(boolean warn) {
+    m_warnWhenDisconnected = warn;
+  }
+
+  /**
    * Get the button value (starting at button 1).
    *
    * <p>The buttons are returned in a single 16 bit value with one bit representing the state of
@@ -127,6 +143,9 @@ public class GenericHID {
    * @return The state of the button.
    */
   public boolean getRawButton(int button) {
+    if (!m_warnWhenDisconnected && !isConnected()) {
+      return false;
+    }
     return DriverStation.getStickButton(m_port, (byte) button);
   }
 
@@ -141,6 +160,9 @@ public class GenericHID {
    * @return Whether the button was pressed since the last check.
    */
   public boolean getRawButtonPressed(int button) {
+    if (!m_warnWhenDisconnected && !isConnected()) {
+      return false;
+    }
     return DriverStation.getStickButtonPressed(m_port, (byte) button);
   }
 
@@ -155,6 +177,9 @@ public class GenericHID {
    * @return Whether the button was released since the last check.
    */
   public boolean getRawButtonReleased(int button) {
+    if (!m_warnWhenDisconnected && !isConnected()) {
+      return false;
+    }
     return DriverStation.getStickButtonReleased(m_port, button);
   }
 
@@ -179,6 +204,9 @@ public class GenericHID {
    * @return The value of the axis.
    */
   public double getRawAxis(int axis) {
+    if (!m_warnWhenDisconnected && !isConnected()) {
+      return 0.0;
+    }
     return DriverStation.getStickAxis(m_port, axis);
   }
 
@@ -192,6 +220,9 @@ public class GenericHID {
    * @return the angle of the POV in degrees, or -1 if the POV is not pressed.
    */
   public int getPOV(int pov) {
+    if (!m_warnWhenDisconnected && !isConnected()) {
+      return -1;
+    }
     return DriverStation.getStickPOV(m_port, pov);
   }
 


### PR DESCRIPTION
Not sure if we'd want this to be a decorator method instead (which modifies the instance and returns the instance), but having a setter was really simple and should work for every reasonable use case. A decorator would also be hard to name- Following the convention of `Command.ignoringDisable()`, this would be `GenericHID.warningWhenDisconnected()`, which doesn't work well because "warning" is mostly used as a noun

I don't think we have unit tests for generic HID, but I tested locally with all 9 permutations of (no call to warnWhenDisconnected() | warnWhenDisconnected(true) | warnWhenDisconnected(false)) x (no controller | xbox controller | controller without enough buttons).
Here's the diff I tested with:
```diff
diff --git a/developerRobot/src/main/java/frc/robot/Robot.java b/developerRobot/src/main/java/frc/robot/Robot.java
index 6cf3f4738..abcf007b2 100644
--- a/developerRobot/src/main/java/frc/robot/Robot.java
+++ b/developerRobot/src/main/java/frc/robot/Robot.java
@@ -5,13 +5,21 @@
 package frc.robot;
 
 import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj2.command.Commands;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 
 public class Robot extends TimedRobot {
   /**
    * This function is run when the robot is first started up and should be used for any
    * initialization code.
    */
-  public Robot() {}
+  public Robot() {
+    var controller = new CommandXboxController(0);
+    controller.warnWhenDisconnected(false);
+    controller.leftStick().whileTrue(Commands.none());
+    Commands.print("Beep").andThen(Commands.waitSeconds(1)).repeatedly().schedule();
+  }
 
   /** This function is run once each time the robot enters autonomous mode. */
   @Override
@@ -35,5 +43,7 @@ public class Robot extends TimedRobot {
 
   /** This function is called periodically during all modes. */
   @Override
-  public void robotPeriodic() {}
+  public void robotPeriodic() {
+    CommandScheduler.getInstance().run();
+  }
 }
diff --git a/developerRobot/src/main/native/cpp/Robot.cpp b/developerRobot/src/main/native/cpp/Robot.cpp
index 6e013599e..1ed15c3c4 100644
--- a/developerRobot/src/main/native/cpp/Robot.cpp
+++ b/developerRobot/src/main/native/cpp/Robot.cpp
@@ -2,15 +2,26 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+#include <frc/DriverStation.h>
 #include <frc/TimedRobot.h>
+#include <frc2/command/Commands.h>
+#include <frc2/command/CommandScheduler.h>
+#include <frc2/command/button/CommandXboxController.h>
 
 class Robot : public frc::TimedRobot {
  public:
+  frc2::CommandXboxController controller{0};
+  frc2::CommandPtr beeper = frc2::cmd::Print("Beep").AndThen(frc2::cmd::Wait(1_s)).Repeatedly();
+
   /**
    * This function is run when the robot is first started up and should be
    * used for any initialization code.
    */
-  Robot() {}
+  Robot() {
+    controller.WarnWhenDisconnected(false);
+    controller.LeftStick().WhileTrue(frc2::cmd::None());
+    beeper.Schedule();
+  }
 
   /**
    * This function is run once each time the robot enters autonomous mode
@@ -40,7 +51,9 @@ class Robot : public frc::TimedRobot {
   /**
    * This function is called periodically during all modes
    */
-  void RobotPeriodic() override {}
+  void RobotPeriodic() override {
+    frc2::CommandScheduler::GetInstance().Run();
+  }
 };
 
 int main() {
 ```
 The beep command makes it easier to tell if warnings are still being emitted.