### PR TITLE
[bazel] Simple shared library implementation

### DIFF
--- a/apriltag/BUILD.bazel
+++ b/apriltag/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_pkg//:mappings.bzl", "pkg_files")
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("@rules_python//python:defs.bzl", "py_binary")
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
 load("//shared/bazel/rules:packaging.bzl", "pkg_java_files")
@@ -59,15 +59,28 @@ wpilib_cc_library(
         exclude = ["src/main/native/cpp/jni/**"],
     ),
     hdrs = glob(["src/main/native/include/**/*"]),
-    defines = ["WPILIB_EXPORTS"],
     extra_hdr_pkg_files = [":thirdparty-apriltag-src-pkg"],
     extra_src_pkg_files = [":apriltag-java-jni-hdrs-pkg"],
+    local_defines = ["WPILIB_EXPORTS"],
     strip_include_prefix = "src/main/native/include",
     visibility = ["//visibility:public"],
     deps = [
         ":thirdparty-apriltag",
         "//wpimath",
         "//wpiutil",
+    ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/apriltag",
+    auto_export_windows_symbols = False,
+    dynamic_deps = [
+        "//wpimath:shared/wpimath",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":apriltag",
     ],
 )
 
@@ -91,6 +104,18 @@ wpilib_jni_cc_library(
     deps = [
         ":apriltag",
     ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/apriltagjni",
+    auto_export_windows_symbols = False,
+    dynamic_deps = [
+        ":shared/apriltag",
+        "//wpimath:shared/wpimath",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":apriltagjni"],
 )
 
 wpilib_jni_java_library(

--- a/datalog/BUILD.bazel
+++ b/datalog/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_python//python:defs.bzl", "py_binary")
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
 
@@ -24,6 +24,15 @@ wpilib_cc_library(
     ],
 )
 
+wpilib_cc_shared_library(
+    name = "shared/datalog",
+    dynamic_deps = [
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":datalog"],
+)
+
 wpilib_cc_static_library(
     name = "static/datalog",
     static_deps = [
@@ -41,6 +50,17 @@ wpilib_jni_cc_library(
     deps = [
         ":datalog",
     ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/datalogjni",
+    auto_export_windows_symbols = False,
+    dynamic_deps = [
+        ":shared/datalog",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":datalogjni"],
 )
 
 wpilib_jni_java_library(

--- a/hal/BUILD.bazel
+++ b/hal/BUILD.bazel
@@ -4,7 +4,7 @@ load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_pkg//:mappings.bzl", "pkg_files")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//hal:generate.bzl", "generate_hal")
-load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
 
@@ -111,6 +111,23 @@ wpilib_cc_library(
     }),
 )
 
+wpilib_cc_shared_library(
+    name = "shared/wpiHal",
+    dynamic_deps = [
+        "//wpiutil:shared/wpiutil",
+    ] + select({
+        "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": [
+            "//ntcore:shared/ntcore",
+            "//wpinet:shared/wpinet",
+        ],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":wpiHal",
+    ],
+)
+
 wpilib_cc_static_library(
     name = "static/wpiHal",
     static_deps = [
@@ -135,6 +152,19 @@ wpilib_jni_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":wpiHal",
+    ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/wpiHaljni",
+    auto_export_windows_symbols = False,
+    dynamic_deps = [
+        ":shared/wpiHal",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":wpiHaljni",
     ],
 )
 

--- a/ntcore/BUILD.bazel
+++ b/ntcore/BUILD.bazel
@@ -5,7 +5,7 @@ load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//ntcore:generate_ntcore.bzl", "generate_ntcore")
-load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
 load("//shared/bazel/rules:packaging.bzl", "pkg_java_files")
@@ -101,6 +101,19 @@ wpilib_cc_library(
     ],
 )
 
+wpilib_cc_shared_library(
+    name = "shared/ntcore",
+    dynamic_deps = [
+        "//datalog:shared/datalog",
+        "//wpinet:shared/wpinet",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ntcore",
+    ],
+)
+
 wpilib_cc_static_library(
     name = "static/ntcore",
     static_deps = [
@@ -122,6 +135,17 @@ wpilib_jni_cc_library(
     deps = [
         ":ntcore",
     ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/ntcorejni",
+    auto_export_windows_symbols = False,
+    dynamic_deps = [
+        ":shared/ntcore",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":ntcorejni"],
 )
 
 wpilib_jni_java_library(

--- a/romiVendordep/BUILD.bazel
+++ b/romiVendordep/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 load("@rules_java//java:defs.bzl", "java_binary", "java_library")
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 
 wpilib_cc_library(
     name = "romiVendordep",
@@ -14,6 +14,21 @@ wpilib_cc_library(
         "//ntcore",
         "//wpilibc",
         "//wpinet",
+    ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/romiVendordep",
+    dynamic_deps = [
+        "//hal:shared/wpiHal",
+        "//ntcore:shared/ntcore",
+        "//wpilibc:shared/wpilibc",
+        "//wpinet:shared/wpinet",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":romiVendordep",
     ],
 )
 

--- a/shared/bazel/rules/cc_rules.bzl
+++ b/shared/bazel/rules/cc_rules.bzl
@@ -149,6 +149,32 @@ def wpilib_cc_library(
             tags = ["no-remote"],
         )
 
+def wpilib_cc_shared_library(
+        name,
+        auto_export_windows_symbols = True,
+        **kwargs):
+    features = []
+    if auto_export_windows_symbols:
+        features.append("windows_export_all_symbols")
+
+    native.cc_shared_library(
+        name = name,
+        features = features,
+        **kwargs
+    )
+
+    pkg_files(
+        name = name + "-shared.pkg",
+        srcs = [":" + name],
+        tags = ["manual"],
+    )
+
+    pkg_zip(
+        name = name + "-shared-zip",
+        srcs = ["//:license_pkg_files", name + "-shared.pkg"],
+        tags = ["no-remote", "manual"],
+    )
+
 CcStaticLibraryInfo = provider(
     "Information about a cc static library.",
     fields = {
@@ -347,4 +373,16 @@ def wpilib_cc_static_library(
         name = name,
         static_lib_name = static_lib_name,
         **kwargs
+    )
+
+    pkg_files(
+        name = name + "-static.pkg",
+        srcs = [":" + name],
+        tags = ["manual"],
+    )
+
+    pkg_zip(
+        name = name + "-static-zip",
+        srcs = ["//:license_pkg_files", name + "-static.pkg"],
+        tags = ["no-remote", "manual"],
     )

--- a/simulation/halsim_ds_socket/BUILD.bazel
+++ b/simulation/halsim_ds_socket/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 
 cc_library(
     name = "headers",
@@ -42,6 +42,18 @@ wpilib_cc_library(
         "//hal:wpiHal",
         "//wpinet",
     ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/halsim_ds_socket",
+    auto_export_windows_symbols = False,
+    dynamic_deps = [
+        "//hal:shared/wpiHal",
+        "//wpinet:shared/wpinet",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":halsim_ds_socket"],
 )
 
 wpilib_cc_static_library(

--- a/simulation/halsim_ws_core/BUILD.bazel
+++ b/simulation/halsim_ws_core/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 
 wpilib_cc_library(
     name = "halsim_ws_core",
@@ -16,6 +16,20 @@ wpilib_cc_library(
         "//hal:wpiHal",
         "//wpinet",
         "//wpiutil",
+    ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/halsim_ws_core",
+    auto_export_windows_symbols = False,
+    dynamic_deps = [
+        "//hal:shared/wpiHal",
+        "//wpinet:shared/wpinet",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":halsim_ws_core",
     ],
 )
 

--- a/simulation/halsim_ws_server/BUILD.bazel
+++ b/simulation/halsim_ws_server/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 
 cc_library(
     name = "headers",
@@ -39,6 +39,20 @@ wpilib_cc_library(
     deps = [
         ":headers",
         "//simulation/halsim_ws_core",
+    ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/halsim_ws_server",
+    auto_export_windows_symbols = False,
+    dynamic_deps = [
+        "//hal:shared/wpiHal",
+        "//wpinet:shared/wpinet",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":halsim_ws_server",
     ],
 )
 

--- a/simulation/halsim_xrp/BUILD.bazel
+++ b/simulation/halsim_xrp/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 
 wpilib_cc_library(
     name = "halsim_xrp",
@@ -41,6 +41,19 @@ wpilib_cc_library(
     deps = [
         "//simulation/halsim_ws_core",
         "//wpinet",
+    ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/halsim_xrp",
+    auto_export_windows_symbols = False,
+    dynamic_deps = [
+        "//wpinet:shared/wpinet",
+        "//hal:shared/wpiHal",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":halsim_xrp",
     ],
 )
 

--- a/wpilibNewCommands/BUILD.bazel
+++ b/wpilibNewCommands/BUILD.bazel
@@ -4,7 +4,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("@rules_python//python:defs.bzl", "py_binary")
-load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:packaging.bzl", "pkg_java_files")
 load("//wpilibNewCommands:generate.bzl", "generate_wpilib_new_commands")
@@ -66,6 +66,20 @@ wpilib_cc_library(
         "//wpilibc",
         "//wpinet",
     ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/wpilibNewCommands",
+    dynamic_deps = [
+        "//hal:shared/wpiHal",
+        "//ntcore:shared/ntcore",
+        "//wpilibc:shared/wpilibc",
+        "//wpimath:shared/wpimath",
+        "//wpinet:shared/wpinet",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":wpilibNewCommands"],
 )
 
 wpilib_cc_static_library(

--- a/wpilibc/BUILD.bazel
+++ b/wpilibc/BUILD.bazel
@@ -2,7 +2,7 @@ load("@allwpilib_pip_deps//:requirements.bzl", "requirement")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_python//python:defs.bzl", "py_binary")
-load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules/gen:gen-version-file.bzl", "generate_version_file")
 load("//wpilibc:generate.bzl", "generate_wpilibc")
 
@@ -104,6 +104,22 @@ wpilib_cc_library(
         "//wpimath",
         "//wpinet",
         "//wpiutil",
+    ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/wpilibc",
+    dynamic_deps = [
+        "//datalog:shared/datalog",
+        "//hal:shared/wpiHal",
+        "//ntcore:shared/ntcore",
+        "//wpimath:shared/wpimath",
+        "//wpinet:shared/wpinet",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":wpilibc",
     ],
 )
 

--- a/wpimath/BUILD.bazel
+++ b/wpimath/BUILD.bazel
@@ -4,7 +4,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("@rules_python//python:defs.bzl", "py_binary")
-load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
 load("//shared/bazel/rules:packaging.bzl", "pkg_java_files")
@@ -121,13 +121,16 @@ wpilib_cc_library(
         exclude = ["src/main/native/cpp/jni/**"],
     ),
     hdrs = glob(["src/main/native/include/**"]),
-    defines = ["WPILIB_EXPORTS"],
     extra_src_pkg_files = [
         ":wpimath-java-jni-hdrs-pkg",
     ],
     includes = [
         "src/main/native/include",
         "src/main/native/thirdparty/sleipnir/src",
+    ],
+    local_defines = [
+        "WPILIB_EXPORTS",
+        "SLEIPNIR_EXPORTS",
     ],
     strip_include_prefix = "src/main/native/include",
     third_party_header_only_libraries = [
@@ -141,6 +144,18 @@ wpilib_cc_library(
     deps = [
         ":nanopb-generated-headers",
         "//wpiutil",
+    ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/wpimath",
+    auto_export_windows_symbols = False,
+    dynamic_deps = [
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":wpimath",
     ],
 )
 
@@ -163,6 +178,17 @@ wpilib_jni_cc_library(
     deps = [
         ":wpimath",
     ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/wpimathjni",
+    auto_export_windows_symbols = False,
+    dynamic_deps = [
+        ":shared/wpimath",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":wpimathjni"],
 )
 
 wpilib_jni_java_library(

--- a/wpinet/BUILD.bazel
+++ b/wpinet/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_pkg//:mappings.bzl", "pkg_files")
-load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
 load("//shared/bazel/rules/gen:gen-resources.bzl", "generate_resources")
@@ -149,6 +149,17 @@ wpilib_cc_library(
     ],
 )
 
+wpilib_cc_shared_library(
+    name = "shared/wpinet",
+    dynamic_deps = [
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":wpinet",
+    ],
+)
+
 wpilib_cc_static_library(
     name = "static/wpinet",
     static_deps = [
@@ -171,6 +182,17 @@ wpilib_jni_cc_library(
     deps = [
         ":wpinet",
     ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/wpinetjni",
+    auto_export_windows_symbols = False,
+    dynamic_deps = [
+        ":shared/wpinet",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":wpinetjni"],
 )
 
 wpilib_jni_java_library(

--- a/wpiutil/BUILD.bazel
+++ b/wpiutil/BUILD.bazel
@@ -4,7 +4,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("@rules_python//python:defs.bzl", "py_binary")
-load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
 load("//shared/bazel/rules:packaging.bzl", "pkg_java_files")
@@ -171,6 +171,14 @@ wpilib_cc_library(
     }),
 )
 
+wpilib_cc_shared_library(
+    name = "shared/wpiutil",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":wpiutil",
+    ],
+)
+
 wpilib_cc_static_library(
     name = "static/wpiutil",
     visibility = ["//visibility:public"],
@@ -201,6 +209,16 @@ wpilib_jni_cc_library(
     deps = [
         ":wpiutil",
     ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/wpiutiljni",
+    auto_export_windows_symbols = False,
+    dynamic_deps = [
+        ":shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":wpiutiljni"],
 )
 
 wpilib_cc_static_library(

--- a/xrpVendordep/BUILD.bazel
+++ b/xrpVendordep/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 load("@rules_java//java:defs.bzl", "java_binary", "java_library")
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 
 wpilib_cc_library(
     name = "xrpVendordep",
@@ -15,6 +15,19 @@ wpilib_cc_library(
         "//wpilibc",
         "//wpinet",
     ],
+)
+
+wpilib_cc_shared_library(
+    name = "shared/xrpVendordep",
+    dynamic_deps = [
+        "//hal:shared/wpiHal",
+        "//ntcore:shared/ntcore",
+        "//wpilibc:shared/wpilibc",
+        "//wpinet:shared/wpinet",
+        "//wpiutil:shared/wpiutil",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":xrpVendordep"],
 )
 
 wpilib_cc_static_library(


### PR DESCRIPTION
This is another watered down version of #8025 that does the bare minimum to get most of the libraries building and linking shared libraries. Austins PR seems to attempt to get very accurate comparison results with the gradle publishing process, such as splitting out debug symbols. That implementation is still very linux focused, so this breaks out the majority of the important guts, which might unblock his unpublished maven work.

The symbol exports in DLL's are not perfect, but get pretty close without having to change bazels default compiler flags. The same was true of linux .so's. The windows implementation of `cc_shared_library` does not seem to handle transitive deps on purpose, so that results in more explicit `dynamic_deps` call outs.