### PR TITLE
[bazel] Put eigen in an external repo like bzlmod

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -95,6 +95,14 @@ http_archive(
     url = "https://github.com/TendTo/rules_doxygen/releases/download/2.4.2/rules_doxygen-2.4.2.tar.gz",
 )
 
+# This gives us a repository layout which matches what normal BCR modules expect.
+# The goal here is to make it easier to depend on external projects which already
+# include @eigen without introducing multiple eigen versions.
+local_repository(
+    name = "eigen",
+    path = "wpimath/src/main/native/thirdparty/eigen/include/",
+)
+
 load("@bazel_features//:deps.bzl", "bazel_features_deps")
 
 bazel_features_deps()

--- a/upstream_utils/eigen.py
+++ b/upstream_utils/eigen.py
@@ -133,10 +133,12 @@ def copy_upstream_src(wpilib_root: Path):
 
     for f in [
         ".clang-format",
+        "BUILD.bazel",
         "COPYING.APACHE",
         "COPYING.BSD",
         "COPYING.MINPACK",
         "COPYING.MPL2",
+        "WORKSPACE",
     ]:
         shutil.copyfile(
             f,

--- a/upstream_utils/eigen.py
+++ b/upstream_utils/eigen.py
@@ -131,11 +131,17 @@ def copy_upstream_src(wpilib_root: Path):
             f, [wpimath / "src/main/native/thirdparty/eigen/include"]
         )
 
-    for f in ["COPYING.APACHE", ".clang-format", "COPYING.BSD", "COPYING.MINPACK", "COPYING.MPL2"]:
-      shutil.copyfile(
-          f,
-          wpimath / "src/main/native/thirdparty/eigen/include" / f,
-      )
+    for f in [
+        ".clang-format",
+        "COPYING.APACHE",
+        "COPYING.BSD",
+        "COPYING.MINPACK",
+        "COPYING.MPL2",
+    ]:
+        shutil.copyfile(
+            f,
+            wpimath / "src/main/native/thirdparty/eigen/include" / f,
+        )
 
 
 def main():

--- a/upstream_utils/eigen.py
+++ b/upstream_utils/eigen.py
@@ -131,10 +131,11 @@ def copy_upstream_src(wpilib_root: Path):
             f, [wpimath / "src/main/native/thirdparty/eigen/include"]
         )
 
-    shutil.copyfile(
-        ".clang-format",
-        wpimath / "src/main/native/thirdparty/eigen/include/.clang-format",
-    )
+    for f in ["COPYING.APACHE", ".clang-format", "COPYING.BSD", "COPYING.MINPACK", "COPYING.MPL2"]:
+      shutil.copyfile(
+          f,
+          wpimath / "src/main/native/thirdparty/eigen/include" / f,
+      )
 
 
 def main():

--- a/upstream_utils/eigen_patches/0001-Disable-warnings.patch
+++ b/upstream_utils/eigen_patches/0001-Disable-warnings.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Wed, 18 May 2022 09:14:24 -0700
-Subject: [PATCH 1/2] Disable warnings
+Subject: [PATCH 1/3] Disable warnings
 
 ---
  Eigen/src/Core/util/DisableStupidWarnings.h | 9 +++++++++

--- a/upstream_utils/eigen_patches/0002-Intellisense-fix.patch
+++ b/upstream_utils/eigen_patches/0002-Intellisense-fix.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Fri, 20 Jan 2023 23:41:56 -0800
-Subject: [PATCH 2/2] Intellisense fix
+Subject: [PATCH 2/3] Intellisense fix
 
 ---
  Eigen/src/Core/util/ConfigureVectorization.h | 7 +++++++

--- a/upstream_utils/eigen_patches/0003-Add-build-files-from-bzlmod-for-eigen.patch
+++ b/upstream_utils/eigen_patches/0003-Add-build-files-from-bzlmod-for-eigen.patch
@@ -1,7 +1,7 @@
-From 6c9418872ac6cf574795bd2712dbc04ba5645c1d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Austin Schuh <austin.linux@gmail.com>
 Date: Sat, 9 Aug 2025 12:45:23 -0700
