### PR TITLE
[wpimath] Update parameter type from list to collection in Java nearest methods

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose2d.java
@@ -20,9 +20,9 @@ import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import edu.wpi.first.util.struct.StructSerializable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Objects;
 
 /** Represents a 2D pose containing translational and rotational elements. */
@@ -347,13 +347,13 @@ public class Pose2d implements Interpolatable<Pose2d>, ProtobufSerializable, Str
   }
 
   /**
-   * Returns the nearest Pose2d from a list of poses. If two or more poses in the list have the same
-   * distance from this pose, return the one with the closest rotation component.
+   * Returns the nearest Pose2d from a collection of poses. If two or more poses in the collection
+   * have the same distance from this pose, return the one with the closest rotation component.
    *
-   * @param poses The list of poses to find the nearest.
-   * @return The nearest Pose2d from the list.
+   * @param poses The collection of poses to find the nearest.
+   * @return The nearest Pose2d from the collection.
    */
-  public Pose2d nearest(List<Pose2d> poses) {
+  public Pose2d nearest(Collection<Pose2d> poses) {
     return Collections.min(
         poses,
         Comparator.comparing(

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose3d.java
@@ -21,9 +21,9 @@ import edu.wpi.first.math.numbers.N4;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import edu.wpi.first.util.struct.StructSerializable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Objects;
 
 /** Represents a 3D pose containing translational and rotational elements. */
@@ -400,13 +400,13 @@ public class Pose3d implements Interpolatable<Pose3d>, ProtobufSerializable, Str
   }
 
   /**
-   * Returns the nearest Pose3d from a list of poses. If two or more poses in the list have the same
-   * distance from this pose, return the one with the closest rotation component.
+   * Returns the nearest Pose3d from a collection of poses. If two or more poses in the collection
+   * have the same distance from this pose, return the one with the closest rotation component.
    *
-   * @param poses The list of poses to find the nearest.
-   * @return The nearest Pose3d from the list.
+   * @param poses The collection of poses to find the nearest.
+   * @return The nearest Pose3d from the collection.
    */
-  public Pose3d nearest(List<Pose3d> poses) {
+  public Pose3d nearest(Collection<Pose3d> poses) {
     return Collections.min(
         poses,
         Comparator.comparing(

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation2d.java
@@ -20,9 +20,9 @@ import edu.wpi.first.math.numbers.N2;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import edu.wpi.first.util.struct.StructSerializable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -273,12 +273,12 @@ public class Translation2d
   }
 
   /**
-   * Returns the nearest Translation2d from a list of translations.
+   * Returns the nearest Translation2d from a collection of translations.
    *
-   * @param translations The list of translations.
-   * @return The nearest Translation2d from the list.
+   * @param translations The collection of translations.
+   * @return The nearest Translation2d from the collection.
    */
-  public Translation2d nearest(List<Translation2d> translations) {
+  public Translation2d nearest(Collection<Translation2d> translations) {
     return Collections.min(translations, Comparator.comparing(this::getDistance));
   }
 

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
@@ -20,9 +20,9 @@ import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import edu.wpi.first.util.struct.StructSerializable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -305,7 +305,7 @@ public class Translation3d
    * @param translations The collection of translations to find the nearest.
    * @return The nearest Translation3d from the collection.
    */
-  public Translation3d nearest(List<Translation3d> translations) {
+  public Translation3d nearest(Collection<Translation3d> translations) {
     return Collections.min(translations, Comparator.comparing(this::getDistance));
   }
 


### PR DESCRIPTION
Update parameter type of `nearest()` methods on geometry classes in Java to take in a `Collection` instead of specifically a `List`. This is helpful because `Collection` is a super interface of `List`, letting the function take in more general data instead of unnecessarily requiring ordered lists. 

This requires no change of the method itself and keeps the same functionality.

Fixes #7873