### PR TITLE
Add reset() for Debouncer

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
@@ -60,7 +60,8 @@ public class Debouncer {
 
   private boolean hasElapsed() {
     return m_prevTimeSeconds.isEmpty()
-        || MathSharedStore.getTimestamp() - m_prevTimeSeconds.getAsDouble() >= m_debounceTimeSeconds;
+        || MathSharedStore.getTimestamp() - m_prevTimeSeconds.getAsDouble()
+            >= m_debounceTimeSeconds;
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
@@ -4,6 +4,8 @@
 
 package edu.wpi.first.math.filter;
 
+import java.util.Optional;
+
 import edu.wpi.first.math.MathSharedStore;
 
 /**
@@ -25,7 +27,7 @@ public class Debouncer {
   private DebounceType m_debounceType;
   private boolean m_baseline;
 
-  private double m_prevTimeSeconds;
+  private Optional<Double> m_prevTimeSeconds;
 
   /**
    * Creates a new Debouncer.
@@ -54,11 +56,14 @@ public class Debouncer {
   }
 
   private void resetTimer() {
-    m_prevTimeSeconds = MathSharedStore.getTimestamp();
+    m_prevTimeSeconds = Optional.of(MathSharedStore.getTimestamp());
   }
 
   private boolean hasElapsed() {
-    return MathSharedStore.getTimestamp() - m_prevTimeSeconds >= m_debounceTimeSeconds;
+    if (m_prevTimeSeconds.isEmpty()) {
+      return true;
+    }
+    return MathSharedStore.getTimestamp() - m_prevTimeSeconds.get() >= m_debounceTimeSeconds;
   }
 
   /**
@@ -81,6 +86,16 @@ public class Debouncer {
     } else {
       return m_baseline;
     }
+  }
+
+  /**
+   * Resets the debouncer such that it will now behave as if enough time has passed, even if the
+   * actual elapsed time is below the limit.
+   *
+   * This is helpful if you want to clear the internal "memory" or state.
+   */
+  public void reset() {
+    m_prevTimeSeconds = Optional.empty();
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
@@ -5,7 +5,7 @@
 package edu.wpi.first.math.filter;
 
 import edu.wpi.first.math.MathSharedStore;
-import java.util.Optional;
+import java.util.OptionalDouble;
 
 /**
  * A simple debounce filter for boolean streams. Requires that the boolean change value from
@@ -26,7 +26,7 @@ public class Debouncer {
   private DebounceType m_debounceType;
   private boolean m_baseline;
 
-  private Optional<Double> m_prevTimeSeconds;
+  private OptionalDouble m_prevTimeSeconds;
 
   /**
    * Creates a new Debouncer.
@@ -55,12 +55,12 @@ public class Debouncer {
   }
 
   private void resetTimer() {
-    m_prevTimeSeconds = Optional.of(MathSharedStore.getTimestamp());
+    m_prevTimeSeconds = OptionalDouble.of(MathSharedStore.getTimestamp());
   }
 
   private boolean hasElapsed() {
     return m_prevTimeSeconds.isEmpty()
-        || MathSharedStore.getTimestamp() - m_prevTimeSeconds.get() >= m_debounceTimeSeconds;
+        || MathSharedStore.getTimestamp() - m_prevTimeSeconds.getAsDouble() >= m_debounceTimeSeconds;
   }
 
   /**
@@ -91,7 +91,7 @@ public class Debouncer {
    * "memory" or state.
    */
   public void reset() {
-    m_prevTimeSeconds = Optional.empty();
+    m_prevTimeSeconds = OptionalDouble.empty();
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
@@ -4,9 +4,8 @@
 
 package edu.wpi.first.math.filter;
 
-import java.util.Optional;
-
 import edu.wpi.first.math.MathSharedStore;
+import java.util.Optional;
 
 /**
  * A simple debounce filter for boolean streams. Requires that the boolean change value from
@@ -60,10 +59,8 @@ public class Debouncer {
   }
 
   private boolean hasElapsed() {
-    if (m_prevTimeSeconds.isEmpty()) {
-      return true;
-    }
-    return MathSharedStore.getTimestamp() - m_prevTimeSeconds.get() >= m_debounceTimeSeconds;
+    return m_prevTimeSeconds.isEmpty()
+      || MathSharedStore.getTimestamp() - m_prevTimeSeconds.get() >= m_debounceTimeSeconds;
   }
 
   /**
@@ -90,9 +87,8 @@ public class Debouncer {
 
   /**
    * Resets the debouncer such that it will now behave as if enough time has passed, even if the
-   * actual elapsed time is below the limit.
-   *
-   * This is helpful if you want to clear the internal "memory" or state.
+   * actual elapsed time is below the limit. This is helpful if you want to clear the internal
+   * "memory" or state.
    */
   public void reset() {
     m_prevTimeSeconds = Optional.empty();

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
@@ -60,7 +60,7 @@ public class Debouncer {
 
   private boolean hasElapsed() {
     return m_prevTimeSeconds.isEmpty()
-      || MathSharedStore.getTimestamp() - m_prevTimeSeconds.get() >= m_debounceTimeSeconds;
+        || MathSharedStore.getTimestamp() - m_prevTimeSeconds.get() >= m_debounceTimeSeconds;
   }
 
   /**

--- a/wpimath/src/test/java/edu/wpi/first/math/filter/DebouncerTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/filter/DebouncerTest.java
@@ -75,7 +75,7 @@ class DebouncerTest {
     var debouncer = new Debouncer(1.0, Debouncer.DebounceType.kFalling);
 
     assertTrue(debouncer.calculate(false));
-    
+
     debouncer.reset();
 
     assertFalse(debouncer.calculate(false));

--- a/wpimath/src/test/java/edu/wpi/first/math/filter/DebouncerTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/filter/DebouncerTest.java
@@ -74,13 +74,20 @@ class DebouncerTest {
   void debounceResetTest() {
     var debouncer = new Debouncer(1.0, Debouncer.DebounceType.kFalling);
 
+    // This is true because the timer hasn't yet elapsed, so it returns the baseline.
     assertTrue(debouncer.calculate(false));
 
+    // Clears timer to be (effectively) elapsed.
     debouncer.reset();
 
+    // Now, the debouncer accepts the new input and returns it rather than the baseline.
     assertFalse(debouncer.calculate(false));
+
+    // The baseline here returns true and also resets the timer so that it now behaves like it did
+    // at the start of the test.
     assertTrue(debouncer.calculate(true));
 
+    // Ensure consistency with previous behavior.
     assertTrue(debouncer.calculate(false));
   }
 

--- a/wpimath/src/test/java/edu/wpi/first/math/filter/DebouncerTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/filter/DebouncerTest.java
@@ -71,6 +71,20 @@ class DebouncerTest {
   }
 
   @Test
+  void debounceResetTest() {
+    var debouncer = new Debouncer(1.0, Debouncer.DebounceType.kFalling);
+
+    assertTrue(debouncer.calculate(false));
+    
+    debouncer.reset();
+
+    assertFalse(debouncer.calculate(false));
+    assertTrue(debouncer.calculate(true));
+
+    assertTrue(debouncer.calculate(false));
+  }
+
+  @Test
   void debounceParamsTest() {
     var debouncer = new Debouncer(0.02, Debouncer.DebounceType.kBoth);
 


### PR DESCRIPTION
For more information, see #8086. Basically, there's currently no way to override the internal clock on the `Debouncer` class to reset state. This feature is helpful when we *know* the state changed (e.x. eject gamepiece) but the `Debouncer` forces us to wait the debounce time to get the correct reading.

The method `reset()` on `Debouncer` works like this:

```java
var debouncer = new Debouncer(1.0, Debouncer.DebounceType.kFalling);

debouncer.calculate(true); // this is true.
debouncer.calculate(false); // this is also true.

debouncer.reset(); // clears timer to be effectively elapsed

debouncer.calculate(false); // now this returns false, even if we were previously still within the time window.

debouncer.calculate(true); // this internally sets the last time, so from here
                           // on we're back to the original behavior. (This is true)

debouncer.calculate(false); // this is true
```

This still needs a C++ impl to be merged, but the change is probably very simple.

Finally, I'm curious if we should rename `reset()`. It's not the most informative, and I'm worried it could confuse people who are reading the source code and see `reset()` as well as `resetTimer()`. From an external perspective, `reset()` is the only method (`resetTimer()` is private), but I'm not sure if it's the most informative name. Ideas would be appreciated.