### PR TITLE
[glass] Fix compilation error with protobuf 30.1

### DIFF
--- a/glass/src/libnt/native/cpp/NetworkTables.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTables.cpp
@@ -360,7 +360,7 @@ static void UpdateProtobufValueSource(NetworkTablesModel& model,
                                       const google::protobuf::Message& msg,
                                       std::string_view name, int64_t time) {
   auto desc = msg.GetDescriptor();
-  out->typeStr = "proto:" + desc->full_name();
+  out->typeStr = fmt::format("proto:{}", desc->full_name());
   if (!out->valueChildrenMap ||
       desc->field_count() != static_cast<int>(out->valueChildren.size())) {
     out->valueChildren.clear();


### PR DESCRIPTION
```
/home/tav/frc/wpilib/allwpilib/glass/src/libnt/native/cpp/NetworkTables.cpp: In function ‘void UpdateProtobufValueSource(glass::NetworkTablesModel&, glass::NetworkTablesModel::ValueSource*, const google::protobuf::Message&, std::string_view, int64_t)’:
/home/tav/frc/wpilib/allwpilib/glass/src/libnt/native/cpp/NetworkTables.cpp:363:27: error: no match for ‘operator+’ (operand types are ‘const char [7]’ and ‘google::protobuf::internal::DescriptorStringView’ {aka ‘std::basic_string_view<char>’})
  363 |   out->typeStr = "proto:" + desc->full_name();
      |                  ~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~
      |                  |                         |
      |                  const char [7]            google::protobuf::internal::DescriptorStringView {aka std::basic_string_view<char>}
```