### PR TITLE
Add runStartEnd to Commands v2

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -106,6 +106,20 @@ public final class Commands {
   }
 
   /**
+   * Constructs a command that runs an action once, and then runs an action every
+   * iteration until interrupted.
+   *
+   * @param start the action to run on start
+   * @param run the action to run every iteration
+   * @param requirements subsystems the action requires
+   */
+  public static Command startRunEnd(Runnable start, Runnable run, Runnable end, Subsystem... requirements) {
+    requireNonNullParam(end, "end", "Command.runEnd");
+    return new FunctionalCommand(
+      start, run, interrupted -> end.run(), () -> false, requirements);
+  }
+
+  /**
    * Constructs a command that prints a message and finishes.
    *
    * @param message the message to print

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
@@ -159,6 +159,18 @@ public interface Subsystem {
   }
 
   /**
+   * Constructs a command that runs an action once, and then runs an action every
+   * iteration until interrupted.
+   *
+   * @param start the action to run on start
+   * @param run the action to run every iteration
+   * @param requirements subsystems the action requires
+   */
+  default Command startRunEnd(Runnable start, Runnable run, Runnable end) {
+    return Commands.startRunEnd(start, run, end, this);
+  }
+  
+  /**
    * Constructs a {@link DeferredCommand} with the provided supplier. This subsystem is added as a
    * requirement.
    *

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
@@ -70,6 +70,16 @@ CommandPtr cmd::StartRun(std::function<void()> start, std::function<void()> run,
       .ToPtr();
 }
 
+
+CommandPtr cmd::StartRunEnd(std::function<void> start, std::function<void()> run, std::function<void()> end,
+                       Requirements requirements) {
+  return FunctionalCommand(std::move(start), std::move(run),
+                           [end = std::move(end)](bool interrupted) { end(); },
+                           [] { return false; }, requirements)
+      .ToPtr();
+}
+
+
 CommandPtr cmd::Print(std::string_view msg) {
   return PrintCommand(msg).ToPtr();
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Subsystem.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Subsystem.cpp
@@ -69,6 +69,12 @@ CommandPtr Subsystem::StartRun(std::function<void()> start,
   return cmd::StartRun(std::move(start), std::move(run), {this});
 }
 
+CommandPtr Subsystem::StartRunEnd(std::function<void()>, 
+                                  std::function<void()> run, 
+                                  std::function<void()> end) {
+  return cmd::StartRunEnd(std::move(start), std::move(run), std::move(end), {this});
+}
+
 CommandPtr Subsystem::Defer(wpi::unique_function<CommandPtr()> supplier) {
   return cmd::Defer(std::move(supplier), {this});
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
@@ -97,10 +97,22 @@ CommandPtr RunEnd(std::function<void()> run, std::function<void()> end,
 [[nodiscard]]
 CommandPtr StartRun(std::function<void()> start, std::function<void()> run,
                     Requirements requirements = {});
+/**
+ * Constructs a command that runs an action once, and then runs an action every
+ * iteration until interrupted, and then runs a third action.
+ *
+ * @param run the action to run every iteration
+ * @param end the action to run on interrupt
+ * @param requirements subsystems the action requires
+ */
+[[nodiscard]]
+CommandPtr StartRunEnd(std::function<void> start, std::function<void()> run, std::function<void()> end,
+                  Requirements requirements = {});
+
 
 /**
  * Constructs a command that prints a message and finishes.
- *
+ * 
  * @param msg the message to print
  */
 [[nodiscard]]

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
@@ -170,6 +170,18 @@ class Subsystem {
   CommandPtr StartRun(std::function<void()> start, std::function<void()> run);
 
   /**
+   * Constructs a command that runs an action once, and then runs an action every
+   * iteration until interrupted.
+   *
+   * @param start the action to run on start
+   * @param run the action to run every iteration
+   * @param requirements subsystems the action requires
+   */
+  [[nodiscard]]
+  CommandPtr StartRunEnd(std::function<void()>, std::function<void()> run, std::function<void()> end);
+
+
+  /**
    * Constructs a DeferredCommand with the provided supplier. This subsystem is
    * added as a requirement.
    *


### PR DESCRIPTION
Adds a method like startRun or runEnd to Commands and Subsystem to make it easier to write commands that have a start, running, and end actions. I’ve seen this mentioned in a few places so I figured I might as well write it.