### PR TITLE
[wpilibj] Add Preferences.getNetworkTable()

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Preferences.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Preferences.java
@@ -98,6 +98,15 @@ public final class Preferences {
   }
 
   /**
+   * Gets the network table used for preferences entries.
+   *
+   * @return the network table used for preferences entries
+   */
+  public static NetworkTable getNetworkTable() {
+    return m_table;
+  }
+
+  /**
    * Gets the preferences keys.
    *
    * @return a collection of the keys

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/PreferencesTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/PreferencesTest.java
@@ -91,6 +91,13 @@ class PreferencesTest {
         "Preferences was not empty!  Preferences in table: " + Arrays.toString(keys.toArray()));
   }
 
+  @Test
+  void getNetworkTableTest() {
+    NetworkTable networkTable = Preferences.getNetworkTable();
+
+    assertEquals(m_table, networkTable);
+  }
+
   @ParameterizedTest
   @MethodSource("defaultKeyProvider")
   void defaultKeysTest(String key) {


### PR DESCRIPTION
Use case: Our team has a shared library that includes wrapper APIs for the
Java Preferences API. The wrapper API adds a topic (with a topic name starting
with ".") where it stores non-persistent data that is used for validation.

The code for our wrapper API is [here](https://github.com/Prospect-Robotics/lib2813/blob/main/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java).

The unit tests for those classes use Preferences.setNetworkTableInstance()
to ensure that the tests are isolated. Since there is no current API to get
the current preference table, our wrapper APIs either have to take in a
NetworkTableInstance (which makes the classes less simple to use) or our code
to add these internal topics needs to use the default network table instance (making the
tests not completely isolated).

Providing an API to get the NetworkTable used by Preferences would allow our
API to remain simple and our tests to be truly isolated. It doesn't appear
to be something that would be hard to maintain.

I reviewed the C++ and Python APIs, and they appear to not have an equivalent
to setNetworkTableInstance() so this PR only updates the Java API.
