### PR TITLE
Update and enable priority_mutex for systemcore

### DIFF
--- a/wpiutil/src/main/native/include/wpi/priority_mutex.h
+++ b/wpiutil/src/main/native/include/wpi/priority_mutex.h
@@ -13,9 +13,7 @@
 
 namespace wpi {
 
-// TODO replace this with systemcore once our compiler has the defines
-// for RT
-#if defined(__FRC_ROBORIO__) && !defined(WPI_USE_PRIORITY_MUTEX)
+#if defined(__FRC_SYSTEMCORE__) && !defined(WPI_USE_PRIORITY_MUTEX)
 #define WPI_USE_PRIORITY_MUTEX
 #endif
 
@@ -43,15 +41,11 @@ class priority_recursive_mutex {
   pthread_mutex_t* native_handle() { return &m_mutex; }
 
  private:
-// Do the equivalent of setting PTHREAD_PRIO_INHERIT and
-// PTHREAD_MUTEX_RECURSIVE_NP.
-#ifdef __PTHREAD_MUTEX_HAVE_PREV
+  // Do the equivalent of setting PTHREAD_PRIO_INHERIT and
+  // PTHREAD_MUTEX_RECURSIVE_NP.
+  // from glibc sysdeps/nptl/pthreadP.h: PTHREAD_MUTEX_PRIO_INHERIT_NP = 32
   pthread_mutex_t m_mutex = {
-      {0, 0, 0, 0, 0x20 | PTHREAD_MUTEX_RECURSIVE_NP, __PTHREAD_SPINS, {0, 0}}};
-#else
-  pthread_mutex_t m_mutex = {
-      {0, 0, 0, 0x20 | PTHREAD_MUTEX_RECURSIVE_NP, 0, {__PTHREAD_SPINS}}};
-#endif
+      {__PTHREAD_MUTEX_INITIALIZER(0x20 | PTHREAD_MUTEX_RECURSIVE_NP)}};
 };
 
 class priority_mutex {
@@ -74,12 +68,9 @@ class priority_mutex {
   pthread_mutex_t* native_handle() { return &m_mutex; }
 
  private:
-// Do the equivalent of setting PTHREAD_PRIO_INHERIT.
-#ifdef __PTHREAD_MUTEX_HAVE_PREV
-  pthread_mutex_t m_mutex = {{0, 0, 0, 0, 0x20, __PTHREAD_SPINS, {0, 0}}};
-#else
-  pthread_mutex_t m_mutex = {{0, 0, 0, 0x20, 0, {__PTHREAD_SPINS}}};
-#endif
+  // Do the equivalent of setting PTHREAD_PRIO_INHERIT.
+  // from glibc sysdeps/nptl/pthreadP.h: PTHREAD_MUTEX_PRIO_INHERIT_NP = 32
+  pthread_mutex_t m_mutex = {{__PTHREAD_MUTEX_INITIALIZER(0x20)}};
 };
 
 #endif  // defined(WPI_USE_PRIORITY_MUTEX) && defined(__linux__)


### PR DESCRIPTION
Everything is part of glibc, so no special toolchain or patches needed. 
`priority_mutex_test` passes on my laptop after setting `WPI_HAVE_PRIORITY_MUTEX` and enabling the priority inversion tests.