### PR TITLE
[wpilib] Remove unhelpful comments from BooleanEvent

### DIFF
--- a/wpilibc/src/main/native/include/frc/event/BooleanEvent.h
+++ b/wpilibc/src/main/native/include/frc/event/BooleanEvent.h
@@ -129,8 +129,12 @@ class BooleanEvent {
                             frc::Debouncer::DebounceType::kRising);
 
  private:
+  /// Poller loop.
   EventLoop* m_loop;
+
   std::function<bool()> m_signal;
-  std::shared_ptr<bool> m_state;  // A programmer's worst nightmare.
+
+  /// The state of the condition in the current loop poll.
+  std::shared_ptr<bool> m_state;
 };
 }  // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/event/BooleanEvent.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/event/BooleanEvent.java
@@ -28,7 +28,7 @@ public class BooleanEvent implements BooleanSupplier {
 
   private final BooleanSupplier m_signal;
 
-  /** The state of the condition in the current loop poll. Nightmare to manage. */
+  /** The state of the condition in the current loop poll. */
   private final AtomicBoolean m_state = new AtomicBoolean(false);
 
   /**


### PR DESCRIPTION
These were apparently a meme about state being hard to manage rather than a statement about the code itself. I spent a while trying to find some complex logic this comment was alluding to that would indicate why it's "a nightmare to manage".