### PR TITLE
[bazel] Avoid globally linking macOS SDK frameworks

### DIFF
--- a/cscore/BUILD.bazel
+++ b/cscore/BUILD.bazel
@@ -40,6 +40,13 @@ objc_library(
         "src/main/native/include",
         "src/main/native/objcpp",
     ],
+    sdk_frameworks = [
+        "CoreFoundation",
+        "AVFoundation",
+        "Foundation",
+        "CoreMedia",
+        "CoreVideo",
+    ],
     tags = ["manual"],
     deps = [
         "//wpinet:wpinet.static",

--- a/shared/bazel/compiler_flags/osx_flags.rc
+++ b/shared/bazel/compiler_flags/osx_flags.rc
@@ -26,17 +26,6 @@ build:macos --conlyopt=-Wno-missing-field-initializers
 build:macos --conlyopt=-Wno-unused-private-field
 build:macos --conlyopt=-Wno-fixed-enum-extension"
 
-
-build:macos --linkopt=-framework
-build:macos --linkopt=CoreFoundation
-build:macos --linkopt=-framework
-build:macos --linkopt=AVFoundation
-build:macos --linkopt=-framework
-build:macos --linkopt=Foundation
-build:macos --linkopt=-framework
-build:macos --linkopt=CoreMedia
-build:macos --linkopt=-framework
-build:macos --linkopt=CoreVideo
 build:macos --linkopt=-headerpad_max_install_names
 build:macos --linkopt=-Wl,-rpath,'@loader_path'"
 


### PR DESCRIPTION
Currently in the Bazel build we link every C/C++/ObjC binary to the Foundation frameworks that `//cscore` requires, despite most things not having any Objective C deps otherwise.