### PR TITLE
[glass] Fix compilation errors from C++23 Clang

### DIFF
--- a/glass/src/libnt/native/cpp/NTMechanism2D.cpp
+++ b/glass/src/libnt/native/cpp/NTMechanism2D.cpp
@@ -30,80 +30,15 @@ static void ConvertColor(std::string_view in, ImU32* out) {
   }
 }
 
-namespace {
-
-class NTMechanismObjectModel;
-
-class NTMechanismGroupImpl final {
- public:
-  NTMechanismGroupImpl(nt::NetworkTableInstance inst, std::string_view path,
-                       std::string_view name)
-      : m_inst{inst}, m_path{path}, m_name{name} {}
-
-  const char* GetName() const { return m_name.c_str(); }
-  void ForEachObject(wpi::function_ref<void(MechanismObjectModel& model)> func);
-
-  void NTUpdate(const nt::Event& event, std::string_view name);
-
- protected:
-  nt::NetworkTableInstance m_inst;
-  std::string m_path;
-  std::string m_name;
-  std::vector<std::unique_ptr<NTMechanismObjectModel>> m_objects;
-};
-
-class NTMechanismObjectModel final : public MechanismObjectModel {
- public:
-  NTMechanismObjectModel(nt::NetworkTableInstance inst, std::string_view path,
-                         std::string_view name)
-      : m_group{inst, path, name},
-        m_typeTopic{inst.GetTopic(fmt::format("{}/.type", path))},
-        m_colorTopic{inst.GetTopic(fmt::format("{}/color", path))},
-        m_weightTopic{inst.GetTopic(fmt::format("{}/weight", path))},
-        m_angleTopic{inst.GetTopic(fmt::format("{}/angle", path))},
-        m_lengthTopic{inst.GetTopic(fmt::format("{}/length", path))} {}
-
-  const char* GetName() const final { return m_group.GetName(); }
-  void ForEachObject(
-      wpi::function_ref<void(MechanismObjectModel& model)> func) final {
-    m_group.ForEachObject(func);
-  }
-
-  const char* GetType() const final { return m_typeValue.c_str(); }
-  ImU32 GetColor() const final { return m_colorValue; }
-  double GetWeight() const final { return m_weightValue; }
-  frc::Rotation2d GetAngle() const final { return m_angleValue; }
-  units::meter_t GetLength() const final { return m_lengthValue; }
-
-  bool NTUpdate(const nt::Event& event, std::string_view name);
-
- private:
-  NTMechanismGroupImpl m_group;
-
-  nt::Topic m_typeTopic;
-  nt::Topic m_colorTopic;
-  nt::Topic m_weightTopic;
-  nt::Topic m_angleTopic;
-  nt::Topic m_lengthTopic;
-
-  std::string m_typeValue;
-  ImU32 m_colorValue = IM_COL32_WHITE;
-  double m_weightValue = 1.0;
-  frc::Rotation2d m_angleValue;
-  units::meter_t m_lengthValue = 0.0_m;
-};
-
-}  // namespace
-
-void NTMechanismGroupImpl::ForEachObject(
+void NTMechanism2DModel::NTMechanismGroupImpl::ForEachObject(
     wpi::function_ref<void(MechanismObjectModel& model)> func) {
   for (auto&& obj : m_objects) {
     func(*obj);
   }
 }
 
-void NTMechanismGroupImpl::NTUpdate(const nt::Event& event,
-                                    std::string_view name) {
+void NTMechanism2DModel::NTMechanismGroupImpl::NTUpdate(const nt::Event& event,
+                                                        std::string_view name) {
   if (name.empty()) {
     return;
   }
@@ -140,8 +75,8 @@ void NTMechanismGroupImpl::NTUpdate(const nt::Event& event,
   }
 }
 
-bool NTMechanismObjectModel::NTUpdate(const nt::Event& event,
-                                      std::string_view childName) {
+bool NTMechanism2DModel::NTMechanismObjectModel::NTUpdate(
+    const nt::Event& event, std::string_view childName) {
   if (auto info = event.GetTopicInfo()) {
     if (info->topic == m_typeTopic.GetHandle()) {
       if (event.flags & nt::EventFlags::kUnpublish) {
@@ -180,31 +115,6 @@ bool NTMechanismObjectModel::NTUpdate(const nt::Event& event,
   }
   return false;
 }
-
-class NTMechanism2DModel::RootModel final : public MechanismRootModel {
- public:
-  RootModel(nt::NetworkTableInstance inst, std::string_view path,
-            std::string_view name)
-      : m_group{inst, path, name},
-        m_xTopic{inst.GetTopic(fmt::format("{}/x", path))},
-        m_yTopic{inst.GetTopic(fmt::format("{}/y", path))} {}
-
-  const char* GetName() const final { return m_group.GetName(); }
-  void ForEachObject(
-      wpi::function_ref<void(MechanismObjectModel& model)> func) final {
-    m_group.ForEachObject(func);
-  }
-
-  bool NTUpdate(const nt::Event& event, std::string_view childName);
-
-  frc::Translation2d GetPosition() const override { return m_pos; };
-
- private:
-  NTMechanismGroupImpl m_group;
-  nt::Topic m_xTopic;
-  nt::Topic m_yTopic;
-  frc::Translation2d m_pos;
-};
 
 bool NTMechanism2DModel::RootModel::NTUpdate(const nt::Event& event,
                                              std::string_view childName) {

--- a/glass/src/libnt/native/include/glass/networktables/NTMechanism2D.h
+++ b/glass/src/libnt/native/include/glass/networktables/NTMechanism2D.h
@@ -55,7 +55,92 @@ class NTMechanism2DModel : public Mechanism2DModel {
   frc::Translation2d m_dimensionsValue;
   ImU32 m_bgColorValue = 0;
 
-  class RootModel;
+  class NTMechanismObjectModel;
+  class NTMechanismGroupImpl final {
+   public:
+    NTMechanismGroupImpl(nt::NetworkTableInstance inst, std::string_view path,
+                         std::string_view name)
+        : m_inst{inst}, m_path{path}, m_name{name} {}
+
+    const char* GetName() const { return m_name.c_str(); }
+    void ForEachObject(
+        wpi::function_ref<void(MechanismObjectModel& model)> func);
+
+    void NTUpdate(const nt::Event& event, std::string_view name);
+
+   protected:
+    nt::NetworkTableInstance m_inst;
+    std::string m_path;
+    std::string m_name;
+    std::vector<std::unique_ptr<NTMechanismObjectModel>> m_objects;
+  };
+
+  class NTMechanismObjectModel final : public MechanismObjectModel {
+   public:
+    NTMechanismObjectModel(nt::NetworkTableInstance inst, std::string_view path,
+                           std::string_view name)
+        : m_group{inst, path, name},
+          m_typeTopic{inst.GetTopic(fmt::format("{}/.type", path))},
+          m_colorTopic{inst.GetTopic(fmt::format("{}/color", path))},
+          m_weightTopic{inst.GetTopic(fmt::format("{}/weight", path))},
+          m_angleTopic{inst.GetTopic(fmt::format("{}/angle", path))},
+          m_lengthTopic{inst.GetTopic(fmt::format("{}/length", path))} {}
+
+    const char* GetName() const final { return m_group.GetName(); }
+    void ForEachObject(
+        wpi::function_ref<void(MechanismObjectModel& model)> func) final {
+      m_group.ForEachObject(func);
+    }
+
+    const char* GetType() const final { return m_typeValue.c_str(); }
+    ImU32 GetColor() const final { return m_colorValue; }
+    double GetWeight() const final { return m_weightValue; }
+    frc::Rotation2d GetAngle() const final { return m_angleValue; }
+    units::meter_t GetLength() const final { return m_lengthValue; }
+
+    bool NTUpdate(const nt::Event& event, std::string_view name);
+
+   private:
+    NTMechanismGroupImpl m_group;
+
+    nt::Topic m_typeTopic;
+    nt::Topic m_colorTopic;
+    nt::Topic m_weightTopic;
+    nt::Topic m_angleTopic;
+    nt::Topic m_lengthTopic;
+
+    std::string m_typeValue;
+    ImU32 m_colorValue = IM_COL32_WHITE;
+    double m_weightValue = 1.0;
+    frc::Rotation2d m_angleValue;
+    units::meter_t m_lengthValue = 0.0_m;
+  };
+
+  class RootModel final : public MechanismRootModel {
+   public:
+    RootModel(nt::NetworkTableInstance inst, std::string_view path,
+              std::string_view name)
+        : m_group{inst, path, name},
+          m_xTopic{inst.GetTopic(fmt::format("{}/x", path))},
+          m_yTopic{inst.GetTopic(fmt::format("{}/y", path))} {}
+
+    const char* GetName() const final { return m_group.GetName(); }
+    void ForEachObject(
+        wpi::function_ref<void(MechanismObjectModel& model)> func) final {
+      m_group.ForEachObject(func);
+    }
+
+    bool NTUpdate(const nt::Event& event, std::string_view childName);
+
+    frc::Translation2d GetPosition() const override { return m_pos; };
+
+   private:
+    NTMechanismGroupImpl m_group;
+    nt::Topic m_xTopic;
+    nt::Topic m_yTopic;
+    frc::Translation2d m_pos;
+  };
+
   std::vector<std::unique_ptr<RootModel>> m_roots;
 };
 


### PR DESCRIPTION
```
In file included from /Users/runner/work/allwpilib/allwpilib/glass/src/libnt/native/cpp/NTMechanism2D.cpp:5:
In file included from /Users/runner/work/allwpilib/allwpilib/glass/src/libnt/native/include/glass/networktables/NTMechanism2D.h:7:
In file included from /Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/memory:898:
In file included from /Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/shared_ptr.h:31:
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/unique_ptr.h:66:19: error: invalid application of 'sizeof' to an incomplete type '(anonymous namespace)::NTMechanismObjectModel'
    static_assert(sizeof(_Tp) >= 0, "cannot delete an incomplete type");
                  ^~~~~~~~~~~
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/unique_ptr.h:300:7: note: in instantiation of member function 'std::default_delete<(anonymous namespace)::NTMechanismObjectModel>::operator()' requested here
      __ptr_.second()(__tmp);
      ^
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/unique_ptr.h:266:75: note: in instantiation of member function 'std::unique_ptr<(anonymous namespace)::NTMechanismObjectModel>::reset' requested here
  _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_SINCE_CXX23 ~unique_ptr() { reset(); }
                                                                          ^
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/construct_at.h:69:13: note: in instantiation of member function 'std::unique_ptr<(anonymous namespace)::NTMechanismObjectModel>::~unique_ptr' requested here
    __loc->~_Tp();
            ^
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/construct_at.h:104:10: note: in instantiation of function template specialization 'std::__destroy_at<std::unique_ptr<(anonymous namespace)::NTMechanismObjectModel>, 0>' requested here
    std::__destroy_at(__loc);
         ^
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/allocator_traits.h:323:16: note: in instantiation of function template specialization 'std::destroy_at<std::unique_ptr<(anonymous namespace)::NTMechanismObjectModel>, 0>' requested here
        _VSTD::destroy_at(__p);
               ^
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/vector:944:25: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<std::unique_ptr<(anonymous namespace)::NTMechanismObjectModel>>>::destroy<std::unique_ptr<(anonymous namespace)::NTMechanismObjectModel>, void, void>' requested here
        __alloc_traits::destroy(__alloc(), std::__to_address(--__soon_to_be_end));
                        ^
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/vector:938:29: note: in instantiation of member function 'std::vector<std::unique_ptr<(anonymous namespace)::NTMechanismObjectModel>>::__base_destruct_at_end' requested here
  void __clear() _NOEXCEPT {__base_destruct_at_end(this->__begin_);}
                            ^
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/vector:489:20: note: in instantiation of member function 'std::vector<std::unique_ptr<(anonymous namespace)::NTMechanismObjectModel>>::__clear' requested here
            __vec_.__clear();
                   ^
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/vector:500:67: note: in instantiation of member function 'std::vector<std::unique_ptr<(anonymous namespace)::NTMechanismObjectModel>>::__destroy_vector::operator()' requested here
  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI ~vector() { __destroy_vector(*this)(); }
                                                                  ^
/Users/runner/work/allwpilib/allwpilib/glass/src/libnt/native/cpp/NTMechanism2D.cpp:39:3: note: in instantiation of member function 'std::vector<std::unique_ptr<(anonymous namespace)::NTMechanismObjectModel>>::~vector' requested here
  NTMechanismGroupImpl(nt::NetworkTableInstance inst, std::string_view path,
  ^
/Users/runner/work/allwpilib/allwpilib/glass/src/libnt/native/cpp/NTMechanism2D.cpp:35:7: note: forward declaration of '(anonymous namespace)::NTMechanismObjectModel'
class NTMechanismObjectModel;
      ^
```

Explicitly declaring NTMechanismObjectModel's destructor fixes this specific error, but I get errors for RootModel from other .cpp files like StandardNetworkTables.cpp as well.
```
In file included from /home/tav/frc/wpilib/allwpilib/glass/src/libnt/native/cpp/StandardNetworkTables.cpp:5:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.1.1/../../../../include/c++/15.1.1/memory:80:
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.1.1/../../../../include/c++/15.1.1/bits/unique_ptr.h:91:16: error: invalid application of 'sizeof' to an incomplete type 'glass::NTMechanism2DModel::RootModel'
   91 |         static_assert(sizeof(_Tp)>0,
      |                       ^~~~~~~~~~~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.1.1/../../../../include/c++/15.1.1/bits/unique_ptr.h:399:4: note: in instantiation of member function 'std::default_delete<glass::NTMechanism2DModel::RootModel>::operator()' requested here
  399 |           get_deleter()(std::move(__ptr));
      |           ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.1.1/../../../../include/c++/15.1.1/bits/stl_construct.h:88:15: note: in instantiation of member function 'std::unique_ptr<glass::NTMechanism2DModel::RootModel>::~unique_ptr' requested here
   88 |         __location->~_Tp();
      |                      ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.1.1/../../../../include/c++/15.1.1/bits/stl_construct.h:164:12: note: in instantiation of function template specialization 'std::destroy_at<std::unique_ptr<glass::NTMechanism2DModel::RootModel>>' requested here
  164 |       std::destroy_at(__pointer);
      |            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.1.1/../../../../include/c++/15.1.1/bits/stl_construct.h:212:9: note: in instantiation of function template specialization 'std::_Destroy<std::unique_ptr<glass::NTMechanism2DModel::RootModel>>' requested here
  212 |           std::_Destroy(std::__addressof(*__first));
      |                ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.1.1/../../../../include/c++/15.1.1/bits/alloc_traits.h:1045:12: note: in instantiation of function template specialization 'std::_Destroy<std::unique_ptr<glass::NTMechanism2DModel::RootModel> *>' requested here
 1045 |       std::_Destroy(__first, __last);
      |            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.1.1/../../../../include/c++/15.1.1/bits/stl_vector.h:802:7: note: in instantiation of function template specialization 'std::_Destroy<std::unique_ptr<glass::NTMechanism2DModel::RootModel> *, std::unique_ptr<glass::NTMechanism2DModel::RootModel>>' requested here
  802 |         std::_Destroy(this->_M_impl._M_start, this->_M_impl._M_finish,
      |              ^
/home/tav/frc/wpilib/allwpilib/glass/src/libnt/native/include/glass/networktables/NTMechanism2D.h:29:3: note: in instantiation of member function 'std::vector<std::unique_ptr<glass::NTMechanism2DModel::RootModel>>::~vector' requested here
   29 |   ~NTMechanism2DModel() override {}
      |   ^
/home/tav/frc/wpilib/allwpilib/glass/src/libnt/native/include/glass/networktables/NTMechanism2D.h:58:9: note: forward declaration of 'glass::NTMechanism2DModel::RootModel'
   58 |   class RootModel;
      |         ^
```