### PR TITLE
[wpiutil] Add nested struct schemas before parent schema

### DIFF
--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/DataLog.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/DataLog.java
@@ -451,10 +451,10 @@ public class DataLog implements AutoCloseable {
     if (!seen.add(typeString)) {
       throw new UnsupportedOperationException(typeString + ": circular reference with " + seen);
     }
-    addSchema(typeString, "structschema", struct.getSchema(), timestamp);
     for (Struct<?> inner : struct.getNested()) {
       addSchemaImpl(inner, timestamp, seen);
     }
+    addSchema(typeString, "structschema", struct.getSchema(), timestamp);
     seen.remove(typeString);
   }
 


### PR DESCRIPTION
When adding struct schemas, the current logic is to add the parent/outer schema, and then add the schemas for any nested inner schemas.

This necessitates a bunch of extra logic for consumers of the datalog format, since you may see a sequence of struct schema definitions like this:

```
Start(150, name='/.schema/struct:Pose2d', type='structschema', metadata='') [14.160558]
Data(150, size=45) <name='/.schema/struct:Pose2d', type='structschema'> [14.160558]
Start(151, name='/.schema/struct:Rotation2d', type='structschema', metadata='') [14.160558]
Data(151, size=12) <name='/.schema/struct:Rotation2d', type='structschema'> [14.160558]
```

Here the `Pose2d` struct schema is defined, which references `Translation2d` and `Rotation2d` as nested schemas. The issue is that we are referencing the `Rotation2d` schema before it has been defined.

In AdvantageScope, there's a [bunch of dedicated logic](https://github.com/Mechanical-Advantage/AdvantageScope/blob/f767ffbac2c020b76eb811d1f32fff55765733cb/src/shared/log/Log.ts#L340-L357) specifically for dealing with this case. Changing this behavior in WPILib makes it easier for members of the community to build tools on top of the datalog spec.

Semi-related: `StructLogEntry` has a similar issue, where the constructor of its superclass `DataLogEntry` creates a start record referencing a struct type that hasn't been defined yet. `StructLogEntry` adds the schema, but only after the `DataLogEntry` has been executed