### PR TITLE
Fix I2C order on systemcore

### DIFF
--- a/hal/src/main/native/systemcore/I2C.cpp
+++ b/hal/src/main/native/systemcore/I2C.cpp
@@ -25,8 +25,8 @@
 using namespace hal;
 
 namespace {
-constexpr const char* physicalPorts[kNumI2cBuses] = {"/dev/i2c-1",
-                                                     "/dev/i2c-10"};
+constexpr const char* physicalPorts[kNumI2cBuses] = {"/dev/i2c-10",
+                                                     "/dev/i2c-1"};
 
 struct I2C {
   wpi::mutex initMutex;


### PR DESCRIPTION
We'll just have to document that alpha is backwards.