### PR TITLE
Mention X11-dev dependency in developer README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,12 @@ Using Gradle makes building WPILib very straightforward. It only has a few depen
 - Raspberry Pi toolchain (optional)
     - Run `./gradlew installArm32Toolchain` after cloning this repository
 
+
 On macOS ARM, run `softwareupdate --install-rosetta`. This is necessary to be able to use the macOS x86 roboRIO toolchain on ARM.
 
 On linux, run `sudo apt install gfortran`. This is necessary to be able to build WPIcal on linux platforms.
+
+On linux, run `sudo apt install libx11-dev libgl-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev` to be able to build things depending on glfw.
 
 ## Setup
 


### PR DESCRIPTION
Tested a bazel build of //... on a (relatively) clean Debian system.

It feels like there is a more pricnipled list we could provide (e.g., libglfw3-dev), although I think most of those would also end up installing more than necessarily required.