### PR TITLE
Small fixes to build on GCC 15

### DIFF
--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -43,6 +43,7 @@ nativeUtils.platformConfigs.each {
 nativeUtils.platformConfigs.each {
   if (it.name.contains('linux')) {
     it.cppCompiler.debugArgs.add("-gz=zlib")
+    // Suppress warning in OpenCV 4.10 from GCC 15
     it.cppCompiler.args.add("-Wno-overloaded-virtual")
   }
 }

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -43,8 +43,8 @@ nativeUtils.platformConfigs.each {
 nativeUtils.platformConfigs.each {
   if (it.name.contains('linux')) {
     it.cppCompiler.debugArgs.add("-gz=zlib")
-    // Suppress warning in OpenCV 4.10 from GCC 15
-    it.cppCompiler.args.add("-Wno-overloaded-virtual")
+    // Make warning in OpenCV 4.10 from GCC 15 not an error
+    it.cppCompiler.args.add("-Wno-error=overloaded-virtual")
   }
 }
 

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -43,6 +43,8 @@ nativeUtils.platformConfigs.each {
 nativeUtils.platformConfigs.each {
   if (it.name.contains('linux')) {
     it.cppCompiler.debugArgs.add("-gz=zlib")
+
+    // Suppress warning in OpenCV 3.10 from GCC 15
     it.cppCompiler.args.add("-Wno-overloaded-virtual")
   }
 }

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -43,6 +43,7 @@ nativeUtils.platformConfigs.each {
 nativeUtils.platformConfigs.each {
   if (it.name.contains('linux')) {
     it.cppCompiler.debugArgs.add("-gz=zlib")
+    it.cppCompiler.args.add("-Wno-overloaded-virtual")
   }
 }
 

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -43,8 +43,6 @@ nativeUtils.platformConfigs.each {
 nativeUtils.platformConfigs.each {
   if (it.name.contains('linux')) {
     it.cppCompiler.debugArgs.add("-gz=zlib")
-
-    // Suppress warning in OpenCV 3.10 from GCC 15
     it.cppCompiler.args.add("-Wno-overloaded-virtual")
   }
 }

--- a/upstream_utils/protobuf_patches/0001-Fix-sign-compare-warnings.patch
+++ b/upstream_utils/protobuf_patches/0001-Fix-sign-compare-warnings.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 10 Jun 2023 14:13:07 -0700
-Subject: [PATCH 01/14] Fix sign-compare warnings
+Subject: [PATCH 01/15] Fix sign-compare warnings
 
 ---
  src/google/protobuf/compiler/importer.cc                  | 2 +-

--- a/upstream_utils/protobuf_patches/0002-Remove-redundant-move.patch
+++ b/upstream_utils/protobuf_patches/0002-Remove-redundant-move.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 10 Jun 2023 14:41:39 -0700
-Subject: [PATCH 02/14] Remove redundant move
+Subject: [PATCH 02/15] Remove redundant move
 
 ---
  src/google/protobuf/extension_set.h | 2 +-

--- a/upstream_utils/protobuf_patches/0003-Fix-maybe-uninitialized-warnings.patch
+++ b/upstream_utils/protobuf_patches/0003-Fix-maybe-uninitialized-warnings.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 10 Jun 2023 15:00:20 -0700
-Subject: [PATCH 03/14] Fix maybe-uninitialized warnings
+Subject: [PATCH 03/15] Fix maybe-uninitialized warnings
 
 ---
  src/google/protobuf/arena.cc                     |  6 +++---

--- a/upstream_utils/protobuf_patches/0004-Fix-coded_stream-WriteRaw.patch
+++ b/upstream_utils/protobuf_patches/0004-Fix-coded_stream-WriteRaw.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 10 Jun 2023 15:03:38 -0700
-Subject: [PATCH 04/14] Fix coded_stream WriteRaw
+Subject: [PATCH 04/15] Fix coded_stream WriteRaw
 
 ---
  src/google/protobuf/implicit_weak_message.h | 2 +-

--- a/upstream_utils/protobuf_patches/0005-Suppress-enum-enum-conversion-warning.patch
+++ b/upstream_utils/protobuf_patches/0005-Suppress-enum-enum-conversion-warning.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 10 Jun 2023 15:13:45 -0700
-Subject: [PATCH 05/14] Suppress enum-enum conversion warning
+Subject: [PATCH 05/15] Suppress enum-enum conversion warning
 
 ---
  src/google/protobuf/generated_message_tctable_impl.h | 9 +++++++++

--- a/upstream_utils/protobuf_patches/0006-Fix-noreturn-function-returning.patch
+++ b/upstream_utils/protobuf_patches/0006-Fix-noreturn-function-returning.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 10 Jun 2023 15:16:46 -0700
-Subject: [PATCH 06/14] Fix noreturn function returning
+Subject: [PATCH 06/15] Fix noreturn function returning
 
 ---
  src/google/protobuf/generated_message_tctable_impl.h | 3 +++

--- a/upstream_utils/protobuf_patches/0007-Work-around-GCC-12-restrict-warning-compiler-bug.patch
+++ b/upstream_utils/protobuf_patches/0007-Work-around-GCC-12-restrict-warning-compiler-bug.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 10 Jun 2023 15:59:45 -0700
-Subject: [PATCH 07/14] Work around GCC 12 restrict warning compiler bug
+Subject: [PATCH 07/15] Work around GCC 12 restrict warning compiler bug
 
 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
 ---

--- a/upstream_utils/protobuf_patches/0008-Disable-MSVC-switch-warning.patch
+++ b/upstream_utils/protobuf_patches/0008-Disable-MSVC-switch-warning.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Tue, 13 Jun 2023 23:56:15 -0700
-Subject: [PATCH 08/14] Disable MSVC switch warning
+Subject: [PATCH 08/15] Disable MSVC switch warning
 
 ---
  src/google/protobuf/generated_message_reflection.cc | 4 ++++

--- a/upstream_utils/protobuf_patches/0010-Disable-pedantic-warning.patch
+++ b/upstream_utils/protobuf_patches/0010-Disable-pedantic-warning.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Wed, 14 Jun 2023 00:02:26 -0700
-Subject: [PATCH 10/14] Disable pedantic warning
+Subject: [PATCH 10/15] Disable pedantic warning
 
 ---
  src/google/protobuf/descriptor.h                    | 8 ++++++++

--- a/upstream_utils/protobuf_patches/0011-Avoid-use-of-sprintf.patch
+++ b/upstream_utils/protobuf_patches/0011-Avoid-use-of-sprintf.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Mon, 9 Oct 2023 19:28:08 -0700
-Subject: [PATCH 11/14] Avoid use of sprintf
+Subject: [PATCH 11/15] Avoid use of sprintf
 
 ---
  src/google/protobuf/stubs/strutil.cc | 14 +++++++++++---

--- a/upstream_utils/protobuf_patches/0012-Suppress-stringop-overflow-warning-false-positives.patch
+++ b/upstream_utils/protobuf_patches/0012-Suppress-stringop-overflow-warning-false-positives.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Fri, 10 Nov 2023 14:17:53 -0800
-Subject: [PATCH 12/14] Suppress stringop-overflow warning false positives
+Subject: [PATCH 12/15] Suppress stringop-overflow warning false positives
 
 ---
  src/google/protobuf/io/coded_stream.h    | 7 +++++++

--- a/upstream_utils/protobuf_patches/0013-Switch-descriptor-to-not-use-globals-from-header-inl.patch
+++ b/upstream_utils/protobuf_patches/0013-Switch-descriptor-to-not-use-globals-from-header-inl.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Thad House <thadhouse1@gmail.com>
 Date: Sun, 18 Aug 2024 22:43:37 -0700
-Subject: [PATCH 13/14] Switch descriptor to not use globals from header inline
+Subject: [PATCH 13/15] Switch descriptor to not use globals from header inline
  functions
 
 ---

--- a/upstream_utils/protobuf_patches/0014-Remove-deprecated-ATOMIC_VAR_INIT.patch
+++ b/upstream_utils/protobuf_patches/0014-Remove-deprecated-ATOMIC_VAR_INIT.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: braykoff <99614905+Braykoff@users.noreply.github.com>
 Date: Mon, 23 Dec 2024 15:12:02 -0500
-Subject: [PATCH 14/14] Remove deprecated ATOMIC_VAR_INIT
+Subject: [PATCH 14/15] Remove deprecated ATOMIC_VAR_INIT
 
 ---
  src/google/protobuf/stubs/common.cc | 2 +-

--- a/upstream_utils/protobuf_patches/0015-Ignore-GCC-15-warning.patch
+++ b/upstream_utils/protobuf_patches/0015-Ignore-GCC-15-warning.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: iris <snazzsinclair@gmail.com>
 Date: Thu, 7 Aug 2025 15:02:46 -0500
-Subject: [PATCH 15/15] ignore a warning that GCC15 introduced
-
+Subject: [PATCH 15/15] Ignore GCC 15 warning
 ---
  src/google/protobuf/generated_message_tctable_lite.cc | 4 ++++
  1 file changed, 4 insertions(+)

--- a/upstream_utils/protobuf_patches/0015-Ignore-GCC-15-warning.patch
+++ b/upstream_utils/protobuf_patches/0015-Ignore-GCC-15-warning.patch
@@ -2,6 +2,7 @@ From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: iris <snazzsinclair@gmail.com>
 Date: Thu, 7 Aug 2025 15:02:46 -0500
 Subject: [PATCH 15/15] Ignore GCC 15 warning
+
 ---
  src/google/protobuf/generated_message_tctable_lite.cc | 4 ++++
  1 file changed, 4 insertions(+)

--- a/upstream_utils/protobuf_patches/0015-ignore-a-warning-that-GCC15-introduced.patch
+++ b/upstream_utils/protobuf_patches/0015-ignore-a-warning-that-GCC15-introduced.patch
@@ -1,22 +1,22 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Peter Johnson <johnson.peter@gmail.com>
-Date: Tue, 13 Jun 2023 23:58:50 -0700
-Subject: [PATCH 09/15] Disable unused function warning
+From: iris <snazzsinclair@gmail.com>
+Date: Thu, 7 Aug 2025 15:02:46 -0500
+Subject: [PATCH 15/15] ignore a warning that GCC15 introduced
 
 ---
  src/google/protobuf/generated_message_tctable_lite.cc | 4 ++++
  1 file changed, 4 insertions(+)
 
 diff --git a/src/google/protobuf/generated_message_tctable_lite.cc b/src/google/protobuf/generated_message_tctable_lite.cc
-index 2268b2be4d4c60c545765469549d73c6a468dac8..23557a614752a9f0c93d8bd56724f3bc0f962185 100644
+index 23557a614752a9f0c93d8bd56724f3bc0f962185..ddb29cbddac62914b42e26d1758bb31e7e0d9204 100644
 --- a/src/google/protobuf/generated_message_tctable_lite.cc
 +++ b/src/google/protobuf/generated_message_tctable_lite.cc
-@@ -43,6 +43,10 @@
- #include <google/protobuf/port_def.inc>
- // clang-format on
+@@ -47,6 +47,10 @@
+ #pragma GCC diagnostic ignored "-Wunused-function"
+ #endif
  
-+#ifdef __GNUC__
-+#pragma GCC diagnostic ignored "-Wunused-function"
++#if __GNUC__ >= 15
++#pragma GCC diagnostic ignored "-Wmaybe-musttail-local-addr"
 +#endif
 +
  namespace google {

--- a/wpiutil/src/main/native/thirdparty/protobuf/src/generated_message_tctable_lite.cpp
+++ b/wpiutil/src/main/native/thirdparty/protobuf/src/generated_message_tctable_lite.cpp
@@ -46,7 +46,9 @@
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wunused-function"
 #endif
-
+#if __GNUC__ >= 15
+#pragma GCC diagnostic ignored "-Wmaybe-musttail-local-addr"
+#endif
 namespace google {
 namespace protobuf {
 namespace internal {

--- a/wpiutil/src/main/native/thirdparty/protobuf/src/generated_message_tctable_lite.cpp
+++ b/wpiutil/src/main/native/thirdparty/protobuf/src/generated_message_tctable_lite.cpp
@@ -46,9 +46,11 @@
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wunused-function"
 #endif
+
 #if __GNUC__ >= 15
 #pragma GCC diagnostic ignored "-Wmaybe-musttail-local-addr"
 #endif
+
 namespace google {
 namespace protobuf {
 namespace internal {


### PR DESCRIPTION
On Arch Linux, the GCC package is GCC 15.1.1, which introduced some new warnings. Small changes were made here to build on 15.1.1.