### PR TITLE
[datalog] Overload DataLogReaderThread::GetEntry to accept an entry id

### DIFF
--- a/datalog/src/main/native/include/wpi/datalog/DataLogReaderThread.h
+++ b/datalog/src/main/native/include/wpi/datalog/DataLogReaderThread.h
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <functional>
 #include <map>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -76,6 +77,15 @@ class DataLogReaderThread {
       return nullptr;
     }
     return &it->second;
+  }
+
+  const DataLogReaderEntry* GetEntry(int entry) const {
+    std::scoped_lock lock{m_mutex};
+    auto it = m_entriesById.find(entry);
+    if (it == m_entriesById.end()) {
+      return nullptr;
+    }
+    return it->second;
   }
 
   wpi::StructDescriptorDatabase& GetStructDatabase() { return m_structDb; }

--- a/datalog/src/main/native/include/wpi/datalog/DataLogReaderThread.h
+++ b/datalog/src/main/native/include/wpi/datalog/DataLogReaderThread.h
@@ -7,7 +7,6 @@
 #include <atomic>
 #include <functional>
 #include <map>
-#include <mutex>
 #include <string>
 #include <string_view>
 #include <thread>


### PR DESCRIPTION
It is useful when programmatically interacting with DataLogs to be able to retrieve an record's associated metadata (entry name, type, and metadata string), but the only reference to an entry that a record contains is the id. `DataLogReaderThread` already builds a map of id->`DataLogReaderEntry`, but it was unexposed until now.

Fixes #8126 