### PR TITLE
Clean-up and simplify CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,26 +11,18 @@
 # This should make it easy to add new rules without breaking existing ones.
 
 # Global rule:
-*  @wpilibsuite/wpilib
+*  @PeterJohnson @ThadHouse @calcmogul @rzblue
 
-/cameraserver/  @wpilibsuite/camera-server
+/epilogue-*/ @SamCarlberg @PeterJohnson @ThadHouse @calcmogul @rzblue
 
-/cscore/  @wpilibsuite/camera-server
+/romiVendordep/ @zhiquanyeo @jpokornyiii @PeterJohnson @ThadHouse @calcmogul @rzblue
 
-/hal/  @wpilibsuite/hardware
-/hal/src/main/java/**/sim/  @wpilibsuite/simulation
-/hal/src/main/native/include/mockdata/  @wpilibsuite/simulation
-/hal/src/main/native/include/simulation/  @wpilibsuite/simulation
-/hal/src/main/native/sim/  @wpilibsuite/simulation
+/simulation/  @zhiquanyeo @jpokornyiii @PeterJohnson @ThadHouse @calcmogul @rzblue
 
-/ntcore/  @wpilibsuite/network-tables
+/wpilibNewCommands/ @Starlight220 @PeterJohnson @ThadHouse @calcmogul @rzblue
 
-/simulation/  @wpilibsuite/simulation
+/wpilib?Examples/ @sciencewhiz @jasondaming @Starlight220 @PeterJohnson @ThadHouse @calcmogul @rzblue
 
-/wpilibNewCommands/  @wpilibsuite/commandbased
+/wpiunits/ @SamCarlberg @PeterJohnson @ThadHouse @calcmogul @rzblue
 
-/wpilibcExamples/  @wpilibsuite/wpilib @wpilibsuite/documentation
-
-/wpilibjExamples/  @wpilibsuite/wpilib @wpilibsuite/documentation
-
-/wpiutil/  @PeterJohnson
+/xrpVendordep/ @zhiquanyeo @jpokornyiii @PeterJohnson @ThadHouse @calcmogul @rzblue


### PR DESCRIPTION
The existing setup-up of groups was hard to maintain because of the many nested groups, and not very visible. This makes it much more clear.
Additionally, there were a few directories that only had a single maintainer. This ensures the core team is on every directory, and then adds people ass necessary.