### PR TITLE
Add superclass field & method logging to Epilogue

### DIFF
--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/LoggerGenerator.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/LoggerGenerator.java
@@ -117,7 +117,7 @@ public class LoggerGenerator {
 
     List<VariableElement> fieldsToLog = new ArrayList<>();
     List<ExecutableElement> methodsToLog = new ArrayList<>();
-    collectLoggables(clazz, fieldsToLog, methodsToLog);
+    collectLoggables(clazz, fieldsToLog, methodsToLog, true);
 
     // Validate no name collisions
     Map<String, List<Element>> usedNames =
@@ -162,7 +162,7 @@ public class LoggerGenerator {
     writeLoggerFile(clazz, config, fieldsToLog, methodsToLog);
   }
 
-  private void collectLoggables(TypeElement clazz, List<VariableElement> fields, List<ExecutableElement> methods) {
+  private void collectLoggables(TypeElement clazz, List<VariableElement> fields, List<ExecutableElement> methods, boolean isRoot) {
     var config = clazz.getAnnotation(Logged.class);
     if (config == null) {
       config = m_defaultConfig;
@@ -185,6 +185,7 @@ public class LoggerGenerator {
               .filter(notSkipped)
               .filter(optedIn)
               .filter(e -> !e.getModifiers().contains(Modifier.STATIC))
+              .filter(e -> isRoot || e.getModifiers().contains(Modifier.PUBLIC))
               .filter(this::isLoggable)
               .toList();
     }
@@ -208,7 +209,7 @@ public class LoggerGenerator {
 
     TypeElement superclass = (TypeElement) m_processingEnv.getTypeUtils().asElement(clazz.getSuperclass());
     if (superclass != null) {
-      collectLoggables(superclass, fields, methods);
+      collectLoggables(superclass, fields, methods, false);
     }
   }
 

--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/LoggerGenerator.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/LoggerGenerator.java
@@ -114,42 +114,10 @@ public class LoggerGenerator {
     if (config == null) {
       config = m_defaultConfig;
     }
-    boolean requireExplicitOptIn = config.strategy() == Logged.Strategy.OPT_IN;
 
-    Predicate<Element> notSkipped = LoggerGenerator::isNotSkipped;
-    Predicate<Element> optedIn =
-        e -> !requireExplicitOptIn || e.getAnnotation(Logged.class) != null;
-
-    List<VariableElement> fieldsToLog;
-    if (Objects.equals(clazz.getSuperclass().toString(), "java.lang.Record")) {
-      // Do not log record members - just use the accessor methods
-      fieldsToLog = List.of();
-    } else {
-      fieldsToLog =
-          clazz.getEnclosedElements().stream()
-              .filter(e -> e instanceof VariableElement)
-              .map(e -> (VariableElement) e)
-              .filter(notSkipped)
-              .filter(optedIn)
-              .filter(e -> !e.getModifiers().contains(Modifier.STATIC))
-              .filter(this::isLoggable)
-              .toList();
-    }
-
-    List<ExecutableElement> methodsToLog =
-        clazz.getEnclosedElements().stream()
-            .filter(e -> e instanceof ExecutableElement)
-            .map(e -> (ExecutableElement) e)
-            .filter(notSkipped)
-            .filter(optedIn)
-            .filter(e -> !e.getModifiers().contains(Modifier.STATIC))
-            .filter(e -> e.getModifiers().contains(Modifier.PUBLIC))
-            .filter(e -> e.getParameters().isEmpty())
-            .filter(e -> e.getReceiverType() != null)
-            .filter(kIsBuiltInJavaMethod.negate())
-            .filter(this::isLoggable)
-            .filter(e -> !isSimpleGetterMethodForLoggedField(e, fieldsToLog))
-            .toList();
+    List<VariableElement> fieldsToLog = new ArrayList<>();
+    List<ExecutableElement> methodsToLog = new ArrayList<>();
+    collectLoggables(clazz, fieldsToLog, methodsToLog);
 
     // Validate no name collisions
     Map<String, List<Element>> usedNames =
@@ -192,6 +160,56 @@ public class LoggerGenerator {
         });
 
     writeLoggerFile(clazz, config, fieldsToLog, methodsToLog);
+  }
+
+  private void collectLoggables(TypeElement clazz, List<VariableElement> fields, List<ExecutableElement> methods) {
+    var config = clazz.getAnnotation(Logged.class);
+    if (config == null) {
+      config = m_defaultConfig;
+    }
+    boolean requireExplicitOptIn = config.strategy() == Logged.Strategy.OPT_IN;
+
+    Predicate<Element> notSkipped = LoggerGenerator::isNotSkipped;
+    Predicate<Element> optedIn =
+        e -> !requireExplicitOptIn || e.getAnnotation(Logged.class) != null;
+
+    List<VariableElement> classFields;
+    if (Objects.equals(clazz.getSuperclass().toString(), "java.lang.Record")) {
+      // Do not log record members - just use the accessor methods
+      classFields = List.of();
+    } else {
+      classFields =
+        clazz.getEnclosedElements().stream()
+              .filter(e -> e instanceof VariableElement)
+              .map(e -> (VariableElement) e)
+              .filter(notSkipped)
+              .filter(optedIn)
+              .filter(e -> !e.getModifiers().contains(Modifier.STATIC))
+              .filter(this::isLoggable)
+              .toList();
+    }
+    fields.addAll(classFields);
+
+    methods.addAll(
+      clazz.getEnclosedElements().stream()
+              .filter(e -> e instanceof ExecutableElement)
+              .map(e -> (ExecutableElement) e)
+              .filter(notSkipped)
+              .filter(optedIn)
+              .filter(e -> !e.getModifiers().contains(Modifier.STATIC))
+              .filter(e -> e.getModifiers().contains(Modifier.PUBLIC))
+              .filter(e -> e.getParameters().isEmpty())
+              .filter(e -> e.getReceiverType() != null)
+              .filter(kIsBuiltInJavaMethod.negate())
+              .filter(this::isLoggable)
+              .filter(e -> !isSimpleGetterMethodForLoggedField(e, classFields))
+              .toList()
+    );
+
+    TypeElement superclass = (TypeElement) m_processingEnv.getTypeUtils().asElement(clazz.getSuperclass());
+    if (superclass != null) {
+      collectLoggables(superclass, fields, methods);
+    }
   }
 
   private void writeLoggerFile(

--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
@@ -498,14 +498,15 @@ class AnnotationProcessorTest {
         @Logged
         public double a;
         @Logged public double getB() { return 0; }
+        public double getC() { return 1; }             // not annotated, not logged
       }
 
       @Logged
       class BaseExample extends Grandparent {
         public double x;
-        double z;
+        double z;                                      // not public, not logged
         public double getValue() { return 2.0; }
-        private double getOtherValue() { return 3.0; }
+        private double getOtherValue() { return 3.0; } // not public, not logged
       }
 
       @Logged

--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
@@ -445,6 +445,95 @@ class AnnotationProcessorTest {
   }
 
   @Test
+  void superclassStillOptIn() {
+    String source =
+        """
+      package edu.wpi.first.epilogue;
+
+      class BaseExample {
+        double x;
+        public double getValue() { return 2.0; }
+      }
+
+      @Logged
+      class Example extends BaseExample {
+        double y;
+      }
+    """;
+
+    String expectedGeneratedSource =
+        """
+      package edu.wpi.first.epilogue;
+
+      import edu.wpi.first.epilogue.Logged;
+      import edu.wpi.first.epilogue.Epilogue;
+      import edu.wpi.first.epilogue.logging.ClassSpecificLogger;
+      import edu.wpi.first.epilogue.logging.EpilogueBackend;
+
+      public class ExampleLogger extends ClassSpecificLogger<Example> {
+        public ExampleLogger() {
+          super(Example.class);
+        }
+
+        @Override
+        public void update(EpilogueBackend backend, Example object) {
+          if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
+            backend.log("y", object.y);
+          }
+        }
+      }
+      """;
+
+    assertLoggerGenerates(source, expectedGeneratedSource);
+  }
+
+  @Test
+  void superclass() {
+    String source =
+        """
+      package edu.wpi.first.epilogue;
+
+      @Logged
+      class BaseExample {
+        double x;
+        public double getValue() { return 2.0; }
+      }
+
+      @Logged
+      class Example extends BaseExample {
+        double y;
+      }
+    """;
+
+    String expectedGeneratedSource =
+        """
+      package edu.wpi.first.epilogue;
+
+      import edu.wpi.first.epilogue.Logged;
+      import edu.wpi.first.epilogue.Epilogue;
+      import edu.wpi.first.epilogue.logging.ClassSpecificLogger;
+      import edu.wpi.first.epilogue.logging.EpilogueBackend;
+
+      public class ExampleLogger extends ClassSpecificLogger<Example> {
+        public ExampleLogger() {
+          super(Example.class);
+        }
+
+        @Override
+        public void update(EpilogueBackend backend, Example object) {
+          if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
+            backend.log("y", object.y);
+            backend.log("x", object.x);
+            backend.log("getValue", object.getValue());
+          }
+        }
+      }
+      """;
+
+    assertLoggerGenerates(source, expectedGeneratedSource);
+  }
+
+  @Test
   void bytes() {
     String source =
         """

--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
@@ -450,8 +450,9 @@ class AnnotationProcessorTest {
         """
       package edu.wpi.first.epilogue;
 
+      // nothing should be logged from BaseExample
       class BaseExample {
-        double x;
+        public double x;
         public double getValue() { return 2.0; }
       }
 
@@ -493,10 +494,18 @@ class AnnotationProcessorTest {
         """
       package edu.wpi.first.epilogue;
 
+      class Grandparent {
+        @Logged
+        public double a;
+        @Logged public double getB() { return 0; }
+      }
+
       @Logged
-      class BaseExample {
-        double x;
+      class BaseExample extends Grandparent {
+        public double x;
+        double z;
         public double getValue() { return 2.0; }
+        private double getOtherValue() { return 3.0; }
       }
 
       @Logged
@@ -524,7 +533,9 @@ class AnnotationProcessorTest {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
             backend.log("y", object.y);
             backend.log("x", object.x);
+            backend.log("a", object.a);
             backend.log("getValue", object.getValue());
+            backend.log("getB", object.getB());
           }
         }
       }


### PR DESCRIPTION
Epilogue currently only logs fields and methods belonging to the class it is directly logging - if that class inherits from a class with `@Loggable` annotations present, those fields and methods are not included. This makes it difficult to use Epilogue in scenarios where inheritance is utilized, like on Subsystem or IO abstractions. 

This PR fixes this so that the superclass is recursively checked and any valid loggable fields in the superclass (and it's superclass, and so forth) are included too. This theoretically also enables library-defined loggable classes as long as the user subclasses it.

The criteria for a superclass field to be included is the same as a normal loggable field except for the added stipulation that it must be public - otherwise it's not guaranteed that the field is accessible from the child class we're logging.