### PR TITLE
[units] add `as` method for unit conversion in Measure interface

### DIFF
--- a/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
@@ -76,6 +76,8 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *   Seconds.of(15).in(Minutes) // 0.25
    * </pre>
    *
+   * Equivalent to calling {@link #as(Unit)}.
+   *
    * @param unit the unit to convert this measure to
    * @return the value of this measure in the given unit
    */
@@ -85,6 +87,25 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
     } else {
       return unit.fromBaseUnits(baseUnitMagnitude());
     }
+  }
+
+  /**
+   * Converts this measure to a measure with a different unit of the same type,
+   * eg minutes to seconds.
+   * Converting to the same unit is equivalent to calling {@link #magnitude()}.
+   *
+   * <pre>
+   *   Meters.of(12).as(Feet) // 39.3701
+   *   Seconds.of(15).as(Minutes) // 0.25
+   * </pre>
+   *
+   * Equivalent to calling {@link #in(Unit)}.
+   *
+   * @param unit the unit to convert this measure to
+   * @return the value of this measure in the given unit
+   */
+  default double as(U unit) {
+    return in(unit);
   }
 
   /**

--- a/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
@@ -76,7 +76,7 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
    *   Seconds.of(15).in(Minutes) // 0.25
    * </pre>
    *
-   * Equivalent to calling {@link #as(Unit)}.
+   * <p>Equivalent to calling {@link #as(Unit)}.
    *
    * @param unit the unit to convert this measure to
    * @return the value of this measure in the given unit
@@ -90,16 +90,15 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
   }
 
   /**
-   * Converts this measure to a measure with a different unit of the same type,
-   * eg minutes to seconds.
-   * Converting to the same unit is equivalent to calling {@link #magnitude()}.
+   * Converts this measure to a measure with a different unit of the same type, eg minutes to
+   * seconds. Converting to the same unit is equivalent to calling {@link #magnitude()}.
    *
    * <pre>
    *   Meters.of(12).as(Feet) // 39.3701
    *   Seconds.of(15).as(Minutes) // 0.25
    * </pre>
    *
-   * Equivalent to calling {@link #in(Unit)}.
+   * <p>Equivalent to calling {@link #in(Unit)}.
    *
    * @param unit the unit to convert this measure to
    * @return the value of this measure in the given unit


### PR DESCRIPTION
In languages like Kotlin, `in` is a keyword, making the `Measure.in` method annoying to use:
```kt
val meters = Units.Inches.of(10).`in`(Units.Meters)
```

This PR simply adds a default method `as(U unit)` to Measure, which calls the equivalent `in(unit)` method to make Kotlin compatibility easier.