### PR TITLE
Fix more emscripten compiler errors

### DIFF
--- a/cmake/modules/CompileWarnings.cmake
+++ b/cmake/modules/CompileWarnings.cmake
@@ -46,7 +46,7 @@ macro(wpilib_target_warnings target)
 
     # Suppress warning "enumeration types with a fixed underlying type are a
     # Clang extension"
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT EMSCRIPTEN)
         target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-fixed-enum-extension>)
     endif()
 

--- a/ntcore/src/test/native/cpp/ValueTest.cpp
+++ b/ntcore/src/test/native/cpp/ValueTest.cpp
@@ -271,6 +271,8 @@ TEST_F(ValueTest, StringArray) {
   NT_DisposeValue(&cv);
 }
 
+// Google Test doesn't have ASSERT_DEATH when compiled with emscripten
+#ifndef __EMSCRIPTEN__
 #ifdef NDEBUG
 TEST_F(ValueDeathTest, DISABLED_GetAssertions) {
 #else
@@ -285,6 +287,7 @@ TEST_F(ValueDeathTest, GetAssertions) {
   ASSERT_DEATH((void)v.GetDoubleArray(), "type == NT_DOUBLE_ARRAY");
   ASSERT_DEATH((void)v.GetStringArray(), "type == NT_STRING_ARRAY");
 }
+#endif
 
 TEST_F(ValueTest, UnassignedComparison) {
   Value v1, v2;

--- a/upstream_utils/debugging_patches/0001-Guard-gnu-flatten-attribute.patch
+++ b/upstream_utils/debugging_patches/0001-Guard-gnu-flatten-attribute.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Thu, 21 Nov 2024 17:51:15 -0800
-Subject: [PATCH 1/4] Guard [[gnu::flatten]] attribute
+Subject: [PATCH 1/5] Guard [[gnu::flatten]] attribute
 
 ---
  include/debugging.hpp | 10 ++++++++--

--- a/upstream_utils/debugging_patches/0002-Remove-debugger_query-argument-from-Windows-and-macO.patch
+++ b/upstream_utils/debugging_patches/0002-Remove-debugger_query-argument-from-Windows-and-macO.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Thu, 21 Nov 2024 17:23:48 -0800
-Subject: [PATCH 2/4] Remove debugger_query argument from Windows and macOS
+Subject: [PATCH 2/5] Remove debugger_query argument from Windows and macOS
 
 ---
  src/macos.cxx   | 2 +-

--- a/upstream_utils/debugging_patches/0003-Fix-exception-mask-type-typo-on-macOS.patch
+++ b/upstream_utils/debugging_patches/0003-Fix-exception-mask-type-typo-on-macOS.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Thu, 21 Nov 2024 18:09:37 -0800
-Subject: [PATCH 3/4] Fix exception mask type typo on macOS
+Subject: [PATCH 3/5] Fix exception mask type typo on macOS
 
 ---
  src/macos.cxx | 2 +-

--- a/upstream_utils/debugging_patches/0004-Remove-NOMINMAX-macro-from-Windows.patch
+++ b/upstream_utils/debugging_patches/0004-Remove-NOMINMAX-macro-from-Windows.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Thu, 21 Nov 2024 18:49:53 -0800
-Subject: [PATCH 4/4] Remove NOMINMAX macro from Windows
+Subject: [PATCH 4/5] Remove NOMINMAX macro from Windows
 
 ---
  src/windows.cxx | 1 -

--- a/upstream_utils/debugging_patches/0005-Add-emscripten-shim.patch
+++ b/upstream_utils/debugging_patches/0005-Add-emscripten-shim.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tyler Veness <calcmogul@gmail.com>
+Date: Tue, 8 Apr 2025 15:28:38 -0700
+Subject: [PATCH 5/5] Add emscripten shim
+
+---
+ src/emscripten.cxx | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+ create mode 100644 src/emscripten.cxx
+
+diff --git a/src/emscripten.cxx b/src/emscripten.cxx
+new file mode 100644
+index 0000000000000000000000000000000000000000..16924894cc0c6085b27b33e6b9f2a6e6d582d116
+--- /dev/null
++++ b/src/emscripten.cxx
+@@ -0,0 +1,18 @@
++#if defined(__EMSCRIPTEN__)
++
++#	include <debugging.hpp>
++
++#	include <atomic>
++#	include <fstream>
++#	include <string>
++
++namespace wpi {
++
++bool is_debugger_present() noexcept
++{
++  return false;
++}
++
++} // namespace wpi
++
++#endif

--- a/upstream_utils/memory_patches/0001-Group-doxygen-into-memory-module.patch
+++ b/upstream_utils/memory_patches/0001-Group-doxygen-into-memory-module.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ryan Blue <ryanzblue@gmail.com>
 Date: Wed, 21 Aug 2024 20:50:15 -0400
-Subject: [PATCH 1/2] Group doxygen into memory module
+Subject: [PATCH 1/3] Group doxygen into memory module
 
 ---
  .../foonathan/memory/aligned_allocator.hpp    |  2 +-

--- a/upstream_utils/memory_patches/0002-Remove-conflicting-doxygen-concept-alias.patch
+++ b/upstream_utils/memory_patches/0002-Remove-conflicting-doxygen-concept-alias.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ryan Blue <ryanzblue@gmail.com>
 Date: Wed, 21 Aug 2024 21:47:32 -0400
-Subject: [PATCH 2/2] Remove conflicting doxygen 'concept' alias
+Subject: [PATCH 2/3] Remove conflicting doxygen 'concept' alias
 
 \concept was added as a doxygen command in 1.9.2 and is meant to be applied to concepts. Inserting them into standard comment paragraphs causes doxygen to interpret the following text as a concept name and add it to the documentation, as well as remove the text from the paragraph.
 In the upstream repo, this alias links to markdown documentation, so it's not usable for us anyways.

--- a/upstream_utils/memory_patches/0003-Fix-deprecation-warning-for-UDLs.patch
+++ b/upstream_utils/memory_patches/0003-Fix-deprecation-warning-for-UDLs.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tyler Veness <calcmogul@gmail.com>
+Date: Tue, 8 Apr 2025 15:30:06 -0700
+Subject: [PATCH 3/3] Fix deprecation warning for UDLs
+
+---
+ include/foonathan/memory/memory_arena.hpp | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/include/foonathan/memory/memory_arena.hpp b/include/foonathan/memory/memory_arena.hpp
+index eb969a677329b5b2d536f39f9a15817f040cf79f..d91f2a58cef56278cdb091daf34cebba7ec5b92c 100644
+--- a/include/foonathan/memory/memory_arena.hpp
++++ b/include/foonathan/memory/memory_arena.hpp
+@@ -656,32 +656,32 @@ namespace foonathan
+             /// \returns The number of bytes `value` is in the given unit.
+             /// \ingroup memory_core
+             /// @{
+-            constexpr std::size_t operator"" _KiB(unsigned long long value) noexcept
++            constexpr std::size_t operator""_KiB(unsigned long long value) noexcept
+             {
+                 return std::size_t(value * 1024);
+             }
+ 
+-            constexpr std::size_t operator"" _KB(unsigned long long value) noexcept
++            constexpr std::size_t operator""_KB(unsigned long long value) noexcept
+             {
+                 return std::size_t(value * 1000);
+             }
+ 
+-            constexpr std::size_t operator"" _MiB(unsigned long long value) noexcept
++            constexpr std::size_t operator""_MiB(unsigned long long value) noexcept
+             {
+                 return std::size_t(value * 1024 * 1024);
+             }
+ 
+-            constexpr std::size_t operator"" _MB(unsigned long long value) noexcept
++            constexpr std::size_t operator""_MB(unsigned long long value) noexcept
+             {
+                 return std::size_t(value * 1000 * 1000);
+             }
+ 
+-            constexpr std::size_t operator"" _GiB(unsigned long long value) noexcept
++            constexpr std::size_t operator""_GiB(unsigned long long value) noexcept
+             {
+                 return std::size_t(value * 1024 * 1024 * 1024);
+             }
+ 
+-            constexpr std::size_t operator"" _GB(unsigned long long value) noexcept
++            constexpr std::size_t operator""_GB(unsigned long long value) noexcept
+             {
+                 return std::size_t(value * 1000 * 1000 * 1000);
+             }

--- a/wpiutil/src/main/native/thirdparty/debugging/src/emscripten.cpp
+++ b/wpiutil/src/main/native/thirdparty/debugging/src/emscripten.cpp
@@ -1,0 +1,18 @@
+#if defined(__EMSCRIPTEN__)
+
+#	include <debugging.hpp>
+
+#	include <atomic>
+#	include <fstream>
+#	include <string>
+
+namespace wpi {
+
+bool is_debugger_present() noexcept
+{
+  return false;
+}
+
+} // namespace wpi
+
+#endif

--- a/wpiutil/src/main/native/thirdparty/memory/include/wpi/memory/memory_arena.hpp
+++ b/wpiutil/src/main/native/thirdparty/memory/include/wpi/memory/memory_arena.hpp
@@ -656,32 +656,32 @@ namespace wpi
             /// \returns The number of bytes `value` is in the given unit.
             /// \ingroup memory_core
             /// @{
-            constexpr std::size_t operator"" _KiB(unsigned long long value) noexcept
+            constexpr std::size_t operator""_KiB(unsigned long long value) noexcept
             {
                 return std::size_t(value * 1024);
             }
 
-            constexpr std::size_t operator"" _KB(unsigned long long value) noexcept
+            constexpr std::size_t operator""_KB(unsigned long long value) noexcept
             {
                 return std::size_t(value * 1000);
             }
 
-            constexpr std::size_t operator"" _MiB(unsigned long long value) noexcept
+            constexpr std::size_t operator""_MiB(unsigned long long value) noexcept
             {
                 return std::size_t(value * 1024 * 1024);
             }
 
-            constexpr std::size_t operator"" _MB(unsigned long long value) noexcept
+            constexpr std::size_t operator""_MB(unsigned long long value) noexcept
             {
                 return std::size_t(value * 1000 * 1000);
             }
 
-            constexpr std::size_t operator"" _GiB(unsigned long long value) noexcept
+            constexpr std::size_t operator""_GiB(unsigned long long value) noexcept
             {
                 return std::size_t(value * 1024 * 1024 * 1024);
             }
 
-            constexpr std::size_t operator"" _GB(unsigned long long value) noexcept
+            constexpr std::size_t operator""_GB(unsigned long long value) noexcept
             {
                 return std::size_t(value * 1000 * 1000 * 1000);
             }

--- a/wpiutil/src/test/native/include/wpi/SpanMatcher.h
+++ b/wpiutil/src/test/native/include/wpi/SpanMatcher.h
@@ -70,6 +70,6 @@ void SpanMatcher<T>::DescribeNegationTo(::std::ostream* os) const {
 
 }  // namespace wpi
 
-inline std::span<const uint8_t> operator"" _us(const char* str, size_t len) {
+inline std::span<const uint8_t> operator""_us(const char* str, size_t len) {
   return {reinterpret_cast<const uint8_t*>(str), len};
 }


### PR DESCRIPTION
I ran the CMake configure with:
```bash
emcmake cmake -B build-wasm -S . \
  -DCMAKE_BUILD_TYPE=Release \
  -DBUILD_SHARED_LIBS=OFF \
  -DWITH_SIMULATION_MODULES=OFF \
  -DWITH_PROTOBUF=OFF \
  -DWITH_GUI=OFF \
  -DWITH_CSCORE=OFF
```

* Turned off simulation modules because they require shared libraries
* Turned off GUI because glfw requires libssh
* Turned off cscore because it requires OpenCV

I still get the following compiler errors:

```
/home/tav/frc/wpilib/allwpilib/wpinet/src/main/native/thirdparty/libuv/src/unix/linux.cpp:43:10: fatal error: 'sys/epoll.h' file not found
   43 | #include <sys/epoll.h>
      |          ^~~~~~~~~~~~~
```
```
/home/tav/frc/wpilib/allwpilib/wpinet/src/main/native/thirdparty/libuv/src/unix/stream.cpp:991:56: error: comparison of integers of different signs: 'unsigned long' and 'long' [-Werror,-Wsign-compare]
  991 |   for (cmsg = CMSG_FIRSTHDR(msg); cmsg != NULL; cmsg = CMSG_NXTHDR(msg, cmsg)) {
      |                                                        ^~~~~~~~~~~~~~~~~~~~~~
/home/tav/.cache/emscripten/sysroot/include/sys/socket.h:358:44: note: expanded from macro 'CMSG_NXTHDR'
  358 |         __CMSG_LEN(cmsg) + sizeof(struct cmsghdr) >= __MHDR_END(mhdr) - (unsigned char *)(cmsg) \
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```
/home/tav/frc/wpilib/allwpilib/wpinet/src/main/native/thirdparty/libuv/src/unix/core.cpp:748:56: error: comparison of integers of different signs: 'unsigned long' and 'long' [-Werror,-Wsign-compare]
  748 |   for (cmsg = CMSG_FIRSTHDR(msg); cmsg != NULL; cmsg = CMSG_NXTHDR(msg, cmsg))
      |                                                        ^~~~~~~~~~~~~~~~~~~~~~
/home/tav/.cache/emscripten/sysroot/include/sys/socket.h:358:44: note: expanded from macro 'CMSG_NXTHDR'
  358 |         __CMSG_LEN(cmsg) + sizeof(struct cmsghdr) >= __MHDR_END(mhdr) - (unsigned char *)(cmsg) \
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```