### PR TITLE
Backport 2027 CAN API to 2026

### DIFF
--- a/hal/src/main/native/athena/CAN2027.cpp
+++ b/hal/src/main/native/athena/CAN2027.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "hal/CAN2027.h"
+
+#include "hal/Errors.h"
+#include <FRC_NetworkCommunication/CANSessionMux.h>
+#include <memory>
+#include <algorithm>
+
+extern "C" {
+
+void HAL_CAN2027_SendMessage(int32_t busId, uint32_t messageId,
+                             const struct HAL_CAN2027Message* message,
+                             int32_t periodMs, int32_t* status) {
+  if (busId != 0) {
+    *status = PARAMETER_OUT_OF_RANGE;
+    return;
+  }
+  if (message->flags != 0) {
+    *status = PARAMETER_OUT_OF_RANGE;
+    return;
+  }
+  FRC_NetworkCommunication_CANSessionMux_sendMessage(
+      messageId, message->data, message->dataSize, periodMs, status);
+}
+
+void HAL_CAN2027_ReceiveMessage(int32_t busId, uint32_t messageId,
+                                struct HAL_CAN2027ReceiveMessage* message,
+                                int32_t* status) {
+  if (busId != 0) {
+    *status = PARAMETER_OUT_OF_RANGE;
+    return;
+  }
+  message->message.flags = 0;
+  uint32_t tsms = 0;
+  FRC_NetworkCommunication_CANSessionMux_receiveMessage(
+      &messageId, 0x1FFFFFFF, message->message.data, &message->message.dataSize,
+      &tsms, status);
+  message->timeStamp = tsms * 1000;
+}
+
+void HAL_CAN2027_GetCANStatus(int32_t busId, float* percentBusUtilization,
+                              uint32_t* busOffCount, uint32_t* txFullCount,
+                              uint32_t* receiveErrorCount,
+                              uint32_t* transmitErrorCount, int32_t* status) {
+  if (busId != 0) {
+    *status = PARAMETER_OUT_OF_RANGE;
+    return;
+  }
+  FRC_NetworkCommunication_CANSessionMux_getCANStatus(
+      percentBusUtilization, busOffCount, txFullCount, receiveErrorCount,
+      transmitErrorCount, status);
+}
+
+HAL_CAN2027StreamHandle HAL_CAN2027_OpenStreamSession(int32_t busId,
+                                                      uint32_t messageId,
+                                                      uint32_t messageIDMask,
+                                                      uint32_t maxMessages,
+                                                      int32_t* status) {
+  if (busId != 0) {
+    *status = PARAMETER_OUT_OF_RANGE;
+    return HAL_kInvalidHandle;
+  }
+  uint32_t sessionHandle = 0;
+  FRC_NetworkCommunication_CANSessionMux_openStreamSession(
+      &sessionHandle, messageId, messageIDMask, maxMessages, status);
+  return sessionHandle;
+}
+
+void HAL_CAN2027_CloseStreamSession(HAL_CAN2027StreamHandle sessionHandle) {
+  FRC_NetworkCommunication_CANSessionMux_closeStreamSession(sessionHandle);
+}
+
+void HAL_CAN2027_ReadStreamSession(HAL_CAN2027StreamHandle sessionHandle,
+                                   struct HAL_CAN2027StreamMessage* messages,
+                                   uint32_t messagesToRead,
+                                   uint32_t* messagesRead, int32_t* status) {
+  std::unique_ptr<tCANStreamMessage[]> ncMessages =
+      std::make_unique<tCANStreamMessage[]>(messagesToRead);
+  *messagesRead = 0;
+  FRC_NetworkCommunication_CANSessionMux_readStreamSession(
+      sessionHandle, ncMessages.get(), messagesToRead, messagesRead, status);
+  for (uint32_t i = 0; i < *messagesRead; i++) {
+    messages[i].messageId = ncMessages[i].messageID;
+    messages[i].message.timeStamp = ncMessages[i].timeStamp * 1000;
+    messages[i].message.message.dataSize = ncMessages[i].dataSize;
+    std::copy_n(ncMessages[i].data, ncMessages[i].dataSize,
+                messages[i].message.message.data);
+  }
+}
+}

