### PR TITLE
[wpilib] An attempt to add ks support to Flywheel and DCMotor sim classes

### DIFF
--- a/wpilibc/src/main/native/cpp/simulation/DCMotorSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/DCMotorSim.cpp
@@ -7,6 +7,7 @@
 #include <wpi/MathExtras.h>
 
 #include "frc/RobotController.h"
+#include "frc/system/NumericalIntegration.h"
 
 using namespace frc;
 using namespace frc::sim;
@@ -34,6 +35,7 @@ DCMotorSim::DCMotorSim(const units::volt_t ks,
       //
       //   B = GKₜ/(RJ)
       //   J = GKₜ/(RB)
+      //
       // Solve for frictionAcceleration (f)
       //
       //   f = ks/ka
@@ -43,6 +45,7 @@ DCMotorSim::DCMotorSim(const units::volt_t ks,
       m_gearing(-gearbox.Kv.value() * m_plant.A(1, 1) / m_plant.B(1, 0)),
       m_j(m_gearing * gearbox.Kt.value() /
           (gearbox.R.value() * m_plant.B(1, 0))),
+      m_ks{ks},
       m_frictionAcceleration{ks.value() * m_gearing * gearbox.Kt.value() /
                              (gearbox.R.value() * m_j.value())} {}
 
@@ -78,12 +81,16 @@ units::newton_meter_t DCMotorSim::GetTorque() const {
 }
 
 units::ampere_t DCMotorSim::GetCurrentDraw() const {
-  // I = V / R - omega / (Kv * R)
+  // V = IR + omega / Kv + ks * sgn(omega)
+  // IR = V - omega / Kv - ks * sgn(omega)
+  // I = V / R - omega / (Kv * R) - ks * sgn(omega) / R
+  // I = (V - ks * sgn(omega)) / R - omega / (Kv * R)
   // Reductions are greater than 1, so a reduction of 10:1 would mean the motor
   // is spinning 10x faster than the output.
+  units::volt_t frictionVoltage = wpi::sgn(m_x(1)) * m_ks;
   return m_gearbox.Current(units::radians_per_second_t{m_x(1)} * m_gearing,
-                           units::volt_t{m_u(0)}) *
-         wpi::sgn(m_u(0));
+                           units::volt_t{m_u(0) - frictionVoltage.value()}) *
+         wpi::sgn(m_u(0) - frictionVoltage.value());
 }
 
 units::volt_t DCMotorSim::GetInputVoltage() const {
@@ -97,7 +104,16 @@ void DCMotorSim::SetInputVoltage(units::volt_t voltage) {
 
 Vectord<2> DCMotorSim::UpdateX(const Vectord<2>& currentXhat,
                                const Vectord<1>& u, units::second_t dt) {
-  return m_plant.CalculateX(currentXhat, u, dt);
+  Vectord<2> updatedXhat = RKDP(
+      [&](const auto& x, const auto& u) -> Vectord<2> {
+        Vectord<2> xdot =
+            m_plant.A() * x + m_plant.B() * u +
+            Vectord<2>{0, -m_frictionAcceleration.value()} * wpi::sgn(x(1));
+        return xdot;
+      },
+      currentXhat, u, dt);
+
+  return updatedXhat;
 }
 
 const DCMotor& DCMotorSim::GetGearbox() const {

--- a/wpilibc/src/main/native/cpp/simulation/DCMotorSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/DCMotorSim.cpp
@@ -73,7 +73,9 @@ units::radians_per_second_t DCMotorSim::GetAngularVelocity() const {
 
 units::radians_per_second_squared_t DCMotorSim::GetAngularAcceleration() const {
   return units::radians_per_second_squared_t{
-      (m_plant.A() * m_x + m_plant.B() * m_u)(1, 0)};
+      (m_plant.A() * m_x + m_plant.B() * m_u -
+       Vectord<2>{0.0, -m_frictionAcceleration.value() * wpi::sgn(m_x(1, 0))})(
+          0, 0)};
 }
 
 units::newton_meter_t DCMotorSim::GetTorque() const {

--- a/wpilibc/src/main/native/cpp/simulation/FlywheelSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/FlywheelSim.cpp
@@ -53,7 +53,8 @@ units::radians_per_second_t FlywheelSim::GetAngularVelocity() const {
 units::radians_per_second_squared_t FlywheelSim::GetAngularAcceleration()
     const {
   return units::radians_per_second_squared_t{
-      (m_plant.A() * m_x + m_plant.B() * m_u)(0, 0)};
+      (m_plant.A() * m_x + m_plant.B() * m_u -
+       Vectord<1>{-m_frictionAcceleration.value() * wpi::sgn(m_x(0))})(0, 0)};
 }
 
 units::newton_meter_t FlywheelSim::GetTorque() const {

--- a/wpilibc/src/main/native/cpp/simulation/FlywheelSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/FlywheelSim.cpp
@@ -86,8 +86,9 @@ Vectord<1> FlywheelSim::UpdateX(const Vectord<1>& currentXhat,
                                 const Vectord<1>& u, units::second_t dt) {
   Vectord<1> updatedXhat = RKDP(
       [&](const auto& x, const auto& u) -> Vectord<1> {
-        Vectord<1> xdot = m_plant.A() * x + m_plant.B() * u +
-                          Vectord<1>{-m_frictionAcceleration.value()} * wpi::sgn(x(0));
+        Vectord<1> xdot =
+            m_plant.A() * x + m_plant.B() * u +
+            Vectord<1>{-m_frictionAcceleration.value()} * wpi::sgn(x(0));
         return xdot;
       },
       currentXhat, u, dt);

--- a/wpilibc/src/main/native/include/frc/simulation/DCMotorSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/DCMotorSim.h
@@ -140,6 +140,7 @@ class DCMotorSim : public LinearSystemSim<2, 1, 2> {
   DCMotor m_gearbox;
   double m_gearing;
   units::kilogram_square_meter_t m_j;
+  units::volt_t m_ks;
   units::radians_per_second_squared_t m_frictionAcceleration;
 };
 }  // namespace frc::sim

--- a/wpilibc/src/main/native/include/frc/simulation/DCMotorSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/DCMotorSim.h
@@ -23,6 +23,7 @@ class DCMotorSim : public LinearSystemSim<2, 1, 2> {
   /**
    * Creates a simulated DC motor mechanism.
    *
+   * @param ks                 The static friction voltage.
    * @param plant              The linear system representing the DC motor. This
    * system can be created with LinearSystemId::DCMotorSystem(). If
    * LinearSystemId::DCMotorSystem(kV, kA) is used, the distance unit must be
@@ -31,7 +32,8 @@ class DCMotorSim : public LinearSystemSim<2, 1, 2> {
    * gearbox.
    * @param measurementStdDevs The standard deviation of the measurement noise.
    */
-  DCMotorSim(const LinearSystem<2, 1, 2>& plant, const DCMotor& gearbox,
+  DCMotorSim(const units::volt_t ks, const LinearSystem<2, 1, 2>& plant,
+             const DCMotor& gearbox,
              const std::array<double, 2>& measurementStdDevs = {0.0, 0.0});
 
   using LinearSystemSim::SetState;
@@ -123,9 +125,21 @@ class DCMotorSim : public LinearSystemSim<2, 1, 2> {
    */
   units::kilogram_square_meter_t GetJ() const;
 
+ protected:
+  /**
+   * Updates the state estimate of the DC motor.
+   *
+   * @param currentXhat The current state estimate.
+   * @param u           The system inputs (voltage).
+   * @param dt          The time difference between controller updates.
+   */
+  Vectord<2> UpdateX(const Vectord<2>& currentXhat, const Vectord<1>& u,
+                     units::second_t dt) override;
+
  private:
   DCMotor m_gearbox;
   double m_gearing;
   units::kilogram_square_meter_t m_j;
+  units::radians_per_second_squared_t m_frictionAcceleration;
 };
 }  // namespace frc::sim

--- a/wpilibc/src/main/native/include/frc/simulation/FlywheelSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/FlywheelSim.h
@@ -22,6 +22,7 @@ class FlywheelSim : public LinearSystemSim<1, 1, 1> {
   /**
    * Creates a simulated flywheel mechanism.
    *
+   * @param ks                 The static friction voltage.
    * @param plant              The linear system representing the flywheel. This
    *                           system can be created with
    *                           LinearSystemId::FlywheelSystem() or
@@ -30,7 +31,8 @@ class FlywheelSim : public LinearSystemSim<1, 1, 1> {
    *                           gearbox.
    * @param measurementStdDevs The standard deviation of the measurement noise.
    */
-  FlywheelSim(const LinearSystem<1, 1, 1>& plant, const DCMotor& gearbox,
+  FlywheelSim(const units::volt_t ks, const LinearSystem<1, 1, 1>& plant,
+              const DCMotor& gearbox,
               const std::array<double, 1>& measurementStdDevs = {0.0});
 
   using LinearSystemSim::SetState;
@@ -99,9 +101,22 @@ class FlywheelSim : public LinearSystemSim<1, 1, 1> {
    */
   units::kilogram_square_meter_t J() const { return m_j; }
 
+ protected:
+  /**
+   * Updates the state estimate of the DC motor.
+   *
+   * @param currentXhat The current state estimate.
+   * @param u           The system inputs (voltage).
+   * @param dt          The time difference between controller updates.
+   */
+  Vectord<1> UpdateX(const Vectord<1>& currentXhat, const Vectord<1>& u,
+                     units::second_t dt) override;
+
  private:
   DCMotor m_gearbox;
   double m_gearing;
   units::kilogram_square_meter_t m_j;
+  units::volt_t m_ks;
+  units::radians_per_second_squared_t m_frictionAcceleration;
 };
 }  // namespace frc::sim

--- a/wpilibc/src/test/native/cpp/simulation/DCMotorSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/DCMotorSimTest.cpp
@@ -42,7 +42,7 @@ TEST(DCMotorSimTest, VoltageSteadyState) {
     encoderSim.SetRate(sim.GetAngularVelocity().value());
   }
 
-  EXPECT_NEAR((gearbox.Kv * 12_V).value(), encoder.GetRate(), 0.1);
+  EXPECT_NEAR((gearbox.Kv * (12_V - ks)).value(), encoder.GetRate(), 0.1);
 
   // Decay
   for (int i = 0; i < 100; i++) {

--- a/wpilibc/src/test/native/cpp/simulation/DCMotorSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/DCMotorSimTest.cpp
@@ -16,9 +16,10 @@
 
 TEST(DCMotorSimTest, VoltageSteadyState) {
   frc::DCMotor gearbox = frc::DCMotor::NEO(1);
+  auto ks = units::volt_t{0.12};
   auto plant = frc::LinearSystemId::DCMotorSystem(
       frc::DCMotor::NEO(1), units::kilogram_square_meter_t{0.0005}, 1.0);
-  frc::sim::DCMotorSim sim{plant, gearbox};
+  frc::sim::DCMotorSim sim{ks, plant, gearbox};
 
   frc::Encoder encoder{0, 1};
   frc::sim::EncoderSim encoderSim{encoder};
@@ -62,9 +63,10 @@ TEST(DCMotorSimTest, VoltageSteadyState) {
 
 TEST(DCMotorSimTest, PositionFeedbackControl) {
   frc::DCMotor gearbox = frc::DCMotor::NEO(1);
+  auto ks = units::volt_t{0.12};
   auto plant = frc::LinearSystemId::DCMotorSystem(
       frc::DCMotor::NEO(1), units::kilogram_square_meter_t{0.0005}, 1.0);
-  frc::sim::DCMotorSim sim{plant, gearbox};
+  frc::sim::DCMotorSim sim{ks, plant, gearbox};
 
   frc::PIDController controller{0.04, 0.0, 0.001};
 

--- a/wpilibc/src/test/native/cpp/simulation/StateSpaceSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/StateSpaceSimTest.cpp
@@ -25,10 +25,11 @@ TEST(StateSpaceSimTest, FlywheelSim) {
   const frc::LinearSystem<1, 1, 1> plant =
       frc::LinearSystemId::IdentifyVelocitySystem<units::radian>(
           0.02_V / 1_rad_per_s, 0.01_V / 1_rad_per_s_sq);
-  frc::sim::FlywheelSim sim{plant, frc::DCMotor::NEO(2)};
+  units::volt_t ks = 0.12_V;
+  frc::sim::FlywheelSim sim{ks, plant, frc::DCMotor::NEO(2)};
   frc::PIDController controller{0.2, 0.0, 0.0};
   frc::SimpleMotorFeedforward<units::radian> feedforward{
-      0_V, 0.02_V / 1_rad_per_s, 0.01_V / 1_rad_per_s_sq};
+      ks, 0.02_V / 1_rad_per_s, 0.01_V / 1_rad_per_s_sq};
   frc::Encoder encoder{0, 1};
   frc::sim::EncoderSim encoderSim{encoder};
   frc::PWMVictorSPX motor{0};

--- a/wpilibcExamples/src/main/cpp/examples/FlywheelBangBangController/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/FlywheelBangBangController/cpp/Robot.cpp
@@ -94,10 +94,11 @@ class Robot : public frc::TimedRobot {
       0.5 * 1.5_lb * 4_in * 4_in;
 
   frc::DCMotor m_gearbox = frc::DCMotor::NEO(1);
+  units::volt_t m_ks = units::volt_t{0.12};
   frc::LinearSystem<1, 1, 1> m_plant{frc::LinearSystemId::FlywheelSystem(
       m_gearbox, kFlywheelMomentOfInertia, kFlywheelGearing)};
 
-  frc::sim::FlywheelSim m_flywheelSim{m_plant, m_gearbox};
+  frc::sim::FlywheelSim m_flywheelSim{m_ks, m_plant, m_gearbox};
   frc::sim::EncoderSim m_encoderSim{m_encoder};
 };
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
@@ -205,7 +205,12 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
    * @return The DC motor's acceleration in Radians Per Second Squared.
    */
   public double getAngularAccelerationRadPerSecSq() {
-    var acceleration = (m_plant.getA().times(m_x)).plus(m_plant.getB().times(m_u));
+    var acceleration =
+        (m_plant.getA().times(m_x))
+            .plus(m_plant.getB().times(m_u))
+            .minus(
+                MatBuilder.fill(
+                    Nat.N2(), Nat.N1(), 0, m_frictionAcceleration * Math.signum(m_x.get(0, 0))));
     return acceleration.get(1, 0);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
@@ -8,10 +8,14 @@ import static edu.wpi.first.units.Units.Radians;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.RadiansPerSecondPerSecond;
 
+import edu.wpi.first.math.MatBuilder;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N2;
 import edu.wpi.first.math.system.LinearSystem;
+import edu.wpi.first.math.system.NumericalIntegration;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.units.measure.Angle;
@@ -30,9 +34,16 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
   // The moment of inertia for the DC motor mechanism.
   private final double m_jKgMetersSquared;
 
+  // The static friction voltage.
+  private final double m_ks;
+
+  // The static friction acceleration.
+  private final double m_frictionAcceleration;
+
   /**
    * Creates a simulated DC motor mechanism.
    *
+   * @param ks The static friction voltage in volts.
    * @param plant The linear system representing the DC motor. This system can be created with
    *     {@link edu.wpi.first.math.system.plant.LinearSystemId#createDCMotorSystem(DCMotor, double,
    *     double)} or {@link
@@ -44,7 +55,8 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
    *     noise is desired. If present must have 2 elements. The first element is for position. The
    *     second element is for velocity.
    */
-  public DCMotorSim(LinearSystem<N2, N1, N2> plant, DCMotor gearbox, double... measurementStdDevs) {
+  public DCMotorSim(
+      double ks, LinearSystem<N2, N1, N2> plant, DCMotor gearbox, double... measurementStdDevs) {
     super(plant, measurementStdDevs);
     m_gearbox = gearbox;
 
@@ -64,8 +76,18 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
     //
     //   B = GKₜ/(RJ)
     //   J = GKₜ/(RB)
+    //
+    // Solve for frictionAcceleration (f)
+    //
+    //   f = ks/ka
+    //   ka = 1/B
+    //   ka = RJ/(GKₜ)
+    //   f = ksGKₜ/RJ
     m_gearing = -gearbox.KvRadPerSecPerVolt * plant.getA(1, 1) / plant.getB(1, 0);
     m_jKgMetersSquared = m_gearing * gearbox.KtNMPerAmp / (gearbox.rOhms * plant.getB(1, 0));
+    m_ks = ks;
+    m_frictionAcceleration =
+        ks * m_gearing * gearbox.KtNMPerAmp / gearbox.rOhms / m_jKgMetersSquared;
   }
 
   /**
@@ -211,11 +233,15 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
    * @return The DC motor's current draw.
    */
   public double getCurrentDrawAmps() {
-    // I = V / R - omega / (Kv * R)
+    // V = IR + omega / Kv + ks * sgn(omega)
+    // IR = V - omega / Kv - ks * sgn(omega)
+    // I = V / R - omega / (Kv * R) - ks * sgn(omega) / R
+    // I = (V - ks * sgn(omega)) / R - omega / (Kv * R)
     // Reductions are output over input, so a reduction of 2:1 means the motor is spinning
     // 2x faster than the output
-    return m_gearbox.getCurrent(m_x.get(1, 0) * m_gearing, m_u.get(0, 0))
-        * Math.signum(m_u.get(0, 0));
+    double frictionVoltageVolts = Math.signum(m_x.get(1, 0)) * m_ks;
+    return m_gearbox.getCurrent(m_x.get(1, 0) * m_gearing, m_u.get(0, 0) - frictionVoltageVolts)
+        * Math.signum(m_u.get(0, 0) - frictionVoltageVolts);
   }
 
   /**
@@ -235,5 +261,29 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
   public void setInputVoltage(double volts) {
     setInput(volts);
     clampInput(RobotController.getBatteryVoltage());
+  }
+
+  @Override
+  protected Matrix<N2, N1> updateX(Matrix<N2, N1> currentXhat, Matrix<N1, N1> u, double dtSeconds) {
+    Matrix<N2, N1> updatedXhat =
+        NumericalIntegration.rkdp(
+            (Matrix<N2, N1> x, Matrix<N1, N1> _u) -> {
+              Matrix<N2, N1> xdot =
+                  m_plant
+                      .getA()
+                      .times(x)
+                      .plus(m_plant.getB().times(_u))
+                      .plus(
+                          MatBuilder.fill(
+                              Nat.N2(),
+                              Nat.N1(),
+                              0,
+                              -m_frictionAcceleration * Math.signum(x.get(1, 0))));
+              return xdot;
+            },
+            currentXhat,
+            u,
+            dtSeconds);
+    return updatedXhat;
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/FlywheelSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/FlywheelSim.java
@@ -154,7 +154,12 @@ public class FlywheelSim extends LinearSystemSim<N1, N1, N1> {
    * @return The flywheel's acceleration in Radians Per Second Squared.
    */
   public double getAngularAccelerationRadPerSecSq() {
-    var acceleration = (m_plant.getA().times(m_x)).plus(m_plant.getB().times(m_u));
+    var acceleration =
+        (m_plant.getA().times(m_x))
+            .plus(m_plant.getB().times(m_u))
+            .minus(
+                MatBuilder.fill(
+                    Nat.N1(), Nat.N1(), m_frictionAcceleration * Math.signum(m_x.get(0, 0))));
     return acceleration.get(0, 0);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/FlywheelSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/FlywheelSim.java
@@ -7,9 +7,13 @@ package edu.wpi.first.wpilibj.simulation;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.RadiansPerSecondPerSecond;
 
+import edu.wpi.first.math.MatBuilder;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.system.LinearSystem;
+import edu.wpi.first.math.system.NumericalIntegration;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.system.plant.LinearSystemId;
 import edu.wpi.first.math.util.Units;
@@ -28,9 +32,16 @@ public class FlywheelSim extends LinearSystemSim<N1, N1, N1> {
   // The moment of inertia for the flywheel mechanism.
   private final double m_jKgMetersSquared;
 
+  // The static friction voltage.
+  private final double m_ks;
+
+  // The static friction acceleration.
+  private final double m_frictionAcceleration;
+
   /**
    * Creates a simulated flywheel mechanism.
    *
+   * @param ks The static friction voltage in volts.
    * @param plant The linear system that represents the flywheel. Use either {@link
    *     LinearSystemId#createFlywheelSystem(DCMotor, double, double)} if using physical constants
    *     or {@link LinearSystemId#identifyVelocitySystem(double, double)} if using system
@@ -40,7 +51,7 @@ public class FlywheelSim extends LinearSystemSim<N1, N1, N1> {
    *     noise is desired. If present must have 1 element for velocity.
    */
   public FlywheelSim(
-      LinearSystem<N1, N1, N1> plant, DCMotor gearbox, double... measurementStdDevs) {
+      double ks, LinearSystem<N1, N1, N1> plant, DCMotor gearbox, double... measurementStdDevs) {
     super(plant, measurementStdDevs);
     m_gearbox = gearbox;
 
@@ -60,8 +71,18 @@ public class FlywheelSim extends LinearSystemSim<N1, N1, N1> {
     //
     //   B = GKₜ/(RJ)
     //   J = GKₜ/(RB)
+    //
+    // Solve for frictionAcceleration (f)
+    //
+    //   f = ks/ka
+    //   ka = 1/B
+    //   ka = RJ/(GKₜ)
+    //   f = ksGKₜ/RJ
     m_gearing = -gearbox.KvRadPerSecPerVolt * plant.getA(0, 0) / plant.getB(0, 0);
     m_jKgMetersSquared = m_gearing * gearbox.KtNMPerAmp / (gearbox.rOhms * plant.getB(0, 0));
+    m_ks = ks;
+    m_frictionAcceleration =
+        ks * m_gearing * gearbox.KtNMPerAmp / gearbox.rOhms / m_jKgMetersSquared;
   }
 
   /**
@@ -161,11 +182,15 @@ public class FlywheelSim extends LinearSystemSim<N1, N1, N1> {
    * @return The flywheel's current draw.
    */
   public double getCurrentDrawAmps() {
-    // I = V / R - omega / (Kv * R)
+    // V = IR + omega / Kv + ks * sgn(omega)
+    // IR = V - omega / Kv - ks * sgn(omega)
+    // I = V / R - omega / (Kv * R) - ks * sgn(omega) / R
+    // I = (V - ks * sgn(omega)) / R - omega / (Kv * R)
     // Reductions are output over input, so a reduction of 2:1 means the motor is spinning
     // 2x faster than the flywheel
-    return m_gearbox.getCurrent(m_x.get(0, 0) * m_gearing, m_u.get(0, 0))
-        * Math.signum(m_u.get(0, 0));
+    double frictionVoltageVolts = Math.signum(m_x.get(0, 0)) * m_ks;
+    return m_gearbox.getCurrent(m_x.get(0, 0) * m_gearing, m_u.get(0, 0) - frictionVoltageVolts)
+        * Math.signum(m_u.get(0, 0) - frictionVoltageVolts);
   }
 
   /**
@@ -185,5 +210,29 @@ public class FlywheelSim extends LinearSystemSim<N1, N1, N1> {
   public void setInputVoltage(double volts) {
     setInput(volts);
     clampInput(RobotController.getBatteryVoltage());
+  }
+
+  @Override
+  protected Matrix<N1, N1> updateX(Matrix<N1, N1> currentXhat, Matrix<N1, N1> u, double dtSeconds) {
+    Matrix<N1, N1> updatedXhat =
+        NumericalIntegration.rkdp(
+            (Matrix<N1, N1> x, Matrix<N1, N1> _u) -> {
+              Matrix<N1, N1> xdot =
+                  m_plant
+                      .getA()
+                      .times(x)
+                      .plus(m_plant.getB().times(_u))
+                      .plus(
+                          MatBuilder.fill(
+                              Nat.N1(),
+                              Nat.N1(),
+                              0,
+                              -m_frictionAcceleration * Math.signum(x.get(1, 0))));
+              return xdot;
+            },
+            currentXhat,
+            u,
+            dtSeconds);
+    return updatedXhat;
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DCMotorSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DCMotorSimTest.java
@@ -24,7 +24,8 @@ class DCMotorSimTest {
 
     DCMotor gearbox = DCMotor.getNEO(1);
     LinearSystem<N2, N1, N2> plant = LinearSystemId.createDCMotorSystem(gearbox, 0.0005, 1);
-    DCMotorSim sim = new DCMotorSim(plant, gearbox);
+    double ks = 0.12;
+    DCMotorSim sim = new DCMotorSim(ks, plant, gearbox);
 
     try (var motor = new PWMVictorSPX(0);
         var encoder = new Encoder(0, 1)) {
@@ -42,7 +43,7 @@ class DCMotorSimTest {
         encoderSim.setRate(sim.getAngularVelocityRadPerSec());
       }
 
-      assertEquals(gearbox.KvRadPerSecPerVolt * 12, encoder.getRate(), 0.1);
+      assertEquals(gearbox.KvRadPerSecPerVolt * (12 - ks), encoder.getRate(), 0.1);
 
       for (int i = 0; i < 100; i++) {
         motor.setVoltage(0);
@@ -65,7 +66,8 @@ class DCMotorSimTest {
 
     DCMotor gearbox = DCMotor.getNEO(1);
     LinearSystem<N2, N1, N2> plant = LinearSystemId.createDCMotorSystem(gearbox, 0.0005, 1);
-    DCMotorSim sim = new DCMotorSim(plant, gearbox);
+    double ks = 0.12;
+    DCMotorSim sim = new DCMotorSim(ks, plant, gearbox);
 
     try (var motor = new PWMVictorSPX(0);
         var encoder = new Encoder(0, 1);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/flywheelbangbangcontroller/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/flywheelbangbangcontroller/Robot.java
@@ -62,7 +62,7 @@ public class Robot extends TimedRobot {
   private final LinearSystem<N1, N1, N1> m_plant =
       LinearSystemId.createFlywheelSystem(m_gearbox, kFlywheelGearing, kFlywheelMomentOfInertia);
 
-  private final FlywheelSim m_flywheelSim = new FlywheelSim(m_plant, m_gearbox);
+  private final FlywheelSim m_flywheelSim = new FlywheelSim(kFlywheelKs, m_plant, m_gearbox);
   private final EncoderSim m_encoderSim = new EncoderSim(m_encoder);
 
   public Robot() {


### PR DESCRIPTION
So it's my understanding the Dormand Prince (rkdp) numerical integration is a good choice for functions with discontinuities like -ks/ka sgn(v).  

This PR modifies the updateX methods in the above reference class to handle this discontinuity with rkdp.  It also requires that ks be passed into both wrapper class constructors.  


