### PR TITLE
Add temp value for HAL_GetUserVoltage3V3

### DIFF
--- a/hal/src/main/native/systemcore/Power.cpp
+++ b/hal/src/main/native/systemcore/Power.cpp
@@ -55,8 +55,9 @@ double HAL_GetVinVoltage(int32_t* status) {
 
 double HAL_GetUserVoltage3V3(int32_t* status) {
   initializePower(status);
-  *status = HAL_HANDLE_ERROR;
-  return 0;
+  // Until we have a value, make this work, as lots of other
+  // code depends on it.
+  return 3.3;
 }
 
 double HAL_GetUserCurrent3V3(int32_t* status) {


### PR DESCRIPTION
Lots of higher level code in allwpilib depends on this, so we should return at least a valid and sane value, rather then erroring