### PR TITLE
[cmd, wpimath] Deprecate Mecanum/SwerveControllerCommand and HolonomicDriveController

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommand.java
@@ -37,7 +37,10 @@ import java.util.function.Supplier;
  * to the angle given in the final state of the trajectory.
  *
  * <p>This class is provided by the NewCommands VendorDep
+ *
+ * @deprecated Will be removed with no replacement.
  */
+@Deprecated(forRemoval = true, since = "2026")
 @SuppressWarnings("removal")
 public class MecanumControllerCommand extends Command {
   private final Timer m_timer = new Timer();

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommand.java
@@ -30,7 +30,11 @@ import java.util.function.Supplier;
  * to the angle given in the final state of the trajectory.
  *
  * <p>This class is provided by the NewCommands VendorDep
+ *
+ * @deprecated Will be removed with no replacement.
  */
+@Deprecated(forRemoval = true, since = "2026")
+@SuppressWarnings("removal")
 public class SwerveControllerCommand extends Command {
   private final Timer m_timer = new Timer();
   private final Trajectory m_trajectory;

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/MecanumControllerCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/MecanumControllerCommand.cpp
@@ -10,6 +10,8 @@
 #include <units/velocity.h>
 #include <units/voltage.h>
 
+WPI_IGNORE_DEPRECATED
+
 using namespace frc2;
 using kv_unit = units::compound_unit<units::volts,
                                      units::inverse<units::meters_per_second>>;

--- a/wpilibNewCommands/src/main/native/include/frc2/command/MecanumControllerCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/MecanumControllerCommand.h
@@ -19,12 +19,14 @@
 #include <units/length.h>
 #include <units/velocity.h>
 #include <units/voltage.h>
+#include <wpi/deprecated.h>
 
 #include "frc2/command/Command.h"
 #include "frc2/command/CommandHelper.h"
 #include "frc2/command/Requirements.h"
 
 #pragma once
+WPI_IGNORE_DEPRECATED
 
 namespace frc2 {
 /**
@@ -47,8 +49,10 @@ namespace frc2 {
  * trajectory.
  *
  * This class is provided by the NewCommands VendorDep
+ * @deprecated Will be removed with no replacement.
  */
-class MecanumControllerCommand
+class [[deprecated("Will be removed with no replacement.")]]
+MecanumControllerCommand
     : public CommandHelper<Command, MecanumControllerCommand> {
  public:
   /**
@@ -267,3 +271,4 @@ class MecanumControllerCommand
   units::second_t m_prevTime;
 };
 }  // namespace frc2
+WPI_UNIGNORE_DEPRECATED

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SwerveControllerCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SwerveControllerCommand.h
@@ -18,12 +18,14 @@
 #include <units/length.h>
 #include <units/time.h>
 #include <units/voltage.h>
+#include <wpi/deprecated.h>
 
 #include "frc2/command/Command.h"
 #include "frc2/command/CommandHelper.h"
 #include "frc2/command/Requirements.h"
 
 #pragma once
+WPI_IGNORE_DEPRECATED
 
 namespace frc2 {
 
@@ -47,9 +49,11 @@ namespace frc2 {
  * trajectory.
  *
  * This class is provided by the NewCommands VendorDep
+ * @deprecated Will be removed with no replacement.
  */
 template <size_t NumModules>
-class SwerveControllerCommand
+class [[deprecated("Will be removed with no replacement.")]]
+SwerveControllerCommand
     : public CommandHelper<Command, SwerveControllerCommand<NumModules>> {
   using voltsecondspermeter =
       units::compound_unit<units::voltage::volt, units::second,
@@ -266,5 +270,5 @@ class SwerveControllerCommand
   units::second_t m_prevTime;
   frc::Rotation2d m_finalRotation;
 };
-
 }  // namespace frc2
+WPI_UNIGNORE_DEPRECATED

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommandTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
+@SuppressWarnings("removal")
 class MecanumControllerCommandTest {
   @BeforeEach
   void setupAll() {

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommandTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
+@SuppressWarnings("removal")
 class SwerveControllerCommandTest {
   @BeforeEach
   void setup() {

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/MecanumControllerCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/MecanumControllerCommandTest.cpp
@@ -17,6 +17,7 @@
 #include <frc/simulation/SimHooks.h>
 #include <frc/trajectory/TrajectoryGenerator.h>
 #include <gtest/gtest.h>
+#include <wpi/deprecated.h>
 
 #include "CommandTestBase.h"
 
@@ -97,9 +98,9 @@ TEST_F(MecanumControllerCommandTest, ReachesReference) {
 
   auto endState = trajectory.Sample(trajectory.TotalTime());
 
+  WPI_IGNORE_DEPRECATED
   auto command = frc2::MecanumControllerCommand(
       trajectory, [&]() { return getRobotPose(); }, m_kinematics,
-
       frc::PIDController(0.6, 0, 0), frc::PIDController(0.6, 0, 0),
       m_rotController, 8.8_mps,
       [&](units::meters_per_second_t frontLeft,
@@ -127,6 +128,7 @@ TEST_F(MecanumControllerCommandTest, ReachesReference) {
   }
   m_timer.Stop();
   command.End(false);
+  WPI_UNIGNORE_DEPRECATED
 
   EXPECT_NEAR_UNITS(endState.pose.X(), getRobotPose().X(), kxTolerance);
   EXPECT_NEAR_UNITS(endState.pose.Y(), getRobotPose().Y(), kyTolerance);

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/SwerveControllerCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/SwerveControllerCommandTest.cpp
@@ -18,6 +18,7 @@
 #include <frc/simulation/SimHooks.h>
 #include <frc/trajectory/TrajectoryGenerator.h>
 #include <gtest/gtest.h>
+#include <wpi/deprecated.h>
 
 #include "CommandTestBase.h"
 
@@ -82,6 +83,7 @@ TEST_F(SwerveControllerCommandTest, ReachesReference) {
 
   auto endState = trajectory.Sample(trajectory.TotalTime());
 
+  WPI_IGNORE_DEPRECATED
   auto command = frc2::SwerveControllerCommand<4>(
       trajectory, [&]() { return getRobotPose(); }, m_kinematics,
 
@@ -105,6 +107,7 @@ TEST_F(SwerveControllerCommandTest, ReachesReference) {
   }
   m_timer.Stop();
   command.End(false);
+  WPI_UNIGNORE_DEPRECATED
 
   EXPECT_NEAR_UNITS(endState.pose.X(), getRobotPose().X(), kxTolerance);
   EXPECT_NEAR_UNITS(endState.pose.Y(), getRobotPose().Y(), kyTolerance);

--- a/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/cpp/RobotContainer.cpp
@@ -17,6 +17,7 @@
 #include <frc2/command/MecanumControllerCommand.h>
 #include <frc2/command/SequentialCommandGroup.h>
 #include <frc2/command/button/JoystickButton.h>
+#include <wpi/deprecated.h>
 
 #include "Constants.h"
 
@@ -66,6 +67,7 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand() {
       // Pass the config
       config);
 
+  WPI_IGNORE_DEPRECATED
   frc2::CommandPtr mecanumControllerCommand =
       frc2::MecanumControllerCommand(
           exampleTrajectory, [this]() { return m_drive.GetPose(); },
@@ -106,6 +108,7 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand() {
 
           {&m_drive})
           .ToPtr();
+  WPI_UNIGNORE_DEPRECATED
 
   // Reset odometry to the initial pose of the trajectory, run path following
   // command, then stop at the end.

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
@@ -18,6 +18,7 @@
 #include <frc2/command/button/JoystickButton.h>
 #include <units/angle.h>
 #include <units/velocity.h>
+#include <wpi/deprecated.h>
 
 #include "Constants.h"
 #include "subsystems/DriveSubsystem.h"
@@ -74,6 +75,7 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand() {
   thetaController.EnableContinuousInput(units::radian_t{-std::numbers::pi},
                                         units::radian_t{std::numbers::pi});
 
+  WPI_IGNORE_DEPRECATED
   frc2::CommandPtr swerveControllerCommand =
       frc2::SwerveControllerCommand<4>(
           exampleTrajectory, [this]() { return m_drive.GetPose(); },
@@ -88,6 +90,7 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand() {
 
           {&m_drive})
           .ToPtr();
+  WPI_UNIGNORE_DEPRECATED
 
   // Reset odometry to the initial pose of the trajectory, run path following
   // command, then stop at the end.

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/RobotContainer.java
@@ -97,6 +97,7 @@ public class RobotContainer {
             new Pose2d(3, 0, Rotation2d.kZero),
             config);
 
+    @SuppressWarnings("removal")
     MecanumControllerCommand mecanumControllerCommand =
         new MecanumControllerCommand(
             exampleTrajectory,

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/RobotContainer.java
@@ -100,6 +100,7 @@ public class RobotContainer {
             AutoConstants.kPThetaController, 0, 0, AutoConstants.kThetaControllerConstraints);
     thetaController.enableContinuousInput(-Math.PI, Math.PI);
 
+    @SuppressWarnings("removal")
     SwerveControllerCommand swerveControllerCommand =
         new SwerveControllerCommand(
             exampleTrajectory,

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/HolonomicDriveController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/HolonomicDriveController.java
@@ -20,7 +20,10 @@ import edu.wpi.first.math.util.Units;
  * x and y, and one profiled PID controller for the angular direction. Because the heading dynamics
  * are decoupled from translations, users can specify a custom heading that the drivetrain should
  * point toward. This heading reference is profiled for smoothness.
+ *
+ * @deprecated Use individual PID controllers instead.
  */
+@Deprecated(forRemoval = true, since = "2026")
 public class HolonomicDriveController {
   private Pose2d m_poseError = Pose2d.kZero;
   private Rotation2d m_rotationError = Rotation2d.kZero;

--- a/wpimath/src/main/native/include/frc/controller/HolonomicDriveController.h
+++ b/wpimath/src/main/native/include/frc/controller/HolonomicDriveController.h
@@ -31,6 +31,7 @@ namespace frc {
  * angular direction. Because the heading dynamics are decoupled from
  * translations, users can specify a custom heading that the drivetrain should
  * point toward. This heading reference is profiled for smoothness.
+ * @deprecated Use individual PID controllers instead.
  */
 class WPILIB_DLLEXPORT HolonomicDriveController {
  public:
@@ -44,6 +45,7 @@ class WPILIB_DLLEXPORT HolonomicDriveController {
    * @param thetaController A profiled PID controller to respond to error in
    * angle.
    */
+  [[deprecated("Use individual PID controllers instead.")]]
   constexpr HolonomicDriveController(
       PIDController xController, PIDController yController,
       ProfiledPIDController<units::radian> thetaController)

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/HolonomicDriveControllerTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/HolonomicDriveControllerTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("removal")
 class HolonomicDriveControllerTest {
   private static final double kTolerance = 1 / 12.0;
   private static final double kAngularTolerance = Math.toRadians(2);

--- a/wpimath/src/test/native/cpp/controller/HolonomicDriveControllerTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/HolonomicDriveControllerTest.cpp
@@ -5,6 +5,7 @@
 #include <numbers>
 
 #include <gtest/gtest.h>
+#include <wpi/deprecated.h>
 
 #include "frc/MathUtil.h"
 #include "frc/controller/HolonomicDriveController.h"
@@ -20,6 +21,7 @@ static constexpr units::meter_t kTolerance{1 / 12.0};
 static constexpr units::radian_t kAngularTolerance{2.0 * std::numbers::pi /
                                                    180.0};
 
+WPI_IGNORE_DEPRECATED
 TEST(HolonomicDriveControllerTest, ReachesReference) {
   frc::HolonomicDriveController controller{
       frc::PIDController{1.0, 0.0, 0.0}, frc::PIDController{1.0, 0.0, 0.0},


### PR DESCRIPTION
See #8119. I'm leaving the example removal in there because Bazel files need to be updated in 2027, and leaving it here would cause issues on merge.