### PR TITLE
Various CAN fixes

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/can/CANStreamMessage.java
+++ b/hal/src/main/java/edu/wpi/first/hal/can/CANStreamMessage.java
@@ -8,9 +8,9 @@ package edu.wpi.first.hal.can;
 public class CANStreamMessage {
   /** The message data. */
   @SuppressWarnings("MemberName")
-  public final byte[] data = new byte[8];
+  public final byte[] data = new byte[64];
 
-  /** The length of the data received (0-8 bytes). */
+  /** The length of the data received (0-64 bytes). */
   @SuppressWarnings("MemberName")
   public int length;
 

--- a/hal/src/main/native/cpp/jni/CANJNI.cpp
+++ b/hal/src/main/native/cpp/jni/CANJNI.cpp
@@ -214,8 +214,9 @@ Java_edu_wpi_first_hal_can_CANJNI_readCANStreamSession
       }
     }
     JLocal<jbyteArray> toSetArray{
-        env, SetCANStreamObject(env, elem, msg->message.message.dataSize,
-                                msg->messageId, msg->message.timeStamp)};
+        env, SetCANStreamObject(env, elem, msg->message.message.flags,
+                                msg->message.message.dataSize, msg->messageId,
+                                msg->message.timeStamp)};
     auto javaLen = env->GetArrayLength(toSetArray);
     if (javaLen < msg->message.message.dataSize) {
       ThrowIllegalArgumentException(

--- a/hal/src/main/native/cpp/jni/HALUtil.cpp
+++ b/hal/src/main/native/cpp/jni/HALUtil.cpp
@@ -235,13 +235,14 @@ jbyteArray SetCANReceiveMessageObject(JNIEnv* env, jobject canData,
 }
 
 jbyteArray SetCANStreamObject(JNIEnv* env, jobject canStreamData,
-                              int32_t length, uint32_t messageId,
+                              int32_t length, int32_t flags,
+                              uint32_t messageId,
                               uint64_t timestamp) {
   static jmethodID func =
-      env->GetMethodID(canStreamMessageCls, "setStreamData", "(IIJ)[B");
+      env->GetMethodID(canStreamMessageCls, "setStreamData", "(IIIJ)[B");
 
   jbyteArray retVal = static_cast<jbyteArray>(env->CallObjectMethod(
-      canStreamData, func, static_cast<jint>(length),
+      canStreamData, func, static_cast<jint>(length), static_cast<jint>(flags),
       static_cast<jint>(messageId), static_cast<jlong>(timestamp)));
   return retVal;
 }

--- a/hal/src/main/native/cpp/jni/HALUtil.h
+++ b/hal/src/main/native/cpp/jni/HALUtil.h
@@ -67,7 +67,7 @@ jbyteArray SetCANReceiveMessageObject(JNIEnv* env, jobject canData,
                                       uint64_t timestamp);
 
 jbyteArray SetCANStreamObject(JNIEnv* env, jobject canStreamData,
-                              int32_t length, uint32_t messageId,
+                              int32_t length, int32_t flags, uint32_t messageId,
                               uint64_t timestamp);
 
 jobject CreateHALValue(JNIEnv* env, const HAL_Value& value);

--- a/hal/src/main/native/include/hal/CAN.h
+++ b/hal/src/main/native/include/hal/CAN.h
@@ -19,6 +19,8 @@
 #define HAL_ERR_CANSessionMux_InvalidBuffer -44086
 #define HAL_ERR_CANSessionMux_MessageNotFound -44087
 #define HAL_WARN_CANSessionMux_NoToken 44087
+#define HAL_WARN_CANSessionMux_TxQueueFull 44086
+#define HAL_WARN_CANSessionMux_SocketBufferFull 44088
 #define HAL_ERR_CANSessionMux_NotAllowed -44088
 #define HAL_ERR_CANSessionMux_NotInitialized -44089
 #define HAL_ERR_CANSessionMux_SessionOverrun 44050

--- a/hal/src/main/native/include/hal/Errors.h
+++ b/hal/src/main/native/include/hal/Errors.h
@@ -35,6 +35,10 @@
 #define WARN_CANSessionMux_NoToken_MESSAGE "CAN: No token"
 #define ERR_CANSessionMux_NotAllowed_MESSAGE "CAN: Not allowed"
 #define ERR_CANSessionMux_NotInitialized_MESSAGE "CAN: Not initialized"
+#define HAL_WARN_CANSessionMux_TxQueueFull_MESSAGE \
+  "CAN: TX Queue full. Generally caused by a disconnected bus."
+#define HAL_WARN_CANSessionMux_SocketBufferFull_MESSAGE \
+  "CAN: Socket Buffer full. Generally caused by sending too many packets."
 
 #define ERR_FRCSystem_NetCommNotResponding_MESSAGE \
   "FRCSystem: NetComm not responding"

--- a/hal/src/main/native/include/hal/handles/HandlesInternal.h
+++ b/hal/src/main/native/include/hal/handles/HandlesInternal.h
@@ -72,6 +72,7 @@ enum class HAL_HandleEnum {
   CTREPDP = 25,
   REVPDH = 26,
   REVPH = 27,
+  CANStream = 28,
 };
 
 /**

--- a/hal/src/main/native/systemcore/HAL.cpp
+++ b/hal/src/main/native/systemcore/HAL.cpp
@@ -130,6 +130,10 @@ const char* HAL_GetErrorMessage(int32_t code) {
       return ERR_CANSessionMux_NotAllowed_MESSAGE;
     case HAL_ERR_CANSessionMux_NotInitialized:
       return ERR_CANSessionMux_NotInitialized_MESSAGE;
+    case HAL_WARN_CANSessionMux_TxQueueFull:
+      return HAL_WARN_CANSessionMux_TxQueueFull_MESSAGE;
+    case HAL_WARN_CANSessionMux_SocketBufferFull:
+      return HAL_WARN_CANSessionMux_SocketBufferFull_MESSAGE;
     case HAL_PWM_SCALE_ERROR:
       return HAL_PWM_SCALE_ERROR_MESSAGE;
     case HAL_SERIAL_PORT_NOT_FOUND:


### PR DESCRIPTION
Adds CAN stream support.

Fixes issue where sending to a disconnected bus resulted in an invalid buffer error. Instead, that is now converted into a warning.

Fixes issue where sending too many packets to a connected bus resulted in an invalid buffer error. Instead that is now converted into a warning with a better message.