### PR TITLE
[ci] Update Homebrew protobuf version for CMake

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,8 +23,8 @@ jobs:
           - os: macOS-14
             name: macOS
             container: ""
-            env: "PATH=\"/opt/homebrew/opt/protobuf@3/bin:$PATH\""
-            flags: "--preset with-sccache -DCMAKE_BUILD_TYPE=Release -DWITH_EXAMPLES=ON -DCMAKE_LIBRARY_PATH=/opt/homebrew/opt/protobuf@3/lib -DProtobuf_INCLUDE_DIR=/opt/homebrew/opt/protobuf@3/include -DProtobuf_PROTOC_EXECUTABLE=/opt/homebrew/opt/protobuf@3/bin/protoc"
+            env: ""
+            flags: "--preset with-sccache -DCMAKE_BUILD_TYPE=Release -DWITH_EXAMPLES=ON"
           - os: windows-2022
             name: Windows
             container: ""
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
-        run: brew install opencv protobuf@3 ninja
+        run: brew install opencv protobuf@29 ninja
 
       - uses: ilammy/msvc-dev-cmd@v1.13.0
         if: runner.os == 'Windows'


### PR DESCRIPTION
protobuf@3 will be deactivated July 1st, so it's been replaced with protobuf@29.