### PR TITLE
Add systemcore to command vendor dep

### DIFF
--- a/wpilibNewCommands/WPILibNewCommands.json
+++ b/wpilibNewCommands/WPILibNewCommands.json
@@ -25,6 +25,7 @@
       "sharedLibrary": true,
       "skipInvalidPlatforms": true,
       "binaryPlatforms": [
+        "linuxsystemcore",
         "linuxathena",
         "linuxarm32",
         "linuxarm64",


### PR DESCRIPTION
Doing this on main so we can have a single vendor dep. It doesn't hurt anything.