### PR TITLE
[bazel] Shorten the platform suffix for windows arm

### DIFF
--- a/shared/bazel/compiler_flags/windows_flags.rc
+++ b/shared/bazel/compiler_flags/windows_flags.rc
@@ -21,7 +21,7 @@ build:windows --repo_env="BAZEL_LINKOPTS=/DEPENDENTLOADFLAG%:0x1100"
 ################################
 # ARM Windows Flags
 ################################
-build:windows_arm --platforms="@rules_bzlmodrio_toolchains//platforms/windows_arm64" --platform_suffix=windowsarm64
+build:windows_arm --platforms="@rules_bzlmodrio_toolchains//platforms/windows_arm64" --platform_suffix=winarm64
 
 # Ignore duplicate inline statment in tools
 build:windows --host_copt=/wd4141


### PR DESCRIPTION
This needs to be short enough to fit in the windows path restriction. The full name was too long for some targets.