-Subject: Add build files from bzlmod for eigen
+Subject: [PATCH 3/3] Add build files from bzlmod for eigen
 
 This makes it so our vendored version of eigen matches the same API as
 the upstream eigen in bcr.
@@ -12,9 +12,9 @@ the upstream eigen in bcr.
  create mode 100644 wpimath/src/main/native/thirdparty/eigen/include/BUILD.bazel
  create mode 100644 wpimath/src/main/native/thirdparty/eigen/include/WORKSPACE
 
-diff --git a/wpimath/src/main/native/thirdparty/eigen/include/BUILD.bazel b/wpimath/src/main/native/thirdparty/eigen/include/BUILD.bazel
+diff --git a/BUILD.bazel b/BUILD.bazel
 new file mode 100644
-index 000000000..38ce6cb41
+index 0000000000000000000000000000000000000000..38ce6cb417485fb37cafaf1e0f536e7ac56706b0
 --- /dev/null
 +++ b/wpimath/src/main/native/thirdparty/eigen/include/BUILD.bazel
 @@ -0,0 +1,64 @@
@@ -82,9 +82,5 @@ index 000000000..38ce6cb41
 +    includes = ["."],
 +    visibility = ["//visibility:public"],
 +)
-diff --git a/wpimath/src/main/native/thirdparty/eigen/include/WORKSPACE b/wpimath/src/main/native/thirdparty/eigen/include/WORKSPACE
+diff --git a/WORKSPACE b/WORKSPACE
 new file mode 100644
-index 000000000..e69de29bb
--- 
-2.39.5
-

--- a/upstream_utils/eigen_patches/0003-Add-build-files-from-bzlmod-for-eigen.patch
+++ b/upstream_utils/eigen_patches/0003-Add-build-files-from-bzlmod-for-eigen.patch
@@ -6,8 +6,8 @@ Subject: [PATCH 3/3] Add build files from bzlmod for eigen
 This makes it so our vendored version of eigen matches the same API as
 the upstream eigen in bcr.
 ---
- BUILD.bazel      | 64 +++++++++++++++++++
- WORKSPACE        |  0
+ BUILD.bazel | 64 +++++++++++++++++++++++++++++++++++++++++++++++++++++
+ WORKSPACE   |  0
  2 files changed, 64 insertions(+)
  create mode 100644 BUILD.bazel
  create mode 100644 WORKSPACE
@@ -84,3 +84,4 @@ index 0000000000000000000000000000000000000000..38ce6cb417485fb37cafaf1e0f536e7a
 +)
 diff --git a/WORKSPACE b/WORKSPACE
 new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391

--- a/upstream_utils/eigen_patches/0003-Add-build-files-from-bzlmod-for-eigen.patch
+++ b/upstream_utils/eigen_patches/0003-Add-build-files-from-bzlmod-for-eigen.patch
@@ -6,17 +6,17 @@ Subject: [PATCH 3/3] Add build files from bzlmod for eigen
 This makes it so our vendored version of eigen matches the same API as
 the upstream eigen in bcr.
 ---
- .../thirdparty/eigen/include/BUILD.bazel      | 64 +++++++++++++++++++
- .../native/thirdparty/eigen/include/WORKSPACE |  0
+ BUILD.bazel      | 64 +++++++++++++++++++
+ WORKSPACE        |  0
  2 files changed, 64 insertions(+)
- create mode 100644 wpimath/src/main/native/thirdparty/eigen/include/BUILD.bazel
- create mode 100644 wpimath/src/main/native/thirdparty/eigen/include/WORKSPACE
+ create mode 100644 BUILD.bazel
+ create mode 100644 WORKSPACE
 
 diff --git a/BUILD.bazel b/BUILD.bazel
 new file mode 100644
 index 0000000000000000000000000000000000000000..38ce6cb417485fb37cafaf1e0f536e7ac56706b0
 --- /dev/null
-+++ b/wpimath/src/main/native/thirdparty/eigen/include/BUILD.bazel
++++ b/BUILD.bazel
 @@ -0,0 +1,64 @@
 +load("@rules_cc//cc:cc_library.bzl", "cc_library")
 +load("@rules_license//rules:license.bzl", "license")

