### PR TITLE
Fix Gradle Task.project deprecation warning

### DIFF
--- a/shared/examplecheck.gradle
+++ b/shared/examplecheck.gradle
@@ -122,6 +122,7 @@ task checkSnippets(type: Task) {
 }
 
 task checkCommands(type: Task) {
+    def isCppCommands = project.isCppCommands;
     doLast {
         def parsedJson = new groovy.json.JsonSlurper().parseText(commandFile.text)
         fileCheck(parsedJson, commandDirectory)
@@ -132,7 +133,7 @@ task checkCommands(type: Task) {
             assert it.foldername != null
             assert it.replacename != null
             assert it.commandversion != null
-            if (project.isCppCommands) {
+            if (isCppCommands) {
                 assert it.headers != null
                 assert !it.headers.isEmpty()
                 assert it.source != null


### PR DESCRIPTION
```
> Task :wpilibcExamples:checkCommands
Script '/home/tav/frc/wpilib/allwpilib/shared/examplecheck.gradle': line 135
Invocation of Task.project at execution time has been deprecated. This will fail with an error in Gradle 10.0. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/8.14.3/userguide/upgrading_version_7.html#task_project
        at examplecheck_4wsg1s37eigy9vs5arzst20ga$_run_closure5$_closure16$_closure17.doCall$original(/home/tav/frc/wpilib/allwpilib/shared/examplecheck.gradle:135)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```

Moving the project access outside the doLast block makes it occur at confguration time instead.