### PR TITLE
Switch build tag filters from no-roborio to target_compatible_with

### DIFF
--- a/datalogtool/BUILD.bazel
+++ b/datalogtool/BUILD.bazel
@@ -42,10 +42,10 @@ cc_binary(
         "@rules_bzlmodrio_toolchains//constraints/combined:is_cross_compiler": [],
     }),
     tags = [
-        "no-roborio",
         "wpi-cpp-gui",
     ],
     target_compatible_with = select({
+        "@rules_bzlmodrio_toolchains//constraints/is_roborio:roborio": ["@platforms//:incompatible"],
         "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),

--- a/shared/bazel/compiler_flags/roborio_flags.rc
+++ b/shared/bazel/compiler_flags/roborio_flags.rc
@@ -5,7 +5,6 @@
 build:roborio --config=base_linux
 
 build:roborio --platforms=@rules_bzlmodrio_toolchains//platforms/roborio
-build:roborio --build_tag_filters=-no-roborio
 build:roborio --features=compiler_param_file
 build:roborio --platform_suffix=roborio
 build:roborio --incompatible_enable_cc_toolchain_resolution


### PR DESCRIPTION
This uses platforms a lot better.