### PR TITLE
[build] Fix processstarter publishing

### DIFF
--- a/processstarter/publish.gradle
+++ b/processstarter/publish.gradle
@@ -42,6 +42,7 @@ model {
                             }
 
                             from(applicationPath)
+                            into(nativeUtils.getPlatformPath(binary))
                         }
 
                         task.dependsOn binary.tasks.link


### PR DESCRIPTION
artifacts weren't in OS and architecture subfolders n the zip like all the other C++ tools