### PR TITLE
Fix `SequentialCommandGroup.isFinished` is false after command finishes

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SequentialCommandGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SequentialCommandGroup.java
@@ -98,7 +98,7 @@ public class SequentialCommandGroup extends Command {
 
   @Override
   public final boolean isFinished() {
-    return m_currentCommandIndex == m_commands.size();
+    return m_currentCommandIndex == m_commands.size() || m_currentCommandIndex == -1;
   }
 
   @Override


### PR DESCRIPTION
- `end()` sets current command index to -1
- `isFinished()` checks if the current command index equals the command list size
- fixes this by also checking in `isFinished()` if the current command index is -1