### PR TITLE
[wpimath] Fix SimpleMotorFeedforward no-accel overload returning negative voltage outputs

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/controller/SimpleMotorFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/SimpleMotorFeedforward.java
@@ -157,7 +157,7 @@ public class SimpleMotorFeedforward implements ProtobufSerializable, StructSeria
    * @return The computed feedforward.
    */
   public double calculate(double velocity) {
-    return calculate(velocity, 0);
+    return calculate(velocity, velocity);
   }
 
   /**


### PR DESCRIPTION
`SimpleMotorFeedforward::calculate(velocity)` was not updated to account for the removal of `calculate(velocity, acceleration)`, so it would pass `currentVelocity = velocity` and `nextVelocity = 0`, resulting in negative outputs in many scenarios.