### PR TITLE
[bazel] Reduce number of windows builds in CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -67,3 +67,8 @@ common --define="WPILIB_VERSION=2025.424242.3.1-unknown"
 # List of artifact types to build in CI.
 # Anything else gets skipped to speed up CI.
 common:ci --repo_env="WPI_PUBLISH_CLASSIFIER_FILTER=headers,sources,linuxsystemcore,linuxsystemcoredebug,linuxsystemcorestatic,linuxsystemcorestaticdebug,linuxx86-64,linuxx86-64debug,linuxx86-64static,linuxx86-64staticdebug,osxuniversal,osxuniversaldebug,osxuniversalstatic,osxuniversalstaticdebug,windowsarm64,windowsarm64debug,windowsarm64static,windowsarm64staticdebug,windowsx86-64,windowsx86-64debug,windowsx86-64static,windowsx86-64staticdebug"
+
+# The 2 configurations for windows are very slow to build each time.
+# Instead, skip the cross transition for ARM on x86, and the reverse on x86.
+common:ci_windows_x86 --repo_env="WPI_PUBLISH_CLASSIFIER_FILTER=headers,sources,linuxsystemcore,linuxsystemcoredebug,linuxsystemcorestatic,linuxsystemcorestaticdebug,linuxx86-64,linuxx86-64debug,linuxx86-64static,linuxx86-64staticdebug,osxuniversal,osxuniversaldebug,osxuniversalstatic,osxuniversalstaticdebug,windowsx86-64,windowsx86-64debug,windowsx86-64static,windowsx86-64staticdebug"
+common:ci_windows_arm --repo_env="WPI_PUBLISH_CLASSIFIER_FILTER=headers,sources,linuxsystemcore,linuxsystemcoredebug,linuxsystemcorestatic,linuxsystemcorestaticdebug,linuxx86-64,linuxx86-64debug,linuxx86-64static,linuxx86-64staticdebug,osxuniversal,osxuniversaldebug,osxuniversalstatic,osxuniversalstaticdebug,windowsarm64,windowsarm64debug,windowsarm64static,windowsarm64staticdebug"

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: "Windows (native)",             os: windows-2022, action: "test",  config: "",     }
-          - { name: "Windows (arm)",                os: windows-2022, action: "build", config: "--config=windows_arm", }
+          - { name: "Windows (native)",             os: windows-2022, action: "test",  config: "--config=ci_windows_x86",     }
+          - { name: "Windows (arm)",                os: windows-2022, action: "build", config: "--config=windows_arm --config=ci_windows_arm", }
 
     name: "Build ${{ matrix.name }}"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Windows is proving to be a *lot* slower than everything else.  I supect this is because we are building both arm64 and x86 every time, which ends up being twice the work.  Leave those builds in place, but skip doing them in CI.  This should be a 2x speedup when building Windows code.