### PR TITLE
[bazel] Make publishers for c++ hdr / srcs, and java

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@rules_pkg//:mappings.bzl", "pkg_files")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+load("//shared/bazel/rules:publishing.bzl", "publish_all")
 
 pkg_files(
     name = "license_pkg_files",
@@ -49,4 +50,52 @@ write_source_files(
         "//wpiutil:write_wpiutil",
     ],
     tags = ["pregeneration"],
+)
+
+publish_all(
+    name = "publish",
+    targets = [
+        "//apriltag:apriltag-cpp_publish",
+        "//apriltag:apriltag-java_publish",
+        "//cameraserver:cameraserver-cpp_publish",
+        "//cameraserver:cameraserver-java_publish",
+        "//cscore:cscore-cpp_publish",
+        "//cscore:cscore-java_publish",
+        "//datalog:datalog-cpp_publish",
+        "//datalog:datalog-java_publish",
+        "//fieldImages:fieldImages-cpp_publish",
+        "//fieldImages:fieldImages-java_publish",
+        "//epilogue-runtime:epilogue-java_publish",
+        "//epilogue-processor:processor-java_publish",
+        "//glass:libglass-cpp_publish",
+        "//glass:libglassnt-cpp_publish",
+        "//hal:wpiHal-cpp_publish",
+        "//hal:hal-java_publish",
+        "//ntcore:ntcore-cpp_publish",
+        "//ntcore:ntcore-java_publish",
+        "//romiVendordep:romiVendordep-cpp_publish",
+        "//romiVendordep:romiVendordep-java_publish",
+        "//simulation/halsim_ds_socket:halsim_ds_socket-cpp_publish",
+        "//simulation/halsim_gui:halsim_gui-cpp_publish",
+        "//simulation/halsim_ws_client:halsim_ws_client-cpp_publish",
+        "//simulation/halsim_ws_core:halsim_ws_core-cpp_publish",
+        "//simulation/halsim_ws_server:halsim_ws_server-cpp_publish",
+        "//simulation/halsim_xrp:halsim_xrp-cpp_publish",
+        "//thirdparty/googletest:googletest-cpp_publish",
+        "//thirdparty/imgui_suite:imgui-cpp_publish",
+        "//wpigui:wpigui-cpp_publish",
+        "//wpilibc:wpilibc-cpp_publish",
+        "//wpilibj:wpilibj-java_publish",
+        "//wpilibNewCommands:wpilibNewCommands-cpp_publish",
+        "//wpilibNewCommands:wpilibNewCommands-java_publish",
+        "//wpimath:wpimath-cpp_publish",
+        "//wpimath:wpimath-java_publish",
+        "//wpinet:wpinet-cpp_publish",
+        "//wpinet:wpinet-java_publish",
+        "//wpiunits:wpiunits-java_publish",
+        "//wpiutil:wpiutil-cpp_publish",
+        "//wpiutil:wpiutil-java_publish",
+        "//xrpVendordep:xrpVendordep-cpp_publish",
+        "//xrpVendordep:xrpVendordep-java_publish",
+    ],
 )

