### PR TITLE
[bazel] Make bazel work outside //

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,14 +11,14 @@ build --tool_java_runtime_version=remotejdk_17
 test --test_output=errors
 test --test_verbose_timeout_warnings
 
-import shared/bazel/compiler_flags/sanitizers.rc
-import shared/bazel/compiler_flags/base_linux_flags.rc
-import shared/bazel/compiler_flags/linux_flags.rc
-import shared/bazel/compiler_flags/osx_flags.rc
-import shared/bazel/compiler_flags/roborio_flags.rc
-import shared/bazel/compiler_flags/systemcore_flags.rc
-import shared/bazel/compiler_flags/windows_flags.rc
-import shared/bazel/compiler_flags/coverage_flags.rc
+import %workspace%/shared/bazel/compiler_flags/sanitizers.rc
+import %workspace%/shared/bazel/compiler_flags/base_linux_flags.rc
+import %workspace%/shared/bazel/compiler_flags/linux_flags.rc
+import %workspace%/shared/bazel/compiler_flags/osx_flags.rc
+import %workspace%/shared/bazel/compiler_flags/roborio_flags.rc
+import %workspace%/shared/bazel/compiler_flags/systemcore_flags.rc
+import %workspace%/shared/bazel/compiler_flags/windows_flags.rc
+import %workspace%/shared/bazel/compiler_flags/coverage_flags.rc
 
 # Alias toolchain names to what wpilibsuite uses for CI/Artifact naming
 build:athena --config=roborio


### PR DESCRIPTION
The .bazelrc was doing a relative import, not an absolute one.  This looks by accident, fix it.