### PR TITLE
[examples] Update templates to cancel the auto command in AutonomousExit

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/cpp/Robot.cpp
@@ -45,9 +45,9 @@ void Robot::AutonomousInit() {
 
 void Robot::AutonomousPeriodic() {}
 
-void Robot::TeleopInit() {
+void Robot::AutonomousExit() {
   // This makes sure that the autonomous stops running when
-  // teleop starts running. If you want the autonomous to
+  // autonomous mode ends. If you want the autonomous to
   // continue until interrupted by another command, remove
   // this line or comment it out.
   if (autonomousCommand) {
@@ -55,6 +55,8 @@ void Robot::TeleopInit() {
     autonomousCommand.reset();
   }
 }
+
+void Robot::TeleopInit() {}
 
 /**
  * This function is called periodically during operator control.

--- a/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/include/Robot.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/include/Robot.hpp
@@ -18,6 +18,7 @@ class Robot : public wpi::TimedRobot {
   void DisabledPeriodic() override;
   void AutonomousInit() override;
   void AutonomousPeriodic() override;
+  void AutonomousExit() override;
   void TeleopInit() override;
   void TeleopPeriodic() override;
   void UtilityPeriodic() override;

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/Robot.cpp
@@ -53,9 +53,9 @@ void Robot::AutonomousInit() {
 
 void Robot::AutonomousPeriodic() {}
 
-void Robot::TeleopInit() {
+void Robot::AutonomousExit() {
   // This makes sure that the autonomous stops running when
-  // teleop starts running. If you want the autonomous to
+  // autonomous mode ends. If you want the autonomous to
   // continue until interrupted by another command, remove
   // this line or comment it out.
   if (autonomousCommand != nullptr) {
@@ -63,6 +63,8 @@ void Robot::TeleopInit() {
     autonomousCommand = nullptr;
   }
 }
+
+void Robot::TeleopInit() {}
 
 /**
  * This function is called periodically during operator control.

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/Robot.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/Robot.hpp
@@ -16,6 +16,7 @@ class Robot : public wpi::TimedRobot {
   void DisabledPeriodic() override;
   void AutonomousInit() override;
   void AutonomousPeriodic() override;
+  void AutonomousExit() override;
   void TeleopInit() override;
   void TeleopPeriodic() override;
   void UtilityPeriodic() override;

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/Robot.cpp
@@ -53,9 +53,9 @@ void Robot::AutonomousInit() {
 
 void Robot::AutonomousPeriodic() {}
 
-void Robot::TeleopInit() {
+void Robot::AutonomousExit() {
   // This makes sure that the autonomous stops running when
-  // teleop starts running. If you want the autonomous to
+  // autonomous mode ends. If you want the autonomous to
   // continue until interrupted by another command, remove
   // this line or comment it out.
   if (autonomousCommand != nullptr) {
@@ -63,6 +63,8 @@ void Robot::TeleopInit() {
     autonomousCommand = nullptr;
   }
 }
+
+void Robot::TeleopInit() {}
 
 /**
  * This function is called periodically during operator control.

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/include/Robot.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/include/Robot.hpp
@@ -16,6 +16,7 @@ class Robot : public wpi::TimedRobot {
   void DisabledPeriodic() override;
   void AutonomousInit() override;
   void AutonomousPeriodic() override;
+  void AutonomousExit() override;
   void TeleopInit() override;
   void TeleopPeriodic() override;
   void UtilityPeriodic() override;

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/Robot.cpp
@@ -33,15 +33,17 @@ void Robot::AutonomousInit() {
 
 void Robot::AutonomousPeriodic() {}
 
-void Robot::TeleopInit() {
+void Robot::AutonomousExit() {
   // This makes sure that the autonomous stops running when
-  // teleop starts running. If you want the autonomous to
+  // autonomous mode ends. If you want the autonomous to
   // continue until interrupted by another command, remove
   // this line or comment it out.
   if (autonomousCommand) {
     autonomousCommand->Cancel();
   }
 }
+
+void Robot::TeleopInit() {}
 
 void Robot::TeleopPeriodic() {}
 

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/Robot.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/Robot.hpp
@@ -18,6 +18,7 @@ class Robot : public wpi::TimedRobot {
   void DisabledPeriodic() override;
   void AutonomousInit() override;
   void AutonomousPeriodic() override;
+  void AutonomousExit() override;
   void TeleopInit() override;
   void TeleopPeriodic() override;
   void UtilityInit() override;

--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/cpp/Robot.cpp
@@ -43,9 +43,9 @@ void Robot::AutonomousInit() {
 
 void Robot::AutonomousPeriodic() {}
 
-void Robot::TeleopInit() {
+void Robot::AutonomousExit() {
   // This makes sure that the autonomous stops running when
-  // teleop starts running. If you want the autonomous to
+  // autonomous mode ends. If you want the autonomous to
   // continue until interrupted by another command, remove
   // this line or comment it out.
   if (autonomousCommand != nullptr) {
@@ -53,6 +53,8 @@ void Robot::TeleopInit() {
     autonomousCommand = nullptr;
   }
 }
+
+void Robot::TeleopInit() {}
 
 /**
  * This function is called periodically during operator control.

--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/include/Robot.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/include/Robot.hpp
@@ -16,6 +16,7 @@ class Robot : public wpi::TimedRobot {
   void DisabledPeriodic() override;
   void AutonomousInit() override;
   void AutonomousPeriodic() override;
+  void AutonomousExit() override;
   void TeleopInit() override;
   void TeleopPeriodic() override;
   void UtilityPeriodic() override;

--- a/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/cpp/Robot.cpp
@@ -29,13 +29,13 @@ void Robot::AutonomousInit() {
 
 void Robot::AutonomousPeriodic() {}
 
-void Robot::AutonomousExit() {}
-
-void Robot::TeleopInit() {
+void Robot::AutonomousExit() {
   if (autonomousCommand) {
     autonomousCommand->Cancel();
   }
 }
+
+void Robot::TeleopInit() {}
 
 void Robot::TeleopPeriodic() {}
 

--- a/wpilibcExamples/src/main/cpp/examples/XRPReference/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/XRPReference/cpp/Robot.cpp
@@ -43,9 +43,9 @@ void Robot::AutonomousInit() {
 
 void Robot::AutonomousPeriodic() {}
 
-void Robot::TeleopInit() {
+void Robot::AutonomousExit() {
   // This makes sure that the autonomous stops running when
-  // teleop starts running. If you want the autonomous to
+  // autonomous mode ends If you want the autonomous to
   // continue until interrupted by another command, remove
   // this line or comment it out.
   if (autonomousCommand != nullptr) {
@@ -53,6 +53,8 @@ void Robot::TeleopInit() {
     autonomousCommand = nullptr;
   }
 }
+
+void Robot::TeleopInit() {}
 
 /**
  * This function is called periodically during operator control.

--- a/wpilibcExamples/src/main/cpp/examples/XRPReference/include/Robot.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/XRPReference/include/Robot.hpp
@@ -16,6 +16,7 @@ class Robot : public wpi::TimedRobot {
   void DisabledPeriodic() override;
   void AutonomousInit() override;
   void AutonomousPeriodic() override;
+  void AutonomousExit() override;
   void TeleopInit() override;
   void TeleopPeriodic() override;
   void UtilityPeriodic() override;

--- a/wpilibcExamples/src/main/cpp/snippets/SelectCommand/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/snippets/SelectCommand/cpp/Robot.cpp
@@ -44,9 +44,9 @@ void Robot::AutonomousInit() {
 
 void Robot::AutonomousPeriodic() {}
 
-void Robot::TeleopInit() {
+void Robot::AutonomousExit() {
   // This makes sure that the autonomous stops running when
-  // teleop starts running. If you want the autonomous to
+  // autonomous mode ends. If you want the autonomous to
   // continue until interrupted by another command, remove
   // this line or comment it out.
   if (autonomousCommand != nullptr) {
@@ -54,6 +54,8 @@ void Robot::TeleopInit() {
     autonomousCommand = nullptr;
   }
 }
+
+void Robot::TeleopInit() {}
 
 /**
  * This function is called periodically during operator control.

--- a/wpilibcExamples/src/main/cpp/snippets/SelectCommand/include/Robot.hpp
+++ b/wpilibcExamples/src/main/cpp/snippets/SelectCommand/include/Robot.hpp
@@ -16,6 +16,7 @@ class Robot : public wpi::TimedRobot {
   void DisabledPeriodic() override;
   void AutonomousInit() override;
   void AutonomousPeriodic() override;
+  void AutonomousExit() override;
   void TeleopInit() override;
   void TeleopPeriodic() override;
   void UtilityPeriodic() override;

--- a/wpilibcExamples/src/main/cpp/templates/commandv2/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandv2/cpp/Robot.cpp
@@ -44,15 +44,20 @@ void Robot::AutonomousInit() {
 
 void Robot::AutonomousPeriodic() {}
 
-void Robot::TeleopInit() {
+void Robot::AutonomousExit() {
   // This makes sure that the autonomous stops running when
-  // teleop starts running. If you want the autonomous to
+  // autonomous mode ends. If you want the autonomous to
   // continue until interrupted by another command, remove
   // this line or comment it out.
   if (autonomousCommand) {
     autonomousCommand->Cancel();
   }
 }
+
+/**
+ * This function is called once each time the robot enters operator control.
+ */
+void Robot::TeleopInit() {}
 
 /**
  * This function is called periodically during operator control.

--- a/wpilibcExamples/src/main/cpp/templates/commandv2/include/Robot.hpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandv2/include/Robot.hpp
@@ -18,6 +18,7 @@ class Robot : public wpi::TimedRobot {
   void DisabledPeriodic() override;
   void AutonomousInit() override;
   void AutonomousPeriodic() override;
+  void AutonomousExit() override;
   void TeleopInit() override;
   void TeleopPeriodic() override;
   void UtilityPeriodic() override;

--- a/wpilibcExamples/src/main/cpp/templates/commandv2skeleton/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandv2skeleton/cpp/Robot.cpp
@@ -29,13 +29,13 @@ void Robot::AutonomousInit() {
 
 void Robot::AutonomousPeriodic() {}
 
-void Robot::AutonomousExit() {}
-
-void Robot::TeleopInit() {
+void Robot::AutonomousExit() {
   if (autonomousCommand) {
     autonomousCommand->Cancel();
   }
 }
+
+void Robot::TeleopInit() {}
 
 void Robot::TeleopPeriodic() {}
 

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/drivedistanceoffboard/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/drivedistanceoffboard/Robot.java
@@ -74,15 +74,19 @@ public class Robot extends TimedRobot {
   public void autonomousPeriodic() {}
 
   @Override
-  public void teleopInit() {
+  public void autonomousExit() {
     // This makes sure that the autonomous stops running when
-    // teleop starts running. If you want the autonomous to
+    // autonomous mode ends. If you want the autonomous to
     // continue until interrupted by another command, remove
     // this line or comment it out.
     if (autonomousCommand != null) {
       autonomousCommand.cancel();
     }
   }
+
+  /** This function is called once each time the robot enters operator control. */
+  @Override
+  public void teleopInit() {}
 
   /** This function is called periodically during operator control. */
   @Override

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotinlined/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotinlined/Robot.java
@@ -76,15 +76,19 @@ public class Robot extends TimedRobot {
   public void autonomousPeriodic() {}
 
   @Override
-  public void teleopInit() {
+  public void autonomousExit() {
     // This makes sure that the autonomous stops running when
-    // teleop starts running. If you want the autonomous to
+    // autonomous mode ends. If you want the autonomous to
     // continue until interrupted by another command, remove
     // this line or comment it out.
     if (autonomousCommand != null) {
       autonomousCommand.cancel();
     }
   }
+
+  /** This function is called once each time the robot enters operator control. */
+  @Override
+  public void teleopInit() {}
 
   /** This function is called periodically during operator control. */
   @Override

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbottraditional/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbottraditional/Robot.java
@@ -83,15 +83,19 @@ public class Robot extends TimedRobot {
   public void autonomousPeriodic() {}
 
   @Override
-  public void teleopInit() {
+  public void autonomousExit() {
     // This makes sure that the autonomous stops running when
-    // teleop starts running. If you want the autonomous to
+    // autonomous mode ends. If you want the autonomous to
     // continue until interrupted by another command, remove
     // this line or comment it out.
     if (autonomousCommand != null) {
       autonomousCommand.cancel();
     }
   }
+
+  /** This function is called once each time the robot enters operator control. */
+  @Override
+  public void teleopInit() {}
 
   /** This function is called periodically during operator control. */
   @Override

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/Robot.java
@@ -72,15 +72,19 @@ public class Robot extends TimedRobot {
   public void autonomousPeriodic() {}
 
   @Override
-  public void teleopInit() {
+  public void autonomousExit() {
     // This makes sure that the autonomous stops running when
-    // teleop starts running. If you want the autonomous to
+    // autonomous mode ends. If you want the autonomous to
     // continue until interrupted by another command, remove
     // this line or comment it out.
     if (autonomousCommand != null) {
       autonomousCommand.cancel();
     }
   }
+
+  /** This function is called once each time the robot enters operator control. */
+  @Override
+  public void teleopInit() {}
 
   /** This function is called periodically during operator control. */
   @Override

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/romireference/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/romireference/Robot.java
@@ -67,7 +67,7 @@ public class Robot extends TimedRobot {
   public void autonomousPeriodic() {}
 
   @Override
-  public void teleopInit() {
+  public void autonomousExit() {
     // This makes sure that the autonomous stops running which will
     // use the default command which is ArcadeDrive. If you want the autonomous
     // to continue until interrupted by another command, remove
@@ -76,6 +76,10 @@ public class Robot extends TimedRobot {
       autonomousCommand.cancel();
     }
   }
+
+  /** This function is called once each time the robot enters operator control. */
+  @Override
+  public void teleopInit() {}
 
   /** This function is called periodically during operator control. */
   @Override

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/Robot.java
@@ -64,15 +64,19 @@ public class Robot extends TimedRobot {
   public void autonomousPeriodic() {}
 
   @Override
-  public void teleopInit() {
+  public void autonomousExit() {
     // This makes sure that the autonomous stops running when
-    // teleop starts running. If you want the autonomous to
+    // autonomous mode ends. If you want the autonomous to
     // continue until interrupted by another command, remove
     // this line or comment it out.
     if (autonomousCommand != null) {
       autonomousCommand.cancel();
     }
   }
+
+  /** This function is called once each time the robot enters operator control. */
+  @Override
+  public void teleopInit() {}
 
   /** This function is called periodically during operator control. */
   @Override

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/xrpreference/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/xrpreference/Robot.java
@@ -67,15 +67,19 @@ public class Robot extends TimedRobot {
   public void autonomousPeriodic() {}
 
   @Override
-  public void teleopInit() {
+  public void autonomousExit() {
     // This makes sure that the autonomous stops running when
-    // teleop starts running. If you want the autonomous to
+    // autonomous mode ends. If you want the autonomous to
     // continue until interrupted by another command, remove
     // this line or comment it out.
     if (autonomousCommand != null) {
       autonomousCommand.cancel();
     }
   }
+
+  /** This function is called once each time the robot enters operator control. */
+  @Override
+  public void teleopInit() {}
 
   /** This function is called periodically during operator control. */
   @Override

--- a/wpilibjExamples/src/main/java/org/wpilib/snippets/selectcommand/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/snippets/selectcommand/Robot.java
@@ -74,15 +74,19 @@ public class Robot extends TimedRobot {
   public void autonomousPeriodic() {}
 
   @Override
-  public void teleopInit() {
+  public void autonomousExit() {
     // This makes sure that the autonomous stops running when
-    // teleop starts running. If you want the autonomous to
+    // autonomous mode ends. If you want the autonomous to
     // continue until interrupted by another command, remove
     // this line or comment it out.
     if (autonomousCommand != null) {
       autonomousCommand.cancel();
     }
   }
+
+  /** This function is called once each time the robot enters operator control. */
+  @Override
+  public void teleopInit() {}
 
   /** This function is called periodically during operator control. */
   @Override

--- a/wpilibjExamples/src/main/java/org/wpilib/templates/commandv2/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/templates/commandv2/Robot.java
@@ -67,15 +67,19 @@ public class Robot extends TimedRobot {
   public void autonomousPeriodic() {}
 
   @Override
-  public void teleopInit() {
+  public void autonomousExit() {
     // This makes sure that the autonomous stops running when
-    // teleop starts running. If you want the autonomous to
+    // autonomous mode ends. If you want the autonomous to
     // continue until interrupted by another command, remove
     // this line or comment it out.
     if (autonomousCommand != null) {
       autonomousCommand.cancel();
     }
   }
+
+  /** This function is called once each time the robot enters operator control. */
+  @Override
+  public void teleopInit() {}
 
   /** This function is called periodically during operator control. */
   @Override

--- a/wpilibjExamples/src/main/java/org/wpilib/templates/commandv2skeleton/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/templates/commandv2skeleton/Robot.java
@@ -44,14 +44,14 @@ public class Robot extends TimedRobot {
   public void autonomousPeriodic() {}
 
   @Override
-  public void autonomousExit() {}
-
-  @Override
-  public void teleopInit() {
+  public void autonomousExit() {
     if (autonomousCommand != null) {
       autonomousCommand.cancel();
     }
   }
+
+  @Override
+  public void teleopInit() {}
 
   @Override
   public void teleopPeriodic() {}

--- a/wpilibjExamples/src/main/java/org/wpilib/templates/romicommandv2/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/templates/romicommandv2/Robot.java
@@ -67,15 +67,19 @@ public class Robot extends TimedRobot {
   public void autonomousPeriodic() {}
 
   @Override
-  public void teleopInit() {
+  public void autonomousExit() {
     // This makes sure that the autonomous stops running when
-    // teleop starts running. If you want the autonomous to
+    // autonomous mode ends. If you want the autonomous to
     // continue until interrupted by another command, remove
     // this line or comment it out.
     if (autonomousCommand != null) {
       autonomousCommand.cancel();
     }
   }
+
+  /** This function is called once each time the robot enters operator control. */
+  @Override
+  public void teleopInit() {}
 
   /** This function is called periodically during operator control. */
   @Override

--- a/wpilibjExamples/src/main/java/org/wpilib/templates/xrpcommandv2/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/templates/xrpcommandv2/Robot.java
@@ -67,15 +67,19 @@ public class Robot extends TimedRobot {
   public void autonomousPeriodic() {}
 
   @Override
-  public void teleopInit() {
+  public void autonomousExit() {
     // This makes sure that the autonomous stops running when
-    // teleop starts running. If you want the autonomous to
+    // autonomous mode ends. If you want the autonomous to
     // continue until interrupted by another command, remove
     // this line or comment it out.
     if (autonomousCommand != null) {
       autonomousCommand.cancel();
     }
   }
+
+  /** This function is called once each time the robot enters operator control. */
+  @Override
+  public void teleopInit() {}
 
   /** This function is called periodically during operator control. */
   @Override


### PR DESCRIPTION
This change updates the templates that included code that canceled autonomous commands in TeleopInit() to instead cancel them in AutonomousExit().

While in a real competition teleop mode starts after autonomous mode ends, when using the simulator the user can change modes in any order. Commands scheduled in AutonomousInit() should therefore be canceled in AutonomousExit().