### PR TITLE
[bazel] Add publishing rules for other package types

### DIFF
--- a/shared/bazel/rules/packaging.bzl
+++ b/shared/bazel/rules/packaging.bzl
@@ -41,16 +41,42 @@ def zip_java_srcs(name, extra_pkgs = []):
         tags = ["manual"],
     )
 
+_platform_mapping = {
+    "linux-x86-64": "linuxx86-64",
+    "osxuniversal": "osxuniversal",
+    "systemcore": "linuxsystemcore",
+    "windows-arm64": "windowsarm64",
+    "windows-x86-64": "windowsx86-64",
+}
+
+def _filter_artifacts(architectures, artifacts):
+    if architectures == None:
+        return artifacts
+
+    result = {}
+    for ak, av in artifacts.items():
+        if ak == "sources" or ak == "headers":
+            result[ak] = av
+            continue
+
+        for k, v in architectures.items():
+            if ak.startswith(_platform_mapping[v]):
+                result[ak] = av
+                break
+
+    return result
+
 def package_default_jni_project(
         name,
         maven_group_id,
-        maven_artifact_name):
-    """
-    Packages a the C++ libraries for a project that has a JNI component.
+        maven_artifact_name,
+        architectures = None):
+    """Packages the C++ shared and static libraries for a project which has a JNI component.
 
