### PR TITLE
Skip optimization change in uv__preadv_or_pwritev on android

### DIFF
--- a/wpinet/src/main/native/thirdparty/libuv/src/unix/fs.cpp
+++ b/wpinet/src/main/native/thirdparty/libuv/src/unix/fs.cpp
@@ -465,7 +465,7 @@ static ssize_t uv__pwritev_emul(int fd,
  * Disable optimization on armv7 to work around the bug described in
  * https://github.com/libuv/libuv/issues/4532
  */
-#if defined(__arm__) && (__ARM_ARCH == 7)
+#if defined(__arm__) && (__ARM_ARCH == 7) && !defined(__ANDROID__)
 __attribute__((optimize("O0")))
 #endif
 static ssize_t uv__preadv_or_pwritev(int fd,


### PR DESCRIPTION
Arm32 builds on android are on clang which don't have the bug. And the optimize attribute is GCC only.