### PR TITLE
[wpimath] Add copySignPow to MathUtil for joystick input shaping

### DIFF
--- a/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp
+++ b/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp
@@ -115,8 +115,8 @@ DifferentialDrive::WheelSpeeds DifferentialDrive::ArcadeDriveIK(
   // Square the inputs (while preserving the sign) to increase fine control
   // while permitting full power.
   if (squareInputs) {
-    xSpeed = CopysignPow(xSpeed, 2);
-    zRotation = CopysignPow(zRotation, 2);
+    xSpeed = CopySignPow(xSpeed, 2);
+    zRotation = CopySignPow(zRotation, 2);
   }
 
   double leftSpeed = xSpeed - zRotation;
@@ -170,8 +170,8 @@ DifferentialDrive::WheelSpeeds DifferentialDrive::TankDriveIK(
   // Square the inputs (while preserving the sign) to increase fine control
   // while permitting full power.
   if (squareInputs) {
-    leftSpeed = CopysignPow(leftSpeed, 2);
-    rightSpeed = CopysignPow(rightSpeed, 2);
+    leftSpeed = CopySignPow(leftSpeed, 2);
+    rightSpeed = CopySignPow(rightSpeed, 2);
   }
 
   return {leftSpeed, rightSpeed};

--- a/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp
+++ b/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp
@@ -115,8 +115,8 @@ DifferentialDrive::WheelSpeeds DifferentialDrive::ArcadeDriveIK(
   // Square the inputs (while preserving the sign) to increase fine control
   // while permitting full power.
   if (squareInputs) {
-    xSpeed = std::copysign(xSpeed * xSpeed, xSpeed);
-    zRotation = std::copysign(zRotation * zRotation, zRotation);
+    xSpeed = ApplyPowerCurve(xSpeed, 2);
+    zRotation = ApplyPowerCurve(zRotation, 2);
   }
 
   double leftSpeed = xSpeed - zRotation;
@@ -170,8 +170,8 @@ DifferentialDrive::WheelSpeeds DifferentialDrive::TankDriveIK(
   // Square the inputs (while preserving the sign) to increase fine control
   // while permitting full power.
   if (squareInputs) {
-    leftSpeed = std::copysign(leftSpeed * leftSpeed, leftSpeed);
-    rightSpeed = std::copysign(rightSpeed * rightSpeed, rightSpeed);
+    leftSpeed = ApplyPowerCurve(leftSpeed, 2);
+    rightSpeed = ApplyPowerCurve(rightSpeed, 2);
   }
 
   return {leftSpeed, rightSpeed};

--- a/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp
+++ b/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp
@@ -115,8 +115,8 @@ DifferentialDrive::WheelSpeeds DifferentialDrive::ArcadeDriveIK(
   // Square the inputs (while preserving the sign) to increase fine control
   // while permitting full power.
   if (squareInputs) {
-    xSpeed = ApplyPowerCurve(xSpeed, 2);
-    zRotation = ApplyPowerCurve(zRotation, 2);
+    xSpeed = CopysignPow(xSpeed, 2);
+    zRotation = CopysignPow(zRotation, 2);
   }
 
   double leftSpeed = xSpeed - zRotation;
@@ -170,8 +170,8 @@ DifferentialDrive::WheelSpeeds DifferentialDrive::TankDriveIK(
   // Square the inputs (while preserving the sign) to increase fine control
   // while permitting full power.
   if (squareInputs) {
-    leftSpeed = ApplyPowerCurve(leftSpeed, 2);
-    rightSpeed = ApplyPowerCurve(rightSpeed, 2);
+    leftSpeed = CopysignPow(leftSpeed, 2);
+    rightSpeed = CopysignPow(rightSpeed, 2);
   }
 
   return {leftSpeed, rightSpeed};

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -265,8 +265,8 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
     // Square the inputs (while preserving the sign) to increase fine control
     // while permitting full power.
     if (squareInputs) {
-      xSpeed = MathUtil.copysignPow(xSpeed, 2);
-      zRotation = MathUtil.copysignPow(zRotation, 2);
+      xSpeed = MathUtil.copySignPow(xSpeed, 2);
+      zRotation = MathUtil.copySignPow(zRotation, 2);
     }
 
     double leftSpeed = xSpeed - zRotation;
@@ -340,8 +340,8 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
     // Square the inputs (while preserving the sign) to increase fine control
     // while permitting full power.
     if (squareInputs) {
-      leftSpeed = MathUtil.copysignPow(leftSpeed, 2);
-      rightSpeed = MathUtil.copysignPow(rightSpeed, 2);
+      leftSpeed = MathUtil.copySignPow(leftSpeed, 2);
+      rightSpeed = MathUtil.copySignPow(rightSpeed, 2);
     }
 
     return new WheelSpeeds(leftSpeed, rightSpeed);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -265,8 +265,8 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
     // Square the inputs (while preserving the sign) to increase fine control
     // while permitting full power.
     if (squareInputs) {
-      xSpeed = MathUtil.applyPowerCurve(xSpeed, 2);
-      zRotation = MathUtil.applyPowerCurve(zRotation, 2);
+      xSpeed = MathUtil.copysignPow(xSpeed, 2);
+      zRotation = MathUtil.copysignPow(zRotation, 2);
     }
 
     double leftSpeed = xSpeed - zRotation;
@@ -340,8 +340,8 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
     // Square the inputs (while preserving the sign) to increase fine control
     // while permitting full power.
     if (squareInputs) {
-      leftSpeed = MathUtil.applyPowerCurve(leftSpeed, 2);
-      rightSpeed = MathUtil.applyPowerCurve(rightSpeed, 2);
+      leftSpeed = MathUtil.copysignPow(leftSpeed, 2);
+      rightSpeed = MathUtil.copysignPow(rightSpeed, 2);
     }
 
     return new WheelSpeeds(leftSpeed, rightSpeed);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -265,8 +265,8 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
     // Square the inputs (while preserving the sign) to increase fine control
     // while permitting full power.
     if (squareInputs) {
-      xSpeed = Math.copySign(xSpeed * xSpeed, xSpeed);
-      zRotation = Math.copySign(zRotation * zRotation, zRotation);
+      xSpeed = MathUtil.applyPowerCurve(xSpeed, 2);
+      zRotation = MathUtil.applyPowerCurve(zRotation, 2);
     }
 
     double leftSpeed = xSpeed - zRotation;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -340,8 +340,8 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
     // Square the inputs (while preserving the sign) to increase fine control
     // while permitting full power.
     if (squareInputs) {
-      leftSpeed = Math.copySign(leftSpeed * leftSpeed, leftSpeed);
-      rightSpeed = Math.copySign(rightSpeed * rightSpeed, rightSpeed);
+      leftSpeed = MathUtil.applyPowerCurve(leftSpeed, 2);
+      rightSpeed = MathUtil.applyPowerCurve(rightSpeed, 2);
     }
 
     return new WheelSpeeds(leftSpeed, rightSpeed);

--- a/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
@@ -124,7 +124,7 @@ public final class MathUtil {
    * @param maxMagnitude The maximum expected absolute value of input. Must be positive.
    * @return The transformed value with the same sign and scaled to the input range.
    */
-  public static double applyPowerCurve(double value, double exponent, double maxMagnitude) {
+  public static double copysignPow(double value, double exponent, double maxMagnitude) {
     return Math.copySign(Math.pow(Math.abs(value) / maxMagnitude, exponent), value) * maxMagnitude;
   }
 
@@ -138,8 +138,8 @@ public final class MathUtil {
    * @param exponent The exponent to apply.
    * @return The transformed value with the same sign.
    */
-  public static double applyPowerCurve(double value, double exponent) {
-    return applyPowerCurve(value, exponent, 1);
+  public static double copysignPow(double value, double exponent) {
+    return copysignPow(value, exponent, 1);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
@@ -108,16 +108,19 @@ public final class MathUtil {
   }
 
   /**
-   * Applies a power curve to the input value while preserving its sign. The input is first
-   * normalized to the range [-1, 1] from [-maxMagnitude, maxMagnitude], then raised to the given
-   * exponent, and finally rescaled to the original magnitude range. The value stays within
-   * [-maxMagnitude, maxMagnitude].
+   * Applies a power curve transformation to the input value, preserving its sign.
+   *
+   * <p>The function normalizes the input value to the range [0, 1] based on the maximum magnitude,
+   * applies the power transformation, then scales the result back to the original range. This keeps
+   * the value in the original range and gives consistent curve behavior regardless of the input
+   * value's scale.
    *
    * <p>This is useful for applying smoother or more aggressive control response curves (e.g.
    * joystick input shaping).
    *
    * @param value The input value to transform.
-   * @param exponent The exponent to apply (1.0 = linear, 2.0 = squared curve). Must be positive.
+   * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared curve). Must be
+   *     positive.
    * @param maxMagnitude The maximum expected absolute value of input. Must be positive.
    * @return The transformed value with the same sign and scaled to the input range.
    */
@@ -126,7 +129,10 @@ public final class MathUtil {
   }
 
   /**
-   * Applies a power curve to the input value while preserving its sign.
+   * Raises the input to the power of exponent while preserving its sign.
+   *
+   * <p>This is useful for applying smoother or more aggressive control response curves (e.g.
+   * joystick input shaping).
    *
    * @param value The input value to transform.
    * @param exponent The exponent to apply.

--- a/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
@@ -119,7 +119,7 @@ public final class MathUtil {
    * @param maxMagnitude The maximum expected absolute value of input. Must be positive.
    * @return The transformed value with the same sign and scaled to the input range.
    */
-  public static double copysignPow(double value, double exponent, double maxMagnitude) {
+  public static double copySignPow(double value, double exponent, double maxMagnitude) {
     return Math.copySign(Math.pow(Math.abs(value) / maxMagnitude, exponent), value) * maxMagnitude;
   }
 
@@ -132,8 +132,8 @@ public final class MathUtil {
    * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared curve). Must be positive.
    * @return The transformed value with the same sign.
    */
-  public static double copysignPow(double value, double exponent) {
-    return copysignPow(value, exponent, 1);
+  public static double copySignPow(double value, double exponent) {
+    return copySignPow(value, exponent, 1);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
@@ -110,12 +110,17 @@ public final class MathUtil {
   /**
    * Raises the input to the power of the given exponent while preserving its sign.
    *
-   * <p>The function normalizes the input value to the range [0, 1] based on the maximum magnitude, raises it to the power of the exponent, then scales the result back to the original range and copying the sign. This keeps the value in the original range and gives consistent curve behavior regardless of the input value's scale.
+   * <p>The function normalizes the input value to the range [0, 1] based on the maximum magnitude,
+   * raises it to the power of the exponent, then scales the result back to the original range and
+   * copying the sign. This keeps the value in the original range and gives consistent curve
+   * behavior regardless of the input value's scale.
    *
-   * <p>This is useful for applying smoother or more aggressive control response curves (e.g. joystick input shaping).
+   * <p>This is useful for applying smoother or more aggressive control response curves (e.g.
+   * joystick input shaping).
    *
    * @param value The input value to transform.
-   * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared curve). Must be positive.
+   * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared curve). Must be
+   *     positive.
    * @param maxMagnitude The maximum expected absolute value of input. Must be positive.
    * @return The transformed value with the same sign and scaled to the input range.
    */
@@ -126,10 +131,12 @@ public final class MathUtil {
   /**
    * Raises the input to the power of the given exponent while preserving its sign.
    *
-   * <p>This is useful for applying smoother or more aggressive control response curves (e.g. joystick input shaping).
+   * <p>This is useful for applying smoother or more aggressive control response curves (e.g.
+   * joystick input shaping).
    *
    * @param value The input value to transform.
-   * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared curve). Must be positive.
+   * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared curve). Must be
+   *     positive.
    * @return The transformed value with the same sign.
    */
   public static double copySignPow(double value, double exponent) {

--- a/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
@@ -108,6 +108,35 @@ public final class MathUtil {
   }
 
   /**
+   * Applies a power curve to the input value while preserving its sign. The input is first
+   * normalized to the range [-1, 1] from [-maxMagnitude, maxMagnitude], then raised to the given
+   * exponent, and finally rescaled to the original magnitude range. The value stays within
+   * [-maxMagnitude, maxMagnitude].
+   *
+   * <p>This is useful for applying smoother or more aggressive control response curves (e.g.
+   * joystick input shaping).
+   *
+   * @param value The input value to transform.
+   * @param exponent The exponent to apply (1.0 = linear, 2.0 = squared curve). Must be positive.
+   * @param maxMagnitude The maximum expected absolute value of input. Must be positive.
+   * @return The transformed value with the same sign and scaled to the input range.
+   */
+  public static double applyPowerCurve(double value, double exponent, double maxMagnitude) {
+    return Math.copySign(Math.pow(Math.abs(value) / maxMagnitude, exponent), value) * maxMagnitude;
+  }
+
+  /**
+   * Applies a power curve to the input value while preserving its sign.
+   *
+   * @param value The input value to transform.
+   * @param exponent The exponent to apply.
+   * @return The transformed value with the same sign.
+   */
+  public static double applyPowerCurve(double value, double exponent) {
+    return applyPowerCurve(value, exponent, 1);
+  }
+
+  /**
    * Returns modulus of input.
    *
    * @param input Input value to wrap.

--- a/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
@@ -108,19 +108,14 @@ public final class MathUtil {
   }
 
   /**
-   * Applies a power curve transformation to the input value, preserving its sign.
+   * Raises the input to the power of the given exponent while preserving its sign.
    *
-   * <p>The function normalizes the input value to the range [0, 1] based on the maximum magnitude,
-   * applies the power transformation, then scales the result back to the original range. This keeps
-   * the value in the original range and gives consistent curve behavior regardless of the input
-   * value's scale.
+   * <p>The function normalizes the input value to the range [0, 1] based on the maximum magnitude, raises it to the power of the exponent, then scales the result back to the original range and copying the sign. This keeps the value in the original range and gives consistent curve behavior regardless of the input value's scale.
    *
-   * <p>This is useful for applying smoother or more aggressive control response curves (e.g.
-   * joystick input shaping).
+   * <p>This is useful for applying smoother or more aggressive control response curves (e.g. joystick input shaping).
    *
    * @param value The input value to transform.
-   * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared curve). Must be
-   *     positive.
+   * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared curve). Must be positive.
    * @param maxMagnitude The maximum expected absolute value of input. Must be positive.
    * @return The transformed value with the same sign and scaled to the input range.
    */
@@ -129,13 +124,12 @@ public final class MathUtil {
   }
 
   /**
-   * Raises the input to the power of exponent while preserving its sign.
+   * Raises the input to the power of the given exponent while preserving its sign.
    *
-   * <p>This is useful for applying smoother or more aggressive control response curves (e.g.
-   * joystick input shaping).
+   * <p>This is useful for applying smoother or more aggressive control response curves (e.g. joystick input shaping).
    *
    * @param value The input value to transform.
-   * @param exponent The exponent to apply.
+   * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared curve). Must be positive.
    * @return The transformed value with the same sign.
    */
   public static double copysignPow(double value, double exponent) {

--- a/wpimath/src/main/native/include/frc/MathUtil.h
+++ b/wpimath/src/main/native/include/frc/MathUtil.h
@@ -116,30 +116,16 @@ constexpr T ApplyDeadband(T value, T deadband, T maxMagnitude = T{1.0}) {
 template <typename T>
   requires std::is_arithmetic_v<T> || units::traits::is_unit_t_v<T>
 constexpr T ApplyPowerCurve(T value, double exponent, T maxMagnitude = T{1.0}) {
-  T magnitude;
   if constexpr (std::is_arithmetic_v<T>) {
-    magnitude = gcem::abs(value);
+    return gcem::copysign(
+        gcem::pow(gcem::abs(value) / maxMagnitude, exponent) * maxMagnitude,
+        value);
   } else {
-    magnitude = units::math::abs(value);
+    return units::math::copysign(
+        gcem::pow((units::math::abs(value) / maxMagnitude).value(), exponent) *
+            maxMagnitude,
+        value);
   }
-
-  T result;
-
-  if constexpr (std::is_arithmetic_v<T>) {
-    T normalized = magnitude / maxMagnitude;
-    T transformed = gcem::pow(normalized, exponent);
-    result = transformed * maxMagnitude;
-  } else {
-    auto normalizedValue = magnitude / maxMagnitude;
-    auto transformedValue = gcem::pow(normalizedValue.value(), exponent);
-    result = transformedValue * maxMagnitude;
-  }
-
-  if (value < T{0.0}) {
-    return -result;
-  }
-
-  return result;
 }
 
 /**

--- a/wpimath/src/main/native/include/frc/MathUtil.h
+++ b/wpimath/src/main/native/include/frc/MathUtil.h
@@ -108,14 +108,14 @@ constexpr T ApplyDeadband(T value, T deadband, T maxMagnitude = T{1.0}) {
  * @param value The input value to transform.
  * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared
  * curve). Must be positive.
- * @param maxMagnitude The maximum expected absolute value of input. Must be
+ * @param maxMagnitude The maximum expected absolute value of input (Defaults to 1). Must be
  * positive.
  * @return The transformed value with the same sign and scaled to the input
  * range.
  */
 template <typename T>
   requires std::is_arithmetic_v<T> || units::traits::is_unit_t_v<T>
-constexpr T ApplyPowerCurve(T value, double exponent, T maxMagnitude) {
+constexpr T ApplyPowerCurve(T value, double exponent, T maxMagnitude = T{1.0}) {
   T magnitude;
   if constexpr (std::is_arithmetic_v<T>) {
     magnitude = gcem::abs(value);

--- a/wpimath/src/main/native/include/frc/MathUtil.h
+++ b/wpimath/src/main/native/include/frc/MathUtil.h
@@ -108,7 +108,7 @@ constexpr T ApplyDeadband(T value, T deadband, T maxMagnitude = T{1.0}) {
  */
 template <typename T>
   requires std::is_arithmetic_v<T> || units::traits::is_unit_t_v<T>
-constexpr T CopysignPow(T value, double exponent, T maxMagnitude = T{1.0}) {
+constexpr T CopySignPow(T value, double exponent, T maxMagnitude = T{1.0}) {
   if constexpr (std::is_arithmetic_v<T>) {
     return gcem::copysign(
         gcem::pow(gcem::abs(value) / maxMagnitude, exponent) * maxMagnitude,

--- a/wpimath/src/main/native/include/frc/MathUtil.h
+++ b/wpimath/src/main/native/include/frc/MathUtil.h
@@ -97,20 +97,21 @@ constexpr T ApplyDeadband(T value, T deadband, T maxMagnitude = T{1.0}) {
 /**
  * Applies a power curve transformation to the input value, preserving its sign.
  *
- * The function normalizes the input value to the range [0, 1] based on the 
- * maximum magnitude, applies the power transformation, then scales the result 
- * back to the original range. This keeps the value in the original range and 
+ * The function normalizes the input value to the range [0, 1] based on the
+ * maximum magnitude, applies the power transformation, then scales the result
+ * back to the original range. This keeps the value in the original range and
  * gives consistent curve behavior regardless of the input value's scale.
  *
- * This is useful for applying smoother or more aggressive control response 
+ * This is useful for applying smoother or more aggressive control response
  * curves (e.g. joystick input shaping).
  *
  * @param value The input value to transform.
- * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared 
+ * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared
  * curve). Must be positive.
- * @param maxMagnitude The maximum expected absolute value of input. Must be 
+ * @param maxMagnitude The maximum expected absolute value of input. Must be
  * positive.
- * @return The transformed value with the same sign and scaled to the input range.
+ * @return The transformed value with the same sign and scaled to the input
+ * range.
  */
 template <typename T>
   requires std::is_arithmetic_v<T> || units::traits::is_unit_t_v<T>
@@ -121,17 +122,17 @@ constexpr T ApplyPowerCurve(T value, double exponent, T maxMagnitude) {
   } else {
     magnitude = units::math::abs(value);
   }
-  
+
   T normalizedValue = magnitude / maxMagnitude;
   T transformedMagnitude;
-  
+
   if constexpr (std::is_arithmetic_v<T>) {
     transformedMagnitude = gcem::pow(normalizedValue, exponent) * maxMagnitude;
   } else {
     auto numericValue = normalizedValue.template to<double>();
     transformedMagnitude = T{gcem::pow(numericValue, exponent)} * maxMagnitude;
   }
-  
+
   if (value < T{0.0}) {
     return -transformedMagnitude;
   } else {

--- a/wpimath/src/main/native/include/frc/MathUtil.h
+++ b/wpimath/src/main/native/include/frc/MathUtil.h
@@ -95,16 +95,25 @@ constexpr T ApplyDeadband(T value, T deadband, T maxMagnitude = T{1.0}) {
 }
 
 /**
- * Raises the input to the power of the given exponent while preserving its sign.
+ * Raises the input to the power of the given exponent while preserving its
+ * sign.
  *
- * The function normalizes the input value to the range [0, 1] based on the maximum magnitude, raises it to the power of the exponent, then scales the result back to the original range and copying the sign. This keeps the value in the original range and gives consistent curve behavior regardless of the input value's scale.
+ * The function normalizes the input value to the range [0, 1] based on the
+ * maximum magnitude, raises it to the power of the exponent, then scales the
+ * result back to the original range and copying the sign. This keeps the value
+ * in the original range and gives consistent curve behavior regardless of the
+ * input value's scale.
  *
- * This is useful for applying smoother or more aggressive control response curves (e.g. joystick input shaping).
+ * This is useful for applying smoother or more aggressive control response
+ * curves (e.g. joystick input shaping).
  *
  * @param value The input value to transform.
- * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared curve). Must be positive.
- * @param maxMagnitude The maximum expected absolute value of input. Must be positive.
- * @return The transformed value with the same sign and scaled to the input range.
+ * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared
+ * curve). Must be positive.
+ * @param maxMagnitude The maximum expected absolute value of input. Must be
+ * positive.
+ * @return The transformed value with the same sign and scaled to the input
+ * range.
  */
 template <typename T>
   requires std::is_arithmetic_v<T> || units::traits::is_unit_t_v<T>

--- a/wpimath/src/main/native/include/frc/MathUtil.h
+++ b/wpimath/src/main/native/include/frc/MathUtil.h
@@ -115,7 +115,7 @@ constexpr T ApplyDeadband(T value, T deadband, T maxMagnitude = T{1.0}) {
  */
 template <typename T>
   requires std::is_arithmetic_v<T> || units::traits::is_unit_t_v<T>
-constexpr T ApplyPowerCurve(T value, double exponent, T maxMagnitude = T{1.0}) {
+constexpr T CopysignPow(T value, double exponent, T maxMagnitude = T{1.0}) {
   if constexpr (std::is_arithmetic_v<T>) {
     return gcem::copysign(
         gcem::pow(gcem::abs(value) / maxMagnitude, exponent) * maxMagnitude,

--- a/wpimath/src/main/native/include/frc/MathUtil.h
+++ b/wpimath/src/main/native/include/frc/MathUtil.h
@@ -95,6 +95,51 @@ constexpr T ApplyDeadband(T value, T deadband, T maxMagnitude = T{1.0}) {
 }
 
 /**
+ * Applies a power curve transformation to the input value, preserving its sign.
+ *
+ * The function normalizes the input value to the range [0, 1] based on the 
+ * maximum magnitude, applies the power transformation, then scales the result 
+ * back to the original range. This keeps the value in the original range and 
+ * gives consistent curve behavior regardless of the input value's scale.
+ *
+ * This is useful for applying smoother or more aggressive control response 
+ * curves (e.g. joystick input shaping).
+ *
+ * @param value The input value to transform.
+ * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared 
+ * curve). Must be positive.
+ * @param maxMagnitude The maximum expected absolute value of input. Must be 
+ * positive.
+ * @return The transformed value with the same sign and scaled to the input range.
+ */
+template <typename T>
+  requires std::is_arithmetic_v<T> || units::traits::is_unit_t_v<T>
+constexpr T ApplyPowerCurve(T value, double exponent, T maxMagnitude) {
+  T magnitude;
+  if constexpr (std::is_arithmetic_v<T>) {
+    magnitude = gcem::abs(value);
+  } else {
+    magnitude = units::math::abs(value);
+  }
+  
+  T normalizedValue = magnitude / maxMagnitude;
+  T transformedMagnitude;
+  
+  if constexpr (std::is_arithmetic_v<T>) {
+    transformedMagnitude = gcem::pow(normalizedValue, exponent) * maxMagnitude;
+  } else {
+    auto numericValue = normalizedValue.template to<double>();
+    transformedMagnitude = T{gcem::pow(numericValue, exponent)} * maxMagnitude;
+  }
+  
+  if (value < T{0.0}) {
+    return -transformedMagnitude;
+  } else {
+    return transformedMagnitude;
+  }
+}
+
+/**
  * Returns modulus of input.
  *
  * @param input        Input value to wrap.

--- a/wpimath/src/main/native/include/frc/MathUtil.h
+++ b/wpimath/src/main/native/include/frc/MathUtil.h
@@ -123,16 +123,17 @@ constexpr T ApplyPowerCurve(T value, double exponent, T maxMagnitude = T{1.0}) {
     magnitude = units::math::abs(value);
   }
 
-  T normalized = magnitude / maxMagnitude;
+  T result;
 
-  T transformed;
   if constexpr (std::is_arithmetic_v<T>) {
-    transformed = gcem::pow(normalized, exponent);
+    T normalized = magnitude / maxMagnitude;
+    T transformed = gcem::pow(normalized, exponent);
+    result = transformed * maxMagnitude;
   } else {
-    transformed = gcem::pow(normalized.value(), exponent);
+    auto normalizedValue = magnitude / maxMagnitude;
+    auto transformedValue = gcem::pow(normalizedValue.value(), exponent);
+    result = transformedValue * maxMagnitude;
   }
-  
-  T result = transformed * maxMagnitude;
 
   if (value < T{0.0}) {
     return -result;

--- a/wpimath/src/main/native/include/frc/MathUtil.h
+++ b/wpimath/src/main/native/include/frc/MathUtil.h
@@ -108,8 +108,8 @@ constexpr T ApplyDeadband(T value, T deadband, T maxMagnitude = T{1.0}) {
  * @param value The input value to transform.
  * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared
  * curve). Must be positive.
- * @param maxMagnitude The maximum expected absolute value of input (Defaults to 1). Must be
- * positive.
+ * @param maxMagnitude The maximum expected absolute value of input (defaults to
+ * 1). Must be positive.
  * @return The transformed value with the same sign and scaled to the input
  * range.
  */

--- a/wpimath/src/main/native/include/frc/MathUtil.h
+++ b/wpimath/src/main/native/include/frc/MathUtil.h
@@ -123,17 +123,16 @@ constexpr T ApplyPowerCurve(T value, double exponent, T maxMagnitude = T{1.0}) {
     magnitude = units::math::abs(value);
   }
 
-  T result;
+  T normalized = magnitude / maxMagnitude;
 
+  T transformed;
   if constexpr (std::is_arithmetic_v<T>) {
-    T normalized = magnitude / maxMagnitude;
-    T transformed = gcem::pow(normalized, exponent);
-    result = transformed * maxMagnitude;
+    transformed = gcem::pow(normalized, exponent);
   } else {
-    auto normalizedValue = magnitude / maxMagnitude;
-    auto transformedValue = gcem::pow(normalizedValue.value(), exponent);
-    result = transformedValue * maxMagnitude;
+    transformed = gcem::pow(normalized.value(), exponent);
   }
+  
+  T result = transformed * maxMagnitude;
 
   if (value < T{0.0}) {
     return -result;

--- a/wpimath/src/main/native/include/frc/MathUtil.h
+++ b/wpimath/src/main/native/include/frc/MathUtil.h
@@ -95,23 +95,16 @@ constexpr T ApplyDeadband(T value, T deadband, T maxMagnitude = T{1.0}) {
 }
 
 /**
- * Applies a power curve transformation to the input value, preserving its sign.
+ * Raises the input to the power of the given exponent while preserving its sign.
  *
- * The function normalizes the input value to the range [0, 1] based on the
- * maximum magnitude, applies the power transformation, then scales the result
- * back to the original range. This keeps the value in the original range and
- * gives consistent curve behavior regardless of the input value's scale.
+ * The function normalizes the input value to the range [0, 1] based on the maximum magnitude, raises it to the power of the exponent, then scales the result back to the original range and copying the sign. This keeps the value in the original range and gives consistent curve behavior regardless of the input value's scale.
  *
- * This is useful for applying smoother or more aggressive control response
- * curves (e.g. joystick input shaping).
+ * This is useful for applying smoother or more aggressive control response curves (e.g. joystick input shaping).
  *
  * @param value The input value to transform.
- * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared
- * curve). Must be positive.
- * @param maxMagnitude The maximum expected absolute value of input (defaults to
- * 1). Must be positive.
- * @return The transformed value with the same sign and scaled to the input
- * range.
+ * @param exponent The exponent to apply (e.g. 1.0 = linear, 2.0 = squared curve). Must be positive.
+ * @param maxMagnitude The maximum expected absolute value of input. Must be positive.
+ * @return The transformed value with the same sign and scaled to the input range.
  */
 template <typename T>
   requires std::is_arithmetic_v<T> || units::traits::is_unit_t_v<T>

--- a/wpimath/src/main/native/include/frc/MathUtil.h
+++ b/wpimath/src/main/native/include/frc/MathUtil.h
@@ -123,21 +123,23 @@ constexpr T ApplyPowerCurve(T value, double exponent, T maxMagnitude = T{1.0}) {
     magnitude = units::math::abs(value);
   }
 
-  T normalizedValue = magnitude / maxMagnitude;
-  T transformedMagnitude;
+  T result;
 
   if constexpr (std::is_arithmetic_v<T>) {
-    transformedMagnitude = gcem::pow(normalizedValue, exponent) * maxMagnitude;
+    T normalized = magnitude / maxMagnitude;
+    T transformed = gcem::pow(normalized, exponent);
+    result = transformed * maxMagnitude;
   } else {
-    auto numericValue = normalizedValue.template to<double>();
-    transformedMagnitude = T{gcem::pow(numericValue, exponent)} * maxMagnitude;
+    auto normalizedValue = magnitude / maxMagnitude;
+    auto transformedValue = gcem::pow(normalizedValue.value(), exponent);
+    result = transformedValue * maxMagnitude;
   }
 
   if (value < T{0.0}) {
-    return -transformedMagnitude;
-  } else {
-    return transformedMagnitude;
+    return -result;
   }
+
+  return result;
 }
 
 /**

--- a/wpimath/src/test/java/edu/wpi/first/math/MathUtilTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/MathUtilTest.java
@@ -73,41 +73,41 @@ class MathUtilTest extends UtilityClassTest<MathUtil> {
   }
 
   @Test
-  void testCopysignPow() {
-    assertEquals(0.5, MathUtil.copysignPow(0.5, 1.0));
-    assertEquals(-0.5, MathUtil.copysignPow(-0.5, 1.0));
+  void testCopySignPow() {
+    assertEquals(0.5, MathUtil.copySignPow(0.5, 1.0));
+    assertEquals(-0.5, MathUtil.copySignPow(-0.5, 1.0));
 
-    assertEquals(0.5 * 0.5, MathUtil.copysignPow(0.5, 2.0));
-    assertEquals(-(0.5 * 0.5), MathUtil.copysignPow(-0.5, 2.0));
+    assertEquals(0.5 * 0.5, MathUtil.copySignPow(0.5, 2.0));
+    assertEquals(-(0.5 * 0.5), MathUtil.copySignPow(-0.5, 2.0));
 
-    assertEquals(Math.sqrt(0.5), MathUtil.copysignPow(0.5, 0.5));
-    assertEquals(-Math.sqrt(0.5), MathUtil.copysignPow(-0.5, 0.5));
+    assertEquals(Math.sqrt(0.5), MathUtil.copySignPow(0.5, 0.5));
+    assertEquals(-Math.sqrt(0.5), MathUtil.copySignPow(-0.5, 0.5));
 
-    assertEquals(0.0, MathUtil.copysignPow(0.0, 2.0));
-    assertEquals(1.0, MathUtil.copysignPow(1.0, 2.0));
-    assertEquals(-1.0, MathUtil.copysignPow(-1.0, 2.0));
+    assertEquals(0.0, MathUtil.copySignPow(0.0, 2.0));
+    assertEquals(1.0, MathUtil.copySignPow(1.0, 2.0));
+    assertEquals(-1.0, MathUtil.copySignPow(-1.0, 2.0));
 
-    assertEquals(Math.pow(0.8, 0.3), MathUtil.copysignPow(0.8, 0.3));
-    assertEquals(-Math.pow(0.8, 0.3), MathUtil.copysignPow(-0.8, 0.3));
+    assertEquals(Math.pow(0.8, 0.3), MathUtil.copySignPow(0.8, 0.3));
+    assertEquals(-Math.pow(0.8, 0.3), MathUtil.copySignPow(-0.8, 0.3));
   }
 
   @Test
-  void testCopysignPowMaxMagnitude() {
-    assertEquals(5, MathUtil.copysignPow(5.0, 1.0, 10.0));
-    assertEquals(-5, MathUtil.copysignPow(-5.0, 1.0, 10.0));
+  void testCopySignPowMaxMagnitude() {
+    assertEquals(5, MathUtil.copySignPow(5.0, 1.0, 10.0));
+    assertEquals(-5, MathUtil.copySignPow(-5.0, 1.0, 10.0));
 
-    assertEquals(0.5 * 0.5 * 10, MathUtil.copysignPow(5.0, 2.0, 10.0));
-    assertEquals(-0.5 * 0.5 * 10, MathUtil.copysignPow(-5.0, 2.0, 10.0));
+    assertEquals(0.5 * 0.5 * 10, MathUtil.copySignPow(5.0, 2.0, 10.0));
+    assertEquals(-0.5 * 0.5 * 10, MathUtil.copySignPow(-5.0, 2.0, 10.0));
 
-    assertEquals(Math.sqrt(0.5) * 10, MathUtil.copysignPow(5.0, 0.5, 10.0));
-    assertEquals(-Math.sqrt(0.5) * 10, MathUtil.copysignPow(-5.0, 0.5, 10.0));
+    assertEquals(Math.sqrt(0.5) * 10, MathUtil.copySignPow(5.0, 0.5, 10.0));
+    assertEquals(-Math.sqrt(0.5) * 10, MathUtil.copySignPow(-5.0, 0.5, 10.0));
 
-    assertEquals(0.0, MathUtil.copysignPow(0.0, 2.0, 5.0));
-    assertEquals(5.0, MathUtil.copysignPow(5.0, 2.0, 5.0));
-    assertEquals(-5.0, MathUtil.copysignPow(-5.0, 2.0, 5.0));
+    assertEquals(0.0, MathUtil.copySignPow(0.0, 2.0, 5.0));
+    assertEquals(5.0, MathUtil.copySignPow(5.0, 2.0, 5.0));
+    assertEquals(-5.0, MathUtil.copySignPow(-5.0, 2.0, 5.0));
 
-    assertEquals(Math.pow(0.8, 0.3) * 100, MathUtil.copysignPow(80, 0.3, 100.0));
-    assertEquals(-Math.pow(0.8, 0.3) * 100, MathUtil.copysignPow(-80, 0.3, 100.0));
+    assertEquals(Math.pow(0.8, 0.3) * 100, MathUtil.copySignPow(80, 0.3, 100.0));
+    assertEquals(-Math.pow(0.8, 0.3) * 100, MathUtil.copySignPow(-80, 0.3, 100.0));
   }
 
   @Test

--- a/wpimath/src/test/java/edu/wpi/first/math/MathUtilTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/MathUtilTest.java
@@ -76,17 +76,17 @@ class MathUtilTest extends UtilityClassTest<MathUtil> {
   void testApplyPowerCurve() {
     assertEquals(0.5, MathUtil.applyPowerCurve(0.5, 1.0));
     assertEquals(-0.5, MathUtil.applyPowerCurve(-0.5, 1.0));
-    
+
     assertEquals(0.5 * 0.5, MathUtil.applyPowerCurve(0.5, 2.0));
     assertEquals(-(0.5 * 0.5), MathUtil.applyPowerCurve(-0.5, 2.0));
-    
+
     assertEquals(Math.sqrt(0.5), MathUtil.applyPowerCurve(0.5, 0.5));
     assertEquals(-Math.sqrt(0.5), MathUtil.applyPowerCurve(-0.5, 0.5));
-    
+
     assertEquals(0.0, MathUtil.applyPowerCurve(0.0, 2.0));
     assertEquals(1.0, MathUtil.applyPowerCurve(1.0, 2.0));
     assertEquals(-1.0, MathUtil.applyPowerCurve(-1.0, 2.0));
-    
+
     assertEquals(Math.pow(0.8, 0.3), MathUtil.applyPowerCurve(0.8, 0.3));
     assertEquals(-Math.pow(0.8, 0.3), MathUtil.applyPowerCurve(-0.8, 0.3));
   }
@@ -95,10 +95,10 @@ class MathUtilTest extends UtilityClassTest<MathUtil> {
   void testApplyPowerCurveMaxMagnitude() {
     assertEquals(5, MathUtil.applyPowerCurve(5.0, 1.0, 10.0));
     assertEquals(-5, MathUtil.applyPowerCurve(-5.0, 1.0, 10.0));
-    
+
     assertEquals(0.5 * 0.5 * 10, MathUtil.applyPowerCurve(5.0, 2.0, 10.0));
     assertEquals(-0.5 * 0.5 * 10, MathUtil.applyPowerCurve(-5.0, 2.0, 10.0));
-    
+
     assertEquals(Math.sqrt(0.5) * 10, MathUtil.applyPowerCurve(5.0, 0.5, 10.0));
     assertEquals(-Math.sqrt(0.5) * 10, MathUtil.applyPowerCurve(-5.0, 0.5, 10.0));
 

--- a/wpimath/src/test/java/edu/wpi/first/math/MathUtilTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/MathUtilTest.java
@@ -73,41 +73,41 @@ class MathUtilTest extends UtilityClassTest<MathUtil> {
   }
 
   @Test
-  void testApplyPowerCurve() {
-    assertEquals(0.5, MathUtil.applyPowerCurve(0.5, 1.0));
-    assertEquals(-0.5, MathUtil.applyPowerCurve(-0.5, 1.0));
+  void testCopysignPow() {
+    assertEquals(0.5, MathUtil.copysignPow(0.5, 1.0));
+    assertEquals(-0.5, MathUtil.copysignPow(-0.5, 1.0));
 
-    assertEquals(0.5 * 0.5, MathUtil.applyPowerCurve(0.5, 2.0));
-    assertEquals(-(0.5 * 0.5), MathUtil.applyPowerCurve(-0.5, 2.0));
+    assertEquals(0.5 * 0.5, MathUtil.copysignPow(0.5, 2.0));
+    assertEquals(-(0.5 * 0.5), MathUtil.copysignPow(-0.5, 2.0));
 
-    assertEquals(Math.sqrt(0.5), MathUtil.applyPowerCurve(0.5, 0.5));
-    assertEquals(-Math.sqrt(0.5), MathUtil.applyPowerCurve(-0.5, 0.5));
+    assertEquals(Math.sqrt(0.5), MathUtil.copysignPow(0.5, 0.5));
+    assertEquals(-Math.sqrt(0.5), MathUtil.copysignPow(-0.5, 0.5));
 
-    assertEquals(0.0, MathUtil.applyPowerCurve(0.0, 2.0));
-    assertEquals(1.0, MathUtil.applyPowerCurve(1.0, 2.0));
-    assertEquals(-1.0, MathUtil.applyPowerCurve(-1.0, 2.0));
+    assertEquals(0.0, MathUtil.copysignPow(0.0, 2.0));
+    assertEquals(1.0, MathUtil.copysignPow(1.0, 2.0));
+    assertEquals(-1.0, MathUtil.copysignPow(-1.0, 2.0));
 
-    assertEquals(Math.pow(0.8, 0.3), MathUtil.applyPowerCurve(0.8, 0.3));
-    assertEquals(-Math.pow(0.8, 0.3), MathUtil.applyPowerCurve(-0.8, 0.3));
+    assertEquals(Math.pow(0.8, 0.3), MathUtil.copysignPow(0.8, 0.3));
+    assertEquals(-Math.pow(0.8, 0.3), MathUtil.copysignPow(-0.8, 0.3));
   }
 
   @Test
-  void testApplyPowerCurveMaxMagnitude() {
-    assertEquals(5, MathUtil.applyPowerCurve(5.0, 1.0, 10.0));
-    assertEquals(-5, MathUtil.applyPowerCurve(-5.0, 1.0, 10.0));
+  void testCopysignPowMaxMagnitude() {
+    assertEquals(5, MathUtil.copysignPow(5.0, 1.0, 10.0));
+    assertEquals(-5, MathUtil.copysignPow(-5.0, 1.0, 10.0));
 
-    assertEquals(0.5 * 0.5 * 10, MathUtil.applyPowerCurve(5.0, 2.0, 10.0));
-    assertEquals(-0.5 * 0.5 * 10, MathUtil.applyPowerCurve(-5.0, 2.0, 10.0));
+    assertEquals(0.5 * 0.5 * 10, MathUtil.copysignPow(5.0, 2.0, 10.0));
+    assertEquals(-0.5 * 0.5 * 10, MathUtil.copysignPow(-5.0, 2.0, 10.0));
 
-    assertEquals(Math.sqrt(0.5) * 10, MathUtil.applyPowerCurve(5.0, 0.5, 10.0));
-    assertEquals(-Math.sqrt(0.5) * 10, MathUtil.applyPowerCurve(-5.0, 0.5, 10.0));
+    assertEquals(Math.sqrt(0.5) * 10, MathUtil.copysignPow(5.0, 0.5, 10.0));
+    assertEquals(-Math.sqrt(0.5) * 10, MathUtil.copysignPow(-5.0, 0.5, 10.0));
 
-    assertEquals(0.0, MathUtil.applyPowerCurve(0.0, 2.0, 5.0));
-    assertEquals(5.0, MathUtil.applyPowerCurve(5.0, 2.0, 5.0));
-    assertEquals(-5.0, MathUtil.applyPowerCurve(-5.0, 2.0, 5.0));
+    assertEquals(0.0, MathUtil.copysignPow(0.0, 2.0, 5.0));
+    assertEquals(5.0, MathUtil.copysignPow(5.0, 2.0, 5.0));
+    assertEquals(-5.0, MathUtil.copysignPow(-5.0, 2.0, 5.0));
 
-    assertEquals(Math.pow(0.8, 0.3) * 100, MathUtil.applyPowerCurve(80, 0.3, 100.0));
-    assertEquals(-Math.pow(0.8, 0.3) * 100, MathUtil.applyPowerCurve(-80, 0.3, 100.0));
+    assertEquals(Math.pow(0.8, 0.3) * 100, MathUtil.copysignPow(80, 0.3, 100.0));
+    assertEquals(-Math.pow(0.8, 0.3) * 100, MathUtil.copysignPow(-80, 0.3, 100.0));
   }
 
   @Test

--- a/wpimath/src/test/java/edu/wpi/first/math/MathUtilTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/MathUtilTest.java
@@ -73,6 +73,44 @@ class MathUtilTest extends UtilityClassTest<MathUtil> {
   }
 
   @Test
+  void testApplyPowerCurve() {
+    assertEquals(0.5, MathUtil.applyPowerCurve(0.5, 1.0));
+    assertEquals(-0.5, MathUtil.applyPowerCurve(-0.5, 1.0));
+    
+    assertEquals(0.5 * 0.5, MathUtil.applyPowerCurve(0.5, 2.0));
+    assertEquals(-(0.5 * 0.5), MathUtil.applyPowerCurve(-0.5, 2.0));
+    
+    assertEquals(Math.sqrt(0.5), MathUtil.applyPowerCurve(0.5, 0.5));
+    assertEquals(-Math.sqrt(0.5), MathUtil.applyPowerCurve(-0.5, 0.5));
+    
+    assertEquals(0.0, MathUtil.applyPowerCurve(0.0, 2.0));
+    assertEquals(1.0, MathUtil.applyPowerCurve(1.0, 2.0));
+    assertEquals(-1.0, MathUtil.applyPowerCurve(-1.0, 2.0));
+    
+    assertEquals(Math.pow(0.8, 0.3), MathUtil.applyPowerCurve(0.8, 0.3));
+    assertEquals(-Math.pow(0.8, 0.3), MathUtil.applyPowerCurve(-0.8, 0.3));
+  }
+
+  @Test
+  void testApplyPowerCurveMaxMagnitude() {
+    assertEquals(5, MathUtil.applyPowerCurve(5.0, 1.0, 10.0));
+    assertEquals(-5, MathUtil.applyPowerCurve(-5.0, 1.0, 10.0));
+    
+    assertEquals(0.5 * 0.5 * 10, MathUtil.applyPowerCurve(5.0, 2.0, 10.0));
+    assertEquals(-0.5 * 0.5 * 10, MathUtil.applyPowerCurve(-5.0, 2.0, 10.0));
+    
+    assertEquals(Math.sqrt(0.5) * 10, MathUtil.applyPowerCurve(5.0, 0.5, 10.0));
+    assertEquals(-Math.sqrt(0.5) * 10, MathUtil.applyPowerCurve(-5.0, 0.5, 10.0));
+
+    assertEquals(0.0, MathUtil.applyPowerCurve(0.0, 2.0, 5.0));
+    assertEquals(5.0, MathUtil.applyPowerCurve(5.0, 2.0, 5.0));
+    assertEquals(-5.0, MathUtil.applyPowerCurve(-5.0, 2.0, 5.0));
+
+    assertEquals(Math.pow(0.8, 0.3) * 100, MathUtil.applyPowerCurve(80, 0.3, 100.0));
+    assertEquals(-Math.pow(0.8, 0.3) * 100, MathUtil.applyPowerCurve(-80, 0.3, 100.0));
+  }
+
+  @Test
   void testInputModulus() {
     // These tests check error wrapping. That is, the result of wrapping the
     // result of an angle reference minus the measurement.

--- a/wpimath/src/test/native/cpp/MathUtilTest.cpp
+++ b/wpimath/src/test/native/cpp/MathUtilTest.cpp
@@ -103,7 +103,7 @@ TEST(MathUtilTest, ApplyPowerCurveMaxMagnitude) {
                    frc::ApplyPowerCurve(-80.0, 0.3, 100.0));
 }
 
-TEST(MathUtilTest, ApplyDeadbandUnits) {
+TEST(MathUtilTest, ApplyPowerCurveWithUnits) {
   EXPECT_DOUBLE_EQ(
       0, frc::ApplyPowerCurve<units::meters_per_second_t>(0_mps, 2.0).value());
   EXPECT_DOUBLE_EQ(

--- a/wpimath/src/test/native/cpp/MathUtilTest.cpp
+++ b/wpimath/src/test/native/cpp/MathUtilTest.cpp
@@ -83,7 +83,7 @@ TEST(MathUtilTest, ApplyPowerCurve) {
   EXPECT_DOUBLE_EQ(-std::pow(0.8, 0.3), frc::ApplyPowerCurve(-0.8, 0.3));
 }
 
-TEST(MathUtilTest, ApplyPowerCurveMaxMagnitude) {
+TEST(MathUtilTest, ApplyPowerCurveWithMaxMagnitude) {
   EXPECT_DOUBLE_EQ(5.0, frc::ApplyPowerCurve(5.0, 1.0, 10.0));
   EXPECT_DOUBLE_EQ(-5.0, frc::ApplyPowerCurve(-5.0, 1.0, 10.0));
 
@@ -107,9 +107,9 @@ TEST(MathUtilTest, ApplyPowerCurveWithUnits) {
   EXPECT_DOUBLE_EQ(
       0, frc::ApplyPowerCurve<units::meters_per_second_t>(0_mps, 2.0).value());
   EXPECT_DOUBLE_EQ(
-      -1, frc::ApplyPowerCurve<units::meters_per_second_t>(1_mps, 2.0).value());
+      1, frc::ApplyPowerCurve<units::meters_per_second_t>(1_mps, 2.0).value());
   EXPECT_DOUBLE_EQ(
-      1, frc::ApplyPowerCurve<units::meters_per_second_t>(-1_mps, 2.0).value());
+      -1, frc::ApplyPowerCurve<units::meters_per_second_t>(-1_mps, 2.0).value());
 
   EXPECT_DOUBLE_EQ(
       0.5 * 0.5 * 10,

--- a/wpimath/src/test/native/cpp/MathUtilTest.cpp
+++ b/wpimath/src/test/native/cpp/MathUtilTest.cpp
@@ -109,7 +109,8 @@ TEST(MathUtilTest, ApplyPowerCurveWithUnits) {
   EXPECT_DOUBLE_EQ(
       1, frc::ApplyPowerCurve<units::meters_per_second_t>(1_mps, 2.0).value());
   EXPECT_DOUBLE_EQ(
-      -1, frc::ApplyPowerCurve<units::meters_per_second_t>(-1_mps, 2.0).value());
+      -1,
+      frc::ApplyPowerCurve<units::meters_per_second_t>(-1_mps, 2.0).value());
 
   EXPECT_DOUBLE_EQ(
       0.5 * 0.5 * 10,

--- a/wpimath/src/test/native/cpp/MathUtilTest.cpp
+++ b/wpimath/src/test/native/cpp/MathUtilTest.cpp
@@ -65,60 +65,60 @@ TEST(MathUtilTest, ApplyDeadbandLargeMaxMagnitude) {
       frc::ApplyDeadband(100.0, 20.0, std::numeric_limits<double>::infinity()));
 }
 
-TEST(MathUtilTest, ApplyPowerCurve) {
-  EXPECT_DOUBLE_EQ(0.5, frc::ApplyPowerCurve(0.5, 1.0));
-  EXPECT_DOUBLE_EQ(-0.5, frc::ApplyPowerCurve(-0.5, 1.0));
+TEST(MathUtilTest, CopysignPow) {
+  EXPECT_DOUBLE_EQ(0.5, frc::CopysignPow(0.5, 1.0));
+  EXPECT_DOUBLE_EQ(-0.5, frc::CopysignPow(-0.5, 1.0));
 
-  EXPECT_DOUBLE_EQ(0.5 * 0.5, frc::ApplyPowerCurve(0.5, 2.0));
-  EXPECT_DOUBLE_EQ(-(0.5 * 0.5), frc::ApplyPowerCurve(-0.5, 2.0));
+  EXPECT_DOUBLE_EQ(0.5 * 0.5, frc::CopysignPow(0.5, 2.0));
+  EXPECT_DOUBLE_EQ(-(0.5 * 0.5), frc::CopysignPow(-0.5, 2.0));
 
-  EXPECT_DOUBLE_EQ(std::sqrt(0.5), frc::ApplyPowerCurve(0.5, 0.5));
-  EXPECT_DOUBLE_EQ(-std::sqrt(0.5), frc::ApplyPowerCurve(-0.5, 0.5));
+  EXPECT_DOUBLE_EQ(std::sqrt(0.5), frc::CopysignPow(0.5, 0.5));
+  EXPECT_DOUBLE_EQ(-std::sqrt(0.5), frc::CopysignPow(-0.5, 0.5));
 
-  EXPECT_DOUBLE_EQ(0.0, frc::ApplyPowerCurve(0.0, 2.0));
-  EXPECT_DOUBLE_EQ(1.0, frc::ApplyPowerCurve(1.0, 2.0));
-  EXPECT_DOUBLE_EQ(-1.0, frc::ApplyPowerCurve(-1.0, 2.0));
+  EXPECT_DOUBLE_EQ(0.0, frc::CopysignPow(0.0, 2.0));
+  EXPECT_DOUBLE_EQ(1.0, frc::CopysignPow(1.0, 2.0));
+  EXPECT_DOUBLE_EQ(-1.0, frc::CopysignPow(-1.0, 2.0));
 
-  EXPECT_DOUBLE_EQ(std::pow(0.8, 0.3), frc::ApplyPowerCurve(0.8, 0.3));
-  EXPECT_DOUBLE_EQ(-std::pow(0.8, 0.3), frc::ApplyPowerCurve(-0.8, 0.3));
+  EXPECT_DOUBLE_EQ(std::pow(0.8, 0.3), frc::CopysignPow(0.8, 0.3));
+  EXPECT_DOUBLE_EQ(-std::pow(0.8, 0.3), frc::CopysignPow(-0.8, 0.3));
 }
 
-TEST(MathUtilTest, ApplyPowerCurveWithMaxMagnitude) {
-  EXPECT_DOUBLE_EQ(5.0, frc::ApplyPowerCurve(5.0, 1.0, 10.0));
-  EXPECT_DOUBLE_EQ(-5.0, frc::ApplyPowerCurve(-5.0, 1.0, 10.0));
+TEST(MathUtilTest, CopysignPowWithMaxMagnitude) {
+  EXPECT_DOUBLE_EQ(5.0, frc::CopysignPow(5.0, 1.0, 10.0));
+  EXPECT_DOUBLE_EQ(-5.0, frc::CopysignPow(-5.0, 1.0, 10.0));
 
-  EXPECT_DOUBLE_EQ(0.5 * 0.5 * 10, frc::ApplyPowerCurve(5.0, 2.0, 10.0));
-  EXPECT_DOUBLE_EQ(-0.5 * 0.5 * 10, frc::ApplyPowerCurve(-5.0, 2.0, 10.0));
+  EXPECT_DOUBLE_EQ(0.5 * 0.5 * 10, frc::CopysignPow(5.0, 2.0, 10.0));
+  EXPECT_DOUBLE_EQ(-0.5 * 0.5 * 10, frc::CopysignPow(-5.0, 2.0, 10.0));
 
-  EXPECT_DOUBLE_EQ(std::sqrt(0.5) * 10, frc::ApplyPowerCurve(5.0, 0.5, 10.0));
-  EXPECT_DOUBLE_EQ(-std::sqrt(0.5) * 10, frc::ApplyPowerCurve(-5.0, 0.5, 10.0));
+  EXPECT_DOUBLE_EQ(std::sqrt(0.5) * 10, frc::CopysignPow(5.0, 0.5, 10.0));
+  EXPECT_DOUBLE_EQ(-std::sqrt(0.5) * 10, frc::CopysignPow(-5.0, 0.5, 10.0));
 
-  EXPECT_DOUBLE_EQ(0.0, frc::ApplyPowerCurve(0.0, 2.0, 5.0));
-  EXPECT_DOUBLE_EQ(5.0, frc::ApplyPowerCurve(5.0, 2.0, 5.0));
-  EXPECT_DOUBLE_EQ(-5.0, frc::ApplyPowerCurve(-5.0, 2.0, 5.0));
+  EXPECT_DOUBLE_EQ(0.0, frc::CopysignPow(0.0, 2.0, 5.0));
+  EXPECT_DOUBLE_EQ(5.0, frc::CopysignPow(5.0, 2.0, 5.0));
+  EXPECT_DOUBLE_EQ(-5.0, frc::CopysignPow(-5.0, 2.0, 5.0));
 
   EXPECT_DOUBLE_EQ(std::pow(0.8, 0.3) * 100,
-                   frc::ApplyPowerCurve(80.0, 0.3, 100.0));
+                   frc::CopysignPow(80.0, 0.3, 100.0));
   EXPECT_DOUBLE_EQ(-std::pow(0.8, 0.3) * 100,
-                   frc::ApplyPowerCurve(-80.0, 0.3, 100.0));
+                   frc::CopysignPow(-80.0, 0.3, 100.0));
 }
 
-TEST(MathUtilTest, ApplyPowerCurveWithUnits) {
+TEST(MathUtilTest, CopysignPowWithUnits) {
   EXPECT_DOUBLE_EQ(
-      0, frc::ApplyPowerCurve<units::meters_per_second_t>(0_mps, 2.0).value());
+      0, frc::CopysignPow<units::meters_per_second_t>(0_mps, 2.0).value());
   EXPECT_DOUBLE_EQ(
-      1, frc::ApplyPowerCurve<units::meters_per_second_t>(1_mps, 2.0).value());
+      1, frc::CopysignPow<units::meters_per_second_t>(1_mps, 2.0).value());
   EXPECT_DOUBLE_EQ(
       -1,
-      frc::ApplyPowerCurve<units::meters_per_second_t>(-1_mps, 2.0).value());
+      frc::CopysignPow<units::meters_per_second_t>(-1_mps, 2.0).value());
 
   EXPECT_DOUBLE_EQ(
       0.5 * 0.5 * 10,
-      frc::ApplyPowerCurve<units::meters_per_second_t>(5_mps, 2.0, 10_mps)
+      frc::CopysignPow<units::meters_per_second_t>(5_mps, 2.0, 10_mps)
           .value());
   EXPECT_DOUBLE_EQ(
       -0.5 * 0.5 * 10,
-      frc::ApplyPowerCurve<units::meters_per_second_t>(-5_mps, 2.0, 10_mps)
+      frc::CopysignPow<units::meters_per_second_t>(-5_mps, 2.0, 10_mps)
           .value());
 }
 

--- a/wpimath/src/test/native/cpp/MathUtilTest.cpp
+++ b/wpimath/src/test/native/cpp/MathUtilTest.cpp
@@ -65,6 +65,50 @@ TEST(MathUtilTest, ApplyDeadbandLargeMaxMagnitude) {
       frc::ApplyDeadband(100.0, 20.0, std::numeric_limits<double>::infinity()));
 }
 
+TEST(MathUtilTest, ApplyPowerCurve) {
+  EXPECT_DOUBLE_EQ(0.5, frc::ApplyPowerCurve(0.5, 1.0));
+  EXPECT_DOUBLE_EQ(-0.5, frc::ApplyPowerCurve(-0.5, 1.0));
+  
+  EXPECT_DOUBLE_EQ(0.5 * 0.5, frc::ApplyPowerCurve(0.5, 2.0));
+  EXPECT_DOUBLE_EQ(-(0.5 * 0.5), frc::ApplyPowerCurve(-0.5, 2.0));
+  
+  EXPECT_DOUBLE_EQ(std::sqrt(0.5), frc::ApplyPowerCurve(0.5, 0.5));
+  EXPECT_DOUBLE_EQ(-std::sqrt(0.5), frc::ApplyPowerCurve(-0.5, 0.5));
+  
+  EXPECT_DOUBLE_EQ(0.0, frc::ApplyPowerCurve(0.0, 2.0));
+  EXPECT_DOUBLE_EQ(1.0, frc::ApplyPowerCurve(1.0, 2.0));
+  EXPECT_DOUBLE_EQ(-1.0, frc::ApplyPowerCurve(-1.0, 2.0));
+  
+  EXPECT_DOUBLE_EQ(std::pow(0.8, 0.3), frc::ApplyPowerCurve(0.8, 0.3));
+  EXPECT_DOUBLE_EQ(-std::pow(0.8, 0.3), frc::ApplyPowerCurve(-0.8, 0.3));
+}
+
+TEST(MathUtilTest, ApplyPowerCurveMaxMagnitude) {
+  EXPECT_DOUBLE_EQ(5.0, frc::ApplyPowerCurve(5.0, 1.0, 10.0));
+  EXPECT_DOUBLE_EQ(-5.0, frc::ApplyPowerCurve(-5.0, 1.0, 10.0));
+  
+  EXPECT_DOUBLE_EQ(0.5 * 0.5 * 10, frc::ApplyPowerCurve(5.0, 2.0, 10.0));
+  EXPECT_DOUBLE_EQ(-0.5 * 0.5 * 10, frc::ApplyPowerCurve(-5.0, 2.0, 10.0));
+  
+  EXPECT_DOUBLE_EQ(std::sqrt(0.5) * 10, frc::ApplyPowerCurve(5.0, 0.5, 10.0));
+  EXPECT_DOUBLE_EQ(-std::sqrt(0.5) * 10, frc::ApplyPowerCurve(-5.0, 0.5, 10.0));
+  
+  EXPECT_DOUBLE_EQ(0.0, frc::ApplyPowerCurve(0.0, 2.0, 5.0));
+  EXPECT_DOUBLE_EQ(5.0, frc::ApplyPowerCurve(5.0, 2.0, 5.0));
+  EXPECT_DOUBLE_EQ(-5.0, frc::ApplyPowerCurve(-5.0, 2.0, 5.0));
+  
+  EXPECT_DOUBLE_EQ(std::pow(0.8, 0.3) * 100, frc::ApplyPowerCurve(80.0, 0.3, 100.0));
+  EXPECT_DOUBLE_EQ(-std::pow(0.8, 0.3) * 100, frc::ApplyPowerCurve(-80.0, 0.3, 100.0));
+}
+
+TEST(MathUtilTest, ApplyDeadbandUnits) {
+  EXPECT_DOUBLE_EQ(0, frc::ApplyPowerCurve<units::meters_per_second_t>(0_mps, 2.0).value());
+  EXPECT_DOUBLE_EQ(-1, frc::ApplyPowerCurve<units::meters_per_second_t>(1_mps, 2.0).value());
+  EXPECT_DOUBLE_EQ(1, frc::ApplyPowerCurve<units::meters_per_second_t>(-1_mps, 2.0).value());
+
+  EXPECT_DOUBLE_EQ(0.5 * 0.5 * 10, frc::ApplyPowerCurve<units::meters_per_second_t>(5_mps, 2.0, 10_mps).value());
+}
+
 TEST(MathUtilTest, InputModulus) {
   // These tests check error wrapping. That is, the result of wrapping the
   // result of an angle reference minus the measurement.

--- a/wpimath/src/test/native/cpp/MathUtilTest.cpp
+++ b/wpimath/src/test/native/cpp/MathUtilTest.cpp
@@ -65,60 +65,60 @@ TEST(MathUtilTest, ApplyDeadbandLargeMaxMagnitude) {
       frc::ApplyDeadband(100.0, 20.0, std::numeric_limits<double>::infinity()));
 }
 
-TEST(MathUtilTest, CopysignPow) {
-  EXPECT_DOUBLE_EQ(0.5, frc::CopysignPow(0.5, 1.0));
-  EXPECT_DOUBLE_EQ(-0.5, frc::CopysignPow(-0.5, 1.0));
+TEST(MathUtilTest, CopySignPow) {
+  EXPECT_DOUBLE_EQ(0.5, frc::CopySignPow(0.5, 1.0));
+  EXPECT_DOUBLE_EQ(-0.5, frc::CopySignPow(-0.5, 1.0));
 
-  EXPECT_DOUBLE_EQ(0.5 * 0.5, frc::CopysignPow(0.5, 2.0));
-  EXPECT_DOUBLE_EQ(-(0.5 * 0.5), frc::CopysignPow(-0.5, 2.0));
+  EXPECT_DOUBLE_EQ(0.5 * 0.5, frc::CopySignPow(0.5, 2.0));
+  EXPECT_DOUBLE_EQ(-(0.5 * 0.5), frc::CopySignPow(-0.5, 2.0));
 
-  EXPECT_DOUBLE_EQ(std::sqrt(0.5), frc::CopysignPow(0.5, 0.5));
-  EXPECT_DOUBLE_EQ(-std::sqrt(0.5), frc::CopysignPow(-0.5, 0.5));
+  EXPECT_DOUBLE_EQ(std::sqrt(0.5), frc::CopySignPow(0.5, 0.5));
+  EXPECT_DOUBLE_EQ(-std::sqrt(0.5), frc::CopySignPow(-0.5, 0.5));
 
-  EXPECT_DOUBLE_EQ(0.0, frc::CopysignPow(0.0, 2.0));
-  EXPECT_DOUBLE_EQ(1.0, frc::CopysignPow(1.0, 2.0));
-  EXPECT_DOUBLE_EQ(-1.0, frc::CopysignPow(-1.0, 2.0));
+  EXPECT_DOUBLE_EQ(0.0, frc::CopySignPow(0.0, 2.0));
+  EXPECT_DOUBLE_EQ(1.0, frc::CopySignPow(1.0, 2.0));
+  EXPECT_DOUBLE_EQ(-1.0, frc::CopySignPow(-1.0, 2.0));
 
-  EXPECT_DOUBLE_EQ(std::pow(0.8, 0.3), frc::CopysignPow(0.8, 0.3));
-  EXPECT_DOUBLE_EQ(-std::pow(0.8, 0.3), frc::CopysignPow(-0.8, 0.3));
+  EXPECT_DOUBLE_EQ(std::pow(0.8, 0.3), frc::CopySignPow(0.8, 0.3));
+  EXPECT_DOUBLE_EQ(-std::pow(0.8, 0.3), frc::CopySignPow(-0.8, 0.3));
 }
 
-TEST(MathUtilTest, CopysignPowWithMaxMagnitude) {
-  EXPECT_DOUBLE_EQ(5.0, frc::CopysignPow(5.0, 1.0, 10.0));
-  EXPECT_DOUBLE_EQ(-5.0, frc::CopysignPow(-5.0, 1.0, 10.0));
+TEST(MathUtilTest, CopySignPowWithMaxMagnitude) {
+  EXPECT_DOUBLE_EQ(5.0, frc::CopySignPow(5.0, 1.0, 10.0));
+  EXPECT_DOUBLE_EQ(-5.0, frc::CopySignPow(-5.0, 1.0, 10.0));
 
-  EXPECT_DOUBLE_EQ(0.5 * 0.5 * 10, frc::CopysignPow(5.0, 2.0, 10.0));
-  EXPECT_DOUBLE_EQ(-0.5 * 0.5 * 10, frc::CopysignPow(-5.0, 2.0, 10.0));
+  EXPECT_DOUBLE_EQ(0.5 * 0.5 * 10, frc::CopySignPow(5.0, 2.0, 10.0));
+  EXPECT_DOUBLE_EQ(-0.5 * 0.5 * 10, frc::CopySignPow(-5.0, 2.0, 10.0));
 
-  EXPECT_DOUBLE_EQ(std::sqrt(0.5) * 10, frc::CopysignPow(5.0, 0.5, 10.0));
-  EXPECT_DOUBLE_EQ(-std::sqrt(0.5) * 10, frc::CopysignPow(-5.0, 0.5, 10.0));
+  EXPECT_DOUBLE_EQ(std::sqrt(0.5) * 10, frc::CopySignPow(5.0, 0.5, 10.0));
+  EXPECT_DOUBLE_EQ(-std::sqrt(0.5) * 10, frc::CopySignPow(-5.0, 0.5, 10.0));
 
-  EXPECT_DOUBLE_EQ(0.0, frc::CopysignPow(0.0, 2.0, 5.0));
-  EXPECT_DOUBLE_EQ(5.0, frc::CopysignPow(5.0, 2.0, 5.0));
-  EXPECT_DOUBLE_EQ(-5.0, frc::CopysignPow(-5.0, 2.0, 5.0));
+  EXPECT_DOUBLE_EQ(0.0, frc::CopySignPow(0.0, 2.0, 5.0));
+  EXPECT_DOUBLE_EQ(5.0, frc::CopySignPow(5.0, 2.0, 5.0));
+  EXPECT_DOUBLE_EQ(-5.0, frc::CopySignPow(-5.0, 2.0, 5.0));
 
   EXPECT_DOUBLE_EQ(std::pow(0.8, 0.3) * 100,
-                   frc::CopysignPow(80.0, 0.3, 100.0));
+                   frc::CopySignPow(80.0, 0.3, 100.0));
   EXPECT_DOUBLE_EQ(-std::pow(0.8, 0.3) * 100,
-                   frc::CopysignPow(-80.0, 0.3, 100.0));
+                   frc::CopySignPow(-80.0, 0.3, 100.0));
 }
 
-TEST(MathUtilTest, CopysignPowWithUnits) {
+TEST(MathUtilTest, CopySignPowWithUnits) {
   EXPECT_DOUBLE_EQ(
-      0, frc::CopysignPow<units::meters_per_second_t>(0_mps, 2.0).value());
+      0, frc::CopySignPow<units::meters_per_second_t>(0_mps, 2.0).value());
   EXPECT_DOUBLE_EQ(
-      1, frc::CopysignPow<units::meters_per_second_t>(1_mps, 2.0).value());
+      1, frc::CopySignPow<units::meters_per_second_t>(1_mps, 2.0).value());
   EXPECT_DOUBLE_EQ(
       -1,
-      frc::CopysignPow<units::meters_per_second_t>(-1_mps, 2.0).value());
+      frc::CopySignPow<units::meters_per_second_t>(-1_mps, 2.0).value());
 
   EXPECT_DOUBLE_EQ(
       0.5 * 0.5 * 10,
-      frc::CopysignPow<units::meters_per_second_t>(5_mps, 2.0, 10_mps)
+      frc::CopySignPow<units::meters_per_second_t>(5_mps, 2.0, 10_mps)
           .value());
   EXPECT_DOUBLE_EQ(
       -0.5 * 0.5 * 10,
-      frc::CopysignPow<units::meters_per_second_t>(-5_mps, 2.0, 10_mps)
+      frc::CopySignPow<units::meters_per_second_t>(-5_mps, 2.0, 10_mps)
           .value());
 }
 

--- a/wpimath/src/test/native/cpp/MathUtilTest.cpp
+++ b/wpimath/src/test/native/cpp/MathUtilTest.cpp
@@ -115,6 +115,10 @@ TEST(MathUtilTest, ApplyDeadbandUnits) {
       0.5 * 0.5 * 10,
       frc::ApplyPowerCurve<units::meters_per_second_t>(5_mps, 2.0, 10_mps)
           .value());
+  EXPECT_DOUBLE_EQ(
+      -0.5 * 0.5 * 10,
+      frc::ApplyPowerCurve<units::meters_per_second_t>(-5_mps, 2.0, 10_mps)
+          .value());
 }
 
 TEST(MathUtilTest, InputModulus) {

--- a/wpimath/src/test/native/cpp/MathUtilTest.cpp
+++ b/wpimath/src/test/native/cpp/MathUtilTest.cpp
@@ -68,17 +68,17 @@ TEST(MathUtilTest, ApplyDeadbandLargeMaxMagnitude) {
 TEST(MathUtilTest, ApplyPowerCurve) {
   EXPECT_DOUBLE_EQ(0.5, frc::ApplyPowerCurve(0.5, 1.0));
   EXPECT_DOUBLE_EQ(-0.5, frc::ApplyPowerCurve(-0.5, 1.0));
-  
+
   EXPECT_DOUBLE_EQ(0.5 * 0.5, frc::ApplyPowerCurve(0.5, 2.0));
   EXPECT_DOUBLE_EQ(-(0.5 * 0.5), frc::ApplyPowerCurve(-0.5, 2.0));
-  
+
   EXPECT_DOUBLE_EQ(std::sqrt(0.5), frc::ApplyPowerCurve(0.5, 0.5));
   EXPECT_DOUBLE_EQ(-std::sqrt(0.5), frc::ApplyPowerCurve(-0.5, 0.5));
-  
+
   EXPECT_DOUBLE_EQ(0.0, frc::ApplyPowerCurve(0.0, 2.0));
   EXPECT_DOUBLE_EQ(1.0, frc::ApplyPowerCurve(1.0, 2.0));
   EXPECT_DOUBLE_EQ(-1.0, frc::ApplyPowerCurve(-1.0, 2.0));
-  
+
   EXPECT_DOUBLE_EQ(std::pow(0.8, 0.3), frc::ApplyPowerCurve(0.8, 0.3));
   EXPECT_DOUBLE_EQ(-std::pow(0.8, 0.3), frc::ApplyPowerCurve(-0.8, 0.3));
 }
@@ -86,27 +86,35 @@ TEST(MathUtilTest, ApplyPowerCurve) {
 TEST(MathUtilTest, ApplyPowerCurveMaxMagnitude) {
   EXPECT_DOUBLE_EQ(5.0, frc::ApplyPowerCurve(5.0, 1.0, 10.0));
   EXPECT_DOUBLE_EQ(-5.0, frc::ApplyPowerCurve(-5.0, 1.0, 10.0));
-  
+
   EXPECT_DOUBLE_EQ(0.5 * 0.5 * 10, frc::ApplyPowerCurve(5.0, 2.0, 10.0));
   EXPECT_DOUBLE_EQ(-0.5 * 0.5 * 10, frc::ApplyPowerCurve(-5.0, 2.0, 10.0));
-  
+
   EXPECT_DOUBLE_EQ(std::sqrt(0.5) * 10, frc::ApplyPowerCurve(5.0, 0.5, 10.0));
   EXPECT_DOUBLE_EQ(-std::sqrt(0.5) * 10, frc::ApplyPowerCurve(-5.0, 0.5, 10.0));
-  
+
   EXPECT_DOUBLE_EQ(0.0, frc::ApplyPowerCurve(0.0, 2.0, 5.0));
   EXPECT_DOUBLE_EQ(5.0, frc::ApplyPowerCurve(5.0, 2.0, 5.0));
   EXPECT_DOUBLE_EQ(-5.0, frc::ApplyPowerCurve(-5.0, 2.0, 5.0));
-  
-  EXPECT_DOUBLE_EQ(std::pow(0.8, 0.3) * 100, frc::ApplyPowerCurve(80.0, 0.3, 100.0));
-  EXPECT_DOUBLE_EQ(-std::pow(0.8, 0.3) * 100, frc::ApplyPowerCurve(-80.0, 0.3, 100.0));
+
+  EXPECT_DOUBLE_EQ(std::pow(0.8, 0.3) * 100,
+                   frc::ApplyPowerCurve(80.0, 0.3, 100.0));
+  EXPECT_DOUBLE_EQ(-std::pow(0.8, 0.3) * 100,
+                   frc::ApplyPowerCurve(-80.0, 0.3, 100.0));
 }
 
 TEST(MathUtilTest, ApplyDeadbandUnits) {
-  EXPECT_DOUBLE_EQ(0, frc::ApplyPowerCurve<units::meters_per_second_t>(0_mps, 2.0).value());
-  EXPECT_DOUBLE_EQ(-1, frc::ApplyPowerCurve<units::meters_per_second_t>(1_mps, 2.0).value());
-  EXPECT_DOUBLE_EQ(1, frc::ApplyPowerCurve<units::meters_per_second_t>(-1_mps, 2.0).value());
+  EXPECT_DOUBLE_EQ(
+      0, frc::ApplyPowerCurve<units::meters_per_second_t>(0_mps, 2.0).value());
+  EXPECT_DOUBLE_EQ(
+      -1, frc::ApplyPowerCurve<units::meters_per_second_t>(1_mps, 2.0).value());
+  EXPECT_DOUBLE_EQ(
+      1, frc::ApplyPowerCurve<units::meters_per_second_t>(-1_mps, 2.0).value());
 
-  EXPECT_DOUBLE_EQ(0.5 * 0.5 * 10, frc::ApplyPowerCurve<units::meters_per_second_t>(5_mps, 2.0, 10_mps).value());
+  EXPECT_DOUBLE_EQ(
+      0.5 * 0.5 * 10,
+      frc::ApplyPowerCurve<units::meters_per_second_t>(5_mps, 2.0, 10_mps)
+          .value());
 }
 
 TEST(MathUtilTest, InputModulus) {

--- a/wpimath/src/test/native/cpp/MathUtilTest.cpp
+++ b/wpimath/src/test/native/cpp/MathUtilTest.cpp
@@ -109,13 +109,11 @@ TEST(MathUtilTest, CopySignPowWithUnits) {
   EXPECT_DOUBLE_EQ(
       1, frc::CopySignPow<units::meters_per_second_t>(1_mps, 2.0).value());
   EXPECT_DOUBLE_EQ(
-      -1,
-      frc::CopySignPow<units::meters_per_second_t>(-1_mps, 2.0).value());
+      -1, frc::CopySignPow<units::meters_per_second_t>(-1_mps, 2.0).value());
 
   EXPECT_DOUBLE_EQ(
       0.5 * 0.5 * 10,
-      frc::CopySignPow<units::meters_per_second_t>(5_mps, 2.0, 10_mps)
-          .value());
+      frc::CopySignPow<units::meters_per_second_t>(5_mps, 2.0, 10_mps).value());
   EXPECT_DOUBLE_EQ(
       -0.5 * 0.5 * 10,
       frc::CopySignPow<units::meters_per_second_t>(-5_mps, 2.0, 10_mps)


### PR DESCRIPTION
EDIT: Name of method has been updated to copySignPow

This PR adds the simple util method of `applyPowerCurve(value, exponent, maxMagnitude)` to the Java and C++ `MathUtil` classes. This method transforms `value` to be on the power curve of x to the `exponent` while keeping its sign. It also handles a maxMagninude value that is used to keep the curve consistent (and the value in range) whether `value` is between the default of [-1,1] or some other magnitude like [-100,100]. 

Usage:
```java
final double MAX_SPEED = 12.3;

double value = xbox.getLeftX() * MAX_SPEED; // get value from joystick

value = MathUtil.applyDeadband(value, 0.05, MAX_SPEED); // handle deadzone, filters speeds under 0.05

value = MathUtil.applyPowerCurve(value, 2.0, MAX_SPEED); // place the value on the curve of x^2 while keeping it in range and keeping it's direction

```

This technique is commonly used in to improve fine control at low speeds and enable quicker ramp-up at higher joystick deflections, most often with an exponent of 2 (squaring the input). 

Including this function in `MathUtil` puts both commonly used joystick input transformations in one location and makes them easier for new teams to find and use.

This PR also updates the `DifferentialDrive` class to use `applyPowerCurve` in place of its previous manual implementation.

Feedback is appreciated, particularly on the method name and documentation comment, as well as better ways to implement this in C++ without calling `.value()` on unit types. This is my first time trying to add an actually new feature, mostly for the learning experience. I hope it’s a useful addition!