### PR TITLE
[bazel] Add sugar wrappers for halsim extensions

### DIFF
--- a/shared/bazel/rules/halsim_library.bzl
+++ b/shared/bazel/rules/halsim_library.bzl
@@ -1,19 +1,85 @@
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library")
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
+load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
+load("//shared/bazel/rules:publishing.bzl", "host_architectures")
 
 def wpilib_halsim_extension(
         name,
+        static_init_extension_name,
+        deps = [],
+        dynamic_deps = [],
+        static_deps = [],
+        shared_additional_linker_inputs = [],
+        shared_user_link_flags = [],
         **kwargs):
     """
-    Helper wrapper for creating a HALSIM extension. Provides some of the default argments for creating the library.
+    Helper wrapper for creating a HALSIM extension. Builds the base, static, and shared libraries as well as sets up publishing
+
+    This provides the following outputs:
+    <name>        - Base library
+    <name>_static - Used to help the static library creation. Uses the same compilation args as the base library, plus defining `HALSIM_InitExtension`
+    shared/<name> - Shared library
+    static/<name> - Static library
+    <name>-cpp_publish.publish - Publishing target.
+
+    Params:
+    name: Name of the base library.
+    deps: Dependencies, used in creating the base and static base library
+    dynamic_deps: cc_shared_libraries used for linking the shared library
+    static_deps: cc_static_libraries used for linking the static library
+    linkopts: Linker arguments used for creating the base library
+    shared_additional_linker_inputs - See cc_shared_library.additional_linker_inputs
+    shared_user_link_flags - See cc_shared_library.user_link_flags
+    kwargs: Remaining arguments forwarded to the base and static base libraries.
     """
     wpilib_cc_library(
         name = name,
-        includes = ["src/main/native/include"],
         include_license_files = True,
         target_compatible_with = select({
+            "@rules_bzlmodrio_toolchains//constraints/is_roborio:roborio": ["@platforms//:incompatible"],
             "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
             "//conditions:default": [],
         }),
         visibility = ["//visibility:public"],
+        deps = deps,
         **kwargs
+    )
+
+    wpilib_cc_library(
+        name = "{}_static".format(name),
+        copts = [
+            "-DHALSIM_InitExtension=" + static_init_extension_name,
+        ],
+        include_license_files = True,
+        target_compatible_with = select({
+            "@rules_bzlmodrio_toolchains//constraints/is_roborio:roborio": ["@platforms//:incompatible"],
+            "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
+            "//conditions:default": [],
+        }),
+        visibility = ["//visibility:public"],
+        deps = deps,
+        **kwargs
+    )
+
+    wpilib_cc_shared_library(
+        name = "shared/{}".format(name),
+        auto_export_windows_symbols = False,
+        dynamic_deps = dynamic_deps,
+        additional_linker_inputs = shared_additional_linker_inputs,
+        user_link_flags = shared_user_link_flags,
+        visibility = ["//visibility:public"],
+        deps = [":{}".format(name)],
+    )
+
+    wpilib_cc_static_library(
+        name = "static/{}".format(name),
+        static_deps = static_deps,
+        visibility = ["//visibility:public"],
+        deps = [":{}_static".format(name)],
+    )
+
+    package_minimal_cc_project(
+        name = name,
+        architectures = host_architectures,
+        maven_artifact_name = name,
+        maven_group_id = "edu.wpi.first.halsim",
     )

