### PR TITLE
Constient geometry `nearest` functions 

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose2d.java
@@ -20,9 +20,9 @@ import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import edu.wpi.first.util.struct.StructSerializable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Objects;
 
 /** Represents a 2D pose containing translational and rotational elements. */
@@ -347,13 +347,13 @@ public class Pose2d implements Interpolatable<Pose2d>, ProtobufSerializable, Str
   }
 
   /**
-   * Returns the nearest Pose2d from a list of poses. If two or more poses in the list have the same
-   * distance from this pose, return the one with the closest rotation component.
+   * Returns the nearest Pose2d from a collection of poses. If two or more poses in the collection
+   * have the same distance from this pose, return the one with the closest rotation component.
    *
-   * @param poses The list of poses to find the nearest.
-   * @return The nearest Pose2d from the list.
+   * @param poses The collection of poses to find the nearest.
+   * @return The nearest Pose2d from the collection.
    */
-  public Pose2d nearest(List<Pose2d> poses) {
+  public Pose2d nearest(Collection<Pose2d> poses) {
     return Collections.min(
         poses,
         Comparator.comparing(

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose3d.java
@@ -21,9 +21,9 @@ import edu.wpi.first.math.numbers.N4;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import edu.wpi.first.util.struct.StructSerializable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Objects;
 
 /** Represents a 3D pose containing translational and rotational elements. */
@@ -400,13 +400,13 @@ public class Pose3d implements Interpolatable<Pose3d>, ProtobufSerializable, Str
   }
 
   /**
-   * Returns the nearest Pose3d from a list of poses. If two or more poses in the list have the same
-   * distance from this pose, return the one with the closest rotation component.
+   * Returns the nearest Pose3d from a collection of poses. If two or more poses in the collection
+   * have the same distance from this pose, return the one with the closest rotation component.
    *
-   * @param poses The list of poses to find the nearest.
-   * @return The nearest Pose3d from the list.
+   * @param poses The collection of poses to find the nearest.
+   * @return The nearest Pose3d from the collection.
    */
-  public Pose3d nearest(List<Pose3d> poses) {
+  public Pose3d nearest(Collection<Pose3d> poses) {
     return Collections.min(
         poses,
         Comparator.comparing(

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation2d.java
@@ -20,9 +20,9 @@ import edu.wpi.first.math.numbers.N2;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import edu.wpi.first.util.struct.StructSerializable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -273,12 +273,12 @@ public class Translation2d
   }
 
   /**
-   * Returns the nearest Translation2d from a list of translations.
+   * Returns the nearest Translation2d from a collection of translations.
    *
-   * @param translations The list of translations.
-   * @return The nearest Translation2d from the list.
+   * @param translations The collection of translations to find the nearest.
+   * @return The nearest Translation2d from the collection.
    */
-  public Translation2d nearest(List<Translation2d> translations) {
+  public Translation2d nearest(Collection<Translation2d> translations) {
     return Collections.min(translations, Comparator.comparing(this::getDistance));
   }
 

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
@@ -20,6 +20,10 @@ import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import edu.wpi.first.util.struct.StructSerializable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Objects;
 
 /**
@@ -294,6 +298,16 @@ public class Translation3d
    */
   public Translation3d div(double scalar) {
     return new Translation3d(m_x / scalar, m_y / scalar, m_z / scalar);
+  }
+
+  /**
+   * Returns the nearest Translation3d from a collection of translations.
+   *
+   * @param translations The collection of translations to find the nearest.
+   * @return The nearest Translation3d from the collection.
+   */
+  public Translation3d nearest(Collection<Translation3d> translations) {
+    return Collections.min(translations, Comparator.comparing(this::getDistance));
   }
 
   @Override

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
@@ -20,7 +20,6 @@ import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import edu.wpi.first.util.struct.StructSerializable;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;

--- a/wpimath/src/main/native/include/frc/geometry/Pose3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Pose3d.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <algorithm>
+#include <initializer_list>
+#include <span>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>

--- a/wpimath/src/main/native/include/frc/geometry/Translation3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Translation3d.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#include <algorithm>
+#include <initializer_list>
+#include <span>
+
 #include <Eigen/Core>
 #include <wpi/SymbolExports.h>
 #include <wpi/json_fwd.h>
@@ -242,7 +246,7 @@ class WPILIB_DLLEXPORT Translation3d {
     return units::math::abs(m_x - other.m_x) < 1E-9_m &&
            units::math::abs(m_y - other.m_y) < 1E-9_m &&
            units::math::abs(m_z - other.m_z) < 1E-9_m;
-
+  }
 
   /**
    * Returns the nearest Translation3d from a collection of translations

--- a/wpimath/src/main/native/include/frc/geometry/Translation3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Translation3d.h
@@ -242,6 +242,32 @@ class WPILIB_DLLEXPORT Translation3d {
     return units::math::abs(m_x - other.m_x) < 1E-9_m &&
            units::math::abs(m_y - other.m_y) < 1E-9_m &&
            units::math::abs(m_z - other.m_z) < 1E-9_m;
+
+
+  /**
+   * Returns the nearest Translation3d from a collection of translations
+   * @param translations The collection of translations.
+   * @return The nearest Translation3d from the collection.
+   */
+  constexpr Translation3d Nearest(
+      std::span<const Translation3d> translations) const {
+    return *std::min_element(translations.begin(), translations.end(),
+                             [this](Translation3d a, Translation3d b) {
+                               return this->Distance(a) < this->Distance(b);
+                             });
+  }
+
+  /**
+   * Returns the nearest Translation3d from a collection of translations
+   * @param translations The collection of translations.
+   * @return The nearest Translation3d from the collection.
+   */
+  constexpr Translation3d Nearest(
+      std::initializer_list<Translation3d> translations) const {
+    return *std::min_element(translations.begin(), translations.end(),
+                             [this](Translation3d a, Translation3d b) {
+                               return this->Distance(a) < this->Distance(b);
+                             });
   }
 
  private:

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation3dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation3dTest.java
@@ -9,10 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import java.util.List;
-
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.util.Units;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class Translation3dTest {
@@ -209,7 +208,6 @@ class Translation3dTest {
     assertEquals(vec, translation.toVector());
   }
 
-  
   @Test
   void testNearest() {
     var origin = Translation3d.kZero;

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation3dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation3dTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import java.util.List;
+
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.util.Units;
 import org.junit.jupiter.api.Test;
@@ -205,5 +207,24 @@ class Translation3dTest {
     assertEquals(vec.get(2), translation.getZ());
 
     assertEquals(vec, translation.toVector());
+  }
+
+  
+  @Test
+  void testNearest() {
+    var origin = Translation3d.kZero;
+
+    // Distance sort
+    // poses are in order of closest to farthest away from the origin at various positions in 3D
+    // space.
+    final var pose1 = new Translation3d(1, 0, 0);
+    final var pose2 = new Translation3d(0, 2, 0);
+    final var pose3 = new Translation3d(0, 0, 3);
+    final var pose4 = new Translation3d(2, 2, 2);
+    final var pose5 = new Translation3d(3, 3, 3);
+
+    assertEquals(pose3, origin.nearest(List.of(pose5, pose3, pose4)));
+    assertEquals(pose1, origin.nearest(List.of(pose1, pose2, pose3)));
+    assertEquals(pose2, origin.nearest(List.of(pose4, pose2, pose3)));
   }
 }

--- a/wpimath/src/test/native/cpp/geometry/Translation3dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Translation3dTest.cpp
@@ -191,8 +191,8 @@ TEST(Translation3dTest, Nearest) {
   const Translation3d origin{0_m, 0_m, 0_m};
 
   // Distance sort
-  // poses are in order of closest to farthest away from the origin at various positions in 3D
-  // space.
+  // poses are in order of closest to farthest away from the origin at various
+  // positions in 3D space.
   const Translation3d pose1{1_m, 0_m, 0_m};
   const Translation3d pose2{0_m, 2_m, 0_m};
   const Translation3d pose3{0_m, 0_m, 3_m};

--- a/wpimath/src/test/native/cpp/geometry/Translation3dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Translation3dTest.cpp
@@ -186,3 +186,31 @@ TEST(Translation3dTest, Constexpr) {
   static_assert(projected.X() == 1_m);
   static_assert(projected.Y() == 2_m);
 }
+
+TEST(Translation3dTest, Nearest) {
+  const Translation3d origin{0_m, 0_m, 0_m};
+
+  // Distance sort
+  // poses are in order of closest to farthest away from the origin at various positions in 3D
+  // space.
+  const Translation3d pose1{1_m, 0_m, 0_m};
+  const Translation3d pose2{0_m, 2_m, 0_m};
+  const Translation3d pose3{0_m, 0_m, 3_m};
+  const Translation3d pose4{2_m, 2_m, 2_m};
+  const Translation3d pose5{3_m, 3_m, 3_m};
+
+  auto nearest1 = origin.Nearest({pose5, pose3, pose4});
+  EXPECT_DOUBLE_EQ(nearest1.X().value(), pose3.X().value());
+  EXPECT_DOUBLE_EQ(nearest1.Y().value(), pose3.Y().value());
+  EXPECT_DOUBLE_EQ(nearest1.Z().value(), pose3.Z().value());
+
+  auto nearest2 = origin.Nearest({pose1, pose2, pose3});
+  EXPECT_DOUBLE_EQ(nearest2.X().value(), pose1.X().value());
+  EXPECT_DOUBLE_EQ(nearest2.Y().value(), pose1.Y().value());
+  EXPECT_DOUBLE_EQ(nearest2.Z().value(), pose1.Z().value());
+
+  auto nearest3 = origin.Nearest({pose4, pose2, pose3});
+  EXPECT_DOUBLE_EQ(nearest3.X().value(), pose2.X().value());
+  EXPECT_DOUBLE_EQ(nearest3.Y().value(), pose2.Y().value());
+  EXPECT_DOUBLE_EQ(nearest3.Z().value(), pose2.Z().value());
+}


### PR DESCRIPTION
This PR adds a nearest method to the `Translation3d` class to make it consistent with Pose3d and Translation2d. It also makes Java's parameter be a generic collection, which partially fixes #7873 and is non breaking. I believe this is relevant because when implementing nearest for the Translation3d it made sense to use Collection, and I realised all the other nearest methods could do this as well.