-    This assumes that static and shared libraries exist for the project, and
-    that it is built for all native platforms plus systemcore. It runs the
-    per-platform transitions and bundles them all into a single maven_export target.
+    This assumes that shared and static libraries exist for the project, and
+    that they are compatible with the relevant architectures.  This triggers the
+    transitions, packages them up, and deploys them for all native platforms
+    plus systemcore.
     """
     pkg_files(
         name = "{}-static-files".format(name),
@@ -76,6 +102,7 @@ def package_default_jni_project(
             ":{}-static-files".format(name),
             "//:license_pkg_files",
         ],
+        architectures = architectures,
     )
 
     architectures_pkg_zip(
@@ -84,74 +111,284 @@ def package_default_jni_project(
             ":{}-shared-files".format(name),
             "//:license_pkg_files",
         ],
+        architectures = architectures,
     )
 
-    wpilib_maven_export(
+    _wpilib_maven_export_shared_static(
         name = "{}-cpp_publish".format(name),
-        classifier_artifacts = {
-            "headers": ":{}-hdrs-zip".format(name),
-            "linuxsystemcore": ":{}_shared_zip-opt-systemcore".format(name),
-            "linuxsystemcoredebug": ":{}_shared_zip-dbg-systemcore".format(name),
-            "linuxsystemcorestatic": ":{}_static_zip-opt-systemcore".format(name),
-            "linuxsystemcorestaticdebug": ":{}_static_zip-dbg-systemcore".format(name),
-            "sources": ":{}-srcs-zip".format(name),
-        },
-        linux_artifacts = {
-            "linuxx86-64": ":{}_shared_zip-opt-linux-x86-64".format(name),
-            "linuxx86-64debug": ":{}_shared_zip-dbg-linux-x86-64".format(name),
-            "linuxx86-64static": ":{}_static_zip-opt-linux-x86-64".format(name),
-            "linuxx86-64staticdebug": ":{}_static_zip-dbg-linux-x86-64".format(name),
-        },
-        maven_coordinates = "{}:{}:$(WPILIB_VERSION)".format(maven_group_id, maven_artifact_name),
-        osx_artifacts = {
-            "osxuniversal": ":{}_shared_zip-opt-osxuniversal".format(name),
-            "osxuniversaldebug": ":{}_shared_zip-dbg-osxuniversal".format(name),
-            "osxuniversalstatic": ":{}_static_zip-opt-osxuniversal".format(name),
-            "osxuniversalstaticdebug": ":{}_static_zip-dbg-osxuniversal".format(name),
-        },
-        visibility = ["//visibility:public"],
-        windows_artifacts = {
-            "windowsarm64": ":{}_shared_zip-opt-windows-arm64".format(name),
-            "windowsarm64debug": ":{}_shared_zip-dbg-windows-arm64".format(name),
-            "windowsarm64static": ":{}_static_zip-opt-windows-arm64".format(name),
-            "windowsarm64staticdebug": ":{}_static_zip-dbg-windows-arm64".format(name),
-            "windowsx86-64": ":{}_shared_zip-opt-windows-x86-64".format(name),
-            "windowsx86-64debug": ":{}_shared_zip-dbg-windows-x86-64".format(name),
-            "windowsx86-64static": ":{}_static_zip-opt-windows-x86-64".format(name),
-            "windowsx86-64staticdebug": ":{}_static_zip-dbg-windows-x86-64".format(name),
-        },
+        target_name = name,
+        maven_group_id = maven_group_id,
+        maven_artifact_name = maven_artifact_name,
+        architectures = architectures,
     )
 
-def package_minimal_jni_project(
+def package_default_cc_project(
         name,
         maven_group_id,
-        maven_artifact_name):
-    wpilib_maven_export(
+        maven_artifact_name,
+        architectures = None):
+    """Packages the C++ shared and static libraries for a project.
+
+    This assumes that shared and static libraries exist for the project, and
+    that they are compatible with the relevant architectures.  This triggers the
+    transitions, packages them up, and deploys them for all native platforms
+    plus systemcore.
+    """
+    pkg_files(
+        name = "{}-static-files".format(name),
+        srcs = [
+            ":static/{}".format(name),
+        ],
+        prefix = platform_prefix("static"),
+        strip_prefix = "static",
+    )
+
+    pkg_filegroup(
+        name = "{}-shared-files".format(name),
+        srcs = [
+            ":shared/lib{}-shared-files".format(name),
+        ],
+        prefix = platform_prefix("shared"),
+    )
+
+    architectures_pkg_zip(
+        name = "{}_static_zip".format(name),
+        srcs = [
+            ":{}-static-files".format(name),
+            "//:license_pkg_files",
+        ],
+        architectures = architectures,
+    )
+
+    architectures_pkg_zip(
+        name = "{}_shared_zip".format(name),
+        srcs = [
+            ":{}-shared-files".format(name),
+            "//:license_pkg_files",
+        ],
+        architectures = architectures,
+    )
+    _wpilib_maven_export_shared_static(
         name = "{}-cpp_publish".format(name),
-        classifier_artifacts = {
-            "headers": ":{}-hdrs-zip".format(name),
-            "sources": ":{}-srcs-zip".format(name),
-        },
-        linux_artifacts = {},
+        target_name = name,
+        maven_group_id = maven_group_id,
+        maven_artifact_name = maven_artifact_name,
+        architectures = architectures,
+    )
+
+def _wpilib_maven_export_shared_static(
+        name,
+        target_name,
+        maven_group_id,
+        maven_artifact_name,
+        architectures = None):
+    wpilib_maven_export(
+        name = name,
         maven_coordinates = "{}:{}:$(WPILIB_VERSION)".format(maven_group_id, maven_artifact_name),
-        osx_artifacts = {},
+        classifier_artifacts = _filter_artifacts(architectures, {
+            "headers": ":{}-hdrs-zip".format(target_name),
+            "linuxsystemcore": ":{}_shared_zip-opt-systemcore".format(target_name),
+            "linuxsystemcoredebug": ":{}_shared_zip-dbg-systemcore".format(target_name),
+            "linuxsystemcorestatic": ":{}_static_zip-opt-systemcore".format(target_name),
+            "linuxsystemcorestaticdebug": ":{}_static_zip-dbg-systemcore".format(target_name),
+            "sources": ":{}-srcs-zip".format(target_name),
+        }),
+        linux_artifacts = _filter_artifacts(architectures, {
+            "linuxx86-64": ":{}_shared_zip-opt-linux-x86-64".format(target_name),
+            "linuxx86-64debug": ":{}_shared_zip-dbg-linux-x86-64".format(target_name),
+            "linuxx86-64static": ":{}_static_zip-opt-linux-x86-64".format(target_name),
+            "linuxx86-64staticdebug": ":{}_static_zip-dbg-linux-x86-64".format(target_name),
+        }),
+        osx_artifacts = _filter_artifacts(architectures, {
+            "osxuniversal": ":{}_shared_zip-opt-osxuniversal".format(target_name),
+            "osxuniversaldebug": ":{}_shared_zip-dbg-osxuniversal".format(target_name),
+            "osxuniversalstatic": ":{}_static_zip-opt-osxuniversal".format(target_name),
+            "osxuniversalstaticdebug": ":{}_static_zip-dbg-osxuniversal".format(target_name),
+        }),
         visibility = ["//visibility:public"],
-        windows_artifacts = {},
+        windows_artifacts = _filter_artifacts(architectures, {
+            "windowsarm64": ":{}_shared_zip-opt-windows-arm64".format(target_name),
+            "windowsarm64debug": ":{}_shared_zip-dbg-windows-arm64".format(target_name),
+            "windowsarm64static": ":{}_static_zip-opt-windows-arm64".format(target_name),
+            "windowsarm64staticdebug": ":{}_static_zip-dbg-windows-arm64".format(target_name),
+            "windowsx86-64": ":{}_shared_zip-opt-windows-x86-64".format(target_name),
+            "windowsx86-64debug": ":{}_shared_zip-dbg-windows-x86-64".format(target_name),
+            "windowsx86-64static": ":{}_static_zip-opt-windows-x86-64".format(target_name),
+            "windowsx86-64staticdebug": ":{}_static_zip-dbg-windows-x86-64".format(target_name),
+        }),
     )
 
 def package_minimal_cc_project(
         name,
         maven_group_id,
-        maven_artifact_name):
+        maven_artifact_name,
+        architectures = None):
     wpilib_maven_export(
         name = "{}-cpp_publish".format(name),
-        classifier_artifacts = {
+        classifier_artifacts = _filter_artifacts(architectures, {
             "headers": ":{}-hdrs-zip".format(name),
             "sources": ":{}-srcs-zip".format(name),
-        },
+        }),
         linux_artifacts = {},
         maven_coordinates = "{}:{}:$(WPILIB_VERSION)".format(maven_group_id, maven_artifact_name),
         osx_artifacts = {},
         visibility = ["//visibility:public"],
         windows_artifacts = {},
+    )
+
+def package_shared_cc_project(
+        name,
+        maven_group_id,
+        maven_artifact_name,
+        architectures = None):
+    """Packages the C++ shared libraries for a project.
+
+    This assumes that shared libraries exist for the project, and that they
+    are compatible with the relevant architectures.  This triggers the
+    transitions, packages them up, and deploys them for all native platforms
+    plus systemcore.
+    """
+    pkg_filegroup(
+        name = "{}-shared-files".format(name),
+        srcs = [
+            ":shared/lib{}-shared-files".format(name),
+        ],
+        prefix = platform_prefix("shared"),
+    )
+
+    architectures_pkg_zip(
+        name = "{}_shared_zip".format(name),
+        srcs = [
+            ":{}-shared-files".format(name),
+            "//:license_pkg_files",
+        ],
+        architectures = architectures,
+    )
+
+    wpilib_maven_export(
+        name = "{}-cpp_publish".format(name),
+        classifier_artifacts = _filter_artifacts(architectures, {
+            "headers": ":{}-hdrs-zip".format(name),
+            "linuxsystemcore": ":{}_shared_zip-opt-systemcore".format(name),
+            "linuxsystemcoredebug": ":{}_shared_zip-dbg-systemcore".format(name),
+            "sources": ":{}-srcs-zip".format(name),
+        }),
+        linux_artifacts = _filter_artifacts(architectures, {
+            "linuxx86-64": ":{}_shared_zip-opt-linux-x86-64".format(name),
+            "linuxx86-64debug": ":{}_shared_zip-dbg-linux-x86-64".format(name),
+        }),
+        maven_coordinates = "{}:{}:$(WPILIB_VERSION)".format(maven_group_id, maven_artifact_name),
+        osx_artifacts = _filter_artifacts(architectures, {
+            "osxuniversal": ":{}_shared_zip-opt-osxuniversal".format(name),
+            "osxuniversaldebug": ":{}_shared_zip-dbg-osxuniversal".format(name),
+        }),
+        visibility = ["//visibility:public"],
+        windows_artifacts = _filter_artifacts(architectures, {
+            "windowsarm64": ":{}_shared_zip-opt-windows-arm64".format(name),
+            "windowsarm64debug": ":{}_shared_zip-dbg-windows-arm64".format(name),
+            "windowsx86-64": ":{}_shared_zip-opt-windows-x86-64".format(name),
+            "windowsx86-64debug": ":{}_shared_zip-dbg-windows-x86-64".format(name),
+        }),
+    )
+
+def package_static_cc_project(
+        name,
+        maven_group_id,
+        maven_artifact_name,
+        architectures = None):
+    """Packages the C++ static libraries for a project.
+
+    This assumes that static libraries exist for the project, and that they
+    are compatible with the relevant architectures.  This triggers the
+    transitions, packages them up, and deploys them for all native platforms
+    plus systemcore.
+    """
+    pkg_files(
+        name = "{}-static-files".format(name),
+        srcs = [
+            ":static/{}".format(name),
+        ],
+        prefix = platform_prefix("static"),
+        strip_prefix = "static",
+    )
+
+    architectures_pkg_zip(
+        name = "{}_static_zip".format(name),
+        srcs = [
+            ":{}-static-files".format(name),
+            "//:license_pkg_files",
+        ],
+        architectures = architectures,
+    )
+
+    wpilib_maven_export(
+        name = "{}-cpp_publish".format(name),
+        maven_coordinates = "{}:{}:$(WPILIB_VERSION)".format(maven_group_id, maven_artifact_name),
+        classifier_artifacts = _filter_artifacts(architectures, {
+            "headers": ":{}-hdrs-zip".format(name),
+            "linuxsystemcorestatic": ":{}_static_zip-opt-systemcore".format(name),
+            "linuxsystemcorestaticdebug": ":{}_static_zip-dbg-systemcore".format(name),
+            "sources": ":{}-srcs-zip".format(name),
+        }),
+        linux_artifacts = _filter_artifacts(architectures, {
+            "linuxx86-64static": ":{}_static_zip-opt-linux-x86-64".format(name),
+            "linuxx86-64staticdebug": ":{}_static_zip-dbg-linux-x86-64".format(name),
+        }),
+        osx_artifacts = _filter_artifacts(architectures, {
+            "osxuniversalstatic": ":{}_static_zip-opt-osxuniversal".format(name),
+            "osxuniversalstaticdebug": ":{}_static_zip-dbg-osxuniversal".format(name),
+        }),
+        visibility = ["//visibility:public"],
+        windows_artifacts = _filter_artifacts(architectures, {
+            "windowsarm64static": ":{}_static_zip-opt-windows-arm64".format(name),
+            "windowsarm64staticdebug": ":{}_static_zip-dbg-windows-arm64".format(name),
+            "windowsx86-64static": ":{}_static_zip-opt-windows-x86-64".format(name),
+            "windowsx86-64staticdebug": ":{}_static_zip-dbg-windows-x86-64".format(name),
+        }),
+    )
+
+def package_binary_cc_project(
+        name,
+        maven_group_id,
+        maven_artifact_name,
+        architectures = None,
+        renames = None):
+    """Packages the C++ binary targets for a project.
+
+    This assumes that static libraries exist for the project, and that they
+    are compatible with the relevant architectures.  This triggers the
+    transitions, packages them up, and deploys them for just the native
+    platforms.
+    """
+    pkg_files(
+        name = "{}-files".format(name),
+        srcs = [name],
+        prefix = platform_prefix(""),
+        renames = renames,
+    )
+
+    architectures_pkg_zip(
+        name = "{}_zip".format(name),
+        srcs = [
+            ":{}-files".format(name),
+            "//:license_pkg_files",
+        ],
+        architectures = architectures,
+    )
+
+    wpilib_maven_export(
+        name = "{}_publish".format(name),
+        maven_coordinates = "{}:{}:$(WPILIB_VERSION)".format(maven_group_id, maven_artifact_name),
+        classifier_artifacts = {},
+        linux_artifacts = _filter_artifacts(architectures, {
+            "linuxx86-64": ":{}_zip-opt-linux-x86-64".format(name),
+        }),
+        osx_artifacts = _filter_artifacts(architectures, {
+            "osxuniversalstatic": ":{}_zip-opt-osxuniversal".format(name),
+        }),
+        visibility = ["//visibility:public"],
+        windows_artifacts = _filter_artifacts(architectures, {
+            "windowsarm64static": ":{}_zip-opt-windows-arm64".format(name),
+            "windowsx86-64static": ":{}_zip-opt-windows-x86-64".format(name),
+        }),
     )

--- a/shared/bazel/rules/publishing.bzl
+++ b/shared/bazel/rules/publishing.bzl
@@ -44,20 +44,30 @@ def publish_all(name, targets):
         tags = ["manual"],
     )
 
+host_architectures = {
+    "@rules_bzlmodrio_toolchains//platforms/linux_x86_64": "linux-x86-64",
+    "@rules_bzlmodrio_toolchains//platforms/osx": "osxuniversal",
+    "@rules_bzlmodrio_toolchains//platforms/windows_arm64": "windows-arm64",
+    "@rules_bzlmodrio_toolchains//platforms/windows_x86_64": "windows-x86-64",
+}
+
 # Unfortunately, rules_jvm_external really wants each of the classifier
 # artifacts to have a unique name so they can go in the runfiles together and
 # not collide.
 def architectures_pkg_zip(
         name,
         compilation_modes = ["dbg", "opt"],
+        architectures = None,
+        **kwargs):
+    if architectures == None:
         architectures = {
             "@rules_bzlmodrio_toolchains//platforms/linux_x86_64": "linux-x86-64",
             "@rules_bzlmodrio_toolchains//platforms/osx": "osxuniversal",
             "@rules_bzlmodrio_toolchains//platforms/systemcore": "systemcore",
             "@rules_bzlmodrio_toolchains//platforms/windows_arm64": "windows-arm64",
             "@rules_bzlmodrio_toolchains//platforms/windows_x86_64": "windows-x86-64",
-        },
-        **kwargs):
+        }
+
     architectures_target_compatible_with = {
         "linux-x86-64": ["@platforms//os:linux"],
         "osxuniversal": ["@platforms//os:osx"],


### PR DESCRIPTION
This adds shortcuts for static only, shared only, and binary projects. The end result is that it is pretty easy from here to publish all the arifacts needed.