### PR TITLE
Fix Clang 20 warnings

### DIFF
--- a/cmake/modules/CompileWarnings.cmake
+++ b/cmake/modules/CompileWarnings.cmake
@@ -47,7 +47,14 @@ macro(wpilib_target_warnings target)
     # Suppress warning "enumeration types with a fixed underlying type are a
     # Clang extension"
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT EMSCRIPTEN)
-        target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-fixed-enum-extension>)
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 20.0)
+            target_compile_options(
+                ${target}
+                PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-fixed-enum-extension>
+            )
+        else()
+            target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-c23-extensions>)
+        endif()
     endif()
 
     # Compress debug info with GCC

--- a/sysid/src/main/native/include/sysid/view/Analyzer.h
+++ b/sysid/src/main/native/include/sysid/view/Analyzer.h
@@ -208,8 +208,6 @@ class Analyzer : public glass::View {
   std::string m_exception;
   std::vector<std::string> m_missingTests;
 
-  bool m_calcDefaults = false;
-
   // This is true if the error popup needs to be displayed
   bool m_errorPopup = false;
 
@@ -235,11 +233,7 @@ class Analyzer : public glass::View {
   // Data analysis
   std::unique_ptr<AnalysisManager> m_manager;
   int m_dataset = 0;
-  int m_window = 8;
-  double m_threshold = 0.2;
   float m_stepTestDuration = 0;
-
-  bool combinedGraphFit = false;
 
   // Logger
   wpi::Logger& m_logger;

--- a/thirdparty/imgui_suite/CMakeLists.txt
+++ b/thirdparty/imgui_suite/CMakeLists.txt
@@ -53,5 +53,9 @@ target_include_directories(
 
 target_compile_features(imgui PUBLIC cxx_std_20)
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 20.0)
+  target_compile_options(imgui PUBLIC -Wno-nontrivial-memcall)
+endif()
+
 install(TARGETS imgui EXPORT imgui)
 export(TARGETS imgui FILE imgui.cmake NAMESPACE imgui::)


### PR DESCRIPTION
* `-Wfixed-enum-extension` was replaced with `-Wc23-extensions`
* Removed unused private variables in SysId
* Suppressed `-Wnontrivial-memcall` in imgui.h and imgui_internal.h