### PR TITLE
[bazel] Hide wpinet implementation headers

### DIFF
--- a/wpinet/BUILD.bazel
+++ b/wpinet/BUILD.bazel
@@ -120,6 +120,9 @@ cc_library(
         ":tcpsockets-srcs",
     ] + ["native-srcs"],
     hdrs = glob(["src/main/native/include/**/*"]),
+    implementation_deps = [
+        ":private_includes",
+    ],
     includes = ["src/main/native/include"],
     linkopts = select({
         "@bazel_tools//src/conditions:linux": ["-ldl"],
@@ -129,7 +132,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":libuv-headers",
-        ":private_includes",
         ":tcpsockets-headers",
         "//wpiutil:wpiutil.static",
     ],
@@ -153,6 +155,7 @@ cc_test(
     ]),
     tags = ["no-asan"],
     deps = [
+        ":private_includes",
         ":wpinet.static",
         "//thirdparty/googletest:googletest.static",
         "//wpiutil:wpiutil-testlib",


### PR DESCRIPTION
The headers in `wpinet/src/main/native/cpp/*.h` aren't intended to be used by dependents, so they shouldn't get propagated.