### PR TITLE
Upgrade Gradle plugins

### DIFF
--- a/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFieldLayout.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFieldLayout.java
@@ -152,9 +152,10 @@ public class AprilTagFieldLayout {
     var pose =
         switch (origin) {
           case kBlueAllianceWallRightSide -> Pose3d.kZero;
-          case kRedAllianceWallRightSide -> new Pose3d(
-              new Translation3d(m_fieldDimensions.fieldLength, m_fieldDimensions.fieldWidth, 0),
-              new Rotation3d(0, 0, Math.PI));
+          case kRedAllianceWallRightSide ->
+              new Pose3d(
+                  new Translation3d(m_fieldDimensions.fieldLength, m_fieldDimensions.fieldWidth, 0),
+                  new Rotation3d(0, 0, Math.PI));
         };
     setOrigin(pose);
   }

--- a/apriltag/src/test/java/edu/wpi/first/apriltag/AprilTagDetectorTest.java
+++ b/apriltag/src/test/java/edu/wpi/first/apriltag/AprilTagDetectorTest.java
@@ -24,7 +24,6 @@ import org.opencv.core.Mat;
 import org.opencv.imgcodecs.Imgcodecs;
 import org.opencv.imgproc.Imgproc;
 
-@SuppressWarnings("PMD.MutableStaticState")
 class AprilTagDetectorTest {
   @SuppressWarnings("MemberName")
   AprilTagDetector detector;

--- a/build.gradle
+++ b/build.gradle
@@ -17,10 +17,10 @@ plugins {
     id 'edu.wpi.first.GradleVsCode'
     id 'idea'
     id 'visual-studio'
-    id 'net.ltgt.errorprone' version '3.1.0' apply false
-    id 'com.gradleup.shadow' version '8.3.4' apply false
-    id 'com.diffplug.spotless' version '6.20.0' apply false
-    id 'com.github.spotbugs' version '6.0.2' apply false
+    id 'net.ltgt.errorprone' version '4.3.0' apply false
+    id 'com.gradleup.shadow' version '9.0.0' apply false
+    id 'com.diffplug.spotless' version '7.2.1' apply false
+    id 'com.github.spotbugs' version '6.2.3' apply false
 }
 
 wpilibVersioning.buildServerMode = project.hasProperty('buildServer')

--- a/cameraserver/multiCameraServer/build.gradle
+++ b/cameraserver/multiCameraServer/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.google.code.gson:gson:2.13.1'
 
     implementation project(':wpiutil')
     implementation project(':wpinet')

--- a/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServer.java
+++ b/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServer.java
@@ -46,7 +46,7 @@ public final class CameraServer {
   private static final String kPublishName = "/CameraPublisher";
 
   private static final class PropertyPublisher implements AutoCloseable {
-    @SuppressWarnings({"PMD.MissingBreakInSwitch", "PMD.ImplicitSwitchFallThrough", "fallthrough"})
+    @SuppressWarnings("fallthrough")
     PropertyPublisher(NetworkTable table, VideoEvent event) {
       String name;
       String infoName;
@@ -66,7 +66,7 @@ public final class CameraServer {
             break;
           case kEnum:
             m_choicesTopic = table.getStringArrayTopic(infoName + "/choices");
-            // fall through
+          // fallthrough
           case kInteger:
             m_integerValueEntry = table.getIntegerTopic(name).getEntry(0);
             m_minPublisher = table.getIntegerTopic(infoName + "/min").publish();

--- a/cameraserver/src/main/java/edu/wpi/first/vision/VisionPipeline.java
+++ b/cameraserver/src/main/java/edu/wpi/first/vision/VisionPipeline.java
@@ -13,6 +13,7 @@ import org.opencv.core.Mat;
  * @see VisionRunner
  * @see VisionThread
  */
+@FunctionalInterface
 public interface VisionPipeline {
   /**
    * Processes the image input and sets the result objects. Implementations should make these

--- a/cscore/src/main/java/edu/wpi/first/cscore/CvSource.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/CvSource.java
@@ -68,8 +68,9 @@ public class CvSource extends ImageSource {
             case 2 -> PixelFormat.kYUYV; // 2 channels is assumed YUYV
             case 3 -> PixelFormat.kBGR; // 3 channels is assumed BGR
             case 4 -> PixelFormat.kBGRA; // 4 channels is assumed BGRA
-            default -> throw new VideoException(
-                "Unable to get pixel format for " + channels + " channels");
+            default ->
+                throw new VideoException(
+                    "Unable to get pixel format for " + channels + " channels");
           };
 
       putFrame(finalImage, format, true);

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id "org.ysb33r.doxygen" version "1.0.4"
+    id "org.ysb33r.doxygen" version "2.0.0"
 }
 
 evaluationDependsOn(':apriltag')
@@ -62,12 +62,12 @@ doxygen {
     }
 }
 
-doxygen {
-    template 'Doxyfile'
+doxygen.sourceSets.main {
+    template = 'Doxyfile'
 
     cppProjectZips.each {
-        dependsOn it
-        source it.source
+        doxygenDox.dependsOn it
+        sources it.source
         it.ext.includeDirs.each {
             cppIncludeRoots.add(it.absolutePath)
         }
@@ -169,7 +169,7 @@ doxygen {
 tasks.register("zipCppDocs", Zip) {
     archiveBaseName = zipBaseNameCpp
     destinationDirectory = outputsFolder
-    dependsOn doxygen
+    dependsOn doxygenDox
     from ("$buildDir/docs/doxygen/html")
     into '/'
 }

--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
@@ -2536,7 +2536,8 @@ class AnnotationProcessorTest {
         class Example {}
         """;
 
-    String packageInfo = """
+    String packageInfo =
+        """
         package example;
         """;
 

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/LogBackedSendableBuilder.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/LogBackedSendableBuilder.java
@@ -19,7 +19,6 @@ import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 /** A sendable builder implementation that sends data to a {@link EpilogueBackend}. */
-@SuppressWarnings("PMD.CouplingBetweenObjects") // most methods simply delegate to the backend
 public class LogBackedSendableBuilder implements SendableBuilder {
   private final EpilogueBackend m_backend;
   private final Collection<Runnable> m_updates = new ArrayList<>();

--- a/hal/src/main/java/edu/wpi/first/hal/AnalogJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/AnalogJNI.java
@@ -15,19 +15,19 @@ package edu.wpi.first.hal;
 public class AnalogJNI extends JNIWrapper {
   /**
    * <i>native declaration : AthenaJava\target\native\include\HAL\Analog.h:58</i><br>
-   * enum values
+   * enum values.
    */
   public interface AnalogTriggerType {
-    /** <i>native declaration : AthenaJava\target\native\include\HAL\Analog.h:54</i> */
+    /** <i>native declaration : AthenaJava\target\native\include\HAL\Analog.h:54</i>. */
     int kInWindow = 0;
 
-    /** <i>native declaration : AthenaJava\target\native\include\HAL\Analog.h:55</i> */
+    /** <i>native declaration : AthenaJava\target\native\include\HAL\Analog.h:55</i>. */
     int kState = 1;
 
-    /** <i>native declaration : AthenaJava\target\native\include\HAL\Analog.h:56</i> */
+    /** <i>native declaration : AthenaJava\target\native\include\HAL\Analog.h:56</i>. */
     int kRisingPulse = 2;
 
-    /** <i>native declaration : AthenaJava\target\native\include\HAL\Analog.h:57</i> */
+    /** <i>native declaration : AthenaJava\target\native\include\HAL\Analog.h:57</i>. */
     int kFallingPulse = 3;
   }
 

--- a/hal/src/main/java/edu/wpi/first/hal/CANAPITypes.java
+++ b/hal/src/main/java/edu/wpi/first/hal/CANAPITypes.java
@@ -53,7 +53,7 @@ public final class CANAPITypes {
     kFirmwareUpdate(31);
 
     /** The device type ID. */
-    @SuppressWarnings("PMD.MemberName")
+    @SuppressWarnings("MemberName")
     public final int id;
 
     CANDeviceType(int id) {
@@ -108,7 +108,7 @@ public final class CANAPITypes {
     kVividHosting(16);
 
     /** The manufacturer ID. */
-    @SuppressWarnings("PMD.MemberName")
+    @SuppressWarnings("MemberName")
     public final int id;
 
     CANManufacturer(int id) {

--- a/hal/src/main/java/edu/wpi/first/hal/PowerDistributionFaults.java
+++ b/hal/src/main/java/edu/wpi/first/hal/PowerDistributionFaults.java
@@ -125,8 +125,8 @@ public class PowerDistributionFaults {
       case 21 -> Channel21BreakerFault;
       case 22 -> Channel22BreakerFault;
       case 23 -> Channel23BreakerFault;
-      default -> throw new IndexOutOfBoundsException(
-          "Power distribution fault channel out of bounds!");
+      default ->
+          throw new IndexOutOfBoundsException("Power distribution fault channel out of bounds!");
     };
   }
 

--- a/hal/src/main/java/edu/wpi/first/hal/PowerDistributionStickyFaults.java
+++ b/hal/src/main/java/edu/wpi/first/hal/PowerDistributionStickyFaults.java
@@ -134,8 +134,8 @@ public class PowerDistributionStickyFaults {
       case 21 -> Channel21BreakerFault;
       case 22 -> Channel22BreakerFault;
       case 23 -> Channel23BreakerFault;
-      default -> throw new IndexOutOfBoundsException(
-          "Power distribution fault channel out of bounds!");
+      default ->
+          throw new IndexOutOfBoundsException("Power distribution fault channel out of bounds!");
     };
   }
 

--- a/hal/src/main/java/edu/wpi/first/hal/can/CANExceptionFactory.java
+++ b/hal/src/main/java/edu/wpi/first/hal/can/CANExceptionFactory.java
@@ -32,15 +32,14 @@ public final class CANExceptionFactory {
       case NIRioStatus.kRioStatusSuccess -> {
         // Everything is ok... don't throw.
       }
-      case ERR_CANSessionMux_InvalidBuffer,
-          NIRioStatus.kRIOStatusBufferInvalidSize -> throw new CANInvalidBufferException();
-      case ERR_CANSessionMux_MessageNotFound,
-          NIRioStatus.kRIOStatusOperationTimedOut -> throw new CANMessageNotFoundException();
-      case ERR_CANSessionMux_NotAllowed,
-          NIRioStatus.kRIOStatusFeatureNotSupported -> throw new CANMessageNotAllowedException(
-          "MessageID = " + messageID);
-      case ERR_CANSessionMux_NotInitialized,
-          NIRioStatus.kRIOStatusResourceNotInitialized -> throw new CANNotInitializedException();
+      case ERR_CANSessionMux_InvalidBuffer, NIRioStatus.kRIOStatusBufferInvalidSize ->
+          throw new CANInvalidBufferException();
+      case ERR_CANSessionMux_MessageNotFound, NIRioStatus.kRIOStatusOperationTimedOut ->
+          throw new CANMessageNotFoundException();
+      case ERR_CANSessionMux_NotAllowed, NIRioStatus.kRIOStatusFeatureNotSupported ->
+          throw new CANMessageNotAllowedException("MessageID = " + messageID);
+      case ERR_CANSessionMux_NotInitialized, NIRioStatus.kRIOStatusResourceNotInitialized ->
+          throw new CANNotInitializedException();
       default -> throw new UncleanStatusException("Fatal status code detected:  " + status);
     }
   }

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/BufferCallback.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/BufferCallback.java
@@ -5,6 +5,7 @@
 package edu.wpi.first.hal.simulation;
 
 /** Interface for simulation buffer callbacks. */
+@FunctionalInterface
 public interface BufferCallback {
   /**
    * Simulation buffer callback function.

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/ConstBufferCallback.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/ConstBufferCallback.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.hal.simulation;
 
+@FunctionalInterface
 public interface ConstBufferCallback {
   void callback(String name, byte[] buffer, int count);
 }

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/NotifyCallback.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/NotifyCallback.java
@@ -6,6 +6,7 @@ package edu.wpi.first.hal.simulation;
 
 import edu.wpi.first.hal.HALValue;
 
+@FunctionalInterface
 public interface NotifyCallback {
   void callback(String name, HALValue value);
 

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/SpiReadAutoReceiveBufferCallback.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/SpiReadAutoReceiveBufferCallback.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.hal.simulation;
 
+@FunctionalInterface
 public interface SpiReadAutoReceiveBufferCallback {
   int callback(String name, int[] buffer, int numToRead);
 }

--- a/ntcore/src/generate/main/java/EntryImpl.java.jinja
+++ b/ntcore/src/generate/main/java/EntryImpl.java.jinja
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import java.nio.ByteBuffer;
 {% endif %}
 /** NetworkTables {{ TypeName }} implementation. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 final class {{ TypeName }}EntryImpl extends EntryBase implements {{ TypeName }}Entry {
   /**
    * Constructor.

--- a/ntcore/src/generate/main/java/GenericSubscriber.java.jinja
+++ b/ntcore/src/generate/main/java/GenericSubscriber.java.jinja
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import java.util.function.Supplier;
 
 /** NetworkTables generic subscriber. */
-@SuppressWarnings("PMD.MissingOverride")
 public interface GenericSubscriber extends Subscriber, Supplier<NetworkTableValue> {
   /**
    * Get the corresponding topic.

--- a/ntcore/src/generate/main/java/NetworkTableValue.java.jinja
+++ b/ntcore/src/generate/main/java/NetworkTableValue.java.jinja
@@ -9,7 +9,7 @@ package edu.wpi.first.networktables;
 import java.util.Objects;
 
 /** A network table entry value. */
-@SuppressWarnings({"UnnecessaryParentheses", "PMD.MethodReturnsInternalArray"})
+@SuppressWarnings("UnnecessaryParentheses")
 public final class NetworkTableValue {
   NetworkTableValue(NetworkTableType type, Object value, long time, long serverTime) {
     m_type = type;
@@ -176,7 +176,6 @@ public final class NetworkTableValue {
     return out;
   }
 
-  @SuppressWarnings("PMD.AvoidArrayLoops")
   static double[] toNativeDoubleArray(Number[] arr) {
     double[] out = new double[arr.length];
     for (int i = 0; i < arr.length; i++) {
@@ -185,7 +184,6 @@ public final class NetworkTableValue {
     return out;
   }
 
-  @SuppressWarnings("PMD.AvoidArrayLoops")
   static long[] toNativeIntegerArray(Number[] arr) {
     long[] out = new long[arr.length];
     for (int i = 0; i < arr.length; i++) {
@@ -194,7 +192,6 @@ public final class NetworkTableValue {
     return out;
   }
 
-  @SuppressWarnings("PMD.AvoidArrayLoops")
   static float[] toNativeFloatArray(Number[] arr) {
     float[] out = new float[arr.length];
     for (int i = 0; i < arr.length; i++) {

--- a/ntcore/src/generate/main/java/Subscriber.java.jinja
+++ b/ntcore/src/generate/main/java/Subscriber.java.jinja
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import {{ java.SupplierFunctionPackage|default('java.util.function') }}.{{ java.FunctionTypePrefix }}Supplier;
 
 /** NetworkTables {{ TypeName }} subscriber. */
-@SuppressWarnings("PMD.MissingOverride")
 public interface {{ TypeName }}Subscriber extends Subscriber, {{ java.FunctionTypePrefix }}Supplier{{ java.FunctionTypeSuffix }} {
   /**
    * Get the corresponding topic.

--- a/ntcore/src/generate/main/java/Timestamped.java.jinja
+++ b/ntcore/src/generate/main/java/Timestamped.java.jinja
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables timestamped {{ TypeName }}. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 public final class Timestamped{{ TypeName }} {
   /**
    * Create a timestamped value.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/BooleanArrayEntryImpl.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/BooleanArrayEntryImpl.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables BooleanArray implementation. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 final class BooleanArrayEntryImpl extends EntryBase implements BooleanArrayEntry {
   /**
    * Constructor.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/BooleanArraySubscriber.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/BooleanArraySubscriber.java
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import java.util.function.Supplier;
 
 /** NetworkTables BooleanArray subscriber. */
-@SuppressWarnings("PMD.MissingOverride")
 public interface BooleanArraySubscriber extends Subscriber, Supplier<boolean[]> {
   /**
    * Get the corresponding topic.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/BooleanEntryImpl.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/BooleanEntryImpl.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables Boolean implementation. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 final class BooleanEntryImpl extends EntryBase implements BooleanEntry {
   /**
    * Constructor.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/BooleanSubscriber.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/BooleanSubscriber.java
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import java.util.function.BooleanSupplier;
 
 /** NetworkTables Boolean subscriber. */
-@SuppressWarnings("PMD.MissingOverride")
 public interface BooleanSubscriber extends Subscriber, BooleanSupplier {
   /**
    * Get the corresponding topic.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/DoubleArrayEntryImpl.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/DoubleArrayEntryImpl.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables DoubleArray implementation. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 final class DoubleArrayEntryImpl extends EntryBase implements DoubleArrayEntry {
   /**
    * Constructor.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/DoubleArraySubscriber.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/DoubleArraySubscriber.java
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import java.util.function.Supplier;
 
 /** NetworkTables DoubleArray subscriber. */
-@SuppressWarnings("PMD.MissingOverride")
 public interface DoubleArraySubscriber extends Subscriber, Supplier<double[]> {
   /**
    * Get the corresponding topic.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/DoubleEntryImpl.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/DoubleEntryImpl.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables Double implementation. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 final class DoubleEntryImpl extends EntryBase implements DoubleEntry {
   /**
    * Constructor.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/DoubleSubscriber.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/DoubleSubscriber.java
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import java.util.function.DoubleSupplier;
 
 /** NetworkTables Double subscriber. */
-@SuppressWarnings("PMD.MissingOverride")
 public interface DoubleSubscriber extends Subscriber, DoubleSupplier {
   /**
    * Get the corresponding topic.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/FloatArrayEntryImpl.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/FloatArrayEntryImpl.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables FloatArray implementation. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 final class FloatArrayEntryImpl extends EntryBase implements FloatArrayEntry {
   /**
    * Constructor.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/FloatArraySubscriber.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/FloatArraySubscriber.java
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import java.util.function.Supplier;
 
 /** NetworkTables FloatArray subscriber. */
-@SuppressWarnings("PMD.MissingOverride")
 public interface FloatArraySubscriber extends Subscriber, Supplier<float[]> {
   /**
    * Get the corresponding topic.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/FloatEntryImpl.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/FloatEntryImpl.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables Float implementation. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 final class FloatEntryImpl extends EntryBase implements FloatEntry {
   /**
    * Constructor.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/FloatSubscriber.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/FloatSubscriber.java
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import edu.wpi.first.util.function.FloatSupplier;
 
 /** NetworkTables Float subscriber. */
-@SuppressWarnings("PMD.MissingOverride")
 public interface FloatSubscriber extends Subscriber, FloatSupplier {
   /**
    * Get the corresponding topic.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/GenericSubscriber.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/GenericSubscriber.java
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import java.util.function.Supplier;
 
 /** NetworkTables generic subscriber. */
-@SuppressWarnings("PMD.MissingOverride")
 public interface GenericSubscriber extends Subscriber, Supplier<NetworkTableValue> {
   /**
    * Get the corresponding topic.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/IntegerArrayEntryImpl.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/IntegerArrayEntryImpl.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables IntegerArray implementation. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 final class IntegerArrayEntryImpl extends EntryBase implements IntegerArrayEntry {
   /**
    * Constructor.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/IntegerArraySubscriber.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/IntegerArraySubscriber.java
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import java.util.function.Supplier;
 
 /** NetworkTables IntegerArray subscriber. */
-@SuppressWarnings("PMD.MissingOverride")
 public interface IntegerArraySubscriber extends Subscriber, Supplier<long[]> {
   /**
    * Get the corresponding topic.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/IntegerEntryImpl.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/IntegerEntryImpl.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables Integer implementation. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 final class IntegerEntryImpl extends EntryBase implements IntegerEntry {
   /**
    * Constructor.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/IntegerSubscriber.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/IntegerSubscriber.java
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import java.util.function.LongSupplier;
 
 /** NetworkTables Integer subscriber. */
-@SuppressWarnings("PMD.MissingOverride")
 public interface IntegerSubscriber extends Subscriber, LongSupplier {
   /**
    * Get the corresponding topic.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/NetworkTableValue.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/NetworkTableValue.java
@@ -9,7 +9,7 @@ package edu.wpi.first.networktables;
 import java.util.Objects;
 
 /** A network table entry value. */
-@SuppressWarnings({"UnnecessaryParentheses", "PMD.MethodReturnsInternalArray"})
+@SuppressWarnings("UnnecessaryParentheses")
 public final class NetworkTableValue {
   NetworkTableValue(NetworkTableType type, Object value, long time, long serverTime) {
     m_type = type;
@@ -668,7 +668,6 @@ public final class NetworkTableValue {
     return out;
   }
 
-  @SuppressWarnings("PMD.AvoidArrayLoops")
   static double[] toNativeDoubleArray(Number[] arr) {
     double[] out = new double[arr.length];
     for (int i = 0; i < arr.length; i++) {
@@ -677,7 +676,6 @@ public final class NetworkTableValue {
     return out;
   }
 
-  @SuppressWarnings("PMD.AvoidArrayLoops")
   static long[] toNativeIntegerArray(Number[] arr) {
     long[] out = new long[arr.length];
     for (int i = 0; i < arr.length; i++) {
@@ -686,7 +684,6 @@ public final class NetworkTableValue {
     return out;
   }
 
-  @SuppressWarnings("PMD.AvoidArrayLoops")
   static float[] toNativeFloatArray(Number[] arr) {
     float[] out = new float[arr.length];
     for (int i = 0; i < arr.length; i++) {

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/RawEntryImpl.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/RawEntryImpl.java
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import java.nio.ByteBuffer;
 
 /** NetworkTables Raw implementation. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 final class RawEntryImpl extends EntryBase implements RawEntry {
   /**
    * Constructor.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/RawSubscriber.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/RawSubscriber.java
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import java.util.function.Supplier;
 
 /** NetworkTables Raw subscriber. */
-@SuppressWarnings("PMD.MissingOverride")
 public interface RawSubscriber extends Subscriber, Supplier<byte[]> {
   /**
    * Get the corresponding topic.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/StringArrayEntryImpl.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/StringArrayEntryImpl.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables StringArray implementation. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 final class StringArrayEntryImpl extends EntryBase implements StringArrayEntry {
   /**
    * Constructor.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/StringArraySubscriber.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/StringArraySubscriber.java
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import java.util.function.Supplier;
 
 /** NetworkTables StringArray subscriber. */
-@SuppressWarnings("PMD.MissingOverride")
 public interface StringArraySubscriber extends Subscriber, Supplier<String[]> {
   /**
    * Get the corresponding topic.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/StringEntryImpl.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/StringEntryImpl.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables String implementation. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 final class StringEntryImpl extends EntryBase implements StringEntry {
   /**
    * Constructor.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/StringSubscriber.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/StringSubscriber.java
@@ -9,7 +9,6 @@ package edu.wpi.first.networktables;
 import java.util.function.Supplier;
 
 /** NetworkTables String subscriber. */
-@SuppressWarnings("PMD.MissingOverride")
 public interface StringSubscriber extends Subscriber, Supplier<String> {
   /**
    * Get the corresponding topic.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedBoolean.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedBoolean.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables timestamped Boolean. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 public final class TimestampedBoolean {
   /**
    * Create a timestamped value.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedBooleanArray.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedBooleanArray.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables timestamped BooleanArray. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 public final class TimestampedBooleanArray {
   /**
    * Create a timestamped value.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedDouble.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedDouble.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables timestamped Double. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 public final class TimestampedDouble {
   /**
    * Create a timestamped value.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedDoubleArray.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedDoubleArray.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables timestamped DoubleArray. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 public final class TimestampedDoubleArray {
   /**
    * Create a timestamped value.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedFloat.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedFloat.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables timestamped Float. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 public final class TimestampedFloat {
   /**
    * Create a timestamped value.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedFloatArray.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedFloatArray.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables timestamped FloatArray. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 public final class TimestampedFloatArray {
   /**
    * Create a timestamped value.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedInteger.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedInteger.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables timestamped Integer. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 public final class TimestampedInteger {
   /**
    * Create a timestamped value.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedIntegerArray.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedIntegerArray.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables timestamped IntegerArray. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 public final class TimestampedIntegerArray {
   /**
    * Create a timestamped value.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedRaw.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedRaw.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables timestamped Raw. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 public final class TimestampedRaw {
   /**
    * Create a timestamped value.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedString.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedString.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables timestamped String. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 public final class TimestampedString {
   /**
    * Create a timestamped value.

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedStringArray.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/TimestampedStringArray.java
@@ -7,7 +7,6 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables timestamped StringArray. */
-@SuppressWarnings("PMD.ArrayIsStoredDirectly")
 public final class TimestampedStringArray {
   /**
    * Create a timestamped value.

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NTSendable.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NTSendable.java
@@ -8,6 +8,7 @@ import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.util.sendable.SendableBuilder;
 
 /** Interface for NetworkTable Sendable objects. */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface NTSendable extends Sendable {
   /**
    * Initializes this {@link Sendable} object.

--- a/ntcore/src/test/java/edu/wpi/first/networktables/RawTest.java
+++ b/ntcore/src/test/java/edu/wpi/first/networktables/RawTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("PMD.SimplifiableTestAssertion")
 class RawTest {
   private NetworkTableInstance m_inst;
 

--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -72,6 +72,7 @@ publishing {
 }
 
 test {
+    jvmArgs '--enable-native-access=ALL-UNNAMED'
     useJUnitPlatform()
     systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
     testLogging {
@@ -118,7 +119,7 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     devImplementation sourceSets.main.output
@@ -133,7 +134,7 @@ task run(type: JavaExec) {
 build.dependsOn devClasses
 
 jacoco {
-    toolVersion = "0.8.10"
+    toolVersion = "0.8.13"
 }
 
 jacocoTestReport {

--- a/shared/java/javastyle.gradle
+++ b/shared/java/javastyle.gradle
@@ -5,7 +5,7 @@ if (project.hasProperty('skipJavaFormat')) {
 apply plugin: 'checkstyle'
 
 checkstyle {
-    toolVersion = "10.12.2"
+    toolVersion = "11.0.0"
     configDirectory = file("${project.rootDir}/styleguide")
     config = resources.text.fromFile(new File(configDirectory.get().getAsFile(), "checkstyle.xml"))
 }
@@ -13,7 +13,7 @@ checkstyle {
 apply plugin: 'pmd'
 
 pmd {
-    toolVersion = '7.2.0'
+    toolVersion = '7.16.0'
     consoleOutput = true
     reportsDir = file("$project.buildDir/reports/pmd")
     ruleSetFiles = files(new File(rootDir, "styleguide/pmd-ruleset.xml"))
@@ -40,7 +40,7 @@ spotless {
             exclude '**/build/**', '**/build-*/**', '**/bin/**'
         }
         greclipse()
-        indentWithSpaces(4)
+        leadingTabsToSpaces(4)
         trimTrailingWhitespace()
         endWithNewline()
     }
@@ -60,7 +60,7 @@ spotless {
         }
         eclipseWtp('xml')
         trimTrailingWhitespace()
-        indentWithSpaces(2)
+        leadingTabsToSpaces(2)
         endWithNewline()
     }
     format 'misc', {
@@ -69,7 +69,7 @@ spotless {
             exclude '**/build/**', '**/build-*/**', '**/bin/**'
         }
         trimTrailingWhitespace()
-        indentWithSpaces(2)
+        leadingTabsToSpaces(2)
         endWithNewline()
     }
 }

--- a/styleguide/pmd-ruleset.xml
+++ b/styleguide/pmd-ruleset.xml
@@ -6,8 +6,13 @@
 
   <description>PMD Ruleset for WPILib</description>
 
-  <exclude-pattern>.*/*JNI.*</exclude-pattern>
+  <!-- Generated files -->
+  <exclude-pattern>.*/*EntryImpl\.java</exclude-pattern>
+  <exclude-pattern>.*/*Subscriber\.java</exclude-pattern>
+  <exclude-pattern>.*/Timestamped.*\.java</exclude-pattern>
+
   <exclude-pattern>.*/*IntegrationTests.*</exclude-pattern>
+  <exclude-pattern>.*/*JNI.*</exclude-pattern>
   <exclude-pattern>.*/math/proto.*</exclude-pattern>
 
   <rule ref="category/java/bestpractices.xml">
@@ -18,18 +23,19 @@
     <exclude name="AvoidReassigningParameters" />
     <exclude name="AvoidUsingHardCodedIP" />
     <exclude name="ConstantsInInterface" />
-    <exclude name="JUnitAssertionsShouldIncludeMessage" />
-    <exclude name="JUnitTestContainsTooManyAsserts" />
-    <exclude name="JUnitTestsShouldIncludeAssert" />
-    <exclude name="JUnit4TestShouldUseAfterAnnotation" />
-    <exclude name="JUnit4TestShouldUseBeforeAnnotation" />
-    <exclude name="JUnit4TestShouldUseTestAnnotation" />
+    <exclude name="ExhaustiveSwitchHasDefault" />
     <exclude name="LooseCoupling" />
+    <exclude name="NonExhaustiveSwitch" />
     <exclude name="PreserveStackTrace" />
     <exclude name="ReplaceHashtableWithMap" />
     <exclude name="ReplaceVectorWithList" />
-    <exclude name="SwitchStmtsShouldHaveDefault" />
     <exclude name="SystemPrintln" />
+    <exclude name="UnitTestAssertionsShouldIncludeMessage" />
+    <exclude name="UnitTestContainsTooManyAsserts" />
+    <exclude name="UnitTestShouldIncludeAssert" />
+    <exclude name="UnitTestShouldUseAfterAnnotation" />
+    <exclude name="UnitTestShouldUseBeforeAnnotation" />
+    <exclude name="UnitTestShouldUseTestAnnotation" />
     <exclude name="UseVarargs" />
   </rule>
   <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod">
@@ -45,8 +51,8 @@
   </rule>
 
   <rule ref="category/java/design.xml">
-    <exclude name="AvoidThrowingRawExceptionTypes" />
     <exclude name="AvoidThrowingNewInstanceOfSameException" />
+    <exclude name="AvoidThrowingRawExceptionTypes" />
     <exclude name="CognitiveComplexity" />
     <exclude name="CouplingBetweenObjects" />
     <exclude name="CyclomaticComplexity" />
@@ -82,6 +88,7 @@
 
   <rule ref="category/java/multithreading.xml">
     <exclude name="AvoidSynchronizedAtMethodLevel" />
+    <exclude name="AvoidSynchronizedStatement" />
     <exclude name="AvoidUsingVolatile" />
     <exclude name="DoNotUseThreads" />
     <exclude name="UseConcurrentHashMap" />

--- a/styleguide/spotbugs-exclude.xml
+++ b/styleguide/spotbugs-exclude.xml
@@ -1,6 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
   <Match>
+    <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE" />
+    <Class name="edu.wpi.first.wpilibj.DriverStation" />
+  </Match>
+  <Match>
+    <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE" />
+    <Class name="edu.wpi.first.wpilibj.Ultrasonic" />
+  </Match>
+  <Match>
+    <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE" />
+    <Class name="edu.wpi.first.wpilibj.Watchdog" />
+  </Match>
+  <Match>
+    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" />
+    <Class name="edu.wpi.first.wpilibj.ADIS16448_IMU" />
+  </Match>
+  <Match>
+    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" />
+    <Class name="edu.wpi.first.wpilibj.ADIS16470_IMU" />
+  </Match>
+  <Match>
+    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" />
+    <Class name="edu.wpi.first.wpilibj.DriverStation" />
+  </Match>
+  <Match>
+    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" />
+    <Class name="edu.wpi.first.wpilibj.GenericHID" />
+  </Match>
+  <Match>
+    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" />
+    <Class name="edu.wpi.first.wpilibj.Ultrasonic" />
+  </Match>
+  <Match>
+    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" />
+    <Class name="edu.wpi.first.wpilibj.motorcontrol.NidecBrushless" />
+  </Match>
+  <Match>
+    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" />
+    <Class name="edu.wpi.first.wpilibj2.command.CommandScheduler" />
+  </Match>
+  <Match>
     <Bug pattern="CT_CONSTRUCTOR_THROW" />
   </Match>
   <Match>
@@ -30,12 +70,21 @@
   <Match>
     <Bug pattern="EI_EXPOSE_REP2" />
   </Match>
+  <!--
+  Strict reading of Object.equals() contract means that whenever equals() behaviour is defined, all implementations
+  need to adhere to it. The only reason to override the method (assuming correct API design, of course) is to provide
+  a more efficient implementation. This rule would be forcing a @SuppressFBWarnings on perfectly compliant classes.
+  More information at https://github.com/spotbugs/spotbugs/issues/511
+  -->
+  <Match>
+    <Bug pattern="EQ_DOESNT_OVERRIDE_EQUALS" />
+  </Match>
   <Match>
     <Bug pattern="FL_FLOATS_AS_LOOP_COUNTERS" />
   </Match>
   <Match>
     <Bug pattern="IS2_INCONSISTENT_SYNC" />
-    <Source name="MechanismLigament2d.java" />
+    <Class name="edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d" />
   </Match>
   <Match>
     <Bug pattern="MS_CANNOT_BE_FINAL" />
@@ -49,50 +98,81 @@
   </Match>
   <Match>
     <Bug pattern="NM_CLASS_NAMING_CONVENTION" />
-    <Source name="FRCNetComm.java" />
+    <Class name="edu.wpi.first.hal.FRCNetComm$tInstances" />
+  </Match>
+  <Match>
+    <Bug pattern="NM_CLASS_NAMING_CONVENTION" />
+    <Class name="edu.wpi.first.hal.FRCNetComm$tResourceType" />
   </Match>
   <Match>
     <Bug pattern="NS_DANGEROUS_NON_SHORT_CIRCUIT" />
-    <Source name="ParallelCommandGroup.java" />
+    <Class name="edu.wpi.first.wpilibj2.command.ParallelCommandGroup" />
   </Match>
   <Match>
     <Bug pattern="NS_DANGEROUS_NON_SHORT_CIRCUIT" />
-    <Source name="ParallelDeadlineGroup.java" />
+    <Class name="edu.wpi.first.wpilibj2.command.ParallelDeadlineGroup" />
   </Match>
   <Match>
     <Bug pattern="NS_DANGEROUS_NON_SHORT_CIRCUIT" />
-    <Source name="ParallelRaceGroup.java" />
+    <Class name="edu.wpi.first.wpilibj2.command.ParallelRaceGroup" />
   </Match>
   <Match>
     <Bug pattern="NS_DANGEROUS_NON_SHORT_CIRCUIT" />
-    <Source name="ProxyScheduleCommand.java" />
+    <Class name="edu.wpi.first.wpilibj2.command.ProxyScheduleCommand" />
   </Match>
   <Match>
     <Bug pattern="NS_DANGEROUS_NON_SHORT_CIRCUIT" />
-    <Source name="SequentialCommandGroup.java" />
+    <Class name="edu.wpi.first.wpilibj2.command.SequentialCommandGroup" />
   </Match>
   <Match>
     <Bug pattern="NS_DANGEROUS_NON_SHORT_CIRCUIT" />
-    <Source name="SelectCommand.java" />
+    <Class name="edu.wpi.first.wpilibj2.command.SelectCommand" />
   </Match>
   <Match>
     <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE" />
   </Match>
   <Match>
     <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
-    <Source name="AntJunitLauncher.java" />
+    <Class name="edu.wpi.first.wpilibj.test.AntJunitLauncher" />
   </Match>
   <Match>
     <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
-    <Source name="CombinedRuntimeLoader.java" />
+    <Class name="edu.wpi.first.util.CombinedRuntimeLoader" />
+  </Match>
+  <Match>
+    <Bug pattern="RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED" />
+    <Class name="edu.wpi.first.networktables.NetworkTableInstance" />
+  </Match>
+  <Match>
+    <Bug pattern="SC_START_IN_CTOR" />
   </Match>
   <Match>
     <Bug pattern="SF_SWITCH_FALLTHROUGH" />
-    <Source name="CameraServer.java" />
+    <Class name="edu.wpi.first.cameraserver.CameraServer$PropertyPublisher" />
+  </Match>
+  <Match>
+    <Bug pattern="SING_SINGLETON_GETTER_NOT_SYNCHRONIZED" />
+    <Class name="edu.wpi.first.wpilibj.test.TestSuite" />
+  </Match>
+  <Match>
+    <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR" />
+    <Class name="edu.wpi.first.wpilibj.test.TestSuite" />
+  </Match>
+  <Match>
+    <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR" />
+    <Class name="edu.wpi.first.wpilibj2.command.CommandScheduler" />
+  </Match>
+  <Match>
+    <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR" />
+    <Class name="edu.wpi.first.math.geometry.CoordinateAxis" />
+  </Match>
+  <Match>
+    <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR" />
+    <Class name="edu.wpi.first.math.geometry.CoordinateSystem" />
   </Match>
   <Match>
     <Bug pattern="SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA" />
-    <Source name="Ultrasonic.java" />
+    <Class name="edu.wpi.first.wpilibj.Ultrasonic" />
   </Match>
   <Match>
     <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
@@ -142,26 +222,10 @@
     <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
   </Match>
   <Match>
-    <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE" />
-  </Match>
-  <Match>
-    <Bug pattern="SC_START_IN_CTOR" />
-  </Match>
-  <Match>
-    <Bug pattern="RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED" />
-    <Class name="edu.wpi.first.networktables.NetworkTableInstance" />
-  </Match>
-  <!--
-  Strict reading of Object.equals() contract means that whenever equals() behaviour is defined, all implementations
-  need to adhere to it. The only reason to override the method (assuming correct API design, of course) is to provide
-  a more efficient implementation. This rule would be forcing a @SuppressFBWarnings on perfectly compliant classes.
-  More information at https://github.com/spotbugs/spotbugs/issues/511
-  -->
-  <Match>
-    <Bug pattern="EQ_DOESNT_OVERRIDE_EQUALS" />
-  </Match>
-  <Match>
     <Bug pattern="UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD" />
     <Class name="edu.wpi.first.epilogue.EpilogueConfiguration" />
+  </Match>
+  <Match>
+    <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE" />
   </Match>
 </FindBugsFilter>

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelRaceGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelRaceGroup.java
@@ -42,7 +42,6 @@ public class ParallelRaceGroup extends Command {
    *
    * @param commands Commands to add to the group.
    */
-  @SuppressWarnings("PMD.UseArraysAsList")
   public final void addCommands(Command... commands) {
     if (!m_finished) {
       throw new IllegalStateException(

--- a/wpilibc/src/main/native/cpp/DigitalGlitchFilter.cpp
+++ b/wpilibc/src/main/native/cpp/DigitalGlitchFilter.cpp
@@ -39,6 +39,7 @@ DigitalGlitchFilter::~DigitalGlitchFilter() {
   if (m_channelIndex >= 0) {
     std::scoped_lock lock(m_mutex);
     m_filterAllocated[m_channelIndex] = false;
+    m_channelIndex = -1;
   }
 }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16448_IMU.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16448_IMU.java
@@ -29,7 +29,7 @@ import edu.wpi.first.util.sendable.SendableBuilder;
 // CHECKSTYLE.OFF: EmptyCatchBlock
 
 /** This class is for the ADIS16448 IMU that connects to the RoboRIO MXP port. */
-@SuppressWarnings({"PMD.RedundantFieldInitializer", "PMD.ImmutableField"})
+@SuppressWarnings({"PMD.RedundantFieldInitializer", "PMD.ImmutableField", "PMD.UnusedPrivateField"})
 public class ADIS16448_IMU implements AutoCloseable, Sendable {
   // ADIS16448 Register Map Declaration
   private static final int FLASH_CNT = 0x00; // Flash memory write count

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16470_IMU.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16470_IMU.java
@@ -20,7 +20,7 @@ import edu.wpi.first.util.sendable.SendableBuilder;
 // CHECKSTYLE.OFF: EmptyCatchBlock
 
 /** This class is for the ADIS16470 IMU that connects to the RoboRIO SPI port. */
-@SuppressWarnings("PMD.RedundantFieldInitializer")
+@SuppressWarnings({"PMD.RedundantFieldInitializer", "PMD.UnusedPrivateField"})
 public class ADIS16470_IMU implements AutoCloseable, Sendable {
   /* ADIS16470 Register Map Declaration */
   private static final int FLASH_CNT = 0x00; // Flash memory write count

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Alert.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Alert.java
@@ -8,6 +8,7 @@ import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -186,7 +187,7 @@ public class Alert implements AutoCloseable {
   private static final class SendableAlerts implements Sendable {
     private static final Map<String, SendableAlerts> groups = new HashMap<String, SendableAlerts>();
 
-    private final Map<AlertType, Set<PublishedAlert>> m_alerts = new HashMap<>();
+    private final EnumMap<AlertType, Set<PublishedAlert>> m_alerts = new EnumMap<>(AlertType.class);
 
     /**
      * Returns a reference to the set of active alerts for the given type.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalGlitchFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalGlitchFilter.java
@@ -38,11 +38,10 @@ public class DigitalGlitchFilter implements Sendable, AutoCloseable {
       m_mutex.lock();
       try {
         m_filterAllocated[m_channelIndex] = false;
+        m_channelIndex = -1;
       } finally {
         m_mutex.unlock();
       }
-
-      m_channelIndex = -1;
     }
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -285,7 +285,6 @@ public final class DriverStation {
       System.arraycopy(axes.m_axes, 0, m_prevAxes.m_axes, 0, count);
     }
 
-    @SuppressWarnings("PMD.AvoidArrayLoops")
     void appendPOVs(HALJoystickPOVs povs, long timestamp) {
       int count = povs.m_count;
       if (m_sizedPOVs == null || m_sizedPOVs.length != count) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/GenericHID.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/GenericHID.java
@@ -70,7 +70,6 @@ public class GenericHID {
     /** HIDType value. */
     public final int value;
 
-    @SuppressWarnings("PMD.UseConcurrentHashMap")
     private static final Map<Integer, HIDType> map = new HashMap<>();
 
     HIDType(int value) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/I2C.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/I2C.java
@@ -40,6 +40,7 @@ public class I2C implements AutoCloseable {
 
   private final int m_port;
   private final int m_deviceAddress;
+  private ByteBuffer m_readDataToSendBuffer;
 
   /**
    * Constructor.
@@ -264,8 +265,6 @@ public class I2C implements AutoCloseable {
 
     return transaction(registerAddressArray, registerAddressArray.length, buffer, count);
   }
-
-  private ByteBuffer m_readDataToSendBuffer;
 
   /**
    * Execute a read transaction with the device.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -96,29 +96,36 @@ public abstract class RobotBase implements AutoCloseable {
           @Override
           public void reportUsage(MathUsageId id, int count) {
             switch (id) {
-              case kKinematics_DifferentialDrive -> HAL.report(
-                  tResourceType.kResourceType_Kinematics, tInstances.kKinematics_DifferentialDrive);
-              case kKinematics_MecanumDrive -> HAL.report(
-                  tResourceType.kResourceType_Kinematics, tInstances.kKinematics_MecanumDrive);
-              case kKinematics_SwerveDrive -> HAL.report(
-                  tResourceType.kResourceType_Kinematics, tInstances.kKinematics_SwerveDrive);
-              case kTrajectory_TrapezoidProfile -> HAL.report(
-                  tResourceType.kResourceType_TrapezoidProfile, count);
+              case kKinematics_DifferentialDrive ->
+                  HAL.report(
+                      tResourceType.kResourceType_Kinematics,
+                      tInstances.kKinematics_DifferentialDrive);
+              case kKinematics_MecanumDrive ->
+                  HAL.report(
+                      tResourceType.kResourceType_Kinematics, tInstances.kKinematics_MecanumDrive);
+              case kKinematics_SwerveDrive ->
+                  HAL.report(
+                      tResourceType.kResourceType_Kinematics, tInstances.kKinematics_SwerveDrive);
+              case kTrajectory_TrapezoidProfile ->
+                  HAL.report(tResourceType.kResourceType_TrapezoidProfile, count);
               case kFilter_Linear -> HAL.report(tResourceType.kResourceType_LinearFilter, count);
-              case kOdometry_DifferentialDrive -> HAL.report(
-                  tResourceType.kResourceType_Odometry, tInstances.kOdometry_DifferentialDrive);
-              case kOdometry_SwerveDrive -> HAL.report(
-                  tResourceType.kResourceType_Odometry, tInstances.kOdometry_SwerveDrive);
-              case kOdometry_MecanumDrive -> HAL.report(
-                  tResourceType.kResourceType_Odometry, tInstances.kOdometry_MecanumDrive);
-              case kController_PIDController2 -> HAL.report(
-                  tResourceType.kResourceType_PIDController2, count);
-              case kController_ProfiledPIDController -> HAL.report(
-                  tResourceType.kResourceType_ProfiledPIDController, count);
-              case kController_BangBangController -> HAL.report(
-                  tResourceType.kResourceType_BangBangController, count);
-              case kTrajectory_PathWeaver -> HAL.report(
-                  tResourceType.kResourceType_PathWeaverTrajectory, count);
+              case kOdometry_DifferentialDrive ->
+                  HAL.report(
+                      tResourceType.kResourceType_Odometry, tInstances.kOdometry_DifferentialDrive);
+              case kOdometry_SwerveDrive ->
+                  HAL.report(
+                      tResourceType.kResourceType_Odometry, tInstances.kOdometry_SwerveDrive);
+              case kOdometry_MecanumDrive ->
+                  HAL.report(
+                      tResourceType.kResourceType_Odometry, tInstances.kOdometry_MecanumDrive);
+              case kController_PIDController2 ->
+                  HAL.report(tResourceType.kResourceType_PIDController2, count);
+              case kController_ProfiledPIDController ->
+                  HAL.report(tResourceType.kResourceType_ProfiledPIDController, count);
+              case kController_BangBangController ->
+                  HAL.report(tResourceType.kResourceType_BangBangController, count);
+              case kTrajectory_PathWeaver ->
+                  HAL.report(tResourceType.kResourceType_PathWeaverTrajectory, count);
               default -> {
                 // NOP
               }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SynchronousInterrupt.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SynchronousInterrupt.java
@@ -16,7 +16,6 @@ import edu.wpi.first.hal.InterruptJNI;
  * <p>Asynchronous interrupts are handled by the AsynchronousInterrupt class.
  */
 public class SynchronousInterrupt implements AutoCloseable {
-  @SuppressWarnings("PMD.SingularField")
   private final DigitalSource m_source;
 
   private final int m_handle;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Ultrasonic.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Ultrasonic.java
@@ -44,7 +44,6 @@ public class Ultrasonic implements Sendable, AutoCloseable {
   private static Thread m_task;
   private static int m_instances;
 
-  @SuppressWarnings("PMD.SingularField")
   private SimDevice m_simDevice;
 
   private SimBoolean m_simRangeValid;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/LayoutType.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/LayoutType.java
@@ -10,6 +10,7 @@ package edu.wpi.first.wpilibj.shuffleboard;
  *
  * @see BuiltInWidgets the built-in widget types
  */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface LayoutType {
   /**
    * Gets the string type of the layout as defined by that layout in Shuffleboard.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/WidgetType.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/WidgetType.java
@@ -10,6 +10,7 @@ package edu.wpi.first.wpilibj.shuffleboard;
  *
  * @see BuiltInWidgets the built-in widget types
  */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface WidgetType {
   /**
    * Gets the string type of the widget as defined by that widget in Shuffleboard.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/CallbackStore.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/CallbackStore.java
@@ -7,16 +7,19 @@ package edu.wpi.first.wpilibj.simulation;
 /** Manages simulation callbacks; each object is associated with a callback. */
 public class CallbackStore implements AutoCloseable {
   /** <b>Note: This interface is for simulation classes only. It should not be used by teams!</b> */
+  @SuppressWarnings("PMD.ImplicitFunctionalInterface")
   interface CancelCallbackFunc {
     void cancel(int index, int uid);
   }
 
   /** <b>Note: This interface is for simulation classes only. It should not be used by teams!</b> */
+  @SuppressWarnings("PMD.ImplicitFunctionalInterface")
   interface CancelCallbackChannelFunc {
     void cancel(int index, int channel, int uid);
   }
 
   /** <b>Note: This interface is for simulation classes only. It should not be used by teams!</b> */
+  @SuppressWarnings("PMD.ImplicitFunctionalInterface")
   interface CancelCallbackNoIndexFunc {
     void cancel(int uid);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
@@ -58,7 +58,6 @@ import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 /** Implementation detail for SendableBuilder. */
-@SuppressWarnings("PMD.CompareObjectsWithEquals")
 public class SendableBuilderImpl implements NTSendableBuilder {
   @FunctionalInterface
   private interface TimedConsumer<T> {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
@@ -30,7 +30,6 @@ public final class SmartDashboard {
   /**
    * A table linking tables in the SmartDashboard to the {@link Sendable} objects they came from.
    */
-  @SuppressWarnings("PMD.UseConcurrentHashMap")
   private static final Map<String, Sendable> tablesToData = new HashMap<>();
 
   /** The executor for listener tasks; calls listener tasks synchronously from main thread. */

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/AddressableLEDBufferTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/AddressableLEDBufferTest.java
@@ -103,18 +103,21 @@ class AddressableLEDBufferTest {
     buffer.forEach(
         (index, r, g, b) -> {
           switch (index) {
-            case 0 -> assertAll(
-                () -> assertEquals(1, r, "red at index 0"),
-                () -> assertEquals(2, g, "green at index 0"),
-                () -> assertEquals(3, b, "blue at index 0"));
-            case 1 -> assertAll(
-                () -> assertEquals(4, r, "red at index 1"),
-                () -> assertEquals(5, g, "green at index 1"),
-                () -> assertEquals(6, b, "blue at index 1"));
-            case 2 -> assertAll(
-                () -> assertEquals(7, r, "red at index 2"),
-                () -> assertEquals(8, g, "green at index 2"),
-                () -> assertEquals(9, b, "blue at index 2"));
+            case 0 ->
+                assertAll(
+                    () -> assertEquals(1, r, "red at index 0"),
+                    () -> assertEquals(2, g, "green at index 0"),
+                    () -> assertEquals(3, b, "blue at index 0"));
+            case 1 ->
+                assertAll(
+                    () -> assertEquals(4, r, "red at index 1"),
+                    () -> assertEquals(5, g, "green at index 1"),
+                    () -> assertEquals(6, b, "blue at index 1"));
+            case 2 ->
+                assertAll(
+                    () -> assertEquals(7, r, "red at index 2"),
+                    () -> assertEquals(8, g, "green at index 2"),
+                    () -> assertEquals(9, b, "blue at index 2"));
             default -> fail("Unexpected index " + index);
           }
         });

--- a/wpilibjExamples/build.gradle
+++ b/wpilibjExamples/build.gradle
@@ -27,12 +27,12 @@ dependencies {
     implementation project(':epilogue-runtime')
     annotationProcessor project(':epilogue-processor')
 
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 jacoco {
-    toolVersion = "0.8.10"
+    toolVersion = "0.8.13"
 }
 
 jacocoTestReport {

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/commandbased/commands/ExampleCommand.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/commandbased/commands/ExampleCommand.java
@@ -9,7 +9,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 
 /** An example command that uses an example subsystem. */
 public class ExampleCommand extends Command {
-  @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+  @SuppressWarnings("PMD.UnusedPrivateField")
   private final ExampleSubsystem m_subsystem;
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/romicommandbased/commands/ExampleCommand.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/romicommandbased/commands/ExampleCommand.java
@@ -9,7 +9,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 
 /** An example command that uses an example subsystem. */
 public class ExampleCommand extends Command {
-  @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+  @SuppressWarnings("PMD.UnusedPrivateField")
   private final RomiDrivetrain m_subsystem;
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/xrpcommandbased/commands/ExampleCommand.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/xrpcommandbased/commands/ExampleCommand.java
@@ -9,7 +9,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 
 /** An example command that uses an example subsystem. */
 public class ExampleCommand extends Command {
-  @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+  @SuppressWarnings("PMD.UnusedPrivateField")
   private final XRPDrivetrain m_subsystem;
 
   /**

--- a/wpimath/src/generate/main/java/Nat.java.jinja
+++ b/wpimath/src/generate/main/java/Nat.java.jinja
@@ -18,6 +18,7 @@ import edu.wpi.first.math.numbers.N{{ num }};
  *
  * @param <T> The {@link Num} this represents.
  */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface Nat<T extends Num> {
   /**
    * The number this interface represents.

--- a/wpimath/src/generated/main/java/edu/wpi/first/math/Nat.java
+++ b/wpimath/src/generated/main/java/edu/wpi/first/math/Nat.java
@@ -37,6 +37,7 @@ import edu.wpi.first.math.numbers.N20;
  *
  * @param <T> The {@link Num} this represents.
  */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface Nat<T extends Num> {
   /**
    * The number this interface represents.

--- a/wpimath/src/main/java/edu/wpi/first/math/interpolation/Interpolatable.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/interpolation/Interpolatable.java
@@ -11,6 +11,7 @@ package edu.wpi.first.math.interpolation;
  *
  * @param <T> The class that is interpolatable.
  */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface Interpolatable<T> {
   /**
    * Return the interpolated value. This object is assumed to be the starting position, or lower

--- a/wpimath/src/main/java/edu/wpi/first/math/spline/SplineHelper.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/spline/SplineHelper.java
@@ -226,7 +226,7 @@ public final class SplineHelper {
    * @param splines An array of un-optimized quintic splines.
    * @return An array of optimized quintic splines.
    */
-  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  @SuppressWarnings("LocalVariableName")
   public static QuinticHermiteSpline[] optimizeCurvature(QuinticHermiteSpline[] splines) {
     // If there's only spline in the array, we can't optimize anything so just return that.
     if (splines.length < 2) {

--- a/wpiunits/src/generate/main/java/Measure-immutable.java.jinja
+++ b/wpiunits/src/generate/main/java/Measure-immutable.java.jinja
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record Immutable{{ helpers['type_decl'](name) }}(double magnitude, double baseUnitMagnitude, {{ helpers['mtou'](name) }} unit) implements {{ helpers['type_usage'](name) }} {
   @Override
   public {{ helpers['type_usage'](name) }} copy() {

--- a/wpiunits/src/generate/main/java/Measure-mutable.java.jinja
+++ b/wpiunits/src/generate/main/java/Measure-mutable.java.jinja
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class Mut{{ helpers['type_decl'](name) }}
   extends MutableMeasureBase<{{ helpers['mtou'](name) }}, {{ helpers['type_usage'](name) }}, Mut{{ helpers['type_usage'](name) }}>
   implements {{ helpers['type_usage'](name) }} {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableAcceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableAcceleration.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableAcceleration<D extends Unit>(double magnitude, double baseUnitMagnitude, AccelerationUnit<D> unit) implements Acceleration<D> {
   @Override
   public Acceleration<D> copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableAngle.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableAngle.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableAngle(double magnitude, double baseUnitMagnitude, AngleUnit unit) implements Angle {
   @Override
   public Angle copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableAngularAcceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableAngularAcceleration.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableAngularAcceleration(double magnitude, double baseUnitMagnitude, AngularAccelerationUnit unit) implements AngularAcceleration {
   @Override
   public AngularAcceleration copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableAngularMomentum.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableAngularMomentum.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableAngularMomentum(double magnitude, double baseUnitMagnitude, AngularMomentumUnit unit) implements AngularMomentum {
   @Override
   public AngularMomentum copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableAngularVelocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableAngularVelocity.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableAngularVelocity(double magnitude, double baseUnitMagnitude, AngularVelocityUnit unit) implements AngularVelocity {
   @Override
   public AngularVelocity copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableCurrent.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableCurrent.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableCurrent(double magnitude, double baseUnitMagnitude, CurrentUnit unit) implements Current {
   @Override
   public Current copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableDimensionless.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableDimensionless.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableDimensionless(double magnitude, double baseUnitMagnitude, DimensionlessUnit unit) implements Dimensionless {
   @Override
   public Dimensionless copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableDistance.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableDistance.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableDistance(double magnitude, double baseUnitMagnitude, DistanceUnit unit) implements Distance {
   @Override
   public Distance copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableEnergy.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableEnergy.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableEnergy(double magnitude, double baseUnitMagnitude, EnergyUnit unit) implements Energy {
   @Override
   public Energy copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableForce.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableForce.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableForce(double magnitude, double baseUnitMagnitude, ForceUnit unit) implements Force {
   @Override
   public Force copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableFrequency.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableFrequency.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableFrequency(double magnitude, double baseUnitMagnitude, FrequencyUnit unit) implements Frequency {
   @Override
   public Frequency copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableLinearAcceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableLinearAcceleration.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableLinearAcceleration(double magnitude, double baseUnitMagnitude, LinearAccelerationUnit unit) implements LinearAcceleration {
   @Override
   public LinearAcceleration copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableLinearMomentum.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableLinearMomentum.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableLinearMomentum(double magnitude, double baseUnitMagnitude, LinearMomentumUnit unit) implements LinearMomentum {
   @Override
   public LinearMomentum copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableLinearVelocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableLinearVelocity.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableLinearVelocity(double magnitude, double baseUnitMagnitude, LinearVelocityUnit unit) implements LinearVelocity {
   @Override
   public LinearVelocity copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableMass.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableMass.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableMass(double magnitude, double baseUnitMagnitude, MassUnit unit) implements Mass {
   @Override
   public Mass copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableMomentOfInertia.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableMomentOfInertia.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableMomentOfInertia(double magnitude, double baseUnitMagnitude, MomentOfInertiaUnit unit) implements MomentOfInertia {
   @Override
   public MomentOfInertia copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableMult.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableMult.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableMult<A extends Unit, B extends Unit>(double magnitude, double baseUnitMagnitude, MultUnit<A, B> unit) implements Mult<A, B> {
   @Override
   public Mult<A, B> copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutablePer.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutablePer.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutablePer<Dividend extends Unit, Divisor extends Unit>(double magnitude, double baseUnitMagnitude, PerUnit<Dividend, Divisor> unit) implements Per<Dividend, Divisor> {
   @Override
   public Per<Dividend, Divisor> copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutablePower.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutablePower.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutablePower(double magnitude, double baseUnitMagnitude, PowerUnit unit) implements Power {
   @Override
   public Power copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableResistance.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableResistance.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableResistance(double magnitude, double baseUnitMagnitude, ResistanceUnit unit) implements Resistance {
   @Override
   public Resistance copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableTemperature.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableTemperature.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableTemperature(double magnitude, double baseUnitMagnitude, TemperatureUnit unit) implements Temperature {
   @Override
   public Temperature copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableTime.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableTime.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableTime(double magnitude, double baseUnitMagnitude, TimeUnit unit) implements Time {
   @Override
   public Time copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableTorque.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableTorque.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableTorque(double magnitude, double baseUnitMagnitude, TorqueUnit unit) implements Torque {
   @Override
   public Torque copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableVelocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableVelocity.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableVelocity<D extends Unit>(double magnitude, double baseUnitMagnitude, VelocityUnit<D> unit) implements Velocity<D> {
   @Override
   public Velocity<D> copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableVoltage.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/ImmutableVoltage.java
@@ -9,7 +9,7 @@ package edu.wpi.first.units.measure;
 import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public record ImmutableVoltage(double magnitude, double baseUnitMagnitude, VoltageUnit unit) implements Voltage {
   @Override
   public Voltage copy() {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutAcceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutAcceleration.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutAcceleration<D extends Unit>
   extends MutableMeasureBase<AccelerationUnit<D>, Acceleration<D>, MutAcceleration<D>>
   implements Acceleration<D> {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutAngle.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutAngle.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutAngle
   extends MutableMeasureBase<AngleUnit, Angle, MutAngle>
   implements Angle {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutAngularAcceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutAngularAcceleration.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutAngularAcceleration
   extends MutableMeasureBase<AngularAccelerationUnit, AngularAcceleration, MutAngularAcceleration>
   implements AngularAcceleration {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutAngularMomentum.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutAngularMomentum.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutAngularMomentum
   extends MutableMeasureBase<AngularMomentumUnit, AngularMomentum, MutAngularMomentum>
   implements AngularMomentum {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutAngularVelocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutAngularVelocity.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutAngularVelocity
   extends MutableMeasureBase<AngularVelocityUnit, AngularVelocity, MutAngularVelocity>
   implements AngularVelocity {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutCurrent.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutCurrent.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutCurrent
   extends MutableMeasureBase<CurrentUnit, Current, MutCurrent>
   implements Current {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutDimensionless.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutDimensionless.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutDimensionless
   extends MutableMeasureBase<DimensionlessUnit, Dimensionless, MutDimensionless>
   implements Dimensionless {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutDistance.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutDistance.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutDistance
   extends MutableMeasureBase<DistanceUnit, Distance, MutDistance>
   implements Distance {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutEnergy.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutEnergy.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutEnergy
   extends MutableMeasureBase<EnergyUnit, Energy, MutEnergy>
   implements Energy {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutForce.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutForce.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutForce
   extends MutableMeasureBase<ForceUnit, Force, MutForce>
   implements Force {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutFrequency.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutFrequency.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutFrequency
   extends MutableMeasureBase<FrequencyUnit, Frequency, MutFrequency>
   implements Frequency {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutLinearAcceleration.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutLinearAcceleration.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutLinearAcceleration
   extends MutableMeasureBase<LinearAccelerationUnit, LinearAcceleration, MutLinearAcceleration>
   implements LinearAcceleration {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutLinearMomentum.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutLinearMomentum.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutLinearMomentum
   extends MutableMeasureBase<LinearMomentumUnit, LinearMomentum, MutLinearMomentum>
   implements LinearMomentum {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutLinearVelocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutLinearVelocity.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutLinearVelocity
   extends MutableMeasureBase<LinearVelocityUnit, LinearVelocity, MutLinearVelocity>
   implements LinearVelocity {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutMass.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutMass.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutMass
   extends MutableMeasureBase<MassUnit, Mass, MutMass>
   implements Mass {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutMomentOfInertia.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutMomentOfInertia.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutMomentOfInertia
   extends MutableMeasureBase<MomentOfInertiaUnit, MomentOfInertia, MutMomentOfInertia>
   implements MomentOfInertia {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutMult.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutMult.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutMult<A extends Unit, B extends Unit>
   extends MutableMeasureBase<MultUnit<A, B>, Mult<A, B>, MutMult<A, B>>
   implements Mult<A, B> {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutPer.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutPer.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutPer<Dividend extends Unit, Divisor extends Unit>
   extends MutableMeasureBase<PerUnit<Dividend, Divisor>, Per<Dividend, Divisor>, MutPer<Dividend, Divisor>>
   implements Per<Dividend, Divisor> {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutPower.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutPower.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutPower
   extends MutableMeasureBase<PowerUnit, Power, MutPower>
   implements Power {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutResistance.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutResistance.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutResistance
   extends MutableMeasureBase<ResistanceUnit, Resistance, MutResistance>
   implements Resistance {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutTemperature.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutTemperature.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutTemperature
   extends MutableMeasureBase<TemperatureUnit, Temperature, MutTemperature>
   implements Temperature {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutTime.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutTime.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutTime
   extends MutableMeasureBase<TimeUnit, Time, MutTime>
   implements Time {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutTorque.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutTorque.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutTorque
   extends MutableMeasureBase<TorqueUnit, Torque, MutTorque>
   implements Torque {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutVelocity.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutVelocity.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutVelocity<D extends Unit>
   extends MutableMeasureBase<VelocityUnit<D>, Velocity<D>, MutVelocity<D>>
   implements Velocity<D> {

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutVoltage.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/MutVoltage.java
@@ -10,7 +10,7 @@ import static edu.wpi.first.units.Units.*;
 import edu.wpi.first.units.*;
 import edu.wpi.first.units.mutable.MutableMeasureBase;
 
-@SuppressWarnings({"unchecked", "cast", "checkstyle", "PMD"})
+@SuppressWarnings({"unchecked", "cast", "checkstyle"})
 public final class MutVoltage
   extends MutableMeasureBase<VoltageUnit, Voltage, MutVoltage>
   implements Voltage {

--- a/wpiutil/src/main/java/edu/wpi/first/util/cleanup/ReflectionCleanup.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/cleanup/ReflectionCleanup.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Field;
  * your `close` method, that will use reflection to find all `AutoCloseable` instance members and
  * close them.
  */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface ReflectionCleanup extends AutoCloseable {
   /**
    * Default implementation that uses reflection to find all AutoCloseable fields not marked

--- a/wpiutil/src/main/java/edu/wpi/first/util/sendable/Sendable.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/sendable/Sendable.java
@@ -5,6 +5,7 @@
 package edu.wpi.first.util.sendable;
 
 /** The base interface for objects that can be sent over the network. */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface Sendable {
   /**
    * Initializes this {@link Sendable} object.

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/StructGenerator.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/StructGenerator.java
@@ -435,7 +435,6 @@ public final class StructGenerator {
     }
 
     int size = 0;
-    boolean failed = false;
 
     for (final E constant : enumVariants) {
       final String name = constant.name();
@@ -451,6 +450,8 @@ public final class StructGenerator {
         List.of(allEnumFields).stream()
             .filter(f -> !f.isEnumConstant() && !Modifier.isStatic(f.getModifiers()))
             .toList();
+
+    boolean failed = false;
 
     for (final Field field : enumFields) {
       final Class<?> type = field.getType();

--- a/wpiutil/src/test/java/edu/wpi/first/util/cleanup/CleanupPoolTest.java
+++ b/wpiutil/src/test/java/edu/wpi/first/util/cleanup/CleanupPoolTest.java
@@ -87,7 +87,6 @@ class CleanupPoolTest {
   }
 
   @Test
-  @SuppressWarnings("PMD.AvoidCatchingGenericException")
   void cleanupStackWithExceptionInCloseWorks() {
     List<AutoCloseableObject> objects = new ArrayList<>();
     objects.add(new AutoCloseableObject());


### PR DESCRIPTION
Most of the changes are for suppressing new linter purification rites and removing redundant PMD suppressions. Spotbugs generated more thread safety warnings this time, but most of them seemed like false positives.

The Doxygen 2.0 Gradle plugin changed the folder it downloads the hosted binary from. It expects the binary to be at:

> https://frcmaven.wpi.edu/artifactory/generic-release-mirror/doxygen/Release_1_12_0/doxygen-1.12.0.linux.bin.tar.gz

instead of:

> https://frcmaven.wpi.edu/artifactory/generic-release-mirror/doxygen/rel-1.12.0/doxygen-1.12.0.linux.bin.tar.gz

See [this issue](https://gitlab.com/ysb33rOrg/gradle/doxygen-gradle-plugin/-/issues?show=eyJpaWQiOiIzOCIsImZ1bGxfcGF0aCI6InlzYjMzck9yZy9ncmFkbGUvZG94eWdlbi1ncmFkbGUtcGx1Z2luIiwiaWQiOjEzMzM1NzU3N30%3D). We'll need to copy the binaries to the new location to fix the documentation CI.