--- a/upstream_utils/eigen_patches/0003-bazel-build-files.patch
+++ b/upstream_utils/eigen_patches/0003-bazel-build-files.patch
@@ -1,0 +1,90 @@
+From 6c9418872ac6cf574795bd2712dbc04ba5645c1d Mon Sep 17 00:00:00 2001
+From: Austin Schuh <austin.linux@gmail.com>
+Date: Sat, 9 Aug 2025 12:45:23 -0700
+Subject: Add build files from bzlmod for eigen
+
+This makes it so our vendored version of eigen matches the same API as
+the upstream eigen in bcr.
+---
+ .../thirdparty/eigen/include/BUILD.bazel      | 64 +++++++++++++++++++
+ .../native/thirdparty/eigen/include/WORKSPACE |  0
+ 2 files changed, 64 insertions(+)
+ create mode 100644 wpimath/src/main/native/thirdparty/eigen/include/BUILD.bazel
+ create mode 100644 wpimath/src/main/native/thirdparty/eigen/include/WORKSPACE
+
+diff --git a/wpimath/src/main/native/thirdparty/eigen/include/BUILD.bazel b/wpimath/src/main/native/thirdparty/eigen/include/BUILD.bazel
+new file mode 100644
+index 000000000..38ce6cb41
+--- /dev/null
++++ b/wpimath/src/main/native/thirdparty/eigen/include/BUILD.bazel
+@@ -0,0 +1,64 @@
++load("@rules_cc//cc:cc_library.bzl", "cc_library")
++load("@rules_license//rules:license.bzl", "license")
++
++package(
++    default_applicable_licenses = [
++        ":license.APACHE",
++        ":license.BSD",
++        ":license.MINPACK",  # Only used by unsupported/** not by Eigen/**.
++        ":license.MPL2",
++    ],
++)
++
++exports_files(glob(["COPYING.*"]))
++
++# Note: Eigen is primarily an MPL2 library with small bits of code under other
++# licenses. Previous versions of Eigen contained LGPL code which needed to be
++# carefully excluded, but as of approximately 2023-02-07 all LGPL code has been
++# removed upstream so does not need any special handling here.
++
++license(
++    name = "license.APACHE",
++    license_kinds = ["@rules_license//licenses/spdx:Apache-2.0"],
++    license_text = "COPYING.APACHE",
++)
++
++license(
++    name = "license.BSD",
++    license_kinds = ["@rules_license//licenses/spdx:BSD-3-Clause"],
++    license_text = "COPYING.BSD",
++)
++
++license(
++    name = "license.MINPACK",
++    license_kinds = ["@rules_license//licenses/spdx:BSD-3-Clause-Attribution"],
++    license_text = "COPYING.MINPACK",
++)
++
++license(
++    name = "license.MPL2",
++    license_kinds = ["@rules_license//licenses/spdx:MPL-2.0"],
++    license_text = "COPYING.MPL2",
++)
++
++HDRS = glob(
++    [
++        "Eigen/**",
++        "unsupported/Eigen/**",
++    ],
++    exclude = [
++        # We don't want any documentation files.
++        "**/*.md",
++        "**/*.txt",
++        "unsupported/Eigen/NonLinearOptimization",
++        #"unsupported/Eigen/MatrixFunctions",
++        "unsupported/Eigen/Polynomials",
++    ],
++)
++
++cc_library(
++    name = "eigen",
++    hdrs = HDRS,
++    includes = ["."],
++    visibility = ["//visibility:public"],
++)
+diff --git a/wpimath/src/main/native/thirdparty/eigen/include/WORKSPACE b/wpimath/src/main/native/thirdparty/eigen/include/WORKSPACE
+new file mode 100644
+index 000000000..e69de29bb
+-- 
+2.39.5
+

--- a/wpimath/BUILD.bazel
+++ b/wpimath/BUILD.bazel
@@ -99,10 +99,19 @@ filegroup(
     srcs = glob(["src/generated/main/java/**/*.java"]),
 )
 
-third_party_cc_lib_helper(
-    name = "eigen",
-    include_root = "src/main/native/thirdparty/eigen/include",
+cc_library(
+    name = "eigen-headers",
     visibility = ["//visibility:public"],
+    deps = [
+        "@eigen",
+    ],
+)
+
+pkg_files(
+    name = "eigen-hdrs-pkg",
+    srcs = [
+        "@eigen",
+    ],
 )
 
 third_party_cc_lib_helper(

--- a/wpimath/BUILD.bazel
+++ b/wpimath/BUILD.bazel
@@ -7,7 +7,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 load("//shared/bazel/rules:cc_rules.bzl", "generate_def_windows", "third_party_cc_lib_helper", "wpilib_cc_library", "wpilib_cc_shared_library", "wpilib_cc_static_library")
 load("//shared/bazel/rules:java_rules.bzl", "wpilib_java_junit5_test")
 load("//shared/bazel/rules:jni_rules.bzl", "wpilib_jni_cc_library", "wpilib_jni_java_library")
-load("//shared/bazel/rules:packaging.bzl", "package_default_jni_project")
+load("//shared/bazel/rules:packaging.bzl", "package_default_jni_project", "pkg_files_headers")
 load("//wpimath:generate.bzl", "generate_wpimath")
 
 filegroup(
@@ -107,11 +107,9 @@ cc_library(
     ],
 )
 
-pkg_files(
+pkg_files_headers(
     name = "eigen-hdrs-pkg",
-    srcs = [
-        "@eigen",
-    ],
+    dep = "@eigen",
 )
 
 third_party_cc_lib_helper(

--- a/wpimath/BUILD.bazel
+++ b/wpimath/BUILD.bazel
@@ -99,12 +99,10 @@ filegroup(
     srcs = glob(["src/generated/main/java/**/*.java"]),
 )
 
-cc_library(
+alias(
     name = "eigen-headers",
+    actual = "@eigen",
     visibility = ["//visibility:public"],
-    deps = [
-        "@eigen",
-    ],
 )
 
 pkg_files_headers(

--- a/wpimath/src/main/native/thirdparty/eigen/include/BUILD.bazel
+++ b/wpimath/src/main/native/thirdparty/eigen/include/BUILD.bazel
@@ -1,0 +1,64 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [
+        ":license.APACHE",
+        ":license.BSD",
+        ":license.MINPACK",  # Only used by unsupported/** not by Eigen/**.
+        ":license.MPL2",
+    ],
+)
+
+exports_files(glob(["COPYING.*"]))
+
+# Note: Eigen is primarily an MPL2 library with small bits of code under other
+# licenses. Previous versions of Eigen contained LGPL code which needed to be
+# carefully excluded, but as of approximately 2023-02-07 all LGPL code has been
+# removed upstream so does not need any special handling here.
+
+license(
+    name = "license.APACHE",
+    license_kinds = ["@rules_license//licenses/spdx:Apache-2.0"],
+    license_text = "COPYING.APACHE",
+)
+
+license(
+    name = "license.BSD",
+    license_kinds = ["@rules_license//licenses/spdx:BSD-3-Clause"],
+    license_text = "COPYING.BSD",
+)
+
+license(
+    name = "license.MINPACK",
+    license_kinds = ["@rules_license//licenses/spdx:BSD-3-Clause-Attribution"],
+    license_text = "COPYING.MINPACK",
+)
+
+license(
+    name = "license.MPL2",
+    license_kinds = ["@rules_license//licenses/spdx:MPL-2.0"],
+    license_text = "COPYING.MPL2",
+)
+
+HDRS = glob(
+    [
+        "Eigen/**",
+        "unsupported/Eigen/**",
+    ],
+    exclude = [
+        # We don't want any documentation files.
+        "**/*.md",
+        "**/*.txt",
+        "unsupported/Eigen/NonLinearOptimization",
+        #"unsupported/Eigen/MatrixFunctions",
+        "unsupported/Eigen/Polynomials",
+    ],
+)
+
+cc_library(
+    name = "eigen",
+    hdrs = HDRS,
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)

--- a/wpimath/src/main/native/thirdparty/eigen/include/COPYING.APACHE
+++ b/wpimath/src/main/native/thirdparty/eigen/include/COPYING.APACHE
@@ -1,0 +1,203 @@
+/*
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/

--- a/wpimath/src/main/native/thirdparty/eigen/include/COPYING.BSD
+++ b/wpimath/src/main/native/thirdparty/eigen/include/COPYING.BSD
@@ -1,0 +1,26 @@
+/*
+ Copyright (c) 2011, Intel Corporation. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of Intel Corporation nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/

--- a/wpimath/src/main/native/thirdparty/eigen/include/COPYING.MINPACK
+++ b/wpimath/src/main/native/thirdparty/eigen/include/COPYING.MINPACK
@@ -1,0 +1,51 @@
+Minpack Copyright Notice (1999) University of Chicago.  All rights reserved
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above
+copyright notice, this list of conditions and the following
+disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials
+provided with the distribution.
+
+3. The end-user documentation included with the
+redistribution, if any, must include the following
+acknowledgment:
+
+   "This product includes software developed by the
+   University of Chicago, as Operator of Argonne National
+   Laboratory.
+
+Alternately, this acknowledgment may appear in the software
+itself, if and wherever such third-party acknowledgments
+normally appear.
+
+4. WARRANTY DISCLAIMER. THE SOFTWARE IS SUPPLIED "AS IS"
+WITHOUT WARRANTY OF ANY KIND. THE COPYRIGHT HOLDER, THE
+UNITED STATES, THE UNITED STATES DEPARTMENT OF ENERGY, AND
+THEIR EMPLOYEES: (1) DISCLAIM ANY WARRANTIES, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE
+OR NON-INFRINGEMENT, (2) DO NOT ASSUME ANY LEGAL LIABILITY
+OR RESPONSIBILITY FOR THE ACCURACY, COMPLETENESS, OR
+USEFULNESS OF THE SOFTWARE, (3) DO NOT REPRESENT THAT USE OF
+THE SOFTWARE WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS, (4)
+DO NOT WARRANT THAT THE SOFTWARE WILL FUNCTION
+UNINTERRUPTED, THAT IT IS ERROR-FREE OR THAT ANY ERRORS WILL
+BE CORRECTED.
+
+5. LIMITATION OF LIABILITY. IN NO EVENT WILL THE COPYRIGHT
+HOLDER, THE UNITED STATES, THE UNITED STATES DEPARTMENT OF
+ENERGY, OR THEIR EMPLOYEES: BE LIABLE FOR ANY INDIRECT,
+INCIDENTAL, CONSEQUENTIAL, SPECIAL OR PUNITIVE DAMAGES OF
+ANY KIND OR NATURE, INCLUDING BUT NOT LIMITED TO LOSS OF
+PROFITS OR LOSS OF DATA, FOR ANY REASON WHATSOEVER, WHETHER
+SUCH LIABILITY IS ASSERTED ON THE BASIS OF CONTRACT, TORT
+(INCLUDING NEGLIGENCE OR STRICT LIABILITY), OR OTHERWISE,
+EVEN IF ANY OF SAID PARTIES HAS BEEN WARNED OF THE
+POSSIBILITY OF SUCH LOSS OR DAMAGES.

--- a/wpimath/src/main/native/thirdparty/eigen/include/COPYING.MPL2
+++ b/wpimath/src/main/native/thirdparty/eigen/include/COPYING.MPL2
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/wpimath/src/main/native/thirdparty/eigen/include/COPYING.README
+++ b/wpimath/src/main/native/thirdparty/eigen/include/COPYING.README
@@ -1,0 +1,6 @@
+Eigen is primarily MPL2 licensed. See COPYING.MPL2 and these links:
+  http://www.mozilla.org/MPL/2.0/
+  http://www.mozilla.org/MPL/2.0/FAQ.html
+
+Some files contain third-party code under BSD or other MPL2-compatible licenses,
+whence the other COPYING.* files here.

--- a/wpimath/src/main/native/thirdparty/eigen/include/COPYING.README
+++ b/wpimath/src/main/native/thirdparty/eigen/include/COPYING.README
@@ -1,6 +1,0 @@
-Eigen is primarily MPL2 licensed. See COPYING.MPL2 and these links:
-  http://www.mozilla.org/MPL/2.0/
-  http://www.mozilla.org/MPL/2.0/FAQ.html
-
-Some files contain third-party code under BSD or other MPL2-compatible licenses,
-whence the other COPYING.* files here.


### PR DESCRIPTION
This sets us up to use AOS, which wants `@eigen` to resolve, without introducing a second version or copy of eigen.