### PR TITLE
Implement TriggerGroup

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/TriggerGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/TriggerGroup.java
@@ -1,0 +1,176 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj2.command.button;
+
+import static edu.wpi.first.util.ErrorMessages.requireNonNullParam;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
+
+/**
+ * This class provides an easy way to combine multiple Triggers together in a single group. Each
+ * Trigger in a group is associated with a unique String identifier.
+ *
+ * <p>A common pattern is to combine multiple joystick buttons to perform certain actions, while the
+ * individual buttons perform individual actions. For example, the 'a' and 'b' buttons could be used
+ * to perform 3 actions: one when just a is pressed, one when just b is pressed, and one when both
+ * are pressed.
+ */
+public class TriggerGroup {
+  private final Map<String, BooleanSupplier> m_conditions;
+
+  /**
+   * Creates an empty TriggerGroup. This can be used as a starting point for creating TriggerGroups
+   * by chaining the {@link #add(String, BooleanSupplier)} method.
+   */
+  public TriggerGroup() {
+    this(Map.of());
+  }
+
+  /**
+   * Creates a TriggerGroup from the given map of named conditions. The map is copied to ensure
+   * immutability.
+   *
+   * @param conditions A map of named conditions (Triggers).
+   */
+  public TriggerGroup(Map<String, BooleanSupplier> conditions) {
+    m_conditions = Map.copyOf(conditions);
+  }
+
+  /**
+   * Creates a new TriggerGroup with the same conditions as this one, plus an additional named
+   * condition. This method does not modify the original TriggerGroup and can be chained.
+   *
+   * @param key The String identifier associated with the condition.
+   * @param condition The condition to add.
+   * @return A new TriggerGroup.
+   */
+  public TriggerGroup add(String key, BooleanSupplier condition) {
+    requireNonNullParam(key, "key", "add");
+    requireNonNullParam(condition, "condition", "add");
+
+    if (m_conditions.containsKey(key)) {
+      throw new IllegalArgumentException("Key " + key + " already exists in TriggerGroup");
+    }
+
+    HashMap<String, BooleanSupplier> newConditions = new HashMap<>(m_conditions);
+    newConditions.put(key, condition);
+    return new TriggerGroup(newConditions);
+  }
+
+  /**
+   * Creates a Trigger that becomes true only when the specified named conditions are true and all
+   * other conditions in the group are false. *
+   *
+   * @param names The names of the conditions that must be true. All other conditions in the group
+   *     must be false.
+   * @return A Trigger that is true if and only if exactly the specified conditions are true.
+   */
+  public Trigger only(String... names) {
+    checkKeysExist(names);
+    Set<String> expected = Set.of(names);
+
+    return new Trigger(
+        () -> {
+          for (var condition : m_conditions.entrySet()) {
+            boolean expectedValue = expected.contains(condition.getKey());
+            boolean value = condition.getValue().getAsBoolean();
+
+            if (expectedValue != value) {
+              return false;
+            }
+          }
+
+          return true;
+        });
+  }
+
+  /**
+   * Creates a Trigger that becomes true when any of the specified named conditions are true.
+   *
+   * @param names The names of the conditions to check.
+   * @return A Trigger that is true only if at least one of the specified conditions are true.
+   */
+  public Trigger any(String... names) {
+    checkKeysExist(names);
+
+    return new Trigger(
+        () -> {
+          for (var name : names) {
+            if (m_conditions.get(name).getAsBoolean()) {
+              return true;
+            }
+          }
+
+          return false;
+        });
+  }
+
+  /**
+   * Creates a Trigger that becomes true when all of the specified named conditions are true,
+   * regardless of the others in this group.
+   *
+   * @param names The names of the conditions that must be true.
+   * @return A Trigger that is true only if all of the specified conditions are true, regardless of
+   *     the others.
+   */
+  public Trigger allOf(String... names) {
+    checkKeysExist(names);
+
+    return new Trigger(
+        () -> {
+          for (var name : names) {
+            if (!m_conditions.get(name).getAsBoolean()) {
+              return false;
+            }
+          }
+
+          return true;
+        });
+  }
+
+  /**
+   * Creates a Trigger that becomes true only when every single condition in this group is true.
+   *
+   * @return A Trigger that is true if every single condition in this group is true.
+   */
+  public Trigger all() {
+    return allOf(m_conditions.keySet().toArray(new String[0]));
+  }
+
+  /**
+   * Creates a Trigger that becomes true only when every single condition in this group is false.
+   *
+   * @return A Trigger that is true if every single condition in this group is false.
+   */
+  public Trigger none() {
+    return new Trigger(
+        () -> {
+          for (var condition : m_conditions.values()) {
+            if (condition.getAsBoolean()) {
+              return false;
+            }
+          }
+
+          return true;
+        });
+  }
+
+  /**
+   * Helper method that checks that all the provided keys do exist in this TriggerGroup, throwing if
+   * one does not.
+   *
+   * @param keys The list of keys to check.
+   */
+  private void checkKeysExist(String... keys) {
+    for (String k : keys) {
+      if (!m_conditions.containsKey(k)) {
+        throw new IllegalArgumentException("Key " + k + " does not exist in TriggerGroup");
+      }
+    }
+  }
+}

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/TriggerGroup.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/TriggerGroup.cpp
@@ -19,7 +19,6 @@ TriggerGroup TriggerGroup::Add(const std::string& key, Trigger condition) const 
   }
 
   auto newConditions = m_conditions;
