### PR TITLE
[wpimath] Add vector product and squared length operations to Translation2d/3d

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation2d.java
@@ -117,9 +117,9 @@ public class Translation2d
    * <p>The square of the distance between translations is defined as (x₂−x₁)²+(y₂−y₁)².
    *
    * @param other The translation to compute the squared distance to.
-   * @return The square of the distance between the two translations.
+   * @return The square of the distance between the two translations, in square meters.
    */
-  public double getDistanceSquared(Translation2d other) {
+  public double getSquaredDistance(Translation2d other) {
     double dx = other.m_x - m_x;
     double dy = other.m_y - m_y;
     return dx * dx + dy * dy;
@@ -185,9 +185,9 @@ public class Translation2d
    * Returns the squared norm, or squared distance from the origin to the translation. This is
    * equivalent to squaring the result of {@link #getNorm()}, but avoids computing a square root.
    *
-   * @return The squared norm of the translation.
+   * @return The squared norm of the translation, in square meters.
    */
-  public double getNormSquared() {
+  public double getSquaredNorm() {
     return m_x * m_x + m_y * m_y;
   }
 
@@ -246,7 +246,7 @@ public class Translation2d
    * <p>The dot product between two translations is defined as x₁x₂+y₁y₂.
    *
    * @param other The translation to compute the dot product with.
-   * @return The dot product between the two translations.
+   * @return The dot product between the two translations, in square meters.
    */
   public double dot(Translation2d other) {
     return m_x * other.m_x + m_y * other.m_y;
@@ -258,7 +258,7 @@ public class Translation2d
    * <p>The 2D cross product between two translations is defined as x₁y₂-x₂y₁.
    *
    * @param other The translation to compute the cross product with.
-   * @return The cross product between the two translations.
+   * @return The cross product between the two translations, in square meters.
    */
   public double cross(Translation2d other) {
     return m_x * other.m_y - m_y * other.m_x;

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation2d.java
@@ -110,6 +110,22 @@ public class Translation2d
   }
 
   /**
+   * Calculates the square of the distance between two translations in 2D space. This is equivalent
+   * to squaring the result of {@link #getDistance(Translation2d)}, but avoids computing a square
+   * root.
+   *
+   * <p>The square of the distance between translations is defined as (x₂−x₁)²+(y₂−y₁)².
+   *
+   * @param other The translation to compute the squared distance to.
+   * @return The square of the distance between the two translations.
+   */
+  public double getDistanceSquared(Translation2d other) {
+    double dx = other.m_x - m_x;
+    double dy = other.m_y - m_y;
+    return dx * dx + dy * dy;
+  }
+
+  /**
    * Returns the X component of the translation.
    *
    * @return The X component of the translation.
@@ -166,6 +182,16 @@ public class Translation2d
   }
 
   /**
+   * Returns the squared norm, or squared distance from the origin to the translation. This is
+   * equivalent to squaring the result of {@link #getNorm()}, but avoids computing a square root.
+   *
+   * @return The squared norm of the translation.
+   */
+  public double getNormSquared() {
+    return m_x * m_x + m_y * m_y;
+  }
+
+  /**
    * Returns the angle this translation forms with the positive X axis.
    *
    * @return The angle of the translation
@@ -212,6 +238,30 @@ public class Translation2d
     return new Translation2d(
         (m_x - other.getX()) * rot.getCos() - (m_y - other.getY()) * rot.getSin() + other.getX(),
         (m_x - other.getX()) * rot.getSin() + (m_y - other.getY()) * rot.getCos() + other.getY());
+  }
+
+  /**
+   * Computes the dot product between this translation and another translation in 2D space.
+   *
+   * <p>The dot product between two translations is defined as x₁x₂+y₁y₂.
+   *
+   * @param other The translation to compute the dot product with.
+   * @return The dot product between the two translations.
+   */
+  public double dot(Translation2d other) {
+    return m_x * other.m_x + m_y * other.m_y;
+  }
+
+  /**
+   * Computes the cross product between this translation and another translation in 2D space.
+   *
+   * <p>The 2D cross product between two translations is defined as x₁y₂-x₂y₁.
+   *
+   * @param other The translation to compute the cross product with.
+   * @return The cross product between the two translations.
+   */
+  public double cross(Translation2d other) {
+    return m_x * other.m_y - m_y * other.m_x;
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
@@ -140,7 +140,7 @@ public class Translation3d
    * @param other The translation to compute the squared distance to.
    * @return The squared distance between the two translations.
    */
-  public double getDistanceSquared(Translation3d other) {
+  public double getSquaredDistance(Translation3d other) {
     double dx = other.m_x - m_x;
     double dy = other.m_y - m_y;
     double dz = other.m_z - m_z;
@@ -228,7 +228,7 @@ public class Translation3d
    *
    * @return The squared norm of the translation.
    */
-  public double getNormSquared() {
+  public double getSquaredNorm() {
     return m_x * m_x + m_y * m_y + m_z * m_z;
   }
 

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
@@ -125,8 +125,26 @@ public class Translation3d
    * @return The distance between the two translations.
    */
   public double getDistance(Translation3d other) {
-    return Math.sqrt(
-        Math.pow(other.m_x - m_x, 2) + Math.pow(other.m_y - m_y, 2) + Math.pow(other.m_z - m_z, 2));
+    double dx = other.m_x - m_x;
+    double dy = other.m_y - m_y;
+    double dz = other.m_z - m_z;
+    return Math.sqrt(dx * dx + dy * dy + dz * dz);
+  }
+
+  /**
+   * Calculates the squared distance between two translations in 3D space. This is equivalent to
+   * squaring the result of {@link #getDistance(Translation3d)}, but avoids computing a square root.
+   *
+   * <p>The squared distance between translations is defined as (x₂−x₁)²+(y₂−y₁)²+(z₂−z₁)².
+   *
+   * @param other The translation to compute the squared distance to.
+   * @return The squared distance between the two translations.
+   */
+  public double getDistanceSquared(Translation3d other) {
+    double dx = other.m_x - m_x;
+    double dy = other.m_y - m_y;
+    double dz = other.m_z - m_z;
+    return dx * dx + dy * dy + dz * dz;
   }
 
   /**
@@ -205,6 +223,16 @@ public class Translation3d
   }
 
   /**
+   * Returns the squared norm, or squared distance from the origin to the translation. This is
+   * equivalent to squaring the result of {@link #getNorm()}, but avoids computing a square root.
+   *
+   * @return The squared norm of the translation.
+   */
+  public double getNormSquared() {
+    return m_x * m_x + m_y * m_y + m_z * m_z;
+  }
+
+  /**
    * Applies a rotation to the translation in 3D space.
    *
    * <p>For example, rotating a Translation3d of &lt;2, 0, 0&gt; by 90 degrees around the Z axis
@@ -228,6 +256,35 @@ public class Translation3d
    */
   public Translation3d rotateAround(Translation3d other, Rotation3d rot) {
     return this.minus(other).rotateBy(rot).plus(other);
+  }
+
+  /**
+   * Computes the dot product between this translation and another translation in 3D space.
+   *
+   * <p>The dot product between two translations is defined as x₁x₂+y₁y₂+z₁z₂.
+   *
+   * @param other The translation to compute the dot product with.
+   * @return The dot product between the two translations.
+   */
+  public double dot(Translation3d other) {
+    return m_x * other.m_x + m_y * other.m_y + m_z * other.m_z;
+  }
+
+  /**
+   * Computes the cross product between this translation and another translation in 3D space. The
+   * resulting translation will be perpendicular to both translations.
+   *
+   * <p>The 3D cross product between two translations is defined as Translation3d(y₁z₂-y₂z₁,
+   * z₁x₂-z₂x₁, x₁y₂-x₂y₁).
+   *
+   * @param other The translation to compute the cross product with.
+   * @return The cross product between the two translations.
+   */
+  public Translation3d cross(Translation3d other) {
+    return new Translation3d(
+        m_y * other.m_z - other.m_y * m_z,
+        m_z * other.m_x - other.m_z * m_x,
+        m_x * other.m_y - other.m_x * m_y);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
@@ -264,7 +264,7 @@ public class Translation3d
    * <p>The dot product between two translations is defined as x₁x₂+y₁y₂+z₁z₂.
    *
    * @param other The translation to compute the dot product with.
-   * @return The dot product between the two translations.
+   * @return The dot product between the two translations, in square meters.
    */
   public double dot(Translation3d other) {
     return m_x * other.m_x + m_y * other.m_y + m_z * other.m_z;

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
@@ -274,14 +274,14 @@ public class Translation3d
    * Computes the cross product between this translation and another translation in 3D space. The
    * resulting translation will be perpendicular to both translations.
    *
-   * <p>The 3D cross product between two translations is defined as Translation3d(y₁z₂-y₂z₁,
-   * z₁x₂-z₂x₁, x₁y₂-x₂y₁).
+   * <p>The 3D cross product between two translations is defined as &lt;y₁z₂-y₂z₁, z₁x₂-z₂x₁,
+   * x₁y₂-x₂y₁&gt;.
    *
    * @param other The translation to compute the cross product with.
    * @return The cross product between the two translations.
    */
-  public Translation3d cross(Translation3d other) {
-    return new Translation3d(
+  public Vector<N3> cross(Translation3d other) {
+    return VecBuilder.fill(
         m_y * other.m_z - other.m_y * m_z,
         m_z * other.m_x - other.m_z * m_x,
         m_x * other.m_y - other.m_x * m_y);

--- a/wpimath/src/main/native/include/frc/geometry/Translation2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Translation2d.h
@@ -13,6 +13,7 @@
 #include <wpi/json_fwd.h>
 
 #include "frc/geometry/Rotation2d.h"
+#include "units/area.h"
 #include "units/length.h"
 #include "units/math.h"
 
@@ -76,6 +77,23 @@ class WPILIB_DLLEXPORT Translation2d {
   }
 
   /**
+   * Calculates the square of the distance between two translations in 2D space.
+   * This is equivalent to squaring the result of Distance(Translation2d), but
+   * avoids computing a square root.
+   *
+   * The square of the distance between translations is defined as
+   * (x₂−x₁)²+(y₂−y₁)².
+   *
+   * @param other The translation to compute the squared distance to.
+   * @return The square of the distance between the two translations.
+   */
+  constexpr units::square_meter_t DistanceSquared(
+      const Translation2d& other) const {
+    return units::math::pow<2>(other.m_x - m_x) +
+           units::math::pow<2>(other.m_y - m_y);
+  }
+
+  /**
    * Returns the X component of the translation.
    *
    * @return The X component of the translation.
@@ -104,6 +122,17 @@ class WPILIB_DLLEXPORT Translation2d {
    * @return The norm of the translation.
    */
   constexpr units::meter_t Norm() const { return units::math::hypot(m_x, m_y); }
+
+  /**
+   * Returns the squared norm, or squared distance from the origin to the
+   * translation. This is equivalent to squaring the result of Norm(), but
+   * avoids computing a square root.
+   *
+   * @return The squared norm of the translation.
+   */
+  constexpr units::square_meter_t NormSquared() const {
+    return units::math::pow<2>(m_x) + units::math::pow<2>(m_y);
+  }
 
   /**
    * Returns the angle this translation forms with the positive X axis.
@@ -155,6 +184,32 @@ class WPILIB_DLLEXPORT Translation2d {
                 other.X(),
             (m_x - other.X()) * rot.Sin() + (m_y - other.Y()) * rot.Cos() +
                 other.Y()};
+  }
+
+  /**
+   * Computes the dot product between this translation and another translation
+   * in 2D space.
+   *
+   * The dot product between two translations is defined as x₁x₂+y₁y₂.
+   *
+   * @param other The translation to compute the dot product with.
+   * @return The dot product between the two translations.
+   */
+  constexpr units::square_meter_t Dot(const Translation2d& other) const {
+    return m_x * other.X() + m_y * other.Y();
+  }
+
+  /**
+   * Computes the cross product between this translation and another translation
+   * in 2D space.
+   *
+   * The 2D cross product between two translations is defined as x₁y₂-x₂y₁.
+   *
+   * @param other The translation to compute the cross product with.
+   * @return The cross product between the two translations.
+   */
+  constexpr units::square_meter_t Cross(const Translation2d& other) const {
+    return m_x * other.Y() - m_y * other.X();
   }
 
   /**

--- a/wpimath/src/main/native/include/frc/geometry/Translation2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Translation2d.h
@@ -87,7 +87,7 @@ class WPILIB_DLLEXPORT Translation2d {
    * @param other The translation to compute the squared distance to.
    * @return The square of the distance between the two translations.
    */
-  constexpr units::square_meter_t DistanceSquared(
+  constexpr units::square_meter_t SquaredDistance(
       const Translation2d& other) const {
     return units::math::pow<2>(other.m_x - m_x) +
            units::math::pow<2>(other.m_y - m_y);
@@ -130,7 +130,7 @@ class WPILIB_DLLEXPORT Translation2d {
    *
    * @return The squared norm of the translation.
    */
-  constexpr units::square_meter_t NormSquared() const {
+  constexpr units::square_meter_t SquaredNorm() const {
     return units::math::pow<2>(m_x) + units::math::pow<2>(m_y);
   }
 

--- a/wpimath/src/main/native/include/frc/geometry/Translation3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Translation3d.h
@@ -212,17 +212,18 @@ class WPILIB_DLLEXPORT Translation3d {
    * translation in 3D space. The resulting translation will be perpendicular to
    * both translations.
    *
-   * The 3D cross product between two translations is defined as
-   * Translation3d{y₁z₂-y₂z₁, z₁x₂-z₂x₁, x₁y₂-x₂y₁}.
+   * The 3D cross product between two translations is defined as <y₁z₂-y₂z₁,
+   * z₁x₂-z₂x₁, x₁y₂-x₂y₁>.
    *
    * @param other The translation to compute the cross product with.
    * @return The cross product between the two translations.
    */
-  constexpr Translation3d Cross(const Translation3d& other) const {
-    return Translation3d{
-        units::meter_t{(m_y * other.Z() - other.Y() * m_z).value()},
-        units::meter_t{(m_z * other.X() - other.Z() * m_x).value()},
-        units::meter_t{(m_x * other.Y() - other.X() * m_y).value()}};
+  constexpr Eigen::Vector<units::square_meter_t, 3> Cross(
+      const Translation3d& other) const {
+    return Eigen::Vector<units::square_meter_t, 3>{
+        {m_y * other.Z() - other.Y() * m_z},
+        {m_z * other.X() - other.Z() * m_x},
+        {m_x * other.Y() - other.X() * m_y}};
   }
 
   /**

--- a/wpimath/src/main/native/include/frc/geometry/Translation3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Translation3d.h
@@ -110,9 +110,9 @@ class WPILIB_DLLEXPORT Translation3d {
    */
   constexpr units::square_meter_t DistanceSquared(
       const Translation3d& other) const {
-      return units::math::pow<2>(other.m_x - m_x) +
-             units::math::pow<2>(other.m_y - m_y) +
-             units::math::pow<2>(other.m_z - m_z);
+    return units::math::pow<2>(other.m_x - m_x) +
+           units::math::pow<2>(other.m_y - m_y) +
+           units::math::pow<2>(other.m_z - m_z);
   }
 
   /**
@@ -219,12 +219,10 @@ class WPILIB_DLLEXPORT Translation3d {
    * @return The cross product between the two translations.
    */
   constexpr Translation3d Cross(const Translation3d& other) const {
-    return Translation3d{units::meter_t{(m_y * other.Z() - other.Y() * m_z)
-                                            .value()},
-                         units::meter_t{(m_z * other.X() - other.Z() * m_x)
-                                            .value()},
-                         units::meter_t{(m_x * other.Y() - other.X() * m_y)
-                                            .value()}};
+    return Translation3d{
+        units::meter_t{(m_y * other.Z() - other.Y() * m_z).value()},
+        units::meter_t{(m_z * other.X() - other.Z() * m_x).value()},
+        units::meter_t{(m_x * other.Y() - other.X() * m_y).value()}};
   }
 
   /**

--- a/wpimath/src/main/native/include/frc/geometry/Translation3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Translation3d.h
@@ -108,7 +108,7 @@ class WPILIB_DLLEXPORT Translation3d {
    * @param other The translation to compute the squared distance to.
    * @return The squared distance between the two translations.
    */
-  constexpr units::square_meter_t DistanceSquared(
+  constexpr units::square_meter_t SquaredDistance(
       const Translation3d& other) const {
     return units::math::pow<2>(other.m_x - m_x) +
            units::math::pow<2>(other.m_y - m_y) +
@@ -161,7 +161,7 @@ class WPILIB_DLLEXPORT Translation3d {
    *
    * @return The squared norm of the translation.
    */
-  constexpr units::square_meter_t NormSquared() const {
+  constexpr units::square_meter_t SquaredNorm() const {
     return m_x * m_x + m_y * m_y + m_z * m_z;
   }
 

--- a/wpimath/src/main/native/include/frc/geometry/Translation3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Translation3d.h
@@ -14,6 +14,7 @@
 
 #include "frc/geometry/Rotation3d.h"
 #include "frc/geometry/Translation2d.h"
+#include "units/area.h"
 #include "units/length.h"
 #include "units/math.h"
 
@@ -97,6 +98,24 @@ class WPILIB_DLLEXPORT Translation3d {
   }
 
   /**
+   * Calculates the squared distance between two translations in 3D space. This
+   * is equivalent to squaring the result of Distance(Translation3d), but avoids
+   * computing a square root.
+   *
+   * The squared distance between translations is defined as
+   * (x₂−x₁)²+(y₂−y₁)²+(z₂−z₁)².
+   *
+   * @param other The translation to compute the squared distance to.
+   * @return The squared distance between the two translations.
+   */
+  constexpr units::square_meter_t DistanceSquared(
+      const Translation3d& other) const {
+      return units::math::pow<2>(other.m_x - m_x) +
+             units::math::pow<2>(other.m_y - m_y) +
+             units::math::pow<2>(other.m_z - m_z);
+  }
+
+  /**
    * Returns the X component of the translation.
    *
    * @return The Z component of the translation.
@@ -136,6 +155,17 @@ class WPILIB_DLLEXPORT Translation3d {
   }
 
   /**
+   * Returns the squared norm, or squared distance from the origin to the
+   * translation. This is equivalent to squaring the result of Norm(), but
+   * avoids computing a square root.
+   *
+   * @return The squared norm of the translation.
+   */
+  constexpr units::square_meter_t NormSquared() const {
+    return m_x * m_x + m_y * m_y + m_z * m_z;
+  }
+
+  /**
    * Applies a rotation to the translation in 3D space.
    *
    * For example, rotating a Translation3d of &lt;2, 0, 0&gt; by 90 degrees
@@ -162,6 +192,39 @@ class WPILIB_DLLEXPORT Translation3d {
   constexpr Translation3d RotateAround(const Translation3d& other,
                                        const Rotation3d& rot) const {
     return (*this - other).RotateBy(rot) + other;
+  }
+
+  /**
+   * Computes the dot product between this translation and another translation
+   * in 3D space.
+   *
+   * The dot product between two translations is defined as x₁x₂+y₁y₂+z₁z₂.
+   *
+   * @param other The translation to compute the dot product with.
+   * @return The dot product between the two translations.
+   */
+  constexpr units::square_meter_t Dot(const Translation3d& other) const {
+    return m_x * other.X() + m_y * other.Y() + m_z * other.Z();
+  }
+
+  /**
+   * Computes the cross product between this translation and another
+   * translation in 3D space. The resulting translation will be perpendicular to
+   * both translations.
+   *
+   * The 3D cross product between two translations is defined as
+   * Translation3d{y₁z₂-y₂z₁, z₁x₂-z₂x₁, x₁y₂-x₂y₁}.
+   *
+   * @param other The translation to compute the cross product with.
+   * @return The cross product between the two translations.
+   */
+  constexpr Translation3d Cross(const Translation3d& other) const {
+    return Translation3d{units::meter_t{(m_y * other.Z() - other.Y() * m_z)
+                                            .value()},
+                         units::meter_t{(m_z * other.X() - other.Z() * m_x)
+                                            .value()},
+                         units::meter_t{(m_x * other.Y() - other.X() * m_y)
+                                            .value()}};
   }
 
   /**

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation2dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation2dTest.java
@@ -87,10 +87,23 @@ class Translation2dTest {
   }
 
   @Test
+  void testNormSquared() {
+    var one = new Translation2d(3.0, 5.0);
+    assertEquals(Math.pow(Math.hypot(3.0, 5.0), 2.0), one.getNormSquared(), kEpsilon);
+  }
+
+  @Test
   void testDistance() {
     var one = new Translation2d(1, 1);
     var two = new Translation2d(6, 6);
     assertEquals(5.0 * Math.sqrt(2.0), one.getDistance(two), kEpsilon);
+  }
+
+  @Test
+  void testDistanceSquared() {
+    var one = new Translation2d(1, 1);
+    var two = new Translation2d(6, 6);
+    assertEquals(50.0, one.getDistanceSquared(two), kEpsilon);
   }
 
   @Test
@@ -153,5 +166,19 @@ class Translation2dTest {
     assertEquals(vec.get(1), translation.getY());
 
     assertEquals(vec, translation.toVector());
+  }
+
+  @Test
+  void testDot() {
+    var one = new Translation2d(2.0, 3.0);
+    var two = new Translation2d(3.0, 4.0);
+    assertEquals(18.0, one.dot(two), kEpsilon);
+  }
+
+  @Test
+  void testCross() {
+    var one = new Translation2d(2.0, 3.0);
+    var two = new Translation2d(3.0, 4.0);
+    assertEquals(-1.0, one.cross(two), kEpsilon);
   }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation2dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation2dTest.java
@@ -87,9 +87,9 @@ class Translation2dTest {
   }
 
   @Test
-  void testNormSquared() {
+  void testSquaredNorm() {
     var one = new Translation2d(3.0, 5.0);
-    assertEquals(34.0, one.getNormSquared(), kEpsilon);
+    assertEquals(34.0, one.getSquaredNorm(), kEpsilon);
   }
 
   @Test
@@ -100,10 +100,10 @@ class Translation2dTest {
   }
 
   @Test
-  void testDistanceSquared() {
+  void testSquaredDistance() {
     var one = new Translation2d(1, 1);
     var two = new Translation2d(6, 6);
-    assertEquals(50.0, one.getDistanceSquared(two), kEpsilon);
+    assertEquals(50.0, one.getSquaredDistance(two), kEpsilon);
   }
 
   @Test

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation2dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation2dTest.java
@@ -89,7 +89,7 @@ class Translation2dTest {
   @Test
   void testNormSquared() {
     var one = new Translation2d(3.0, 5.0);
-    assertEquals(Math.pow(Math.hypot(3.0, 5.0), 2.0), one.getNormSquared(), kEpsilon);
+    assertEquals(34.0, one.getNormSquared(), kEpsilon);
   }
 
   @Test

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation3dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation3dTest.java
@@ -150,10 +150,23 @@ class Translation3dTest {
   }
 
   @Test
+  void testNormSquared() {
+    var one = new Translation3d(3.0, 5.0, 7.0);
+    assertEquals(83.0, one.getNormSquared(), kEpsilon);
+  }
+
+  @Test
   void testDistance() {
     var one = new Translation3d(1.0, 1.0, 1.0);
     var two = new Translation3d(6.0, 6.0, 6.0);
     assertEquals(5.0 * Math.sqrt(3.0), one.getDistance(two), kEpsilon);
+  }
+
+  @Test
+  void testDistanceSquared() {
+    var one = new Translation3d(1.0, 1.0, 1.0);
+    var two = new Translation3d(6.0, 6.0, 6.0);
+    assertEquals(75.0, one.getDistanceSquared(two), kEpsilon);
   }
 
   @Test
@@ -224,5 +237,23 @@ class Translation3dTest {
     assertEquals(translation3, origin.nearest(List.of(translation5, translation3, translation4)));
     assertEquals(translation1, origin.nearest(List.of(translation1, translation2, translation3)));
     assertEquals(translation2, origin.nearest(List.of(translation4, translation2, translation3)));
+  }
+
+  @Test
+  void testDot() {
+    var one = new Translation3d(1.0, 2.0, 3.0);
+    var two = new Translation3d(4.0, 5.0, 6.0);
+    assertEquals(32.0, one.dot(two));
+  }
+
+  @Test
+  void testCross() {
+    var one = new Translation3d(1.0, 2.0, 3.0);
+    var two = new Translation3d(4.0, 5.0, 6.0);
+    var cross = one.cross(two);
+    assertAll(
+        () -> assertEquals(-3.0, cross.getX(), kEpsilon),
+        () -> assertEquals(6.0, cross.getY(), kEpsilon),
+        () -> assertEquals(-3.0, cross.getZ(), kEpsilon));
   }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation3dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation3dTest.java
@@ -253,8 +253,8 @@ class Translation3dTest {
 
     var cross = one.cross(two);
     assertAll(
-        () -> assertEquals(-3.0, cross.getX(), kEpsilon),
-        () -> assertEquals(6.0, cross.getY(), kEpsilon),
-        () -> assertEquals(-3.0, cross.getZ(), kEpsilon));
+        () -> assertEquals(-3.0, cross.get(0, 0), kEpsilon),
+        () -> assertEquals(6.0, cross.get(1, 0), kEpsilon),
+        () -> assertEquals(-3.0, cross.get(2, 0), kEpsilon));
   }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation3dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation3dTest.java
@@ -150,9 +150,9 @@ class Translation3dTest {
   }
 
   @Test
-  void testNormSquared() {
+  void testSquaredNorm() {
     var one = new Translation3d(3.0, 5.0, 7.0);
-    assertEquals(83.0, one.getNormSquared(), kEpsilon);
+    assertEquals(83.0, one.getSquaredNorm(), kEpsilon);
   }
 
   @Test
@@ -163,10 +163,10 @@ class Translation3dTest {
   }
 
   @Test
-  void testDistanceSquared() {
+  void testSquaredDistance() {
     var one = new Translation3d(1.0, 1.0, 1.0);
     var two = new Translation3d(6.0, 6.0, 6.0);
-    assertEquals(75.0, one.getDistanceSquared(two), kEpsilon);
+    assertEquals(75.0, one.getSquaredDistance(two), kEpsilon);
   }
 
   @Test

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation3dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation3dTest.java
@@ -250,6 +250,7 @@ class Translation3dTest {
   void testCross() {
     var one = new Translation3d(1.0, 2.0, 3.0);
     var two = new Translation3d(4.0, 5.0, 6.0);
+
     var cross = one.cross(two);
     assertAll(
         () -> assertEquals(-3.0, cross.getX(), kEpsilon),

--- a/wpimath/src/test/native/cpp/geometry/Translation2dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Translation2dTest.cpp
@@ -68,10 +68,21 @@ TEST(Translation2dTest, Norm) {
   EXPECT_DOUBLE_EQ(std::hypot(3.0, 5.0), one.Norm().value());
 }
 
+TEST(Translation2dTest, NormSquared) {
+  const Translation2d one{3_m, 5_m};
+  EXPECT_DOUBLE_EQ(34.0, one.NormSquared().value());
+}
+
 TEST(Translation2dTest, Distance) {
   const Translation2d one{1_m, 1_m};
   const Translation2d two{6_m, 6_m};
   EXPECT_DOUBLE_EQ(5.0 * std::sqrt(2.0), one.Distance(two).value());
+}
+
+TEST(Translation2dTest, DistanceSquared) {
+  const Translation2d one{1_m, 1_m};
+  const Translation2d two{6_m, 6_m};
+  EXPECT_DOUBLE_EQ(50.0, one.DistanceSquared(two).value());
 }
 
 TEST(Translation2dTest, UnaryMinus) {
@@ -161,4 +172,16 @@ TEST(Translation2dTest, Constexpr) {
   static_assert(negated.X() == (-1_m));
   static_assert(multiplied.X() == 2_m);
   static_assert(divided.Y() == 1_m);
+}
+
+TEST(Translation2dTest, Dot) {
+  const Translation2d one{2_m, 3_m};
+  const Translation2d two{3_m, 4_m};
+  EXPECT_DOUBLE_EQ(18.0, one.Dot(two).value());
+}
+
+TEST(Translation2dTest, Cross) {
+  const Translation2d one{2_m, 3_m};
+  const Translation2d two{3_m, 4_m};
+  EXPECT_DOUBLE_EQ(-1.0, one.Cross(two).value());
 }

--- a/wpimath/src/test/native/cpp/geometry/Translation2dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Translation2dTest.cpp
@@ -68,9 +68,9 @@ TEST(Translation2dTest, Norm) {
   EXPECT_DOUBLE_EQ(std::hypot(3.0, 5.0), one.Norm().value());
 }
 
-TEST(Translation2dTest, NormSquared) {
+TEST(Translation2dTest, SquaredNorm) {
   const Translation2d one{3_m, 5_m};
-  EXPECT_DOUBLE_EQ(34.0, one.NormSquared().value());
+  EXPECT_DOUBLE_EQ(34.0, one.SquaredNorm().value());
 }
 
 TEST(Translation2dTest, Distance) {
@@ -79,10 +79,10 @@ TEST(Translation2dTest, Distance) {
   EXPECT_DOUBLE_EQ(5.0 * std::sqrt(2.0), one.Distance(two).value());
 }
 
-TEST(Translation2dTest, DistanceSquared) {
+TEST(Translation2dTest, SquaredDistance) {
   const Translation2d one{1_m, 1_m};
   const Translation2d two{6_m, 6_m};
-  EXPECT_DOUBLE_EQ(50.0, one.DistanceSquared(two).value());
+  EXPECT_DOUBLE_EQ(50.0, one.SquaredDistance(two).value());
 }
 
 TEST(Translation2dTest, UnaryMinus) {

--- a/wpimath/src/test/native/cpp/geometry/Translation3dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Translation3dTest.cpp
@@ -114,10 +114,21 @@ TEST(Translation3dTest, Norm) {
   EXPECT_NEAR(one.Norm().value(), std::hypot(3, 5, 7), kEpsilon);
 }
 
+TEST(Translation3dTest, NormSquared) {
+  const Translation3d one{3_m, 5_m, 7_m};
+  EXPECT_NEAR(one.NormSquared().value(), 83.0, kEpsilon);
+}
+
 TEST(Translation3dTest, Distance) {
   const Translation3d one{1_m, 1_m, 1_m};
   const Translation3d two{6_m, 6_m, 6_m};
   EXPECT_NEAR(one.Distance(two).value(), 5 * std::sqrt(3), kEpsilon);
+}
+
+TEST(Translation3dTest, DistanceSquared) {
+  const Translation3d one{1_m, 1_m, 1_m};
+  const Translation3d two{6_m, 6_m, 6_m};
+  EXPECT_NEAR(one.DistanceSquared(two).value(), 75.0, kEpsilon);
 }
 
 TEST(Translation3dTest, UnaryMinus) {
@@ -213,4 +224,20 @@ TEST(Translation3dTest, Nearest) {
   EXPECT_DOUBLE_EQ(nearest3.X().value(), translation2.X().value());
   EXPECT_DOUBLE_EQ(nearest3.Y().value(), translation2.Y().value());
   EXPECT_DOUBLE_EQ(nearest3.Z().value(), translation2.Z().value());
+}
+
+TEST(Translation3dTest, Dot) {
+  const Translation3d one{1_m, 2_m, 3_m};
+  const Translation3d two{4_m, 5_m, 6_m};
+  EXPECT_NEAR(one.Dot(two).value(), 32.0, kEpsilon);
+}
+
+TEST(Translation3dTest, Cross) {
+  const Translation3d one{1_m, 2_m, 3_m};
+  const Translation3d two{4_m, 5_m, 6_m};
+
+  auto cross = one.Cross(two);
+  EXPECT_NEAR(cross.X().value(), -3.0, kEpsilon);
+  EXPECT_NEAR(cross.Y().value(), 6.0, kEpsilon);
+  EXPECT_NEAR(cross.Z().value(), -3.0, kEpsilon);
 }

--- a/wpimath/src/test/native/cpp/geometry/Translation3dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Translation3dTest.cpp
@@ -237,7 +237,7 @@ TEST(Translation3dTest, Cross) {
   const Translation3d two{4_m, 5_m, 6_m};
 
   auto cross = one.Cross(two);
-  EXPECT_NEAR(cross.X().value(), -3.0, kEpsilon);
-  EXPECT_NEAR(cross.Y().value(), 6.0, kEpsilon);
-  EXPECT_NEAR(cross.Z().value(), -3.0, kEpsilon);
+  EXPECT_NEAR(cross[0].value(), -3.0, kEpsilon);
+  EXPECT_NEAR(cross[1].value(), 6.0, kEpsilon);
+  EXPECT_NEAR(cross[2].value(), -3.0, kEpsilon);
 }

--- a/wpimath/src/test/native/cpp/geometry/Translation3dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Translation3dTest.cpp
@@ -114,9 +114,9 @@ TEST(Translation3dTest, Norm) {
   EXPECT_NEAR(one.Norm().value(), std::hypot(3, 5, 7), kEpsilon);
 }
 
-TEST(Translation3dTest, NormSquared) {
+TEST(Translation3dTest, SquaredNorm) {
   const Translation3d one{3_m, 5_m, 7_m};
-  EXPECT_NEAR(one.NormSquared().value(), 83.0, kEpsilon);
+  EXPECT_NEAR(one.SquaredNorm().value(), 83.0, kEpsilon);
 }
 
 TEST(Translation3dTest, Distance) {
@@ -125,10 +125,10 @@ TEST(Translation3dTest, Distance) {
   EXPECT_NEAR(one.Distance(two).value(), 5 * std::sqrt(3), kEpsilon);
 }
 
-TEST(Translation3dTest, DistanceSquared) {
+TEST(Translation3dTest, SquaredDistance) {
   const Translation3d one{1_m, 1_m, 1_m};
   const Translation3d two{6_m, 6_m, 6_m};
-  EXPECT_NEAR(one.DistanceSquared(two).value(), 75.0, kEpsilon);
+  EXPECT_NEAR(one.SquaredDistance(two).value(), 75.0, kEpsilon);
 }
 
 TEST(Translation3dTest, UnaryMinus) {


### PR DESCRIPTION
Adds methods to compute the dot and cross products between `Translation2d`s and `Translation3d`s, as well as methods to compute the square of `Distance` and `Norm`, which allows avoiding some calls to `sqrt` in many cases. I'm not sure what the cross product of `Translation3d`s should return, since returning another `Translation3d` is not dimensionally correct (the returned vector should have components of `square_meter_t`, but `Translation3d` has `meter_t` components).