--- a/apriltag/BUILD.bazel
+++ b/apriltag/BUILD.bazel
@@ -1,12 +1,11 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_pkg//:mappings.bzl", "pkg_files")
-load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
-load("//shared/bazel/rules:packaging.bzl", "pkg_java_files")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_jni_project")
 load("//shared/bazel/rules/gen:gen-resources.bzl", "generate_resources")
 
 pkg_files(
@@ -121,6 +120,9 @@ wpilib_cc_shared_library(
 wpilib_jni_java_library(
     name = "apriltag-java",
     srcs = glob(["src/main/java/**/*.java"]),
+    extra_source_pkgs = ["resources"],
+    maven_artifact_name = "apriltag-java",
+    maven_group_id = "edu.wpi.first.apriltag",
     native_libs = [":apriltagjni"],
     resource_strip_prefix = "apriltag/src/main/native/resources",
     resources = glob(["src/main/native/resources/**"]),
@@ -135,21 +137,10 @@ wpilib_jni_java_library(
     ],
 )
 
-pkg_java_files(name = "apriltag-java-srcs")
-
 pkg_files(
     name = "resources",
     srcs = glob(["src/main/native/resources/**"]),
     strip_prefix = "src/main/native/resources/",
-)
-
-pkg_zip(
-    name = "libapriltag-java-sources",
-    srcs = [
-        ":apriltag-java-srcs",
-        ":resources",
-    ],
-    out = "libapriltag-java-sources.jar",
 )
 
 cc_test(
@@ -203,4 +194,10 @@ py_binary(
         "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+)
+
+package_minimal_jni_project(
+    name = "apriltag",
+    maven_artifact_name = "apriltag-cpp",
+    maven_group_id = "edu.wpi.first.apriltag",
 )

--- a/cameraserver/BUILD.bazel
+++ b/cameraserver/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
-load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+load("@rules_java//java:defs.bzl", "java_binary")
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 
 wpilib_cc_library(
     name = "cameraserver",
@@ -28,9 +30,11 @@ wpilib_cc_static_library(
     deps = [":cameraserver"],
 )
 
-java_library(
+wpilib_java_library(
     name = "cameraserver-java",
     srcs = glob(["src/main/java/**/*.java"]),
+    maven_artifact_name = "cameraserver-java",
+    maven_group_id = "edu.wpi.first.cameraserver",
     visibility = ["//visibility:public"],
     deps = [
         "//cscore:cscore-java",
@@ -67,4 +71,10 @@ java_binary(
     main_class = "edu.wpi.first.cameraserver.DevMain",
     deps = [
     ],
+)
+
+package_minimal_cc_project(
+    name = "cameraserver",
+    maven_artifact_name = "cameraserver-cpp",
+    maven_group_id = "edu.wpi.first.cameraserver",
 )

--- a/cscore/BUILD.bazel
+++ b/cscore/BUILD.bazel
@@ -4,6 +4,7 @@ load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
 load("//shared/bazel/rules:objectivec_rules.bzl", "wpilib_objc_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_jni_project")
 
 WIN_SRCS = glob([
     "src/main/native/windows/**/*.cpp",
@@ -106,6 +107,8 @@ wpilib_jni_cc_library(
 wpilib_jni_java_library(
     name = "cscore-java",
     srcs = glob(["src/main/java/**/*.java"]),
+    maven_artifact_name = "cscore-java",
+    maven_group_id = "edu.wpi.first.cscore",
     native_libs = [":cscorejni"],
     visibility = ["//visibility:public"],
     deps = [
@@ -171,3 +174,9 @@ java_binary(
     "usbstream",
     "usbviewer",
 ]]
+
+package_minimal_jni_project(
+    name = "cscore",
+    maven_artifact_name = "cscore-cpp",
+    maven_group_id = "edu.wpi.first.cscore",
+)

--- a/datalog/BUILD.bazel
+++ b/datalog/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_jni_project")
 
 wpilib_cc_library(
     name = "datalog",
@@ -66,6 +67,8 @@ wpilib_cc_shared_library(
 wpilib_jni_java_library(
     name = "datalog-java",
     srcs = glob(["src/main/java/**/*.java"]),
+    maven_artifact_name = "datalog-java",
+    maven_group_id = "edu.wpi.first.datalog",
     native_libs = [":datalogjni"],
     visibility = ["//visibility:public"],
     deps = [
@@ -135,4 +138,10 @@ wpilib_java_junit5_test(
         ":datalog-java",
         "//wpiutil:wpiutil-java",
     ],
+)
+
+package_minimal_jni_project(
+    name = "datalog",
+    maven_artifact_name = "datalog-cpp",
+    maven_group_id = "edu.wpi.first.datalog",
 )

--- a/epilogue-processor/BUILD.bazel
+++ b/epilogue-processor/BUILD.bazel
@@ -1,12 +1,13 @@
-load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
+load("@rules_java//java:defs.bzl", "java_plugin")
 load("@rules_pkg//:mappings.bzl", "pkg_files")
-load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
-load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
-load("//shared/bazel/rules:packaging.bzl", "pkg_java_files")
+load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test", "wpilib_java_library")
 
-java_library(
+wpilib_java_library(
     name = "processor-java",
     srcs = glob(["src/main/java/**/*.java"]),
+    extra_source_pkgs = ["resources"],
+    maven_artifact_name = "epilogue-processor-java",
+    maven_group_id = "edu.wpi.first.epilogue",
     resource_strip_prefix = "epilogue-processor/src/main/resources/",
     resources = glob(["src/main/resources/**"]),
     visibility = ["//visibility:public"],
@@ -18,21 +19,10 @@ java_library(
     ],
 )
 
-pkg_java_files(name = "epilogue-processor-java-srcs")
-
 pkg_files(
     name = "resources",
     srcs = glob(["src/main/resources/**"]),
     strip_prefix = "src/main/resources/",
-)
-
-pkg_zip(
-    name = "libepilogue-processor-java-sources",
-    srcs = [
-        ":epilogue-processor-java-srcs",
-        ":resources",
-    ],
-    out = "libepilogue-processor-java-sources.jar",
 )
 
 java_plugin(

--- a/epilogue-runtime/BUILD.bazel
+++ b/epilogue-runtime/BUILD.bazel
@@ -1,9 +1,10 @@
-load("@rules_java//java:defs.bzl", "java_library")
-load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
+load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test", "wpilib_java_library")
 
-java_library(
+wpilib_java_library(
     name = "epilogue-java",
     srcs = glob(["src/main/java/**/*.java"]),
+    maven_artifact_name = "epilogue-runtime-java",
+    maven_group_id = "edu.wpi.first.epilogue",
     visibility = ["//visibility:public"],
     deps = [
         "//datalog:datalog-java",

--- a/fieldImages/BUILD.bazel
+++ b/fieldImages/BUILD.bazel
@@ -1,9 +1,7 @@
-load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_pkg//:mappings.bzl", "pkg_files")
-load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
-load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
-load("//shared/bazel/rules:packaging.bzl", "pkg_java_files")
+load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test", "wpilib_java_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 load("//shared/bazel/rules/gen:gen-resources.bzl", "generate_resources")
 
 generate_resources(
@@ -34,9 +32,12 @@ wpilib_cc_static_library(
     ],
 )
 
-java_library(
+wpilib_java_library(
     name = "fieldImages-java",
     srcs = glob(["src/main/java/**/*.java"]),
+    extra_source_pkgs = ["resources"],
+    maven_artifact_name = "fieldImages-java",
+    maven_group_id = "edu.wpi.first.fieldImages",
     resource_strip_prefix = "fieldImages/src/main/native/resources",
     resources = glob(["src/main/native/resources/**"]),
     visibility = ["//visibility:public"],
@@ -46,21 +47,10 @@ java_library(
     ],
 )
 
-pkg_java_files(name = "fieldImages-java-srcs")
-
 pkg_files(
     name = "resources",
     srcs = glob(["src/main/native/resources/**"]),
     strip_prefix = "src/main/native/resources/",
-)
-
-pkg_zip(
-    name = "libfieldImages-java-sources",
-    srcs = [
-        ":fieldImages-java-srcs",
-        ":resources",
-    ],
-    out = "libfieldImages-java-sources.jar",
 )
 
 wpilib_java_junit5_test(
@@ -69,4 +59,10 @@ wpilib_java_junit5_test(
     deps = [
         ":fieldImages-java",
     ],
+)
+
+package_minimal_cc_project(
+    name = "fieldImages",
+    maven_artifact_name = "fieldImages-cpp",
+    maven_group_id = "edu.wpi.first.fieldImages",
 )

--- a/glass/BUILD.bazel
+++ b/glass/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 load("//shared/bazel/rules/gen:gen-resources.bzl", "generate_resources")
 load("//shared/bazel/rules/gen:gen-version-file.bzl", "generate_version_file")
 
@@ -96,4 +97,16 @@ cc_binary(
     deps = [
         ":libglassnt",
     ],
+)
+
+package_minimal_cc_project(
+    name = "libglass",
+    maven_artifact_name = "libglass",
+    maven_group_id = "edu.wpi.first.glass",
+)
+
+package_minimal_cc_project(
+    name = "libglassnt",
+    maven_artifact_name = "libglassnt",
+    maven_group_id = "edu.wpi.first.glass",
 )

--- a/hal/BUILD.bazel
+++ b/hal/BUILD.bazel
@@ -7,6 +7,7 @@ load("//hal:generate.bzl", "generate_hal")
 load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_jni_project")
 
 filegroup(
     name = "proto_files",
@@ -171,6 +172,8 @@ wpilib_cc_shared_library(
 wpilib_jni_java_library(
     name = "hal-java",
     srcs = glob(["src/main/java/**/*.java"]),
+    maven_artifact_name = "hal-java",
+    maven_group_id = "edu.wpi.first.hal",
     native_libs = [":wpiHaljni"],
     visibility = ["//visibility:public"],
     deps = [
@@ -212,4 +215,10 @@ java_binary(
     main_class = "edu.wpi.first.hal.DevMain",
     deps = [
     ],
+)
+
+package_minimal_jni_project(
+    name = "wpiHal",
+    maven_artifact_name = "hal-cpp",
+    maven_group_id = "edu.wpi.first.hal",
 )

--- a/ntcore/BUILD.bazel
+++ b/ntcore/BUILD.bazel
@@ -2,13 +2,12 @@ load("@allwpilib_pip_deps//:requirements.bzl", "requirement")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_java//java:defs.bzl", "java_binary")
-load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//ntcore:generate_ntcore.bzl", "generate_ntcore")
 load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
-load("//shared/bazel/rules:packaging.bzl", "pkg_java_files")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_jni_project")
 
 generate_ntcore(
     name = "generate_ntcore",
@@ -151,6 +150,8 @@ wpilib_cc_shared_library(
 wpilib_jni_java_library(
     name = "ntcore-java",
     srcs = glob(["src/main/java/**/*.java"]) + [":generated_java"],
+    maven_artifact_name = "ntcore-java",
+    maven_group_id = "edu.wpi.first.ntcore",
     native_libs = [":ntcorejni"],
     visibility = ["//visibility:public"],
     deps = [
@@ -158,14 +159,6 @@ wpilib_jni_java_library(
         "//wpiutil:wpiutil-java",
         "@maven//:us_hebi_quickbuf_quickbuf_runtime",
     ],
-)
-
-pkg_java_files(name = "ntcore-java-srcs")
-
-pkg_zip(
-    name = "libntcore-java-sources",
-    srcs = [":ntcore-java-srcs"],
-    out = "libntcore-java-sources.jar",
 )
 
 cc_test(
@@ -213,4 +206,10 @@ java_binary(
         "ntcore-java",
         "//wpiutil:wpiutil-java",
     ],
+)
+
+package_minimal_jni_project(
+    name = "ntcore",
+    maven_artifact_name = "ntcore-cpp",
+    maven_group_id = "edu.wpi.first.ntcore",
 )

--- a/romiVendordep/BUILD.bazel
+++ b/romiVendordep/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
-load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+load("@rules_java//java:defs.bzl", "java_binary")
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 
 wpilib_cc_library(
     name = "romiVendordep",
@@ -45,9 +47,11 @@ wpilib_cc_static_library(
     ],
 )
 
-java_library(
+wpilib_java_library(
     name = "romiVendordep-java",
     srcs = glob(["src/main/java/**/*.java"]),
+    maven_artifact_name = "romiVendordep-java",
+    maven_group_id = "edu.wpi.first.romiVendordep",
     visibility = ["//visibility:public"],
     deps = [
         "//hal:hal-java",
@@ -82,4 +86,10 @@ java_binary(
         "//ntcore:ntcore-java",
         "//wpiutil:wpiutil-java",
     ],
+)
+
+package_minimal_cc_project(
+    name = "romiVendordep",
+    maven_artifact_name = "romiVendordep-cpp",
+    maven_group_id = "edu.wpi.first.romiVendordep",
 )

--- a/shared/bazel/rules/cc_rules.bzl
+++ b/shared/bazel/rules/cc_rules.bzl
@@ -135,7 +135,7 @@ def wpilib_cc_library(
         pkg_zip(
             name = name + "-srcs-zip",
             srcs = maybe_license_pkg + extra_src_pkg_files + [name + "-srcs-pkg"] + [lib + "-srcs-pkg" for lib in third_party_libraries],
-            tags = ["no-remote"],
+            tags = ["manual"],
         )
 
     if hdrs_pkg_root:
@@ -148,7 +148,7 @@ def wpilib_cc_library(
         pkg_zip(
             name = name + "-hdrs-zip",
             srcs = extra_hdr_pkg_files + maybe_license_pkg + [name + "-hdrs-pkg"] + [lib + "-hdrs-pkg" for lib in third_party_libraries + third_party_header_only_libraries],
-            tags = ["no-remote"],
+            tags = ["manual"],
         )
 
 def wpilib_cc_shared_library(
@@ -387,16 +387,4 @@ def wpilib_cc_static_library(
         name = name,
         static_lib_name = static_lib_name,
         **kwargs
-    )
-
-    pkg_files(
-        name = name + "-static.pkg",
-        srcs = [":" + name],
-        tags = ["manual"],
-    )
-
-    pkg_zip(
-        name = name + "-static-zip",
-        srcs = ["//:license_pkg_files", name + "-static.pkg"],
-        tags = ["no-remote", "manual"],
     )

--- a/shared/bazel/rules/halsim_library.bzl
+++ b/shared/bazel/rules/halsim_library.bzl
@@ -9,6 +9,7 @@ def wpilib_halsim_extension(
     wpilib_cc_library(
         name = name,
         includes = ["src/main/native/include"],
+        include_license_files = True,
         target_compatible_with = select({
             "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
             "//conditions:default": [],

--- a/shared/bazel/rules/java_rules.bzl
+++ b/shared/bazel/rules/java_rules.bzl
@@ -1,4 +1,34 @@
-load("@rules_java//java:defs.bzl", "java_binary")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+load("//shared/bazel/rules:packaging.bzl", "zip_java_srcs")
+load("//shared/bazel/rules:publishing.bzl", "wpilib_maven_export")
+
+def wpilib_java_library(
+        name,
+        maven_group_id,
+        maven_artifact_name,
+        tags = [],
+        extra_source_pkgs = [],
+        **kwargs):
+    tags = list(tags) if tags else []
+
+    maven_coordinates = "{}:{}:$(WPILIB_VERSION)".format(maven_group_id, maven_artifact_name)
+    tags.append("maven_coordinates=" + maven_coordinates)
+
+    java_library(
+        name = name,
+        tags = tags,
+        **kwargs
+    )
+
+    zip_java_srcs(name = name, extra_pkgs = extra_source_pkgs)
+
+    wpilib_maven_export(
+        name = "{}_publish".format(name),
+        classifier_artifacts = {"sources": ":lib{}-sources.jar".format(name)},
+        lib_name = name,
+        maven_coordinates = maven_coordinates,
+        visibility = ["//visibility:public"],
+    )
 
 def wpilib_java_junit5_test(
         name,

--- a/shared/bazel/rules/jni_rules.bzl
+++ b/shared/bazel/rules/jni_rules.bzl
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
-load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load("@rules_pkg//:mappings.bzl", "filter_directory")
+load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_library")
 
 def _jni_headers_impl(ctx):
     include_dir = ctx.actions.declare_directory(ctx.attr.name + ".h")
@@ -75,7 +75,8 @@ def wpilib_jni_java_library(
     visibility = java_library_args.pop("visibility", default = None)
     testonly = java_library_args.pop("testonly", default = None)
     headers_name = name + ".hdrs"
-    java_library(
+
+    wpilib_java_library(
         name = name,
         visibility = visibility,
         testonly = testonly,

--- a/shared/bazel/rules/packaging.bzl
+++ b/shared/bazel/rules/packaging.bzl
@@ -1,6 +1,8 @@
 load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files")
+load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
+load("//shared/bazel/rules:publishing.bzl", "architectures_pkg_zip", "platform_prefix", "wpilib_maven_export")
 
-def pkg_java_files(name):
+def pkg_java_src_files(name):
     pkg_files(
         name = name + "-java-srcs",
         srcs = native.glob(["src/main/java/**"]),
@@ -27,4 +29,129 @@ def pkg_java_files(name):
             name + "-generated-java-srcs",
             "//shared/bazel/rules:src_jar_dummy_manifest",
         ],
+    )
+
+def zip_java_srcs(name, extra_pkgs = []):
+    pkg_java_src_files("{}-sources.pkg".format(name))
+
+    pkg_zip(
+        name = "lib{}-java-sources".format(name),
+        srcs = ["{}-sources.pkg".format(name)] + extra_pkgs,
+        out = "lib{}-sources.jar".format(name),
+        tags = ["manual"],
+    )
+
+def package_default_jni_project(
+        name,
+        maven_group_id,
+        maven_artifact_name):
+    """
+    Packages a the C++ libraries for a project that has a JNI component.
+
+    This assumes that static and shared libraries exist for the project, and 
+    that it is built for all native platforms plus systemcore. It runs the
+    per-platform transitions and bundles them all into a single maven_export target.
+    """
+    pkg_files(
+        name = "{}-static-files".format(name),
+        srcs = [
+            ":static/{}".format(name),
+        ],
+        prefix = platform_prefix("static"),
+        strip_prefix = "static",
+    )
+
+    pkg_filegroup(
+        name = "{}-shared-files".format(name),
+        srcs = [
+            ":shared/lib{}-shared-files".format(name),
+            ":shared/lib{}jni-shared-files".format(name),
+        ],
+        prefix = platform_prefix("shared"),
+    )
+
+    architectures_pkg_zip(
+        name = "{}_static_zip".format(name),
+        srcs = [
+            ":{}-static-files".format(name),
+            "//:license_pkg_files",
+        ],
+    )
+
+    architectures_pkg_zip(
+        name = "{}_shared_zip".format(name),
+        srcs = [
+            ":{}-shared-files".format(name),
+            "//:license_pkg_files",
+        ],
+    )
+
+    wpilib_maven_export(
+        name = "{}-cpp_publish".format(name),
+        classifier_artifacts = {
+            "headers": ":{}-hdrs-zip".format(name),
+            "linuxsystemcore": ":{}_shared_zip-opt-systemcore".format(name),
+            "linuxsystemcoredebug": ":{}_shared_zip-dbg-systemcore".format(name),
+            "linuxsystemcorestatic": ":{}_static_zip-opt-systemcore".format(name),
+            "linuxsystemcorestaticdebug": ":{}_static_zip-dbg-systemcore".format(name),
+            "sources": ":{}-srcs-zip".format(name),
+        },
+        linux_artifacts = {
+            "linuxx86-64": ":{}_shared_zip-opt-linux-x86-64".format(name),
+            "linuxx86-64debug": ":{}_shared_zip-dbg-linux-x86-64".format(name),
+            "linuxx86-64static": ":{}_static_zip-opt-linux-x86-64".format(name),
+            "linuxx86-64staticdebug": ":{}_static_zip-dbg-linux-x86-64".format(name),
+        },
+        maven_coordinates = "{}:{}:$(WPILIB_VERSION)".format(maven_group_id, maven_artifact_name),
+        osx_artifacts = {
+            "osxuniversal": ":{}_shared_zip-opt-osxuniversal".format(name),
+            "osxuniversaldebug": ":{}_shared_zip-dbg-osxuniversal".format(name),
+            "osxuniversalstatic": ":{}_static_zip-opt-osxuniversal".format(name),
+            "osxuniversalstaticdebug": ":{}_static_zip-dbg-osxuniversal".format(name),
+        },
+        visibility = ["//visibility:public"],
+        windows_artifacts = {
+            "windowsarm64": ":{}_shared_zip-opt-windows-arm64".format(name),
+            "windowsarm64debug": ":{}_shared_zip-dbg-windows-arm64".format(name),
+            "windowsarm64static": ":{}_static_zip-opt-windows-arm64".format(name),
+            "windowsarm64staticdebug": ":{}_static_zip-dbg-windows-arm64".format(name),
+            "windowsx86-64": ":{}_shared_zip-opt-windows-x86-64".format(name),
+            "windowsx86-64debug": ":{}_shared_zip-dbg-windows-x86-64".format(name),
+            "windowsx86-64static": ":{}_static_zip-opt-windows-x86-64".format(name),
+            "windowsx86-64staticdebug": ":{}_static_zip-dbg-windows-x86-64".format(name),
+        },
+    )
+
+def package_minimal_jni_project(
+        name,
+        maven_group_id,
+        maven_artifact_name):
+    wpilib_maven_export(
+        name = "{}-cpp_publish".format(name),
+        classifier_artifacts = {
+            "headers": ":{}-hdrs-zip".format(name),
+            "sources": ":{}-srcs-zip".format(name),
+        },
+        linux_artifacts = {},
+        maven_coordinates = "{}:{}:$(WPILIB_VERSION)".format(maven_group_id, maven_artifact_name),
+        osx_artifacts = {},
+        visibility = ["//visibility:public"],
+        windows_artifacts = {},
+    )
+
+def package_minimal_cc_project(
+        name,
+        maven_group_id,
+        maven_artifact_name):
+    wpilib_maven_export(
+        name = "{}-cpp_publish".format(name),
+        classifier_artifacts = {
+            "headers": ":{}-hdrs-zip".format(name),
+            "sources": ":{}-srcs-zip".format(name),
+        },
+        linux_artifacts = {},
+        maven_coordinates = "{}:{}:$(WPILIB_VERSION)".format(maven_group_id, maven_artifact_name),
+        osx_artifacts = {},
+        visibility = ["//visibility:public"],
+        windows_artifacts = {},
     )

--- a/shared/bazel/rules/publishing.bzl
+++ b/shared/bazel/rules/publishing.bzl
@@ -34,12 +34,14 @@ def publish_all(name, targets):
             '  "$arg"',
             "done",
         ],
+        tags = ["manual"],
     )
     sh_binary(
         name = name,
         srcs = [publish_name + ".sh"],
         args = ["$(location " + x + ".publish)" for x in targets],
         data = [x + ".publish" for x in targets],
+        tags = ["manual"],
     )
 
 # Unfortunately, rules_jvm_external really wants each of the classifier
@@ -68,6 +70,7 @@ def architectures_pkg_zip(
             zip_name = name + "-" + compilation_mode + "-arch-" + shortname
             pkg_zip(
                 name = zip_name,
+                tags = ["manual"],
                 **kwargs
             )
 
@@ -78,6 +81,7 @@ def architectures_pkg_zip(
                 target_platform = platform,
                 compilation_mode = compilation_mode,
                 target_compatible_with = architectures_target_compatible_with[shortname],
+                tags = ["manual"],
             )
 
 def platform_prefix(t):

--- a/simulation/halsim_ds_socket/BUILD.bazel
+++ b/simulation/halsim_ds_socket/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 
 cc_library(
     name = "headers",
@@ -82,4 +83,10 @@ cc_binary(
     deps = [
         ":halsim_ds_socket",
     ],
+)
+
+package_minimal_cc_project(
+    name = "halsim_ds_socket",
+    maven_artifact_name = "halsim_ds_socket",
+    maven_group_id = "edu.wpi.first.halsim",
 )

--- a/simulation/halsim_gui/BUILD.bazel
+++ b/simulation/halsim_gui/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 
 wpilib_cc_library(
     name = "halsim_gui",
@@ -94,4 +95,10 @@ cc_binary(
     deps = [
         ":halsim_gui",
     ],
+)
+
+package_minimal_cc_project(
+    name = "halsim_gui",
+    maven_artifact_name = "halsim_gui",
+    maven_group_id = "edu.wpi.first.halsim",
 )

--- a/simulation/halsim_ws_client/BUILD.bazel
+++ b/simulation/halsim_ws_client/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("//shared/bazel/rules:halsim_library.bzl", "wpilib_halsim_extension")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 
 wpilib_halsim_extension(
     name = "halsim_ws_client",
@@ -18,4 +19,10 @@ cc_binary(
     deps = [
         ":halsim_ws_client",
     ],
+)
+
+package_minimal_cc_project(
+    name = "halsim_ws_client",
+    maven_artifact_name = "halsim_ws_client",
+    maven_group_id = "edu.wpi.first.halsim",
 )

--- a/simulation/halsim_ws_core/BUILD.bazel
+++ b/simulation/halsim_ws_core/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 
 wpilib_cc_library(
     name = "halsim_ws_core",
@@ -44,4 +45,10 @@ wpilib_cc_static_library(
     deps = [
         ":halsim_ws_core",
     ],
+)
+
+package_minimal_cc_project(
+    name = "halsim_ws_core",
+    maven_artifact_name = "halsim_ws_core",
+    maven_group_id = "edu.wpi.first.halsim",
 )

--- a/simulation/halsim_ws_server/BUILD.bazel
+++ b/simulation/halsim_ws_server/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 
 cc_library(
     name = "headers",
@@ -97,4 +98,10 @@ cc_binary(
     deps = [
         ":halsim_ws_server",
     ],
+)
+
+package_minimal_cc_project(
+    name = "halsim_ws_server",
+    maven_artifact_name = "halsim_ws_server",
+    maven_group_id = "edu.wpi.first.halsim",
 )

--- a/simulation/halsim_xrp/BUILD.bazel
+++ b/simulation/halsim_xrp/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 
 wpilib_cc_library(
     name = "halsim_xrp",
@@ -73,4 +74,10 @@ wpilib_cc_static_library(
 cc_binary(
     name = "DevMain-Cpp",
     srcs = ["src/dev/native/cpp/main.cpp"],
+)
+
+package_minimal_cc_project(
+    name = "halsim_xrp",
+    maven_artifact_name = "halsim_xrp",
+    maven_group_id = "edu.wpi.first.halsim",
 )

--- a/thirdparty/googletest/BUILD.bazel
+++ b/thirdparty/googletest/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 
 wpilib_cc_library(
     name = "googletest",
@@ -22,4 +23,10 @@ wpilib_cc_static_library(
     deps = [
         ":googletest",
     ],
+)
+
+package_minimal_cc_project(
+    name = "googletest",
+    maven_artifact_name = "googletest-cpp",
+    maven_group_id = "edu.wpi.first.thirdparty.googletest",
 )

--- a/thirdparty/imgui_suite/BUILD.bazel
+++ b/thirdparty/imgui_suite/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_pkg//:pkg.bzl", "pkg_zip")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:objectivec_rules.bzl", "wpilib_objc_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 
 cc_library(
     name = "gl3w",
@@ -412,7 +413,7 @@ pkg_files(
 )
 
 pkg_zip(
-    name = "imgui-suite-hdrs",
+    name = "imgui-hdrs-zip",
     srcs = [
         "generated-fonts-hdrs-pkg",
         "generated-gl3w-hdrs-pkg",
@@ -423,7 +424,7 @@ pkg_zip(
         "//:license_pkg_files",
     ],
     tags = [
-        "no-remote",
+        "manual",
     ],
 )
 
@@ -464,7 +465,7 @@ pkg_files(
 )
 
 pkg_zip(
-    name = "imgui-suite-srcs",
+    name = "imgui-srcs-zip",
     srcs = [
         "generated-fonts-srcs-pkg",
         "generated-gl3w-srcs-pkg",
@@ -475,6 +476,12 @@ pkg_zip(
         "//:license_pkg_files",
     ],
     tags = [
-        "no-remote",
+        "manual",
     ],
+)
+
+package_minimal_cc_project(
+    name = "imgui",
+    maven_artifact_name = "imguiSuite-cpp",
+    maven_group_id = "edu.wpi.first.thirdparty.imguiSuite",
 )

--- a/wpigui/BUILD.bazel
+++ b/wpigui/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_pkg//:mappings.bzl", "pkg_files")
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:objectivec_rules.bzl", "wpilib_objc_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 
 WIN_SRCS = glob(["src/main/native/directx11/**/*.cpp"])
 
@@ -79,4 +80,10 @@ wpilib_cc_static_library(
     deps = [
         ":wpigui",
     ],
+)
+
+package_minimal_cc_project(
+    name = "wpigui",
+    maven_artifact_name = "wpigui-cpp",
+    maven_group_id = "edu.wpi.first.wpigui",
 )

--- a/wpilibNewCommands/BUILD.bazel
+++ b/wpilibNewCommands/BUILD.bazel
@@ -1,12 +1,11 @@
 load("@allwpilib_pip_deps//:requirements.bzl", "requirement")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
-load("@rules_java//java:defs.bzl", "java_binary", "java_library")
-load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
+load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
-load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
-load("//shared/bazel/rules:packaging.bzl", "pkg_java_files")
+load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test", "wpilib_java_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 load("//wpilibNewCommands:generate.bzl", "generate_wpilib_new_commands")
 
 py_binary(
@@ -93,9 +92,11 @@ wpilib_cc_static_library(
     deps = [":wpilibNewCommands"],
 )
 
-java_library(
+wpilib_java_library(
     name = "wpilibNewCommands-java",
     srcs = glob(["src/main/java/**/*.java"]) + [":generated_java"],
+    maven_artifact_name = "wpilibNewCommands-java",
+    maven_group_id = "edu.wpi.first.wpilibNewCommands",
     visibility = ["//visibility:public"],
     deps = [
         "//cscore:cscore-java",
@@ -107,14 +108,6 @@ java_library(
         "//wpiunits:wpiunits-java",
         "//wpiutil:wpiutil-java",
     ],
-)
-
-pkg_java_files(name = "wpilibNewCommands-java-srcs")
-
-pkg_zip(
-    name = "libwpilibNewCommands-java-sources",
-    srcs = [":wpilibNewCommands-java-srcs"],
-    out = "libwpilibNewCommands-java-sources.jar",
 )
 
 cc_test(
@@ -168,4 +161,10 @@ java_binary(
         "//wpimath:wpimath-java",
         "//wpiutil:wpiutil-java",
     ],
+)
+
+package_minimal_cc_project(
+    name = "wpilibNewCommands",
+    maven_artifact_name = "wpilibNewCommands-cpp",
+    maven_group_id = "edu.wpi.first.wpilibNewCommands",
 )

--- a/wpilibc/BUILD.bazel
+++ b/wpilibc/BUILD.bazel
@@ -1,8 +1,10 @@
 load("@allwpilib_pip_deps//:requirements.bzl", "requirement")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_pkg//:mappings.bzl", "pkg_files")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 load("//shared/bazel/rules/gen:gen-version-file.bzl", "generate_version_file")
 load("//wpilibc:generate.bzl", "generate_wpilibc")
 
@@ -75,6 +77,13 @@ third_party_cc_lib_helper(
     src_root = "src/generated/main/native/cpp",
 )
 
+pkg_files(
+    name = "generated_version_files_pkg",
+    srcs = [
+        ":generate-version",
+    ],
+)
+
 wpilib_cc_library(
     name = "wpilibc",
     srcs = [
@@ -87,6 +96,9 @@ wpilib_cc_library(
     copts = [
         # TODO(austin): this needs to be different for shared vs dynamic.
         "-DDYNAMIC_CAMERA_SERVER",
+    ],
+    extra_src_pkg_files = [
+        ":generated_version_files_pkg",
     ],
     include_license_files = True,
     strip_include_prefix = "src/main/native/include",
@@ -168,4 +180,10 @@ cc_binary(
     deps = [
         ":wpilibc",
     ],
+)
+
+package_minimal_cc_project(
+    name = "wpilibc",
+    maven_artifact_name = "wpilibc-cpp",
+    maven_group_id = "edu.wpi.first.wpilibc",
 )

--- a/wpilibcExamples/build_cpp_examples.bzl
+++ b/wpilibcExamples/build_cpp_examples.bzl
@@ -23,7 +23,7 @@ def _package_type(package_type):
     pkg_zip(
         name = package_type + "-zip",
         srcs = pkgs,
-        tags = ["no-remote"],
+        tags = ["manual"],
     )
 
 def build_examples(halsim_deps = []):

--- a/wpilibj/BUILD.bazel
+++ b/wpilibj/BUILD.bazel
@@ -1,12 +1,10 @@
 load("@allwpilib_pip_deps//:requirements.bzl", "requirement")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_pkg//:mappings.bzl", "pkg_files")
-load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("@rules_python//python:defs.bzl", "py_binary")
-load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
-load("//shared/bazel/rules:packaging.bzl", "pkg_java_files")
+load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test", "wpilib_java_library")
 load("//shared/bazel/rules/gen:gen-version-file.bzl", "generate_version_file")
 load("//wpilibj:generate.bzl", "generate_wpilibj")
 
@@ -72,12 +70,15 @@ filegroup(
     srcs = glob(["src/generated/main/java/**/*.java"]),
 )
 
-java_library(
+wpilib_java_library(
     name = "wpilibj-java",
     srcs = [
         ":generate-version",
         ":generated_java",
     ] + glob(["src/main/java/**/*.java"]),
+    extra_source_pkgs = ["generated_version_files"],
+    maven_artifact_name = "wpilibj-java",
+    maven_group_id = "edu.wpi.first.wpilibj",
     visibility = ["//visibility:public"],
     deps = [
         "//cameraserver:cameraserver-java",
@@ -94,24 +95,12 @@ java_library(
     ],
 )
 
-# Strip the corresponding prefixes off the generated and source files.
-pkg_java_files(name = "java-srcs")
-
 pkg_files(
     name = "generated_version_files",
     srcs = [
         ":generate-version",
     ],
     prefix = "edu/wpi/first/wpilibj/util/",
-)
-
-pkg_zip(
-    name = "libwpilibj-java-sources",
-    srcs = [
-        ":generated_version_files",
-        ":java-srcs",
-    ],
-    out = "libwpilibj-java-sources.jar",
 )
 
 wpilib_java_junit5_test(

--- a/wpilibjExamples/build_java_examples.bzl
+++ b/wpilibjExamples/build_java_examples.bzl
@@ -24,7 +24,7 @@ def _package_type(package_type):
     pkg_zip(
         name = package_type + "-zip",
         srcs = pkgs,
-        tags = ["no-remote"],
+        tags = ["manual"],
     )
 
 def build_examples(halsim_deps):

--- a/wpimath/BUILD.bazel
+++ b/wpimath/BUILD.bazel
@@ -2,12 +2,12 @@ load("@allwpilib_pip_deps//:requirements.bzl", "requirement")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_java//java:defs.bzl", "java_binary")
-load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
+load("@rules_pkg//:mappings.bzl", "pkg_files")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
-load("//shared/bazel/rules:packaging.bzl", "pkg_java_files")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_jni_project")
 load("//wpimath:generate.bzl", "generate_wpimath")
 
 filegroup(
@@ -111,6 +111,12 @@ cc_library(
     strip_include_prefix = "src/generated/main/native/cpp",
 )
 
+pkg_files(
+    name = "protobuf_hdr_pkg",
+    srcs = glob(["src/generated/main/native/cpp/wpimath/protobuf/*.npb.h"]),
+    strip_prefix = "src/generated/main/native/cpp/",
+)
+
 wpilib_cc_library(
     name = "wpimath",
     srcs = glob(
@@ -121,6 +127,7 @@ wpilib_cc_library(
         exclude = ["src/main/native/cpp/jni/**"],
     ),
     hdrs = glob(["src/main/native/include/**"]),
+    extra_hdr_pkg_files = [":protobuf_hdr_pkg"],
     extra_src_pkg_files = [
         ":wpimath-java-jni-hdrs-pkg",
     ],
@@ -194,6 +201,8 @@ wpilib_cc_shared_library(
 wpilib_jni_java_library(
     name = "wpimath-java",
     srcs = [":generated_java"] + glob(["src/main/java/**/*.java"]),
+    maven_artifact_name = "wpimath-java",
+    maven_group_id = "edu.wpi.first.wpimath",
     native_libs = [":wpimathjni"],
     resource_strip_prefix = "wpimath/src/main/proto",
     resources = glob(["src/main/proto/**"]),
@@ -209,14 +218,6 @@ wpilib_jni_java_library(
         "@maven//:org_ejml_ejml_simple",
         "@maven//:us_hebi_quickbuf_quickbuf_runtime",
     ],
-)
-
-pkg_java_files(name = "wpimath-java-srcs")
-
-pkg_zip(
-    name = "libwpimath-java-sources",
-    srcs = [":wpimath-java-srcs"],
-    out = "libwpimath-java-sources.jar",
 )
 
 cc_library(
@@ -282,4 +283,10 @@ py_binary(
         "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+)
+
+package_minimal_jni_project(
+    name = "wpimath",
+    maven_artifact_name = "wpimath-cpp",
+    maven_group_id = "edu.wpi.first.wpimath",
 )

--- a/wpinet/BUILD.bazel
+++ b/wpinet/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_pkg//:mappings.bzl", "pkg_files")
 load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_jni_project")
 load("//shared/bazel/rules/gen:gen-resources.bzl", "generate_resources")
 
 WIN_UV_SRCS = glob([
@@ -198,6 +199,8 @@ wpilib_cc_shared_library(
 wpilib_jni_java_library(
     name = "wpinet-java",
     srcs = glob(["src/main/java/**/*.java"]),
+    maven_artifact_name = "wpinet-java",
+    maven_group_id = "edu.wpi.first.wpinet",
     native_libs = [":wpinetjni"],
     visibility = ["//visibility:public"],
     deps = [
@@ -288,4 +291,10 @@ cc_binary(
     deps = [
         ":wpinet",
     ],
+)
+
+package_minimal_jni_project(
+    name = "wpinet",
+    maven_artifact_name = "wpinet-cpp",
+    maven_group_id = "edu.wpi.first.wpinet",
 )

--- a/wpiunits/BUILD.bazel
+++ b/wpiunits/BUILD.bazel
@@ -1,10 +1,8 @@
 load("@allwpilib_pip_deps//:requirements.bzl", "requirement")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@rules_java//java:defs.bzl", "java_binary", "java_library")
-load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
+load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_python//python:defs.bzl", "py_binary")
-load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
-load("//shared/bazel/rules:packaging.bzl", "pkg_java_files")
+load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test", "wpilib_java_library")
 load("//wpiunits:generate_wpiunits.bzl", "generate_wpiunits")
 
 py_binary(
@@ -32,19 +30,13 @@ write_source_files(
     visibility = ["//visibility:public"],
 )
 
-java_library(
+wpilib_java_library(
     name = "wpiunits-java",
     srcs = glob(["src/main/java/**/*.java"]) + glob(["src/generated/main/java/**/*.java"]),
+    maven_artifact_name = "wpiunits-java",
+    maven_group_id = "edu.wpi.first.wpiunits",
     visibility = ["//visibility:public"],
     deps = [],
-)
-
-pkg_java_files(name = "wpiunits-java-srcs")
-
-pkg_zip(
-    name = "libwpiunits-java-sources",
-    srcs = [":wpiunits-java-srcs"],
-    out = "libwpiunits-java-sources.jar",
 )
 
 wpilib_java_junit5_test(

--- a/wpiutil/BUILD.bazel
+++ b/wpiutil/BUILD.bazel
@@ -2,14 +2,11 @@ load("@allwpilib_pip_deps//:requirements.bzl", "requirement")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_java//java:defs.bzl", "java_binary")
-load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files")
-load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//shared/bazel/rules:cc_rules.bzl", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
-load("//shared/bazel/rules:packaging.bzl", "pkg_java_files")
-load("//shared/bazel/rules:publishing.bzl", "architectures_pkg_zip", "platform_prefix", "wpilib_maven_export")
+load("//shared/bazel/rules:packaging.bzl", "package_default_jni_project")
 load("//shared/bazel/rules/gen:gen-resources.bzl", "generate_resources")
 load("//wpiutil:generate.bzl", "generate_wpiutil")
 
@@ -230,8 +227,9 @@ wpilib_cc_static_library(
 wpilib_jni_java_library(
     name = "wpiutil-java",
     srcs = glob(["src/main/java/**/*.java"]),
+    maven_artifact_name = "wpiutil-java",
+    maven_group_id = "edu.wpi.first.wpiutil",
     native_libs = [":wpiutiljni"],
-    tags = ["maven_coordinates=edu.wpi.first.wpiutil:wpiutil-java:$(WPILIB_VERSION)"],
     visibility = ["//visibility:public"],
     deps = [
         "@maven//:com_fasterxml_jackson_core_jackson_annotations",
@@ -239,14 +237,6 @@ wpilib_jni_java_library(
         "@maven//:com_fasterxml_jackson_core_jackson_databind",
         "@maven//:us_hebi_quickbuf_quickbuf_runtime",
     ],
-)
-
-pkg_java_files(name = "wpiutil-java-srcs")
-
-pkg_zip(
-    name = "libwpiutil-java-sources",
-    srcs = [":wpiutil-java-srcs"],
-    out = "libwpiutil-java-sources.jar",
 )
 
 cc_library(
@@ -305,80 +295,8 @@ java_binary(
     ],
 )
 
-pkg_files(
-    name = "wpiutil-static-files",
-    srcs = [
-        ":static/wpiutil",
-    ],
-    prefix = platform_prefix("static"),
-    strip_prefix = "static",
-)
-
-pkg_filegroup(
-    name = "wpiutil-shared-files",
-    srcs = [
-        ":shared/libwpiutil-shared-files",
-        ":shared/libwpiutiljni-shared-files",
-    ],
-    prefix = platform_prefix("shared"),
-)
-
-architectures_pkg_zip(
-    name = "wpiutil_static_zip",
-    srcs = [
-        ":wpiutil-static-files",
-        "//:license_pkg_files",
-    ],
-)
-
-architectures_pkg_zip(
-    name = "wpiutil_shared_zip",
-    srcs = [
-        ":wpiutil-shared-files",
-        "//:license_pkg_files",
-    ],
-)
-
-wpilib_maven_export(
-    name = "wpiutil-cpp_publish",
-    classifier_artifacts = {
-        "headers": ":wpiutil-hdrs-zip",
-        "linuxsystemcore": ":wpiutil_shared_zip-opt-systemcore",
-        "linuxsystemcoredebug": ":wpiutil_shared_zip-dbg-systemcore",
-        "linuxsystemcorestatic": ":wpiutil_static_zip-opt-systemcore",
-        "linuxsystemcorestaticdebug": ":wpiutil_static_zip-dbg-systemcore",
-        "sources": ":wpiutil-srcs-zip",
-    },
-    linux_artifacts = {
-        "linuxx86-64": ":wpiutil_shared_zip-opt-linux-x86-64",
-        "linuxx86-64debug": ":wpiutil_shared_zip-dbg-linux-x86-64",
-        "linuxx86-64static": ":wpiutil_static_zip-opt-linux-x86-64",
-        "linuxx86-64staticdebug": ":wpiutil_static_zip-dbg-linux-x86-64",
-    },
-    maven_coordinates = "edu.wpi.first.wpiutil:wpiutil-cpp:$(WPILIB_VERSION)",
-    osx_artifacts = {
-        "osxuniversal": ":wpiutil_shared_zip-opt-osxuniversal",
-        "osxuniversaldebug": ":wpiutil_shared_zip-dbg-osxuniversal",
-        "osxuniversalstatic": ":wpiutil_static_zip-opt-osxuniversal",
-        "osxuniversalstaticdebug": ":wpiutil_static_zip-dbg-osxuniversal",
-    },
-    visibility = ["//visibility:public"],
-    windows_artifacts = {
-        "windowsarm64": ":wpiutil_shared_zip-opt-windows-arm64",
-        "windowsarm64debug": ":wpiutil_shared_zip-dbg-windows-arm64",
-        "windowsarm64static": ":wpiutil_static_zip-opt-windows-arm64",
-        "windowsarm64staticdebug": ":wpiutil_static_zip-dbg-windows-arm64",
-        "windowsx86-64": ":wpiutil_shared_zip-opt-windows-x86-64",
-        "windowsx86-64debug": ":wpiutil_shared_zip-dbg-windows-x86-64",
-        "windowsx86-64static": ":wpiutil_static_zip-opt-windows-x86-64",
-        "windowsx86-64staticdebug": ":wpiutil_static_zip-dbg-windows-x86-64",
-    },
-)
-
-wpilib_maven_export(
-    name = "wpiutil-java_publish",
-    classifier_artifacts = {"sources": ":libwpiutil-java-sources.jar"},
-    lib_name = "wpiutil-java",
-    maven_coordinates = "edu.wpi.first.wpiutil:wpiutil-java:$(WPILIB_VERSION)",
-    visibility = ["//visibility:public"],
+package_default_jni_project(
+    name = "wpiutil",
+    maven_artifact_name = "wpiutil-cpp",
+    maven_group_id = "edu.wpi.first.wpiutil",
 )

--- a/xrpVendordep/BUILD.bazel
+++ b/xrpVendordep/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
-load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+load("@rules_java//java:defs.bzl", "java_binary")
 load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 
 wpilib_cc_library(
     name = "xrpVendordep",
@@ -41,9 +43,11 @@ wpilib_cc_static_library(
     deps = [":xrpVendordep"],
 )
 
-java_library(
+wpilib_java_library(
     name = "xrpVendordep-java",
     srcs = glob(["src/main/java/**/*.java"]),
+    maven_artifact_name = "xrpVendordep-java",
+    maven_group_id = "edu.wpi.first.xrpVendordep",
     visibility = ["//visibility:public"],
     deps = [
         "//hal:hal-java",
@@ -79,4 +83,10 @@ java_binary(
         "//ntcore:ntcore-java",
         "//wpiutil:wpiutil-java",
     ],
+)
+
+package_minimal_cc_project(
+    name = "xrpVendordep",
+    maven_artifact_name = "xrpVendordep-cpp",
+    maven_group_id = "edu.wpi.first.xrpVendordep",
 )


### PR DESCRIPTION
This is a watered down version of #8056, that takes advantage of the new publishing stuff, but also doesn't touch the C++ library stuff while Austin works on fixing the shared libraries.

This adds a `wpilib_java_library` that will build a maven bundle as well as create the library, to reduce some boiler plate. Another macro, `package_default_jni_project` has been created to wrap up all of the new publishing information into something that can be reused. It assumes the libraries are named consistently, and there are headers, sources, shared, and static artifacts for each of the platforms, which should be the case for all of the jni projects (wipiutil, wpinet, hal, cscore, ntcore, wpimath)

Temporary stub macros were created to get all of the libraries at least publishing their source code. `package_minimal_jni_project` can theoretically be replaced with `package_default_jni_project` at any time, but I still want to hold off on doing the "build EVERYTHING" until we are satisfied with the buildbuddy usage and maybe have a wpi owned cache set up.

Finally, there is one big `publish_all` added so you can run this all in one step.

This has been tested by running a gradle `./gradlew publishToMavenLocal --Pversion=1234` and a `MAVEN_REPO=file:/tmp/maven bazel run //:publish` and comparing the results after the source, header, and java source zip files have been extracted.