### PR TITLE
[docs] Update readme to say Xcode is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Using Gradle makes building WPILib very straightforward. It only has a few depen
 - C++ compiler
     - On Linux, install GCC 11 or greater
     - On Windows, install [Visual Studio Community 2022](https://visualstudio.microsoft.com/vs/community/) and select the C++ programming language during installation (Gradle can't use the build tools for Visual Studio)
-    - On macOS, install the Xcode command-line build tools via `xcode-select --install`. Xcode 13 or later is required.
+    - On macOS 13.3 or newer, install Xcode 14 or later (the command-line build tools are insufficient).
 - ARM compiler toolchain
     - Run `./gradlew installRoboRioToolchain` after cloning this repository
     - If the WPILib installer was used, this toolchain is already installed


### PR DESCRIPTION
Someone on the Discord couldn't build WPILib with just the command-line tools.

Fixes #7891.