### PR TITLE
Add missing sources to published zip files

### DIFF
--- a/hal/build.gradle
+++ b/hal/build.gradle
@@ -80,6 +80,9 @@ cppHeadersZip {
     from(generatedHeaders) {
         into '/'
     }
+    from('src/mrc/include') {
+        into '/'
+    }
 }
 
 Action<List<String>> symbolFilter = { symbols ->

--- a/ntcore/build.gradle
+++ b/ntcore/build.gradle
@@ -48,6 +48,12 @@ cppHeadersZip {
     }
 }
 
+cppSourcesZip {
+    from(generatedSources) {
+        into '/'
+    }
+}
+
 Action<List<String>> symbolFilter = { symbols ->
     symbols.removeIf({ !it.startsWith('NT_') })
 } as Action<List<String>>;

--- a/shared/javacpp/publish.gradle
+++ b/shared/javacpp/publish.gradle
@@ -23,6 +23,9 @@ task cppSourcesZip(type: Zip) {
     from("$buildDir/generated/cpp") {
         into '/'
     }
+    from("src/generated/main/native/cpp") {
+        into '/'
+    }
 }
 
 task cppHeadersZip(type: Zip) {

--- a/wpilibc/publish.gradle
+++ b/wpilibc/publish.gradle
@@ -21,6 +21,9 @@ task cppSourcesZip(type: Zip) {
     from("$buildDir/generated/cpp") {
         into '/'
     }
+    from("src/generated/main/native/cpp") {
+        into '/'
+    }
 }
 
 cppSourcesZip.dependsOn generateCppVersion

--- a/wpimath/build.gradle
+++ b/wpimath/build.gradle
@@ -52,6 +52,12 @@ cppHeadersZip {
     }
 }
 
+cppSourcesZip {
+    from('src/main/native/thirdparty/sleipnir/src') {
+        into '/'
+    }
+}
+
 model {
     components {
         all {

--- a/wpinet/build.gradle
+++ b/wpinet/build.gradle
@@ -198,6 +198,12 @@ cppHeadersZip {
     }
 }
 
+cppSourcesZip {
+    from('src/main/native/thirdparty/tcpsockets/cpp') {
+        into '/'
+    }
+}
+
 model {
     components {
         all {

--- a/wpiutil/build.gradle
+++ b/wpiutil/build.gradle
@@ -193,6 +193,9 @@ cppHeadersZip {
 }
 
 cppSourcesZip {
+    from('src/main/native/thirdparty/debugging/src') {
+        into '/'
+    }
     from('src/main/native/thirdparty/fmtlib/src') {
         into '/'
     }


### PR DESCRIPTION
Gradle publishing does not capture all of the source files that are used during a build. This should get most of them, and get it equivalent to what bazel pushes out.