--- a/hal/src/main/native/athena/CANAPI2027.cpp
+++ b/hal/src/main/native/athena/CANAPI2027.cpp
@@ -1,0 +1,263 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "hal/CAN2027API.h"
+
+#include <ctime>
+#include <memory>
+
+#include <wpi/DenseMap.h>
+#include <wpi/mutex.h>
+#include <wpi/timestamp.h>
+
+#include "HALInitializer.h"
+#include "PortsInternal.h"
+#include "hal/CAN2027.h"
+#include "hal/Errors.h"
+#include "hal/handles/UnlimitedHandleResource.h"
+
+using namespace hal;
+
+namespace {
+struct CANStorage {
+  HAL_CANManufacturer manufacturer;
+  HAL_CANDeviceType deviceType;
+  int32_t busId;
+  uint8_t deviceId;
+  wpi::mutex periodicSendsMutex;
+  wpi::SmallDenseMap<int32_t, int32_t> periodicSends;
+  wpi::mutex receivesMutex;
+  wpi::SmallDenseMap<int32_t, HAL_CAN2027ReceiveMessage> receives;
+};
+}  // namespace
+
+static UnlimitedHandleResource<HAL_CANHandle, CANStorage, HAL_HandleEnum::CAN>*
+    canHandles;
+
+namespace hal::init {
+void InitializeCAN2027API() {
+  static UnlimitedHandleResource<HAL_CANHandle, CANStorage, HAL_HandleEnum::CAN>
+      cH;
+  canHandles = &cH;
+}
+}  // namespace hal::init
+
+static int32_t CreateCANId(CANStorage* storage, int32_t apiId) {
+  int32_t createdId = 0;
+  createdId |= (static_cast<int32_t>(storage->deviceType) & 0x1F) << 24;
+  createdId |= (static_cast<int32_t>(storage->manufacturer) & 0xFF) << 16;
+  createdId |= (apiId & 0x3FF) << 6;
+  createdId |= (storage->deviceId & 0x3F);
+  return createdId;
+}
+
+extern "C" {
+
+HAL_CANHandle HAL_InitializeCAN2027(int32_t busId, HAL_CANManufacturer manufacturer,
+                                int32_t deviceId, HAL_CANDeviceType deviceType,
+                                int32_t* status) {
+  hal::init::CheckInit();
+
+  if (busId != 0) {
+    *status = PARAMETER_OUT_OF_RANGE;
+    return HAL_kInvalidHandle;
+  }
+
+  auto can = std::make_shared<CANStorage>();
+
+  auto handle = canHandles->Allocate(can);
+
+  if (handle == HAL_kInvalidHandle) {
+    *status = NO_AVAILABLE_RESOURCES;
+    return HAL_kInvalidHandle;
+  }
+
+  can->busId = busId;
+  can->deviceId = deviceId;
+  can->deviceType = deviceType;
+  can->manufacturer = manufacturer;
+
+  return handle;
+}
+
+void HAL_CleanCAN2027(HAL_CANHandle handle) {
+  auto data = canHandles->Free(handle);
+  if (data == nullptr) {
+    return;
+  }
+
+  std::scoped_lock lock(data->periodicSendsMutex);
+
+  for (auto&& i : data->periodicSends) {
+    int32_t s = 0;
+    auto id = CreateCANId(data.get(), i.first);
+    HAL_CAN2027Message message;
+    std::memset(&message, 0, sizeof(message));
+    HAL_CAN2027_SendMessage(data->busId, id, &message,
+                        HAL_CAN2027_SEND_PERIOD_STOP_REPEATING, &s);
+    i.second = -1;
+  }
+}
+
+void HAL_WriteCAN2027Packet(HAL_CANHandle handle, int32_t apiId,
+                        const struct HAL_CAN2027Message* message, int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return;
+  }
+  auto id = CreateCANId(can.get(), apiId);
+
+  std::scoped_lock lock(can->periodicSendsMutex);
+  HAL_CAN2027_SendMessage(can->busId, id, message, HAL_CAN2027_SEND_PERIOD_NO_REPEAT,
+                      status);
+  can->periodicSends[apiId] = -1;
+}
+
+void HAL_WriteCAN2027PacketRepeating(HAL_CANHandle handle, int32_t apiId,
+                                 const struct HAL_CAN2027Message* message,
+                                 int32_t repeatMs, int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return;
+  }
+  auto id = CreateCANId(can.get(), apiId);
+
+  std::scoped_lock lock(can->periodicSendsMutex);
+  HAL_CAN2027_SendMessage(can->busId, id, message, repeatMs, status);
+  can->periodicSends[apiId] = repeatMs;
+}
+
+void HAL_WriteCAN2027RTRFrame(HAL_CANHandle handle, int32_t apiId,
+                          const struct HAL_CAN2027Message* message,
+                          int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return;
+  }
+  auto id = CreateCANId(can.get(), apiId);
+  id |= HAL_CAN2027_IS_FRAME_REMOTE;
+
+  std::scoped_lock lock(can->periodicSendsMutex);
+  HAL_CAN2027_SendMessage(can->busId, id, message, HAL_CAN2027_SEND_PERIOD_NO_REPEAT,
+                      status);
+  can->periodicSends[apiId] = -1;
+}
+
+void HAL_StopCAN2027PacketRepeating(HAL_CANHandle handle, int32_t apiId,
+                                int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return;
+  }
+  auto id = CreateCANId(can.get(), apiId);
+
+  HAL_CAN2027Message message;
+  std::memset(&message, 0, sizeof(message));
+
+  std::scoped_lock lock(can->periodicSendsMutex);
+  HAL_CAN2027_SendMessage(can->busId, id, &message,
+                      HAL_CAN2027_SEND_PERIOD_STOP_REPEATING, status);
+  can->periodicSends[apiId] = -1;
+}
+
+void HAL_ReadCAN2027PacketNew(HAL_CANHandle handle, int32_t apiId,
+                          struct HAL_CAN2027ReceiveMessage* message,
+                          int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return;
+  }
+
+  uint32_t messageId = CreateCANId(can.get(), apiId);
+
+  HAL_CAN2027_ReceiveMessage(can->busId, messageId, message, status);
+
+  if (*status == 0) {
+    std::scoped_lock lock(can->receivesMutex);
+    can->receives[messageId] = *message;
+  }
+}
+
+void HAL_ReadCAN2027PacketLatest(HAL_CANHandle handle, int32_t apiId,
+                             struct HAL_CAN2027ReceiveMessage* message,
+                             int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return;
+  }
+
+  uint32_t messageId = CreateCANId(can.get(), apiId);
+
+  HAL_CAN2027_ReceiveMessage(can->busId, messageId, message, status);
+
+  std::scoped_lock lock(can->receivesMutex);
+  if (*status == 0) {
+    // fresh update
+    can->receives[messageId] = *message;
+  } else {
+    auto i = can->receives.find(messageId);
+    if (i != can->receives.end()) {
+      // Read the data from the stored message into the output
+      *message = i->second;
+      *status = 0;
+    }
+  }
+}
+
+void HAL_ReadCAN2027PacketTimeout(HAL_CANHandle handle, int32_t apiId,
+                              struct HAL_CAN2027ReceiveMessage* message,
+                              int32_t timeoutMs, int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return;
+  }
+
+  uint32_t messageId = CreateCANId(can.get(), apiId);
+
+  HAL_CAN2027_ReceiveMessage(can->busId, messageId, message, status);
+
+  std::scoped_lock lock(can->receivesMutex);
+  if (*status == 0) {
+    // fresh update
+    can->receives[messageId] = *message;
+  } else {
+    auto i = can->receives.find(messageId);
+    if (i != can->receives.end()) {
+      // Found, check if new enough
+      uint64_t now = wpi::Now();
+      if (now - i->second.timeStamp >
+          (static_cast<uint64_t>(timeoutMs) * 1000)) {
+        // Timeout, return bad status
+        *status = HAL_CAN_TIMEOUT;
+        return;
+      }
+      // Read the data from the stored message into the output
+      *message = i->second;
+      *status = 0;
+    }
+  }
+}
+
+uint32_t HAL_StartCAN2027Stream(HAL_CANHandle handle, int32_t apiId, int32_t depth,
+                            int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return 0;
+  }
+
+  uint32_t messageId = CreateCANId(can.get(), apiId);
+
+  uint32_t session = HAL_CAN2027_OpenStreamSession(can->busId, messageId,
+                                               0x1FFFFFFF, depth, status);
+  return session;
+}
+}  // extern "C"