--- a/simulation/halsim_ds_socket/BUILD.bazel
+++ b/simulation/halsim_ds_socket/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
-load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
+load("//shared/bazel/rules:halsim_library.bzl", "wpilib_halsim_extension")
 
 cc_library(
     name = "headers",
@@ -8,63 +7,24 @@ cc_library(
     includes = ["src/main/native/include"],
 )
 
-wpilib_cc_library(
+wpilib_halsim_extension(
     name = "halsim_ds_socket",
     srcs = glob(["src/main/native/cpp/**"]),
-    include_license_files = True,
-    target_compatible_with = select({
-        "@rules_bzlmodrio_toolchains//constraints/is_roborio:roborio": ["@platforms//:incompatible"],
-        "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
-    deps = [
-        ":headers",
-        "//hal:wpiHal",
-        "//wpinet",
-    ],
-)
-
-wpilib_cc_library(
-    name = "halsim_ds_socket_static",
-    srcs = glob(["src/main/native/cpp/**"]),
-    copts = [
-        "-DHALSIM_InitExtension=HALSIM_InitExtension_DS_SOCKET",
-    ],
-    include_license_files = True,
-    target_compatible_with = select({
-        "@rules_bzlmodrio_toolchains//constraints/is_roborio:roborio": ["@platforms//:incompatible"],
-        "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
-    deps = [
-        ":headers",
-        "//hal:wpiHal",
-        "//wpinet",
-    ],
-)
-
-wpilib_cc_shared_library(
-    name = "shared/halsim_ds_socket",
-    auto_export_windows_symbols = False,
     dynamic_deps = [
         "//hal:shared/wpiHal",
         "//wpinet:shared/wpinet",
         "//wpiutil:shared/wpiutil",
     ],
-    visibility = ["//visibility:public"],
-    deps = [":halsim_ds_socket"],
-)
-
-wpilib_cc_static_library(
-    name = "static/halsim_ds_socket",
     static_deps = [
         "//hal:static/wpiHal",
         "//wpinet:static/wpinet",
     ],
-    visibility = ["//visibility:public"],
-    deps = [":halsim_ds_socket_static"],
+    static_init_extension_name = "HALSIM_InitExtension_DS_SOCKET",
+    deps = [
+        ":headers",
+        "//hal:wpiHal",
+        "//wpinet",
+    ],
 )
 
 cc_test(
@@ -83,10 +43,4 @@ cc_binary(
     deps = [
         ":halsim_ds_socket",
     ],
-)
-
-package_minimal_cc_project(
-    name = "halsim_ds_socket",
-    maven_artifact_name = "halsim_ds_socket",
-    maven_group_id = "edu.wpi.first.halsim",
 )

--- a/simulation/halsim_gui/BUILD.bazel
+++ b/simulation/halsim_gui/BUILD.bazel
@@ -1,65 +1,24 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
-load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
+load("//shared/bazel/rules:halsim_library.bzl", "wpilib_halsim_extension")
 
-wpilib_cc_library(
+wpilib_halsim_extension(
     name = "halsim_gui",
     srcs = glob([
         "src/main/native/cpp/*",
         "src/main/native/include/*.h",
     ]),
-    include_license_files = True,
+    dynamic_deps = [
+        "//hal:shared/wpiHal",
+        "//wpimath:shared/wpimath",
+        "//datalog:shared/datalog",
+        "//ntcore:shared/ntcore",
+    ],
     includes = ["src/main/native/include"],
     linkopts = [
         "-lm",
     ],
-    tags = [
-        "wpi-cpp-gui",
-    ],
-    target_compatible_with = select({
-        "@rules_bzlmodrio_toolchains//constraints/is_roborio:roborio": ["@platforms//:incompatible"],
-        "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
-    deps = [
-        "//glass:glassnt",
-        "//hal:wpiHal",
-    ],
-)
-
-wpilib_cc_library(
-    name = "halsim_gui_static",
-    srcs = glob([
-        "src/main/native/cpp/*",
-        "src/main/native/include/*.h",
-    ]),
-    copts = [
-        "-DHALSIM_InitExtension=HALSIM_InitExtension_GUI",
-    ],
-    include_license_files = True,
-    includes = ["src/main/native/include"],
-    linkopts = [
-        "-lm",
-    ],
-    tags = [
-        "wpi-cpp-gui",
-    ],
-    target_compatible_with = select({
-        "@rules_bzlmodrio_toolchains//constraints/is_roborio:roborio": ["@platforms//:incompatible"],
-        "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
-    deps = [
-        "//glass:glassnt",
-        "//hal:wpiHal",
-    ],
-)
-
-wpilib_cc_shared_library(
-    name = "shared/halsim_gui",
-    additional_linker_inputs = select({
+    # https://github.com/bazelbuild/bazel/issues/21893
+    shared_additional_linker_inputs = select({
         "@platforms//os:osx": [
             "//thirdparty/imgui_suite:glfw_src_darwin",
             "//thirdparty/imgui_suite:imgui_src_darwin",
@@ -67,13 +26,8 @@ wpilib_cc_shared_library(
         ],
         "//conditions:default": [],
     }),
-    dynamic_deps = [
-        "//hal:shared/wpiHal",
-        "//wpimath:shared/wpimath",
-        "//datalog:shared/datalog",
-        "//ntcore:shared/ntcore",
-    ],
-    user_link_flags = select({
+    # https://github.com/bazelbuild/bazel/issues/21893
+    shared_user_link_flags = select({
         "@platforms//os:osx": [
             "-Wl,-force_load,$(location //thirdparty/imgui_suite:glfw_src_darwin)",
             "-Wl,-force_load,$(location //thirdparty/imgui_suite:imgui_src_darwin)",
@@ -95,14 +49,6 @@ wpilib_cc_shared_library(
         ],
         "//conditions:default": [],
     }),
-    visibility = ["//visibility:public"],
-    deps = [
-        ":halsim_gui",
-    ],
-)
-
-wpilib_cc_static_library(
-    name = "static/halsim_gui",
     static_deps = [
         "//hal:static/wpiHal",
         "//wpimath:static/wpimath",
@@ -110,9 +56,13 @@ wpilib_cc_static_library(
         "//ntcore:static/ntcore",
         "//glass:static/glassnt",
     ],
-    visibility = ["//visibility:public"],
+    static_init_extension_name = "HALSIM_InitExtension_GUI",
+    tags = [
+        "wpi-cpp-gui",
+    ],
     deps = [
-        ":halsim_gui_static",
+        "//glass:glassnt",
+        "//hal:wpiHal",
     ],
 )
 
@@ -139,10 +89,4 @@ cc_binary(
     deps = [
         ":halsim_gui",
     ],
-)
-
-package_minimal_cc_project(
-    name = "halsim_gui",
-    maven_artifact_name = "halsim_gui",
-    maven_group_id = "edu.wpi.first.halsim",
 )

--- a/simulation/halsim_ws_client/BUILD.bazel
+++ b/simulation/halsim_ws_client/BUILD.bazel
@@ -1,7 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:halsim_library.bzl", "wpilib_halsim_extension")
-load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
 
 wpilib_halsim_extension(
     name = "halsim_ws_client",
@@ -9,49 +7,21 @@ wpilib_halsim_extension(
         "src/main/native/cpp/*.cpp",
         "src/main/native/include/*.h",
     ]),
-    deps = [
-        "//simulation/halsim_ws_core",
-    ],
-)
-
-wpilib_halsim_extension(
-    name = "halsim_ws_client_static",
-    srcs = glob([
-        "src/main/native/cpp/*.cpp",
-        "src/main/native/include/*.h",
-    ]),
-    copts = [
-        "-DHALSIM_InitExtension=HALSIM_InitExtension_WS_CLIENT",
-    ],
-    deps = [
-        "//simulation/halsim_ws_core",
-    ],
-)
-
-wpilib_cc_shared_library(
-    name = "shared/halsim_ws_client",
     dynamic_deps = [
         "//hal:shared/wpiHal",
         "//wpinet:shared/wpinet",
         "//wpiutil:shared/wpiutil",
     ],
-    visibility = ["//visibility:public"],
-    deps = [
-        ":halsim_ws_client",
-    ],
-)
-
-wpilib_cc_static_library(
-    name = "static/halsim_ws_client",
+    includes = ["src/main/native/include"],
     static_deps = [
         "//hal:static/wpiHal",
         "//wpinet:static/wpinet",
         "//wpiutil:static/wpiutil",
         "//simulation/halsim_ws_core:static/halsim_ws_core",
     ],
-    visibility = ["//visibility:public"],
+    static_init_extension_name = "HALSIM_InitExtension_WS_CLIENT",
     deps = [
-        ":halsim_ws_client_static",
+        "//simulation/halsim_ws_core",
     ],
 )
 
@@ -61,10 +31,4 @@ cc_binary(
     deps = [
         ":halsim_ws_client",
     ],
-)
-
-package_minimal_cc_project(
-    name = "halsim_ws_client",
-    maven_artifact_name = "halsim_ws_client",
-    maven_group_id = "edu.wpi.first.halsim",
 )

--- a/simulation/halsim_ws_server/BUILD.bazel
+++ b/simulation/halsim_ws_server/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
-load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
+load("//shared/bazel/rules:halsim_library.bzl", "wpilib_halsim_extension")
 
 cc_library(
     name = "headers",
@@ -8,66 +7,24 @@ cc_library(
     includes = ["src/main/native/include"],
 )
 
-wpilib_cc_library(
+wpilib_halsim_extension(
     name = "halsim_ws_server",
     srcs = glob(["src/main/native/cpp/**"]),
-    include_license_files = True,
-    target_compatible_with = select({
-        "@rules_bzlmodrio_toolchains//constraints/is_roborio:roborio": ["@platforms//:incompatible"],
-        "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
-    deps = [
-        ":headers",
-        "//simulation/halsim_ws_core",
-    ],
-)
-
-wpilib_cc_library(
-    name = "halsim_ws_server_static",
-    srcs = glob(["src/main/native/cpp/**"]),
-    copts = [
-        "-DHALSIM_InitExtension=HALSIM_InitExtension_WS_SERVER",
-    ],
-    include_license_files = True,
-    target_compatible_with = select({
-        "@rules_bzlmodrio_toolchains//constraints/is_roborio:roborio": ["@platforms//:incompatible"],
-        "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
-    deps = [
-        ":headers",
-        "//simulation/halsim_ws_core",
-    ],
-)
-
-wpilib_cc_shared_library(
-    name = "shared/halsim_ws_server",
-    auto_export_windows_symbols = False,
     dynamic_deps = [
         "//hal:shared/wpiHal",
         "//wpinet:shared/wpinet",
         "//wpiutil:shared/wpiutil",
     ],
-    visibility = ["//visibility:public"],
-    deps = [
-        ":halsim_ws_server",
-    ],
-)
-
-wpilib_cc_static_library(
-    name = "static/halsim_ws_server",
     static_deps = [
         "//hal:static/wpiHal",
         "//wpinet:static/wpinet",
         "//wpiutil:static/wpiutil",
         "//simulation/halsim_ws_core:static/halsim_ws_core",
     ],
-    visibility = ["//visibility:public"],
+    static_init_extension_name = "HALSIM_InitExtension_WS_SERVER",
     deps = [
-        ":halsim_ws_server_static",
+        ":headers",
+        "//simulation/halsim_ws_core",
     ],
 )
 
@@ -98,10 +55,4 @@ cc_binary(
     deps = [
         ":halsim_ws_server",
     ],
-)
-
-package_minimal_cc_project(
-    name = "halsim_ws_server",
-    maven_artifact_name = "halsim_ws_server",
-    maven_group_id = "edu.wpi.first.halsim",
 )

--- a/simulation/halsim_xrp/BUILD.bazel
+++ b/simulation/halsim_xrp/BUILD.bazel
@@ -1,83 +1,30 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
-load("//shared/bazel/rules:packaging.bzl", "package_minimal_cc_project")
+load("//shared/bazel/rules:halsim_library.bzl", "wpilib_halsim_extension")
 
-wpilib_cc_library(
+wpilib_halsim_extension(
     name = "halsim_xrp",
     srcs = glob([
         "src/main/native/cpp/*",
         "src/main/native/include/*.h",
     ]),
-    include_license_files = True,
-    includes = ["src/main/native/include"],
-    target_compatible_with = select({
-        "@rules_bzlmodrio_toolchains//constraints/is_roborio:roborio": ["@platforms//:incompatible"],
-        "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
-    deps = [
-        "//simulation/halsim_ws_core",
-        "//wpinet",
-    ],
-)
-
-wpilib_cc_library(
-    name = "halsim_xrp_static",
-    srcs = glob([
-        "src/main/native/cpp/*",
-        "src/main/native/include/*.h",
-    ]),
-    copts = [
-        "-DHALSIM_InitExtension=HALSIM_InitExtension_XRP",
-    ],
-    include_license_files = True,
-    includes = ["src/main/native/include"],
-    target_compatible_with = select({
-        "@rules_bzlmodrio_toolchains//constraints/is_roborio:roborio": ["@platforms//:incompatible"],
-        "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
-    deps = [
-        "//simulation/halsim_ws_core",
-        "//wpinet",
-    ],
-)
-
-wpilib_cc_shared_library(
-    name = "shared/halsim_xrp",
-    auto_export_windows_symbols = False,
     dynamic_deps = [
         "//wpinet:shared/wpinet",
         "//hal:shared/wpiHal",
     ],
-    visibility = ["//visibility:public"],
-    deps = [
-        ":halsim_xrp",
-    ],
-)
-
-wpilib_cc_static_library(
-    name = "static/halsim_xrp",
+    includes = ["src/main/native/include"],
     static_deps = [
         "//wpinet:static/wpinet",
         "//hal:static/wpiHal",
         "//simulation/halsim_ws_core:static/halsim_ws_core",
     ],
-    visibility = ["//visibility:public"],
+    static_init_extension_name = "HALSIM_InitExtension_XRP",
     deps = [
-        ":halsim_xrp_static",
+        "//simulation/halsim_ws_core",
+        "//wpinet",
     ],
 )
 
 cc_binary(
     name = "DevMain-Cpp",
     srcs = ["src/dev/native/cpp/main.cpp"],
-)
-
-package_minimal_cc_project(
-    name = "halsim_xrp",
-    maven_artifact_name = "halsim_xrp",
-    maven_group_id = "edu.wpi.first.halsim",
 )


### PR DESCRIPTION
This should simplify the creation and maintenance of halsim libraries. The macro has been updated to build all of the different flavors that have been set up and greatly reduces the duplication.