-  //newConditions[key] = std::move(condition);
   newConditions.emplace(key, condition);
   return TriggerGroup(std::move(newConditions));
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/TriggerGroup.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/TriggerGroup.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc2/command/button/TriggerGroup.h"
+
+#include <stdexcept>
+#include <set>
+#include <utility>
+
+using namespace frc2;
+
+TriggerGroup TriggerGroup::Add(const std::string& key, Trigger condition) const {
+  if (key.empty()) {
+    throw std::invalid_argument("Key must not be empty in Add()");
+  }
+  if (m_conditions.find(key) != m_conditions.end()) {
+    throw std::invalid_argument("Key '" + key + "' already exists in TriggerGroup");
+  }
+
+  auto newConditions = m_conditions;
+  //newConditions[key] = std::move(condition);
+  newConditions.emplace(key, condition);
+  return TriggerGroup(std::move(newConditions));
+}
+
+Trigger TriggerGroup::Only(const std::vector<std::string>& names) const {
+  CheckKeysExist(names);
+  std::set<std::string> expected(names.begin(), names.end());
+
+  return Trigger([expected, conditions = m_conditions]() {
+    for (const auto& [key, trigger] : conditions) {
+      bool shouldBeTrue = expected.find(key) != expected.end();
+      if (trigger.Get() != shouldBeTrue) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+Trigger TriggerGroup::Any(const std::vector<std::string>& names) const {
+  CheckKeysExist(names);
+
+  return Trigger([names, conditions = m_conditions]() {
+    for (const auto& name : names) {
+      if (conditions.at(name).Get()) {
+        return true;
+      }
+    }
+    return false;
+  });
+}
+
+Trigger TriggerGroup::AllOf(const std::vector<std::string>& names) const {
+  CheckKeysExist(names);
+
+  return Trigger([names, conditions = m_conditions]() {
+    for (const auto& name : names) {
+      if (!conditions.at(name).Get()) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+Trigger TriggerGroup::All() const {
+  std::vector<std::string> keys;
+  keys.reserve(m_conditions.size());
+  for (const auto& [key, _] : m_conditions) {
+    keys.push_back(key);
+  }
+  return AllOf(keys);
+}
+
+Trigger TriggerGroup::None() const {
+  return Trigger([conditions = m_conditions]() {
+    for (const auto& [_, trigger] : conditions) {
+      if (trigger.Get()) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+void TriggerGroup::CheckKeysExist(const std::vector<std::string>& keys) const {
+  for (const auto& key : keys) {
+    if (m_conditions.find(key) == m_conditions.end()) {
+      throw std::invalid_argument("Key '" + key + "' does not exist in TriggerGroup");
+    }
+  }
+}

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/TriggerGroupTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/TriggerGroupTest.java
@@ -1,3 +1,7 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package edu.wpi.first.wpilibj2.command.button;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -10,18 +14,24 @@ import edu.wpi.first.wpilibj2.command.CommandTestBase;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-public class TriggerGroupTest extends CommandTestBase {
+class TriggerGroupTest extends CommandTestBase {
+
   @Test
   void addTest() {
-    TriggerGroup group = new TriggerGroup();
+    TriggerGroup group1 = new TriggerGroup();
 
-    TriggerGroup newGroup = assertDoesNotThrow(() -> group.add("a", () -> false));
+    TriggerGroup group2 = assertDoesNotThrow(() -> group1.add("a", () -> false));
 
-    assertNotEquals(group, newGroup);
+    assertNotEquals(group1, group2);
 
-    assertThrows(IllegalArgumentException.class, () -> newGroup.add("a", () -> true));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          @SuppressWarnings("unused")
+          TriggerGroup group3 = group2.add("a", () -> true);
+        });
 
-    assertDoesNotThrow(() -> newGroup.only("a"));
+    assertDoesNotThrow(() -> group2.only("a"));
   }
 
   @Test
@@ -57,10 +67,8 @@ public class TriggerGroupTest extends CommandTestBase {
 
   @Test
   void allTest() {
-    TriggerGroup group1 =
-        new TriggerGroup(Map.of("a", () -> true, "b", () -> true, "c", () -> false));
-    TriggerGroup group2 =
-        new TriggerGroup(Map.of("a", () -> true, "b", () -> true, "c", () -> true));
+    TriggerGroup group1 = new TriggerGroup(Map.of("a", () -> true, "b", () -> false));
+    TriggerGroup group2 = new TriggerGroup(Map.of("a", () -> true, "b", () -> true));
 
     assertFalse(group1.all());
     assertTrue(group2.all());
@@ -68,10 +76,8 @@ public class TriggerGroupTest extends CommandTestBase {
 
   @Test
   void noneTest() {
-    TriggerGroup group1 =
-        new TriggerGroup(Map.of("a", () -> false, "b", () -> true, "c", () -> false));
-    TriggerGroup group2 =
-        new TriggerGroup(Map.of("a", () -> false, "b", () -> false, "c", () -> false));
+    TriggerGroup group1 = new TriggerGroup(Map.of("a", () -> true, "b", () -> false));
+    TriggerGroup group2 = new TriggerGroup(Map.of("a", () -> false, "b", () -> false));
 
     assertFalse(group1.none());
     assertTrue(group2.none());

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/TriggerGroupTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/TriggerGroupTest.java
@@ -1,0 +1,86 @@
+package edu.wpi.first.wpilibj2.command.button;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.wpilibj2.command.CommandTestBase;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class TriggerGroupTest extends CommandTestBase {
+  @Test
+  void addTest() {
+    TriggerGroup group = new TriggerGroup();
+
+    TriggerGroup newGroup = assertDoesNotThrow(() -> group.add("a", () -> false));
+
+    assertNotEquals(group, newGroup);
+
+    assertThrows(IllegalArgumentException.class, () -> newGroup.add("a", () -> true));
+
+    assertDoesNotThrow(() -> newGroup.only("a"));
+  }
+
+  @Test
+  void onlyTest() {
+    TriggerGroup group =
+        new TriggerGroup(Map.of("a", () -> true, "b", () -> true, "c", () -> false));
+
+    assertTrue(group.only("a", "b"));
+    assertFalse(group.only("a"));
+    assertFalse(group.only("a", "c"));
+    assertFalse(group.only("a", "b", "c"));
+  }
+
+  @Test
+  void anyTest() {
+    TriggerGroup group =
+        new TriggerGroup(Map.of("a", () -> true, "b", () -> true, "c", () -> false));
+
+    assertTrue(group.any("a", "b"));
+    assertTrue(group.any("a", "c"));
+    assertFalse(group.any("c"));
+  }
+
+  @Test
+  void allOfTest() {
+    TriggerGroup group =
+        new TriggerGroup(Map.of("a", () -> true, "b", () -> true, "c", () -> false));
+
+    assertTrue(group.allOf("a", "b"));
+    assertTrue(group.allOf("a"));
+    assertFalse(group.allOf("c"));
+  }
+
+  @Test
+  void allTest() {
+    TriggerGroup group1 =
+        new TriggerGroup(Map.of("a", () -> true, "b", () -> true, "c", () -> false));
+    TriggerGroup group2 =
+        new TriggerGroup(Map.of("a", () -> true, "b", () -> true, "c", () -> true));
+
+    assertFalse(group1.all());
+    assertTrue(group2.all());
+  }
+
+  @Test
+  void noneTest() {
+    TriggerGroup group1 =
+        new TriggerGroup(Map.of("a", () -> false, "b", () -> true, "c", () -> false));
+    TriggerGroup group2 =
+        new TriggerGroup(Map.of("a", () -> false, "b", () -> false, "c", () -> false));
+
+    assertFalse(group1.none());
+    assertTrue(group2.none());
+  }
+
+  @Test
+  void invalidNameTest() {
+    TriggerGroup group = new TriggerGroup(Map.of("a", () -> false));
+
+    assertThrows(IllegalArgumentException.class, () -> group.only("bogus"));
+  }
+}

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/button/TriggerGroupTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/button/TriggerGroupTest.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <utility>
+
+#include "../CommandTestBase.h"
+#include "gtest/gtest.h"
+#include "frc2/command/button/TriggerGroup.h"
+#include "frc2/command/button/Trigger.h"
+
+using namespace frc2;
+
+class TriggerGroupTest : public CommandTestBase {};
+
+TEST_F(TriggerGroupTest, AddTest) {
+  TriggerGroup group1;
+
+  TriggerGroup group2 = group1.Add("a", Trigger());
+
+  EXPECT_NE(&group1, &group2);
+
+  EXPECT_THROW(group2.Add("a", Trigger()), std::invalid_argument);
+
+  EXPECT_NO_THROW(group2.Only({"a"}));
+}
+
+TEST_F(TriggerGroupTest, OnlyTest) {
+  TriggerGroup group = TriggerGroup({
+    {"a", Trigger([] { return true; })},
+    {"b", Trigger([] { return true; })},
+    {"c", Trigger([] { return false; })}
+  });
+
+  EXPECT_TRUE(group.Only({"a", "b"}).Get());
+  EXPECT_FALSE(group.Only({"a"}).Get());
+  EXPECT_FALSE(group.Only({"a", "c"}).Get());
+  EXPECT_FALSE(group.Only({"a", "b", "c"}).Get());
+}
+
+TEST_F(TriggerGroupTest, AnyTest) {
+  TriggerGroup group = TriggerGroup({
+    {"a", Trigger([] { return true; })},
+    {"b", Trigger([] { return true; })},
+    {"c", Trigger([] { return false; })}
+  });
+
+  EXPECT_TRUE(group.Any({"a", "b"}).Get());
+  EXPECT_TRUE(group.Any({"a", "c"}).Get());
+  EXPECT_FALSE(group.Any({"c"}).Get());
+}
+
+TEST_F(TriggerGroupTest, AllOfTest) {
+  TriggerGroup group = TriggerGroup({
+    {"a", Trigger([] { return true; })},
+    {"b", Trigger([] { return true; })},
+    {"c", Trigger([] { return false; })}
+  });
+
+  EXPECT_TRUE(group.AllOf({"a", "b"}).Get());
+  EXPECT_TRUE(group.AllOf({"a"}).Get());
+  EXPECT_FALSE(group.Any({"c"}).Get());
+}
+
+TEST_F(TriggerGroupTest, AllTest) {
+  TriggerGroup group1 = TriggerGroup({
+    {"a", Trigger([] { return true; })},
+    {"b", Trigger([] { return false; })},
+  });
+
+  TriggerGroup group2 = TriggerGroup({
+    {"a", Trigger([] { return true; })},
+    {"b", Trigger([] { return true; })},
+  });
+
+  EXPECT_FALSE(group1.All().Get());
+  EXPECT_TRUE(group2.All().Get());
+}
+
+TEST_F(TriggerGroupTest, NoneTest) {
+  TriggerGroup group1 = TriggerGroup({
+    {"a", Trigger([] { return true; })},
+    {"b", Trigger([] { return false; })},
+  });
+
+  TriggerGroup group2 = TriggerGroup({
+    {"a", Trigger([] { return false; })},
+    {"b", Trigger([] { return false; })},
+  });
+
+  EXPECT_FALSE(group1.None().Get());
+  EXPECT_TRUE(group2.None().Get());
+}
+
+TEST_F(TriggerGroupTest, InvalidNameTest) {
+  TriggerGroup group = TriggerGroup({
+    {"a", Trigger([] { return true; })}
+  });
+
+  EXPECT_THROW(group.Only({"bogus"}), std::invalid_argument);
+}


### PR DESCRIPTION
Resolves #7992 

TriggerGroups allow users to combine multiple Triggers to run a command when a specific combination of Triggers become true. For example:
```java
TriggerGroup group = new TriggerGroup(Map.of("a", controller.a(), "b", controller.b(), "c", controller.c()));

group.only("a", "b").whileTrue(...); // Runs when a and b are true, and c is false
group.any("a", "b").whileTrue(...); // Runs when either a or b are true
group.allOf("a", "b").whileTrue(...); // Runs when a and b are true
group.all().whileTrue(...); // Runs when a, b, and c are true
group.none().whileTrue(); // Runs when a, b, and c are false
```
Also has a cpp implementation and unit tests.

TriggerGroups can also be created by chaining the .add method:
```
TriggerGroup group = new TriggerGroup()
  .add("a", controller.a()),
  .add("b", controller.b());
```
TriggerGroups are immutable.