--- a/hal/src/main/native/athena/HAL.cpp
+++ b/hal/src/main/native/athena/HAL.cpp
@@ -74,6 +74,7 @@ void InitializeHAL() {
   InitializeAnalogTrigger();
   InitializeCAN();
   InitializeCANAPI();
+  InitializeCAN2027API();
   InitializeConstants();
   InitializeCounter();
   InitializeDigitalInternal();

--- a/hal/src/main/native/athena/HALInitializer.h
+++ b/hal/src/main/native/athena/HALInitializer.h
@@ -28,6 +28,7 @@ extern void InitializeAnalogOutput();
 extern void InitializeAnalogTrigger();
 extern void InitializeCAN();
 extern void InitializeCANAPI();
+extern void InitializeCAN2027API();
 extern void InitializeConstants();
 extern void InitializeCounter();
 extern void InitializeDigitalInternal();

--- a/hal/src/main/native/include/hal/CAN2027.h
+++ b/hal/src/main/native/include/hal/CAN2027.h
@@ -1,0 +1,121 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <hal/CAN2027APITypes.h>
+#include <hal/Types.h>
+#include <stdint.h>
+
+typedef HAL_Handle HAL_CAN2027StreamHandle;
+
+/** @} */
+
+/**
+ * @defgroup hal_canstream CAN Stream Functions
+ * @ingroup hal_capi
+ * @{
+ */
+
+/**
+ * Storage for CAN Stream Messages.
+ */
+struct HAL_CAN2027StreamMessage {
+  /** The message ID */
+  uint32_t messageId;
+  /** The message */
+  struct HAL_CAN2027ReceiveMessage message;
+};
+
+/** @} */
+#ifdef __cplusplus
+extern "C" {
+#endif
+/**
+ * @ingroup hal_can
+ * @{
+ */
+/**
+ * Sends a CAN message.
+ *
+ * @param[in] busId     the CAN bus number
+ * @param[in] messageId the message id
+ * @param[in] message   the CAN message
+ * @param[in] periodMs  the repeat period
+ * @param[out] status   Error status variable. 0 on success.
+ */
+void HAL_CAN2027_SendMessage(int32_t busId, uint32_t messageId,
+                         const struct HAL_CAN2027Message* message, int32_t periodMs,
+                         int32_t* status);
+
+/**
+ * Receives a CAN message.
+ *
+ * @param[in] busId       The CAN bus number
+ * @param[in] messageId the message id
+ * @param[out] message  The CAN message
+ * @param[out] status     Error status variable. 0 on success.
+ */
+void HAL_CAN2027_ReceiveMessage(int32_t busId, uint32_t messageId,
+                            struct HAL_CAN2027ReceiveMessage* message,
+                            int32_t* status);
+/**
+ * Gets CAN status information.
+ *
+ * @param[in]  busId                 the bus number
+ * @param[out] percentBusUtilization the bus utilization
+ * @param[out] busOffCount           the number of bus off errors
+ * @param[out] txFullCount           the number of tx full errors
+ * @param[out] receiveErrorCount     the number of receive errors
+ * @param[out] transmitErrorCount    the number of transmit errors
+ * @param[out] status                Error status variable. 0 on success.
+ */
+void HAL_CAN2027_GetCANStatus(int32_t busId, float* percentBusUtilization,
+                          uint32_t* busOffCount, uint32_t* txFullCount,
+                          uint32_t* receiveErrorCount,
+                          uint32_t* transmitErrorCount, int32_t* status);
+/** @} */
+/**
+ * @ingroup hal_canstream
+ * @{
+ */
+/**
+ * Opens a CAN stream.
+ *
+ * @param[in]  busId                   the bus number
+ * @param[in] messageId     the message ID to read
+ * @param[in] messageIDMask the message ID mask
+ * @param[in] maxMessages   the maximum number of messages to stream
+ * @param[out] status        Error status variable. 0 on success.
+ * @return  the stream handle
+ */
+HAL_CAN2027StreamHandle HAL_CAN2027_OpenStreamSession(int32_t busId, uint32_t messageId,
+                                              uint32_t messageIDMask,
+                                              uint32_t maxMessages,
+                                              int32_t* status);
+
+/**
+ * Closes a CAN stream.
+ *
+ * @param sessionHandle the session to close
+ */
+void HAL_CAN2027_CloseStreamSession(HAL_CAN2027StreamHandle sessionHandle);
+
+/**
+ * Reads a CAN stream message.
+ *
+ * @param[in] sessionHandle  the session handle
+ * @param[in] messages       array of messages
+ * @param[in] messagesToRead the max number of messages to read
+ * @param[out] messagesRead   the number of messages actually read
+ * @param[out] status         Error status variable. 0 on success.
+ */
+void HAL_CAN2027_ReadStreamSession(HAL_CAN2027StreamHandle sessionHandle,
+                               struct HAL_CAN2027StreamMessage* messages,
+                               uint32_t messagesToRead, uint32_t* messagesRead,
+                               int32_t* status);
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+/** @} */

--- a/hal/src/main/native/include/hal/CAN2027API.h
+++ b/hal/src/main/native/include/hal/CAN2027API.h
@@ -1,0 +1,152 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <stdint.h>
+
+#include "hal/CAN2027.h"
+#include "hal/CANAPITypes.h"
+#include "hal/CAN2027APITypes.h"
+#include "hal/Types.h"
+
+/**
+ * @defgroup hal_canapi CAN API Functions
+ * @ingroup hal_capi
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initializes a CAN device.
+ *
+ * These follow the FIRST standard CAN layout.
+ * https://docs.wpilib.org/en/stable/docs/software/can-devices/can-addressing.html
+ *
+ * @param[in] busId        the bus id
+ * @param[in] manufacturer the can manufacturer
+ * @param[in] deviceId     the device ID (0-63)
+ * @param[in] deviceType   the device type
+ * @param[out] status      Error status variable. 0 on success.
+ * @return the created CAN handle
+ */
+HAL_CANHandle HAL_InitializeCAN2027(int32_t busId, HAL_CANManufacturer manufacturer,
+                                int32_t deviceId, HAL_CANDeviceType deviceType,
+                                int32_t* status);
+
+/**
+ * Frees a CAN device
+ *
+ * @param handle the CAN handle
+ */
+void HAL_CleanCAN2027(HAL_CANHandle handle);
+
+/**
+ * Writes a packet to the CAN device with a specific ID.
+ *
+ * This ID is 10 bits.
+ *
+ * @param[in] handle  the CAN handle
+ * @param[in] apiId   the ID to write (0-1023)
+ * @param[in] message the message
+ * @param[out] status Error status variable. 0 on success.
+ */
+void HAL_WriteCAN2027Packet(HAL_CANHandle handle, int32_t apiId,
+                        const struct HAL_CAN2027Message* message, int32_t* status);
+
+/**
+ * Writes a repeating packet to the CAN device with a specific ID.
+ *
+ * This ID is 10 bits.
+ *
+ * The device will automatically repeat the packet at the specified interval
+ *
+ * @param[in] handle   the CAN handle
+ * @param[in] apiId    the ID to write (0-1023)
+ * @param[in] message  the message
+ * @param[in] repeatMs the period to repeat in ms
+ * @param[out] status  Error status variable. 0 on success.
+ */
+void HAL_WriteCAN2027PacketRepeating(HAL_CANHandle handle, int32_t apiId,
+                                 const struct HAL_CAN2027Message* message,
+                                 int32_t repeatMs, int32_t* status);
+
+/**
+ * Writes an RTR frame of the specified length to the CAN device with the
+ * specific ID.
+ *
+ * By spec, the length must be equal to the length sent by the other device,
+ * otherwise behavior is unspecified.
+ *
+ * @param[in] handle   the CAN handle
+ * @param[in] apiId    the ID to write (0-1023)
+ * @param[in] message  the message
+ * @param[out] status  Error status variable. 0 on success.
+ */
+void HAL_WriteCAN2027RTRFrame(HAL_CANHandle handle, int32_t apiId,
+                          const struct HAL_CAN2027Message* message,
+                          int32_t* status);
+
+/**
+ * Stops a repeating packet with a specific ID.
+ *
+ * This ID is 10 bits.
+ *
+ * @param[in] handle  the CAN handle
+ * @param[in] apiId   the ID to stop repeating (0-1023)
+ * @param[out] status Error status variable. 0 on success.
+ */
+void HAL_StopCAN2027PacketRepeating(HAL_CANHandle handle, int32_t apiId,
+                                int32_t* status);
+
+/**
+ * Reads a new CAN packet.
+ *
+ * This will only return properly once per packet received. Multiple calls
+ * without receiving another packet will return an error code.
+ *
+ * @param[in] handle    the CAN handle
+ * @param[in] apiId     the ID to read (0-1023)
+ * @param[out] message  the message received.
+ * @param[out] status   Error status variable. 0 on success.
+ */
+void HAL_ReadCAN2027PacketNew(HAL_CANHandle handle, int32_t apiId,
+                          struct HAL_CAN2027ReceiveMessage* message,
+                          int32_t* status);
+
+/**
+ * Reads a CAN packet. The will continuously return the last packet received,
+ * without accounting for packet age.
+ *
+ * @param[in] handle    the CAN handle
+ * @param[in] apiId     the ID to read (0-1023)
+ * @param[out] message  the message received.
+ * @param[out] status   Error status variable. 0 on success.
+ */
+void HAL_ReadCAN2027PacketLatest(HAL_CANHandle handle, int32_t apiId,
+                             struct HAL_CAN2027ReceiveMessage* message,
+                             int32_t* status);
+
+/**
+ * Reads a CAN packet. The will return the last packet received until the
+ * packet is older then the requested timeout. Then it will return an error
+ * code.
+ *
+ * @param[in] handle        the CAN handle
+ * @param[in] apiId         the ID to read (0-1023)
+ * @param[out] message      the message received.
+ * @param[out] timeoutMs    the timeout time for the packet
+ * @param[out] status       Error status variable. 0 on success.
+ */
+void HAL_ReadCAN2027PacketTimeout(HAL_CANHandle handle, int32_t apiId,
+                              struct HAL_CAN2027ReceiveMessage* message,
+                              int32_t timeoutMs, int32_t* status);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+/** @} */

--- a/hal/src/main/native/include/hal/CAN2027APITypes.h
+++ b/hal/src/main/native/include/hal/CAN2027APITypes.h
@@ -1,0 +1,60 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <stdint.h>
+
+#include "hal/Types.h"
+
+/**
+ * Flag for sending a CAN message once.
+ */
+#define HAL_CAN2027_SEND_PERIOD_NO_REPEAT 0
+
+/**
+ * Flag for stopping periodic CAN message sends.
+ */
+#define HAL_CAN2027_SEND_PERIOD_STOP_REPEATING -1
+
+/**
+ * Mask for "is frame remote" in message ID.
+ */
+#define HAL_CAN2027_IS_FRAME_REMOTE 0x40000000
+
+/**
+ * Mask for "is frame 11 bits" in message ID.
+ */
+#define HAL_CAN2027_IS_FRAME_11BIT 0x80000000
+
+HAL_ENUM(HAL_CAN2027Flags) {
+  /** Placeholder for no flags */
+  HAL_CAN2027_NO_FLAGS = 0x0,
+  /**
+   * Mask for if frame will do FD bit rate switching.
+   * Only matters to send.
+   */
+  HAL_CAN2027_FD_BITRATESWITCH = 0x1,
+  /**
+   * Mask for is frame will contain an FD length.
+   */
+  HAL_CAN2027_FD_DATALENGTH = 0x2,
+};
+
+struct HAL_CAN2027Message {
+  /** Flags for the message (HAL_CANFlags) */
+  int32_t flags;
+  /** The size of the data received (0-64 bytes) */
+  uint8_t dataSize;
+  /** The message data */
+  uint8_t data[64];
+};
+
+struct HAL_CAN2027ReceiveMessage {
+  /** Receive timestamp (wpi time) */
+  uint64_t timeStamp;
+  /** The received message */
+  struct HAL_CAN2027Message message;
+};
+/** @} */

--- a/hal/src/main/native/sim/CAN2027.cpp
+++ b/hal/src/main/native/sim/CAN2027.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "hal/CAN2027.h"
+
+#include "hal/CAN.h"
+#include "hal/Errors.h"
+#include "mockdata/CanDataInternal.h"
+
+using namespace hal;
+
+extern "C" {
+
+void HAL_CAN2027_SendMessage(int32_t busId, uint32_t messageId,
+                             const struct HAL_CAN2027Message* message,
+                             int32_t periodMs, int32_t* status) {
+  if (busId != 0) {
+    *status = PARAMETER_OUT_OF_RANGE;
+    return;
+  }
+  if (message->flags != 0) {
+    *status = PARAMETER_OUT_OF_RANGE;
+    return;
+  }
+  SimCanData->sendMessage(messageId, message->data, message->dataSize, periodMs,
+                          status);
+}
+void HAL_CAN2027_ReceiveMessage(int32_t busId, uint32_t messageId,
+                                struct HAL_CAN2027ReceiveMessage* message,
+                                int32_t* status) {
+  if (busId != 0) {
+    *status = PARAMETER_OUT_OF_RANGE;
+    return;
+  }
+  // Use a data size of 42 as call check. Difficult to add check to invoke
+  // handler
+  message->message.dataSize = 42;
+  auto tmpStatus = *status;
+  uint32_t timeStamp = 0;
+  SimCanData->receiveMessage(&messageId, 0x1FFFFFFF, message->message.data,
+                             &message->message.dataSize, &timeStamp, status);
+  // If no handler invoked, return message not found
+  if (message->message.dataSize == 42 && *status == tmpStatus) {
+    message->message.dataSize = 0;
+    *status = HAL_ERR_CANSessionMux_MessageNotFound;
+  }
+  message->timeStamp = timeStamp * 1000;
+}
+HAL_CAN2027StreamHandle HAL_CAN2027_OpenStreamSession(int32_t busId,
+                                                      uint32_t messageId,
+                                                      uint32_t messageIDMask,
+                                                      uint32_t maxMessages,
+                                                      int32_t* status) {
+  if (busId != 0) {
+    *status = PARAMETER_OUT_OF_RANGE;
+    return HAL_kInvalidHandle;
+  }
+  uint32_t sessionHandle = 0;
+  SimCanData->openStreamSession(&sessionHandle, messageId, messageIDMask,
+                                maxMessages, status);
+  return sessionHandle;
+}
+void HAL_CAN2027_CloseStreamSession(HAL_CAN2027StreamHandle sessionHandle) {
+  SimCanData->closeStreamSession(sessionHandle);
+}
+void HAL_CAN2027_ReadStreamSession(HAL_CAN2027StreamHandle sessionHandle,
+                                   struct HAL_CAN2027StreamMessage* messages,
+                                   uint32_t messagesToRead,
+                                   uint32_t* messagesRead, int32_t* status) {
+  std::unique_ptr<HAL_CANStreamMessage[]> ncMessages =
+      std::make_unique<HAL_CANStreamMessage[]>(messagesToRead);
+  *messagesRead = 0;
+  SimCanData->readStreamSession(sessionHandle, ncMessages.get(), messagesToRead,
+                                messagesRead, status);
+  for (uint32_t i = 0; i < *messagesRead; i++) {
+    messages[i].messageId = ncMessages[i].messageID;
+    messages[i].message.timeStamp = ncMessages[i].timeStamp * 1000;
+    messages[i].message.message.dataSize = ncMessages[i].dataSize;
+    std::copy_n(ncMessages[i].data, ncMessages[i].dataSize,
+                messages[i].message.message.data);
+  }
+}
+void HAL_CAN_GetCAN2027Status(int32_t busId, float* percentBusUtilization,
+                              uint32_t* busOffCount, uint32_t* txFullCount,
+                              uint32_t* receiveErrorCount,
+                              uint32_t* transmitErrorCount, int32_t* status) {
+  if (busId != 0) {
+    *status = PARAMETER_OUT_OF_RANGE;
+    return;
+  }
+  SimCanData->getCANStatus(percentBusUtilization, busOffCount, txFullCount,
+                           receiveErrorCount, transmitErrorCount, status);
+}
+
+}  // extern "C"

--- a/hal/src/main/native/sim/CANAPI2027.cpp
+++ b/hal/src/main/native/sim/CANAPI2027.cpp
@@ -1,0 +1,263 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "hal/CAN2027API.h"
+
+#include <ctime>
+#include <memory>
+
+#include <wpi/DenseMap.h>
+#include <wpi/mutex.h>
+#include <wpi/timestamp.h>
+
+#include "HALInitializer.h"
+#include "PortsInternal.h"
+#include "hal/CAN2027.h"
+#include "hal/Errors.h"
+#include "hal/handles/UnlimitedHandleResource.h"
+
+using namespace hal;
+
+namespace {
+struct CANStorage {
+  HAL_CANManufacturer manufacturer;
+  HAL_CANDeviceType deviceType;
+  int32_t busId;
+  uint8_t deviceId;
+  wpi::mutex periodicSendsMutex;
+  wpi::SmallDenseMap<int32_t, int32_t> periodicSends;
+  wpi::mutex receivesMutex;
+  wpi::SmallDenseMap<int32_t, HAL_CAN2027ReceiveMessage> receives;
+};
+}  // namespace
+
+static UnlimitedHandleResource<HAL_CANHandle, CANStorage, HAL_HandleEnum::CAN>*
+    canHandles;
+
+namespace hal::init {
+void InitializeCAN2027API() {
+  static UnlimitedHandleResource<HAL_CANHandle, CANStorage, HAL_HandleEnum::CAN>
+      cH;
+  canHandles = &cH;
+}
+}  // namespace hal::init
+
+static int32_t CreateCANId(CANStorage* storage, int32_t apiId) {
+  int32_t createdId = 0;
+  createdId |= (static_cast<int32_t>(storage->deviceType) & 0x1F) << 24;
+  createdId |= (static_cast<int32_t>(storage->manufacturer) & 0xFF) << 16;
+  createdId |= (apiId & 0x3FF) << 6;
+  createdId |= (storage->deviceId & 0x3F);
+  return createdId;
+}
+
+extern "C" {
+
+HAL_CANHandle HAL_InitializeCAN2027(int32_t busId, HAL_CANManufacturer manufacturer,
+                                int32_t deviceId, HAL_CANDeviceType deviceType,
+                                int32_t* status) {
+  hal::init::CheckInit();
+
+  if (busId != 0) {
+    *status = PARAMETER_OUT_OF_RANGE;
+    return HAL_kInvalidHandle;
+  }
+
+  auto can = std::make_shared<CANStorage>();
+
+  auto handle = canHandles->Allocate(can);
+
+  if (handle == HAL_kInvalidHandle) {
+    *status = NO_AVAILABLE_RESOURCES;
+    return HAL_kInvalidHandle;
+  }
+
+  can->busId = busId;
+  can->deviceId = deviceId;
+  can->deviceType = deviceType;
+  can->manufacturer = manufacturer;
+
+  return handle;
+}
+
+void HAL_CleanCAN2027(HAL_CANHandle handle) {
+  auto data = canHandles->Free(handle);
+  if (data == nullptr) {
+    return;
+  }
+
+  std::scoped_lock lock(data->periodicSendsMutex);
+
+  for (auto&& i : data->periodicSends) {
+    int32_t s = 0;
+    auto id = CreateCANId(data.get(), i.first);
+    HAL_CAN2027Message message;
+    std::memset(&message, 0, sizeof(message));
+    HAL_CAN2027_SendMessage(data->busId, id, &message,
+                        HAL_CAN2027_SEND_PERIOD_STOP_REPEATING, &s);
+    i.second = -1;
+  }
+}
+
+void HAL_WriteCAN2027Packet(HAL_CANHandle handle, int32_t apiId,
+                        const struct HAL_CAN2027Message* message, int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return;
+  }
+  auto id = CreateCANId(can.get(), apiId);
+
+  std::scoped_lock lock(can->periodicSendsMutex);
+  HAL_CAN2027_SendMessage(can->busId, id, message, HAL_CAN2027_SEND_PERIOD_NO_REPEAT,
+                      status);
+  can->periodicSends[apiId] = -1;
+}
+
+void HAL_WriteCAN2027PacketRepeating(HAL_CANHandle handle, int32_t apiId,
+                                 const struct HAL_CAN2027Message* message,
+                                 int32_t repeatMs, int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return;
+  }
+  auto id = CreateCANId(can.get(), apiId);
+
+  std::scoped_lock lock(can->periodicSendsMutex);
+  HAL_CAN2027_SendMessage(can->busId, id, message, repeatMs, status);
+  can->periodicSends[apiId] = repeatMs;
+}
+
+void HAL_WriteCAN2027RTRFrame(HAL_CANHandle handle, int32_t apiId,
+                          const struct HAL_CAN2027Message* message,
+                          int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return;
+  }
+  auto id = CreateCANId(can.get(), apiId);
+  id |= HAL_CAN2027_IS_FRAME_REMOTE;
+
+  std::scoped_lock lock(can->periodicSendsMutex);
+  HAL_CAN2027_SendMessage(can->busId, id, message, HAL_CAN2027_SEND_PERIOD_NO_REPEAT,
+                      status);
+  can->periodicSends[apiId] = -1;
+}
+
+void HAL_StopCAN2027PacketRepeating(HAL_CANHandle handle, int32_t apiId,
+                                int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return;
+  }
+  auto id = CreateCANId(can.get(), apiId);
+
+  HAL_CAN2027Message message;
+  std::memset(&message, 0, sizeof(message));
+
+  std::scoped_lock lock(can->periodicSendsMutex);
+  HAL_CAN2027_SendMessage(can->busId, id, &message,
+                      HAL_CAN2027_SEND_PERIOD_STOP_REPEATING, status);
+  can->periodicSends[apiId] = -1;
+}
+
+void HAL_ReadCAN2027PacketNew(HAL_CANHandle handle, int32_t apiId,
+                          struct HAL_CAN2027ReceiveMessage* message,
+                          int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return;
+  }
+
+  uint32_t messageId = CreateCANId(can.get(), apiId);
+
+  HAL_CAN2027_ReceiveMessage(can->busId, messageId, message, status);
+
+  if (*status == 0) {
+    std::scoped_lock lock(can->receivesMutex);
+    can->receives[messageId] = *message;
+  }
+}
+
+void HAL_ReadCAN2027PacketLatest(HAL_CANHandle handle, int32_t apiId,
+                             struct HAL_CAN2027ReceiveMessage* message,
+                             int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return;
+  }
+
+  uint32_t messageId = CreateCANId(can.get(), apiId);
+
+  HAL_CAN2027_ReceiveMessage(can->busId, messageId, message, status);
+
+  std::scoped_lock lock(can->receivesMutex);
+  if (*status == 0) {
+    // fresh update
+    can->receives[messageId] = *message;
+  } else {
+    auto i = can->receives.find(messageId);
+    if (i != can->receives.end()) {
+      // Read the data from the stored message into the output
+      *message = i->second;
+      *status = 0;
+    }
+  }
+}
+
+void HAL_ReadCAN2027PacketTimeout(HAL_CANHandle handle, int32_t apiId,
+                              struct HAL_CAN2027ReceiveMessage* message,
+                              int32_t timeoutMs, int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return;
+  }
+
+  uint32_t messageId = CreateCANId(can.get(), apiId);
+
+  HAL_CAN2027_ReceiveMessage(can->busId, messageId, message, status);
+
+  std::scoped_lock lock(can->receivesMutex);
+  if (*status == 0) {
+    // fresh update
+    can->receives[messageId] = *message;
+  } else {
+    auto i = can->receives.find(messageId);
+    if (i != can->receives.end()) {
+      // Found, check if new enough
+      uint64_t now = wpi::Now();
+      if (now - i->second.timeStamp >
+          (static_cast<uint64_t>(timeoutMs) * 1000)) {
+        // Timeout, return bad status
+        *status = HAL_CAN_TIMEOUT;
+        return;
+      }
+      // Read the data from the stored message into the output
+      *message = i->second;
+      *status = 0;
+    }
+  }
+}
+
+uint32_t HAL_StartCAN2027Stream(HAL_CANHandle handle, int32_t apiId, int32_t depth,
+                            int32_t* status) {
+  auto can = canHandles->Get(handle);
+  if (!can) {
+    *status = HAL_HANDLE_ERROR;
+    return 0;
+  }
+
+  uint32_t messageId = CreateCANId(can.get(), apiId);
+
+  uint32_t session = HAL_CAN2027_OpenStreamSession(can->busId, messageId,
+                                               0x1FFFFFFF, depth, status);
+  return session;
+}
+}  // extern "C"

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -74,6 +74,7 @@ void InitializeHAL() {
   InitializeAnalogTriggerData();
   InitializeCanData();
   InitializeCANAPI();
+  InitializeCAN2027API();
   InitializeDigitalPWMData();
   InitializeDutyCycleData();
   InitializeDIOData();

--- a/hal/src/main/native/sim/HALInitializer.h
+++ b/hal/src/main/native/sim/HALInitializer.h
@@ -24,6 +24,7 @@ extern void InitializeAnalogOutData();
 extern void InitializeAnalogTriggerData();
 extern void InitializeCanData();
 extern void InitializeCANAPI();
+extern void InitializeCAN2027API();
 extern void InitializeDigitalPWMData();
 extern void InitializeDutyCycleData();
 extern void InitializeDIOData();


### PR DESCRIPTION
This way if vendors want to use the new API, they can.

While I was doing this, I was wondering if we should just completely replace the API in 2026, instead of duplicating it? I'll leave that open to this PR. Its easy enough to switch to that if we want.