### PR TITLE
[wpimath] Pass Translation2d by const reference instead of by value

### DIFF
--- a/wpimath/src/main/native/include/frc/geometry/Translation2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Translation2d.h
@@ -238,10 +238,11 @@ class WPILIB_DLLEXPORT Translation2d {
    */
   constexpr Translation2d Nearest(
       std::span<const Translation2d> translations) const {
-    return *std::min_element(translations.begin(), translations.end(),
-                             [this](Translation2d a, Translation2d b) {
-                               return this->Distance(a) < this->Distance(b);
-                             });
+    return *std::min_element(
+        translations.begin(), translations.end(),
+        [this](const Translation2d& a, const Translation2d& b) {
+          return this->Distance(a) < this->Distance(b);
+        });
   }
 
   /**
@@ -251,10 +252,11 @@ class WPILIB_DLLEXPORT Translation2d {
    */
   constexpr Translation2d Nearest(
       std::initializer_list<Translation2d> translations) const {
-    return *std::min_element(translations.begin(), translations.end(),
-                             [this](Translation2d a, Translation2d b) {
-                               return this->Distance(a) < this->Distance(b);
-                             });
+    return *std::min_element(
+        translations.begin(), translations.end(),
+        [this](const Translation2d& a, const Translation2d& b) {
+          return this->Distance(a) < this->Distance(b);
+        });
   }
 
  private:


### PR DESCRIPTION
Quick fix to update nearest method of Translation2d to pass values by const ref instead of by value in min_element's llamada. 

When adding the Translation3d method, [calcmogul](https://github.com/calcmogul) noticed both C++ translation methods needed a fix.
> Translation2d should be updated similarly, now that I'm looking at it. The rule of thumb is to pass anything larger than the machine word size (e.g., 32 bits on a 32-bit system) by const ref.
> Separate branch/PR.
