### PR TITLE
Add callback for mDNS service resolver

### DIFF
--- a/wpinet/src/main/native/include/wpinet/MulticastServiceResolver.h
+++ b/wpinet/src/main/native/include/wpinet/MulticastServiceResolver.h
@@ -33,7 +33,17 @@ class MulticastServiceResolver {
     std::vector<std::pair<std::string, std::string>> txt;
   };
 
+  /**
+   * Set a copy callback to be called when a service is resolved.
+   * Takes presidence over the move callback. Return true to
+   * not send the data to the event queue.
+   */
   bool SetCopyCallback(std::function<bool(const ServiceData&)> callback);
+
+  /**
+   * Set a move callback to be called when a service is resolved.
+   * Data is moved into the function and cannot be added to the event queue.
+   */
   bool SetMoveCallback(std::function<void(ServiceData&&)> callback);
 
   /**

--- a/wpinet/src/main/native/include/wpinet/MulticastServiceResolver.h
+++ b/wpinet/src/main/native/include/wpinet/MulticastServiceResolver.h
@@ -21,9 +21,9 @@ class MulticastServiceResolver {
   explicit MulticastServiceResolver(std::string_view serviceType);
   ~MulticastServiceResolver() noexcept;
   struct ServiceData {
-    /// IPv4 address.
+    /// IPv4 address in host order.
     unsigned int ipv4Address;
-    /// Port number.
+    /// Port number in host order.
     int port;
     /// Service name.
     std::string serviceName;
@@ -32,20 +32,17 @@ class MulticastServiceResolver {
     /// Service data payload.
     std::vector<std::pair<std::string, std::string>> txt;
   };
-
   /**
    * Set a copy callback to be called when a service is resolved.
    * Takes presidence over the move callback. Return true to
    * not send the data to the event queue.
    */
   bool SetCopyCallback(std::function<bool(const ServiceData&)> callback);
-
   /**
    * Set a move callback to be called when a service is resolved.
    * Data is moved into the function and cannot be added to the event queue.
    */
   bool SetMoveCallback(std::function<void(ServiceData&&)> callback);
-
   /**
    * Starts multicast service resolver.
    */

--- a/wpinet/src/main/native/linux/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/linux/MulticastServiceResolver.cpp
@@ -44,6 +44,26 @@ bool MulticastServiceResolver::HasImplementation() const {
   return pImpl->table.IsValid();
 }
 
