### PR TITLE
[bazel] Update configuration for which platforms to split debug symbols for

### DIFF
--- a/shared/bazel/rules/cc_rules.bzl
+++ b/shared/bazel/rules/cc_rules.bzl
@@ -400,7 +400,8 @@ def wpilib_cc_shared_library(
     _split_debug_symbols(
         name = name + "-symbolsplit",
         copy = select({
-            "@rules_bzlmodrio_toolchains//conditions:linux_x86_64": False,
+            "@rules_bzlmodrio_toolchains//conditions:linux_arm64": False,
+            "@rules_bzlmodrio_toolchains//conditions:linux_x86_64": True,
             "//conditions:default": True,
         }),
         use_debug_name = select({


### PR DESCRIPTION
I could have sworn that we were only splitting debug symbols on x86. The most recent tests I have done suggest that is backwards.  This is easy to reconfigure later if needed.