### PR TITLE
[wpilib] Fix DS data not being refreshed after waitForDsConnection

### DIFF
--- a/wpilibc/src/main/native/cpp/DriverStation.cpp
+++ b/wpilibc/src/main/native/cpp/DriverStation.cpp
@@ -586,6 +586,7 @@ bool DriverStation::WaitForDsConnection(units::second_t timeout) {
   }
 
   HAL_RemoveNewDataEventHandle(event.GetHandle());
+  RefreshData();
   return result;
 }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -1169,6 +1169,7 @@ public final class DriverStation {
       DriverStationJNI.removeNewDataEventHandle(event);
       WPIUtilJNI.destroyEvent(event);
     }
+    refreshData();
     return result;
   }
 


### PR DESCRIPTION
Previously if you had `DriverStation.waitForDsConnection(60)`, `DriverStation.getAlliance().isPresent()` could still be false even if the DS was connected. Refreshing the data at the end of `waitForDsConnection` should prevent this issue from occuring.