### PR TITLE
Add reset() for Debouncer (With C++ version)

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
@@ -60,7 +60,8 @@ public class Debouncer {
 
   private boolean hasElapsed() {
     return m_prevTimeSeconds.isEmpty()
-        || MathSharedStore.getTimestamp() - m_prevTimeSeconds.getAsDouble() >= m_debounceTimeSeconds;
+        || MathSharedStore.getTimestamp() - m_prevTimeSeconds.getAsDouble()
+            >= m_debounceTimeSeconds;
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
@@ -4,6 +4,8 @@
 
 package edu.wpi.first.math.filter;
 
+import java.util.Optional;
+
 import edu.wpi.first.math.MathSharedStore;
 
 /**
@@ -25,7 +27,7 @@ public class Debouncer {
   private DebounceType m_debounceType;
   private boolean m_baseline;
 
-  private double m_prevTimeSeconds;
+  private Optional<Double> m_prevTimeSeconds;
 
   /**
    * Creates a new Debouncer.
@@ -54,11 +56,14 @@ public class Debouncer {
   }
 
   private void resetTimer() {
-    m_prevTimeSeconds = MathSharedStore.getTimestamp();
+    m_prevTimeSeconds = Optional.of(MathSharedStore.getTimestamp());
   }
 
   private boolean hasElapsed() {
-    return MathSharedStore.getTimestamp() - m_prevTimeSeconds >= m_debounceTimeSeconds;
+    if (m_prevTimeSeconds.isEmpty()) {
+      return true;
+    }
+    return MathSharedStore.getTimestamp() - m_prevTimeSeconds.get() >= m_debounceTimeSeconds;
   }
 
   /**
@@ -81,6 +86,16 @@ public class Debouncer {
     } else {
       return m_baseline;
     }
+  }
+
+  /**
+   * Resets the debouncer such that it will now behave as if enough time has passed, even if the
+   * actual elapsed time is below the limit.
+   *
+   * This is helpful if you want to clear the internal "memory" or state.
+   */
+  public void reset() {
+    m_prevTimeSeconds = Optional.empty();
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
@@ -5,7 +5,7 @@
 package edu.wpi.first.math.filter;
 
 import edu.wpi.first.math.MathSharedStore;
-import java.util.Optional;
+import java.util.OptionalDouble;
 
 /**
  * A simple debounce filter for boolean streams. Requires that the boolean change value from
@@ -26,7 +26,7 @@ public class Debouncer {
   private DebounceType m_debounceType;
   private boolean m_baseline;
 
-  private Optional<Double> m_prevTimeSeconds;
+  private OptionalDouble m_prevTimeSeconds;
 
   /**
    * Creates a new Debouncer.
@@ -55,12 +55,12 @@ public class Debouncer {
   }
 
   private void resetTimer() {
-    m_prevTimeSeconds = Optional.of(MathSharedStore.getTimestamp());
+    m_prevTimeSeconds = OptionalDouble.of(MathSharedStore.getTimestamp());
   }
 
   private boolean hasElapsed() {
     return m_prevTimeSeconds.isEmpty()
-        || MathSharedStore.getTimestamp() - m_prevTimeSeconds.get() >= m_debounceTimeSeconds;
+        || MathSharedStore.getTimestamp() - m_prevTimeSeconds.getAsDouble() >= m_debounceTimeSeconds;
   }
 
   /**
@@ -91,7 +91,7 @@ public class Debouncer {
    * "memory" or state.
    */
   public void reset() {
-    m_prevTimeSeconds = Optional.empty();
+    m_prevTimeSeconds = OptionalDouble.empty();
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
@@ -4,9 +4,8 @@
 
 package edu.wpi.first.math.filter;
 
-import java.util.Optional;
-
 import edu.wpi.first.math.MathSharedStore;
+import java.util.Optional;
 
 /**
  * A simple debounce filter for boolean streams. Requires that the boolean change value from
@@ -60,10 +59,8 @@ public class Debouncer {
   }
 
   private boolean hasElapsed() {
-    if (m_prevTimeSeconds.isEmpty()) {
-      return true;
-    }
-    return MathSharedStore.getTimestamp() - m_prevTimeSeconds.get() >= m_debounceTimeSeconds;
+    return m_prevTimeSeconds.isEmpty()
+      || MathSharedStore.getTimestamp() - m_prevTimeSeconds.get() >= m_debounceTimeSeconds;
   }
 
   /**
@@ -90,9 +87,8 @@ public class Debouncer {
 
   /**
    * Resets the debouncer such that it will now behave as if enough time has passed, even if the
-   * actual elapsed time is below the limit.
-   *
-   * This is helpful if you want to clear the internal "memory" or state.
+   * actual elapsed time is below the limit. This is helpful if you want to clear the internal
+   * "memory" or state.
    */
   public void reset() {
     m_prevTimeSeconds = Optional.empty();

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
@@ -60,7 +60,7 @@ public class Debouncer {
 
   private boolean hasElapsed() {
     return m_prevTimeSeconds.isEmpty()
-      || MathSharedStore.getTimestamp() - m_prevTimeSeconds.get() >= m_debounceTimeSeconds;
+        || MathSharedStore.getTimestamp() - m_prevTimeSeconds.get() >= m_debounceTimeSeconds;
   }
 
   /**

--- a/wpimath/src/main/native/cpp/filter/Debouncer.cpp
+++ b/wpimath/src/main/native/cpp/filter/Debouncer.cpp
@@ -19,8 +19,9 @@ void Debouncer::ResetTimer() {
 }
 
 bool Debouncer::HasElapsed() const {
-  return wpi::math::MathSharedStore::GetTimestamp() - m_prevTime >=
-         m_debounceTime;
+  return !m_prevTime.has_value() ||
+         wpi::math::MathSharedStore::GetTimestamp() - m_prevTime.value() >=
+             m_debounceTime;
 }
 
 bool Debouncer::Calculate(bool input) {
@@ -37,4 +38,8 @@ bool Debouncer::Calculate(bool input) {
   } else {
     return m_baseline;
   }
+}
+
+void Debouncer::Reset() {
+  m_prevTime.reset();
 }

--- a/wpimath/src/main/native/include/frc/filter/Debouncer.h
+++ b/wpimath/src/main/native/include/frc/filter/Debouncer.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <wpi/SymbolExports.h>
 #include <wpi/timestamp.h>
 
@@ -49,6 +51,13 @@ class WPILIB_DLLEXPORT Debouncer {
   bool Calculate(bool input);
 
   /**
+   * Resets the debouncer such that it will now behave as if enough time has
+   * passed, even if the actual elapsed time is below the limit. This is helpful
+   * if you want to clear the internal "memory" or state.
+   */
+  void Reset();
+
+  /**
    * Sets the time to debounce.
    *
    * @param time The number of seconds the value must change from baseline
@@ -89,7 +98,7 @@ class WPILIB_DLLEXPORT Debouncer {
   bool m_baseline;
   DebounceType m_debounceType;
 
-  units::second_t m_prevTime;
+  std::optional<units::second_t> m_prevTime;
 
   void ResetTimer();
 

--- a/wpimath/src/test/java/edu/wpi/first/math/filter/DebouncerTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/filter/DebouncerTest.java
@@ -75,7 +75,7 @@ class DebouncerTest {
     var debouncer = new Debouncer(1.0, Debouncer.DebounceType.kFalling);
 
     assertTrue(debouncer.calculate(false));
-    
+
     debouncer.reset();
 
     assertFalse(debouncer.calculate(false));

--- a/wpimath/src/test/java/edu/wpi/first/math/filter/DebouncerTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/filter/DebouncerTest.java
@@ -74,13 +74,20 @@ class DebouncerTest {
   void debounceResetTest() {
     var debouncer = new Debouncer(1.0, Debouncer.DebounceType.kFalling);
 
+    // This is true because the timer hasn't yet elapsed, so it returns the baseline.
     assertTrue(debouncer.calculate(false));
 
+    // Clears timer to be (effectively) elapsed.
     debouncer.reset();
 
+    // Now, the debouncer accepts the new input and returns it rather than the baseline.
     assertFalse(debouncer.calculate(false));
+
+    // The baseline here returns true and also resets the timer so that it now behaves like it did
+    // at the start of the test.
     assertTrue(debouncer.calculate(true));
 
+    // Ensure consistency with previous behavior.
     assertTrue(debouncer.calculate(false));
   }
 

--- a/wpimath/src/test/java/edu/wpi/first/math/filter/DebouncerTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/filter/DebouncerTest.java
@@ -71,6 +71,20 @@ class DebouncerTest {
   }
 
   @Test
+  void debounceResetTest() {
+    var debouncer = new Debouncer(1.0, Debouncer.DebounceType.kFalling);
+
+    assertTrue(debouncer.calculate(false));
+    
+    debouncer.reset();
+
+    assertFalse(debouncer.calculate(false));
+    assertTrue(debouncer.calculate(true));
+
+    assertTrue(debouncer.calculate(false));
+  }
+
+  @Test
   void debounceParamsTest() {
     var debouncer = new Debouncer(0.02, Debouncer.DebounceType.kBoth);
 

--- a/wpimath/src/test/native/cpp/filter/DebouncerTest.cpp
+++ b/wpimath/src/test/native/cpp/filter/DebouncerTest.cpp
@@ -57,6 +57,28 @@ TEST_F(DebouncerTest, DebounceBoth) {
   EXPECT_FALSE(debouncer.Calculate(false));
 }
 
+TEST_F(DebouncerTest, DebounceReset) {
+  frc::Debouncer debouncer{1_s, frc::Debouncer::DebounceType::kFalling};
+
+  // This is true because the timer hasn't yet elapsed, so it returns the
+  // baseline.
+  EXPECT_TRUE(debouncer.Calculate(false));
+
+  // Clears timer to be (effectively) elapsed.
+  debouncer.Reset();
+
+  // Now, the debouncer accepts the new input and returns it rather than the
+  // baseline.
+  EXPECT_FALSE(debouncer.Calculate(false));
+
+  // The baseline here returns true and also resets the timer so that it now
+  // behaves like it did at the start of the test.
+  EXPECT_TRUE(debouncer.Calculate(true));
+
+  // Ensure consistency with previous behavior.
+  EXPECT_TRUE(debouncer.Calculate(false));
+}
+
 TEST_F(DebouncerTest, DebounceParams) {
   frc::Debouncer debouncer{20_ms, frc::Debouncer::DebounceType::kBoth};
 


### PR DESCRIPTION
See #8095 ([therekrab:debouncer-reset](https://github.com/therekrab/allwpilib/tree/debouncer-reset))

closes #8086 

Adds a C++ version of the reset method to the Debouncer class. Java version written by @therekrab.

Please let me know if there is a better way to add on to their pull request.
