### PR TITLE
[ci] Use Bazel fastbuild compilation mode on Windows

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           token: ${{ secrets.BUILDBUDDY_API_KEY }}
 
-      - name: Build Release
-        run: bazel --output_user_root=C:\\bazelroot ${{ matrix.action }} -k ...   --config=ci -c opt ${{ matrix.config }} --verbose_failures
+      - name: bazel ${{ matrix.action }}
+        run: bazel --output_user_root=C:\\bazelroot ${{ matrix.action }} -k ...   --config=ci ${{ matrix.config }} --verbose_failures
         shell: bash
 
   build-mac:
@@ -47,7 +47,7 @@ jobs:
         with:
           token: ${{ secrets.BUILDBUDDY_API_KEY }}
 
-      - name: Build Release
+      - name: bazel test (release)
         run: bazel test -k ...   --config=ci -c opt --config=macos --nojava_header_compilation --verbose_failures
         shell: bash
 
@@ -70,7 +70,7 @@ jobs:
         with:
           token: ${{ secrets.BUILDBUDDY_API_KEY }}
 
-      - name: Build and Test Release
+      - name: bazel ${{ matrix.action }} (release)
         run: bazel ${{ matrix.action }} ... --config=ci -c opt ${{ matrix.config }} -k --verbose_failures
 
   buildifier:


### PR DESCRIPTION
Our Bazel Windows CI builds are currently horrifically slow, especially compared to our Linux and macOS builds. For a ~total cache miss the Windows jobs take 50 minutes wall clock time each.

This changes the CI job to use the default `--compilation_mode=fastbuild` rather than `--compilation_mode=opt`. This brings a Windows job down to 32 minutes in the worst case.

We can build with `-c opt` when we create releases rather than on every CI job.

https://bazel.build/docs/user-manual#compilation-mode