### PR TITLE
[bazel] Install bazel on docker image builds

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -67,6 +67,12 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+
       - name: Setup Artifactory
         uses: ./.github/actions/setup-artifactory-bazel
         with:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -67,11 +67,7 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
-      - uses: bazel-contrib/setup-bazel@0.15.0
-        with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}
-          repository-cache: true
+      - uses: bazelbuild/setup-bazelisk@v3
 
       - name: Setup Artifactory
         uses: ./.github/actions/setup-artifactory-bazel
@@ -79,8 +75,8 @@ jobs:
           username: ${{ secrets.ARTIFACTORY_USERNAME }}
           token: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
-      - name: bazelisk ${{ matrix.action }} (release)
-        run: bazelisk ${{ matrix.action }} ... --config=ci -c opt ${{ matrix.config }} -k --verbose_failures
+      - name: bazel ${{ matrix.action }} (release)
+        run: bazel ${{ matrix.action }} ... --config=ci -c opt ${{ matrix.config }} -k --verbose_failures
 
   buildifier:
     name: "buildifier"

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -67,16 +67,17 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
-      - uses: bazel-contrib/setup-bazel@0.15.0
-        with:
-          bazelisk-cache: true
-          repository-cache: true
-
       - name: Setup Artifactory
         uses: ./.github/actions/setup-artifactory-bazel
         with:
           username: ${{ secrets.ARTIFACTORY_USERNAME }}
           token: ${{ secrets.ARTIFACTORY_PASSWORD }}
+
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          repository-cache: true
+          bazelisk-version: 1.x
 
       - name: bazel ${{ matrix.action }} (release)
         run: bazel ${{ matrix.action }} ... --config=ci -c opt ${{ matrix.config }} -k --verbose_failures

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -67,7 +67,10 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
-      - uses: bazelbuild/setup-bazelisk@v3
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          repository-cache: true
 
       - name: Setup Artifactory
         uses: ./.github/actions/setup-artifactory-bazel

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -79,8 +79,8 @@ jobs:
           username: ${{ secrets.ARTIFACTORY_USERNAME }}
           token: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
-      - name: bazel ${{ matrix.action }} (release)
-        run: bazel ${{ matrix.action }} ... --config=ci -c opt ${{ matrix.config }} -k --verbose_failures
+      - name: bazelisk ${{ matrix.action }} (release)
+        run: bazelisk ${{ matrix.action }} ... --config=ci -c opt ${{ matrix.config }} -k --verbose_failures
 
   buildifier:
     name: "buildifier"


### PR DESCRIPTION
[This](https://github.com/wpilibsuite/allwpilib/pull/8006) PR removed the `setup-bazelisk` step for all of the actions. This works for the native builds because bazel(isk) has been added to the default runners. However, in the 2027 branch we build linux on the `wpilib/ubuntu-base:24.04` so that we can get the gui related sytem libraries (xwindows, etc) by default. The image does not have bazelisk, so it must be done with an explicit step. We can update the image as well, but this fixes (minus the cache issue) the build now.