### PR TITLE
Work around gcc 12 overlap memory region warning

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/I2CCommunication/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/I2CCommunication/cpp/Robot.cpp
@@ -24,7 +24,11 @@ void Robot::RobotPeriodic() {
   std::string allianceString = "U";
   auto alliance = frc::DriverStation::GetAlliance();
   if (alliance.has_value()) {
-    allianceString = alliance == frc::DriverStation::Alliance::kRed ? "R" : "B";
+    if (alliance == frc::DriverStation::Alliance::kRed) {
+      allianceString = "R";
+    } else {
+      allianceString = "B";
+    }
   }
 
   auto string =


### PR DESCRIPTION
Thad says this is a compiler bug, rather than fight it, let's use a new code path through the compiler.

ERROR: /home/austin/local/allwpilib3/wpilibcExamples/BUILD.bazel:50:12: Compiling wpilibcExamples/src/main/cpp/examples/I2CCommunication/cpp/Robot.cpp failed: (Exit 1): gcc failed: error executing CppCompile command (from target //wpilibcExamples:I2CCommunication-test) /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 234 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging In file included from /usr/include/c++/12/ios:40,
                 from /usr/include/c++/12/istream:38,
                 from /usr/include/c++/12/sstream:38,
                 from /usr/include/c++/12/chrono:41,
                 from bazel-out/k8-opt/bin/wpilibc/_virtual_includes/wpilibc.static/frc/TimedRobot.h:7,
                 from bazel-out/k8-opt/bin/wpilibcExamples/_virtual_includes/I2CCommunication-examples-headers/Robot.h:10,
                 from wpilibcExamples/src/main/cpp/examples/I2CCommunication/cpp/Robot.cpp:5:
In static member function 'static constexpr std::char_traits<char>::char_type* std::char_traits<char>::copy(char_type*, const char_type*, std::size_t)',
    inlined from 'static constexpr void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_S_copy(_CharT*, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/basic_string.h:423:21,
    inlined from 'static constexpr void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_S_copy(_CharT*, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/basic_string.h:418:7,
    inlined from 'constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/basic_string.tcc:532:22,
    inlined from 'constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::assign(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/basic_string.h:1647:19,
    inlined from 'constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator=(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/basic_string.h:815:28,
    inlined from 'virtual void Robot::RobotPeriodic()' at wpilibcExamples/src/main/cpp/examples/I2CCommunication/cpp/Robot.cpp:27:77:
/usr/include/c++/12/bits/char_traits.h:431:56: error: 'void* __builtin_memcpy(void*, const void*, long unsigned int)' accessing 9223372036854775810 or more bytes at offsets -4611686018427387902 and [-4611686018427387903, 4611686018427387904] may overlap up to 9223372036854775813 bytes at offset -3 [-Werror=restrict]
  431 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
      |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors