### PR TITLE
[wpical] Allow use of other ChArUco dictionaries for camera calibration

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,12 +1,9 @@
 {
-  "name": "main",
-  "version-string": "latest",
-  "dependencies": [
-    "opencv",
-    "fmt",
-    "libuv",
-    "protobuf",
-    "libssh"
-  ],
-  "builtin-baseline": "37c3e63a1306562f7f59c4c3c8892ddd50fdf992"
+  "name" : "main",
+  "version-string" : "latest",
+  "dependencies" : [ "opencv", "fmt", "libuv", "libssh", {
+    "name" : "protobuf",
+    "version>=" : "5.29.3"
+  } ],
+  "builtin-baseline" : "37c3e63a1306562f7f59c4c3c8892ddd50fdf992"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,9 +1,12 @@
 {
-  "name" : "main",
-  "version-string" : "latest",
-  "dependencies" : [ "opencv", "fmt", "libuv", "libssh", {
-    "name" : "protobuf",
-    "version>=" : "5.29.3"
-  } ],
-  "builtin-baseline" : "37c3e63a1306562f7f59c4c3c8892ddd50fdf992"
+  "name": "main",
+  "version-string": "latest",
+  "dependencies": [
+    "opencv",
+    "fmt",
+    "libuv",
+    "protobuf",
+    "libssh"
+  ],
+  "builtin-baseline": "37c3e63a1306562f7f59c4c3c8892ddd50fdf992"
 }

--- a/wpical/src/main/native/cpp/WPIcal.cpp
+++ b/wpical/src/main/native/cpp/WPIcal.cpp
@@ -501,6 +501,10 @@ static void DisplayGui() {
         ImGui::EndCombo();
       }
 
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
+        ImGui::SetTooltip("Only change if you know what you're doing");
+      }
+
       ImGui::Separator();
       if (ImGui::Button("Calibrate") && !selected_camera_intrinsics.empty()) {
         std::cout << "calibration button pressed" << std::endl;

--- a/wpical/src/main/native/cpp/WPIcal.cpp
+++ b/wpical/src/main/native/cpp/WPIcal.cpp
@@ -23,6 +23,8 @@
 #include <wpi/json.h>
 #include <wpigui.h>
 
+#include <opencv2/aruco/charuco.hpp>
+
 namespace gui = wpi::gui;
 
 const char* GetWPILibVersion();
@@ -226,6 +228,53 @@ static void DisplayGui() {
   static double imagerWidth = 1920;
   static double imagerHeight = 1080;
 
+  static const char* charucoDictNames[] = {
+    "DICT_4X4_50",
+    "DICT_4X4_100",
+    "DICT_4X4_250",
+    "DICT_4X4_1000",
+    "DICT_5X5_50",
+    "DICT_5X5_100",
+    "DICT_5X5_250",
+    "DICT_5X5_1000",
+    "DICT_6X6_50",
+    "DICT_6X6_100",
+    "DICT_6X6_250",
+    "DICT_6X6_1000",
+    "DICT_7X7_50",
+    "DICT_7X7_100",
+    "DICT_7X7_250",
+    "DICT_7X7_1000"
+  };
+
+  static const int charucoDictEnums[] = {
+    cv::aruco::DICT_4X4_50,
+    cv::aruco::DICT_4X4_100,
+    cv::aruco::DICT_4X4_250,
+    cv::aruco::DICT_4X4_1000,
+    cv::aruco::DICT_5X5_50,
+    cv::aruco::DICT_5X5_100,
+    cv::aruco::DICT_5X5_250,
+    cv::aruco::DICT_5X5_1000,
+    cv::aruco::DICT_6X6_50,
+    cv::aruco::DICT_6X6_100,
+    cv::aruco::DICT_6X6_250,
+    cv::aruco::DICT_6X6_1000,
+    cv::aruco::DICT_7X7_50,
+    cv::aruco::DICT_7X7_100,
+    cv::aruco::DICT_7X7_250,
+    cv::aruco::DICT_7X7_1000,
+    cv::aruco::DICT_ARUCO_ORIGINAL,
+    cv::aruco::DICT_APRILTAG_16h5,
+    cv::aruco::DICT_APRILTAG_25h9,
+    cv::aruco::DICT_APRILTAG_36h10,
+    cv::aruco::DICT_APRILTAG_36h11
+  };
+
+  static int currentDictIdx = 0;
+
+  static const int numCharucoDicts = IM_ARRAYSIZE(charucoDictNames);
+
   static int pinnedTag = 1;
 
   static int focusedTag = 1;
@@ -419,6 +468,18 @@ static void DisplayGui() {
       ImGui::SetNextItemWidth(ImGui::GetFontSize() * 12);
       ImGui::InputDouble("Image Height (pixels)", &imagerHeight);
 
+      if (ImGui::BeginCombo("ChArUco Dictionary", charucoDictNames[currentDictIdx])) {
+        for (int i = 0; i < numCharucoDicts; ++i) {
+          bool isSelected = (currentDictIdx == i);
+          if (ImGui::Selectable(charucoDictNames[i], isSelected)) {
+            currentDictIdx = i;
+          }
+          if (isSelected)
+            ImGui::SetItemDefaultFocus();
+        }
+        ImGui::EndCombo();
+      }
+
       ImGui::Separator();
       if (ImGui::Button("Calibrate") && !selected_camera_intrinsics.empty()) {
         std::cout << "calibration button pressed" << std::endl;
@@ -469,7 +530,7 @@ static void DisplayGui() {
         std::cout << "calibration button pressed" << std::endl;
         int ret = cameracalibration::calibrate(
             selected_camera_intrinsics.c_str(), cameraModel, squareWidth,
-            markerWidth, boardWidth, boardHeight, showDebug);
+            markerWidth, boardWidth, boardHeight, showDebug, charucoDictEnums[currentDictIdx]);
         if (ret == 0) {
           size_t lastSeparatorPos =
               selected_camera_intrinsics.find_last_of("/\\");

--- a/wpical/src/main/native/cpp/WPIcal.cpp
+++ b/wpical/src/main/native/cpp/WPIcal.cpp
@@ -271,7 +271,7 @@ static void DisplayGui() {
     cv::aruco::DICT_APRILTAG_36h11
   };
 
-  static int currentDictIdx = 0;
+  static int currentDictIdx = 7; // Default to DICT_5X5_1000
 
   static const int numCharucoDicts = IM_ARRAYSIZE(charucoDictNames);
 
@@ -468,18 +468,6 @@ static void DisplayGui() {
       ImGui::SetNextItemWidth(ImGui::GetFontSize() * 12);
       ImGui::InputDouble("Image Height (pixels)", &imagerHeight);
 
-      if (ImGui::BeginCombo("ChArUco Dictionary", charucoDictNames[currentDictIdx])) {
-        for (int i = 0; i < numCharucoDicts; ++i) {
-          bool isSelected = (currentDictIdx == i);
-          if (ImGui::Selectable(charucoDictNames[i], isSelected)) {
-            currentDictIdx = i;
-          }
-          if (isSelected)
-            ImGui::SetItemDefaultFocus();
-        }
-        ImGui::EndCombo();
-      }
-
       ImGui::Separator();
       if (ImGui::Button("Calibrate") && !selected_camera_intrinsics.empty()) {
         std::cout << "calibration button pressed" << std::endl;
@@ -524,6 +512,18 @@ static void DisplayGui() {
       ImGui::InputInt("Board Width (squares)", &boardWidth);
       ImGui::SetNextItemWidth(ImGui::GetFontSize() * 12);
       ImGui::InputInt("Board Height (squares)", &boardHeight);
+
+      if (ImGui::BeginCombo("ChArUco Dictionary", charucoDictNames[currentDictIdx])) {
+        for (int i = 0; i < numCharucoDicts; ++i) {
+          bool isSelected = (currentDictIdx == i);
+          if (ImGui::Selectable(charucoDictNames[i], isSelected)) {
+            currentDictIdx = i;
+          }
+          if (isSelected)
+            ImGui::SetItemDefaultFocus();
+        }
+        ImGui::EndCombo();
+      }
 
       ImGui::Separator();
       if (ImGui::Button("Calibrate") && !selected_camera_intrinsics.empty()) {

--- a/wpical/src/main/native/cpp/WPIcal.cpp
+++ b/wpical/src/main/native/cpp/WPIcal.cpp
@@ -18,12 +18,11 @@
 #include <GLFW/glfw3.h>
 #include <fmt/format.h>
 #include <imgui.h>
+#include <opencv2/aruco/charuco.hpp>
 #include <portable-file-dialogs.h>
 #include <tagpose.h>
 #include <wpi/json.h>
 #include <wpigui.h>
-
-#include <opencv2/aruco/charuco.hpp>
 
 namespace gui = wpi::gui;
 
@@ -229,49 +228,25 @@ static void DisplayGui() {
   static double imagerHeight = 1080;
 
   static const char* charucoDictNames[] = {
-    "DICT_4X4_50",
-    "DICT_4X4_100",
-    "DICT_4X4_250",
-    "DICT_4X4_1000",
-    "DICT_5X5_50",
-    "DICT_5X5_100",
-    "DICT_5X5_250",
-    "DICT_5X5_1000",
-    "DICT_6X6_50",
-    "DICT_6X6_100",
-    "DICT_6X6_250",
-    "DICT_6X6_1000",
-    "DICT_7X7_50",
-    "DICT_7X7_100",
-    "DICT_7X7_250",
-    "DICT_7X7_1000"
-  };
+      "DICT_4X4_50", "DICT_4X4_100", "DICT_4X4_250", "DICT_4X4_1000",
+      "DICT_5X5_50", "DICT_5X5_100", "DICT_5X5_250", "DICT_5X5_1000",
+      "DICT_6X6_50", "DICT_6X6_100", "DICT_6X6_250", "DICT_6X6_1000",
+      "DICT_7X7_50", "DICT_7X7_100", "DICT_7X7_250", "DICT_7X7_1000"};
 
   static const int charucoDictEnums[] = {
-    cv::aruco::DICT_4X4_50,
-    cv::aruco::DICT_4X4_100,
-    cv::aruco::DICT_4X4_250,
-    cv::aruco::DICT_4X4_1000,
-    cv::aruco::DICT_5X5_50,
-    cv::aruco::DICT_5X5_100,
-    cv::aruco::DICT_5X5_250,
-    cv::aruco::DICT_5X5_1000,
-    cv::aruco::DICT_6X6_50,
-    cv::aruco::DICT_6X6_100,
-    cv::aruco::DICT_6X6_250,
-    cv::aruco::DICT_6X6_1000,
-    cv::aruco::DICT_7X7_50,
-    cv::aruco::DICT_7X7_100,
-    cv::aruco::DICT_7X7_250,
-    cv::aruco::DICT_7X7_1000,
-    cv::aruco::DICT_ARUCO_ORIGINAL,
-    cv::aruco::DICT_APRILTAG_16h5,
-    cv::aruco::DICT_APRILTAG_25h9,
-    cv::aruco::DICT_APRILTAG_36h10,
-    cv::aruco::DICT_APRILTAG_36h11
-  };
+      cv::aruco::DICT_4X4_50,         cv::aruco::DICT_4X4_100,
+      cv::aruco::DICT_4X4_250,        cv::aruco::DICT_4X4_1000,
+      cv::aruco::DICT_5X5_50,         cv::aruco::DICT_5X5_100,
+      cv::aruco::DICT_5X5_250,        cv::aruco::DICT_5X5_1000,
+      cv::aruco::DICT_6X6_50,         cv::aruco::DICT_6X6_100,
+      cv::aruco::DICT_6X6_250,        cv::aruco::DICT_6X6_1000,
+      cv::aruco::DICT_7X7_50,         cv::aruco::DICT_7X7_100,
+      cv::aruco::DICT_7X7_250,        cv::aruco::DICT_7X7_1000,
+      cv::aruco::DICT_ARUCO_ORIGINAL, cv::aruco::DICT_APRILTAG_16h5,
+      cv::aruco::DICT_APRILTAG_25h9,  cv::aruco::DICT_APRILTAG_36h10,
+      cv::aruco::DICT_APRILTAG_36h11};
 
-  static int currentDictIdx = 7; // Default to DICT_5X5_1000
+  static int currentDictIdx = 7;  // Default to DICT_5X5_1000
 
   static const int numCharucoDicts = IM_ARRAYSIZE(charucoDictNames);
 
@@ -513,7 +488,8 @@ static void DisplayGui() {
       ImGui::SetNextItemWidth(ImGui::GetFontSize() * 12);
       ImGui::InputInt("Board Height (squares)", &boardHeight);
 
-      if (ImGui::BeginCombo("ChArUco Dictionary", charucoDictNames[currentDictIdx])) {
+      if (ImGui::BeginCombo("ChArUco Dictionary",
+                            charucoDictNames[currentDictIdx])) {
         for (int i = 0; i < numCharucoDicts; ++i) {
           bool isSelected = (currentDictIdx == i);
           if (ImGui::Selectable(charucoDictNames[i], isSelected)) {
@@ -530,7 +506,8 @@ static void DisplayGui() {
         std::cout << "calibration button pressed" << std::endl;
         int ret = cameracalibration::calibrate(
             selected_camera_intrinsics.c_str(), cameraModel, squareWidth,
-            markerWidth, boardWidth, boardHeight, showDebug, charucoDictEnums[currentDictIdx]);
+            markerWidth, boardWidth, boardHeight, showDebug,
+            charucoDictEnums[currentDictIdx]);
         if (ret == 0) {
           size_t lastSeparatorPos =
               selected_camera_intrinsics.find_last_of("/\\");

--- a/wpical/src/main/native/cpp/cameracalibration.cpp
+++ b/wpical/src/main/native/cpp/cameracalibration.cpp
@@ -157,10 +157,10 @@ int cameracalibration::calibrate(const std::string& input_video,
                                  float marker_width, int board_width,
                                  int board_height, double imagerWidthPixels,
                                  double imagerHeightPixels,
-                                 bool show_debug_window) {
+                                 bool show_debug_window, int dict) {
   // ChArUco Board
   cv::aruco::Dictionary aruco_dict =
-      cv::aruco::getPredefinedDictionary(cv::aruco::DICT_5X5_1000);
+      cv::aruco::getPredefinedDictionary(dict);
   cv::Ptr<cv::aruco::CharucoBoard> charuco_board = new cv::aruco::CharucoBoard(
       cv::Size(board_width, board_height), square_width * 0.0254,
       marker_width * 0.0254, aruco_dict);

--- a/wpical/src/main/native/cpp/cameracalibration.cpp
+++ b/wpical/src/main/native/cpp/cameracalibration.cpp
@@ -46,10 +46,10 @@ static bool filter(std::vector<cv::Point2f> charuco_corners,
 int cameracalibration::calibrate(const std::string& input_video,
                                  CameraModel& camera_model, float square_width,
                                  float marker_width, int board_width,
-                                 int board_height, bool show_debug_window) {
+                                 int board_height, bool show_debug_window, int dict) {
   // ChArUco Board
   cv::aruco::Dictionary aruco_dict =
-      cv::aruco::getPredefinedDictionary(cv::aruco::DICT_5X5_1000);
+      cv::aruco::getPredefinedDictionary(dict);
   cv::Ptr<cv::aruco::CharucoBoard> charuco_board = new cv::aruco::CharucoBoard(
       cv::Size(board_width, board_height), square_width * 0.0254,
       marker_width * 0.0254, aruco_dict);

--- a/wpical/src/main/native/cpp/cameracalibration.cpp
+++ b/wpical/src/main/native/cpp/cameracalibration.cpp
@@ -46,10 +46,10 @@ static bool filter(std::vector<cv::Point2f> charuco_corners,
 int cameracalibration::calibrate(const std::string& input_video,
                                  CameraModel& camera_model, float square_width,
                                  float marker_width, int board_width,
-                                 int board_height, bool show_debug_window, int dict) {
+                                 int board_height, bool show_debug_window,
+                                 int dict) {
   // ChArUco Board
-  cv::aruco::Dictionary aruco_dict =
-      cv::aruco::getPredefinedDictionary(dict);
+  cv::aruco::Dictionary aruco_dict = cv::aruco::getPredefinedDictionary(dict);
   cv::Ptr<cv::aruco::CharucoBoard> charuco_board = new cv::aruco::CharucoBoard(
       cv::Size(board_width, board_height), square_width * 0.0254,
       marker_width * 0.0254, aruco_dict);
@@ -159,8 +159,7 @@ int cameracalibration::calibrate(const std::string& input_video,
                                  double imagerHeightPixels,
                                  bool show_debug_window, int dict) {
   // ChArUco Board
-  cv::aruco::Dictionary aruco_dict =
-      cv::aruco::getPredefinedDictionary(dict);
+  cv::aruco::Dictionary aruco_dict = cv::aruco::getPredefinedDictionary(dict);
   cv::Ptr<cv::aruco::CharucoBoard> charuco_board = new cv::aruco::CharucoBoard(
       cv::Size(board_width, board_height), square_width * 0.0254,
       marker_width * 0.0254, aruco_dict);

--- a/wpical/src/main/native/include/cameracalibration.h
+++ b/wpical/src/main/native/include/cameracalibration.h
@@ -20,11 +20,11 @@ struct CameraModel {
 
 int calibrate(const std::string& input_video, CameraModel& camera_model,
               float square_width, float marker_width, int board_width,
-              int board_height, bool show_debug_window);
+              int board_height, bool show_debug_window, int dict);
 int calibrate(const std::string& input_video, CameraModel& camera_model,
               float square_width, float marker_width, int board_width,
               int board_height, double imagerWidthPixels,
-              double imagerHeightPixels, bool show_debug_window);
+              double imagerHeightPixels, bool show_debug_window, int dict);
 int calibrate(const std::string& input_video, CameraModel& camera_model,
               float square_width, int board_width, int board_height,
               double imagerWidthPixels, double imagerHeightPixels,

--- a/wpical/src/test/native/cpp/test_calibrate.cpp
+++ b/wpical/src/test/native/cpp/test_calibrate.cpp
@@ -29,10 +29,13 @@ const std::string videoLocation = "/altfieldvideo";
 const std::string fileSuffix = ".mp4";
 const std::string videoLocation = "/fieldvideo";
 #endif
+
+const int charucoDict = 7;  // DICT_5X5_1000
+
 TEST(Camera_CalibrationTest, OpenCV_Typical) {
   int ret = cameracalibration::calibrate(
       projectRootPath + "/testcalibration" + fileSuffix, cameraModel, 0.709f,
-      0.551f, 12, 8, false);
+      0.551f, 12, 8, false, charucoDict);
   cameracalibration::dumpJson(cameraModel,
                               calSavePath + "/cameracalibration.json");
   EXPECT_EQ(ret, 0);
@@ -41,21 +44,21 @@ TEST(Camera_CalibrationTest, OpenCV_Typical) {
 TEST(Camera_CalibrationTest, OpenCV_Atypical) {
   int ret = cameracalibration::calibrate(
       projectRootPath + videoLocation + "/long" + fileSuffix, cameraModel,
-      0.709f, 0.551f, 12, 8, false);
+      0.709f, 0.551f, 12, 8, false, charucoDict);
   EXPECT_EQ(ret, 1);
 }
 
 TEST(Camera_CalibrationTest, MRcal_Typical) {
   int ret = cameracalibration::calibrate(
       projectRootPath + "/testcalibration" + fileSuffix, cameraModel, .709f, 12,
-      8, 1080, 1920, false);
+      8, 1080.0, 1920.0, false);
   EXPECT_EQ(ret, 0);
 }
 
 TEST(Camera_CalibrationTest, MRcal_Atypical) {
   int ret = cameracalibration::calibrate(
       projectRootPath + videoLocation + "/short" + fileSuffix, cameraModel,
-      0.709f, 12, 8, 1080, 1920, false);
+      0.709f, 12, 8, 1080.0, 1920.0, false);
   EXPECT_EQ(ret, 1);
 }
 


### PR DESCRIPTION
Currently, WPICal only lets you use the 5x5 1000 markers ChArUco dictionary for calibrating your camera. This PR allows you set what dictionary is used via a drop-down menu. This menu defaults to `DICT_5X5_1000` which is what was used in the previous version. There is also a tool tip when hovering over the drop-down that indicates to only change the selection if you know what you're doing. I don't particularly like my current implementation (I am not an experienced C++ developer) and am open to suggestions on how to improve it. I have also updated the tests accordingly.