### PR TITLE
Check results of subprocess.run in wpimath/generate_quickbuf.py

### DIFF
--- a/wpimath/generate_nanopb.py
+++ b/wpimath/generate_nanopb.py
@@ -19,7 +19,7 @@ def generate_nanopb(nanopb: Path, output_directory: Path, proto_dir: Path):
     proto_files = proto_dir.glob("*.proto")
     for path in proto_files:
         absolute_filename = path.absolute()
-        subprocess.run(
+        subprocess.check_call(
             [
                 sys.executable,
                 nanopb,
@@ -28,8 +28,7 @@ def generate_nanopb(nanopb: Path, output_directory: Path, proto_dir: Path):
                 "-S.cpp",
                 "-e.npb",
                 absolute_filename,
-            ],
-            check=True,
+            ]
         )
     java_files = (output_directory).glob("*")
     for java_file in java_files:

--- a/wpimath/generate_quickbuf.py
+++ b/wpimath/generate_quickbuf.py
@@ -15,7 +15,7 @@ def generate_quickbuf(
     proto_files = proto_dir.glob("*.proto")
     for path in proto_files:
         absolute_filename = path.absolute()
-        subprocess.run(
+        subprocess.check_call(
             [
                 protoc,
                 f"--plugin=protoc-gen-quickbuf={quickbuf_plugin}",


### PR DESCRIPTION
The generator was calling a binary of the wrong architecture and failing internally, but passing the build (incorrectly).  Explode right away.