+bool MulticastServiceResolver::SetCopyCallback(
+    std::function<bool(const ServiceData&)> callback) {
+  std::scoped_lock lock{*pImpl->thread};
+  if (pImpl->client) {
+    return false;
+  }
+  this->copyCallback = std::move(callback);
+  return true;
+}
+
+bool MulticastServiceResolver::SetMoveCallback(
+    std::function<void(ServiceData&&)> callback) {
+  std::scoped_lock lock{*pImpl->thread};
+  if (pImpl->client) {
+    return false;
+  }
+  this->moveCallback = std::move(callback);
+  return true;
+}
+
 static void ResolveCallback(AvahiServiceResolver* r, AvahiIfIndex interface,
                             AvahiProtocol protocol, AvahiResolverEvent event,
                             const char* name, const char* type,

--- a/wpinet/src/main/native/linux/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/linux/MulticastServiceResolver.cpp
@@ -52,7 +52,7 @@ bool MulticastServiceResolver::SetCopyCallback(
   if (pImpl->client) {
     return false;
   }
-  this->copyCallback = std::move(callback);
+  copyCallback = std::move(callback);
   return true;
 }
 
@@ -62,7 +62,7 @@ bool MulticastServiceResolver::SetMoveCallback(
   if (pImpl->client) {
     return false;
   }
-  this->moveCallback = std::move(callback);
+  moveCallback = std::move(callback);
   return true;
 }
 

--- a/wpinet/src/main/native/linux/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/linux/MulticastServiceResolver.cpp
@@ -103,8 +103,8 @@ static void ResolveCallback(AvahiServiceResolver* r, AvahiIfIndex interface,
         outputHostName.append(".");
       } while (true);
 
-      data.ipv4Address = address->data.ipv4.address;
-      data.port = port;
+      data.ipv4Address = ntohl(address->data.ipv4.address);
+      data.port = ntohs(port);
       data.serviceName = name;
       data.hostName = std::string{outputHostName};
 

--- a/wpinet/src/main/native/linux/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/linux/MulticastServiceResolver.cpp
@@ -4,11 +4,12 @@
 
 #include "wpinet/MulticastServiceResolver.h"
 
+#include <arpa/inet.h>
+
 #include <memory>
 #include <string>
 #include <utility>
 
-#include <arpa/inet.h>
 #include <wpi/SmallString.h>
 #include <wpi/StringExtras.h>
 #include <wpi/mutex.h>

--- a/wpinet/src/main/native/linux/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/linux/MulticastServiceResolver.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include <arpa/inet.h>
 #include <wpi/SmallString.h>
 #include <wpi/StringExtras.h>
 #include <wpi/mutex.h>

--- a/wpinet/src/main/native/macOS/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/macOS/MulticastServiceResolver.cpp
@@ -72,8 +72,8 @@ void ServiceGetAddrInfoReply(DNSServiceRef sdRef, DNSServiceFlags flags,
   DnsResolveState* resolveState = static_cast<DnsResolveState*>(context);
 
   resolveState->data.hostName = hostname;
-  resolveState->data.ipv4Address =
-      reinterpret_cast<const struct sockaddr_in*>(address)->sin_addr.s_addr;
+  resolveState->data.ipv4Address = ntohl(
+      reinterpret_cast<const struct sockaddr_in*>(address)->sin_addr.s_addr);
 
   resolveState->pImpl->onFound(std::move(resolveState->data));
 

--- a/wpinet/src/main/native/macOS/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/macOS/MulticastServiceResolver.cpp
@@ -179,6 +179,24 @@ bool MulticastServiceResolver::HasImplementation() const {
   return true;
 }
 
+bool MulticastServiceResolver::SetCopyCallback(
+    std::function<bool(const ServiceData&)> callback) {
+  if (pImpl->serviceRef) {
+    return false;
+  }
+  this->copyCallback = std::move(callback);
+  return true;
+}
+
+bool MulticastServiceResolver::SetMoveCallback(
+    std::function<void(ServiceData&&)> callback) {
+  if (pImpl->serviceRef) {
+    return false;
+  }
+  this->moveCallback = std::move(callback);
+  return true;
+}
+
 void MulticastServiceResolver::Start() {
   if (pImpl->serviceRef) {
     return;

--- a/wpinet/src/main/native/macOS/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/macOS/MulticastServiceResolver.cpp
@@ -184,7 +184,7 @@ bool MulticastServiceResolver::SetCopyCallback(
   if (pImpl->serviceRef) {
     return false;
   }
-  this->copyCallback = std::move(callback);
+  copyCallback = std::move(callback);
   return true;
 }
 
@@ -193,7 +193,7 @@ bool MulticastServiceResolver::SetMoveCallback(
   if (pImpl->serviceRef) {
     return false;
   }
-  this->moveCallback = std::move(callback);
+  moveCallback = std::move(callback);
   return true;
 }
 

--- a/wpinet/src/main/native/windows/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/windows/MulticastServiceResolver.cpp
@@ -70,7 +70,7 @@ bool MulticastServiceResolver::SetCopyCallback(
   if (pImpl->serviceCancel.reserved != nullptr) {
     return false;
   }
-  this->copyCallback = std::move(callback);
+  copyCallback = std::move(callback);
   return true;
 }
 
@@ -79,7 +79,7 @@ bool MulticastServiceResolver::SetMoveCallback(
   if (pImpl->serviceCancel.reserved != nullptr) {
     return false;
   }
-  this->moveCallback = std::move(callback);
+  moveCallback = std::move(callback);
   return true;
 }
 

--- a/wpinet/src/main/native/windows/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/windows/MulticastServiceResolver.cpp
@@ -189,8 +189,8 @@ static _Function_class_(DNS_QUERY_COMPLETION_ROUTINE) VOID WINAPI
         wpi::convertUTF16ToUTF8String(wideServiceName, storage);
 
         data.serviceName = std::string{storage};
-        data.port = foundSrv->Data.Srv.wPort;
-        data.ipv4Address = A->Data.A.IpAddress;
+        data.port = ntohs(foundSrv->Data.Srv.wPort);
+        data.ipv4Address = ntohl(A->Data.A.IpAddress);
 
         impl->onFound(std::move(data));
       }


### PR DESCRIPTION
Without this, the only way to read items is to use the event. And in my use case, adding that would require adding my own thread _just_ for handling that event. 