### PR TITLE
[wpimath] Include acceleration in TrapezoidProfile.calculate() result

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrapezoidProfile.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrapezoidProfile.java
@@ -118,7 +118,8 @@ public class TrapezoidProfile {
     public boolean equals(Object other) {
       return other instanceof State rhs
           && this.position == rhs.position
-          && this.velocity == rhs.velocity;
+          && this.velocity == rhs.velocity
+          && this.acceleration == rhs.acceleration;
     }
 
     @Override
@@ -312,9 +313,10 @@ public class TrapezoidProfile {
 
   // Flip the sign of the velocity and position if the profile is inverted
   private State direct(State in) {
-    State result = new State(in.position, in.velocity);
+    State result = new State(in.position, in.velocity, in.acceleration);
     result.position = result.position * m_direction;
     result.velocity = result.velocity * m_direction;
+    result.acceleration = result.acceleration * m_direction;
     return result;
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrapezoidProfile.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrapezoidProfile.java
@@ -81,11 +81,17 @@ public class TrapezoidProfile {
     /** The velocity at this state. */
     public double velocity;
 
+    /**
+     * The acceleration at this state. This is not used in the calculation of the profile, but is
+     * included in the result.
+     */
+    public double acceleration;
+
     /** Default constructor. */
     public State() {}
 
     /**
-     * Constructs constraints for a Trapezoid Profile.
+     * Constructs a Trapezoid Profile state with zero acceleration.
      *
      * @param position The position at this state.
      * @param velocity The velocity at this state.
@@ -93,6 +99,19 @@ public class TrapezoidProfile {
     public State(double position, double velocity) {
       this.position = position;
       this.velocity = velocity;
+    }
+
+    /**
+     * Constructs a Trapezoid Profile state with acceleration.
+     *
+     * @param position The position at this state.
+     * @param velocity The velocity at this state.
+     * @param acceleration The acceleration at this state.
+     */
+    private State(double position, double velocity, double acceleration) {
+      this.position = position;
+      this.velocity = velocity;
+      this.acceleration = acceleration;
     }
 
     @Override
@@ -168,17 +187,20 @@ public class TrapezoidProfile {
     if (t < m_endAccel) {
       result.velocity += t * m_constraints.maxAcceleration;
       result.position += (m_current.velocity + t * m_constraints.maxAcceleration / 2.0) * t;
+      result.acceleration = m_constraints.maxAcceleration * m_direction;
     } else if (t < m_endFullSpeed) {
       result.velocity = m_constraints.maxVelocity;
       result.position +=
           (m_current.velocity + m_endAccel * m_constraints.maxAcceleration / 2.0) * m_endAccel
               + m_constraints.maxVelocity * (t - m_endAccel);
+      result.acceleration = 0;
     } else if (t <= m_endDecel) {
       result.velocity = goal.velocity + (m_endDecel - t) * m_constraints.maxAcceleration;
       double timeLeft = m_endDecel - t;
       result.position =
           goal.position
               - (goal.velocity + timeLeft * m_constraints.maxAcceleration / 2.0) * timeLeft;
+      result.acceleration = -m_constraints.maxAcceleration * m_direction;
     } else {
       result = goal;
     }

--- a/wpimath/src/test/java/edu/wpi/first/math/trajectory/TrapezoidProfileTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/trajectory/TrapezoidProfileTest.java
@@ -295,4 +295,24 @@ class TrapezoidProfileTest {
       assertLessThanOrEquals(Math.abs(state.velocity), Math.abs(constraints.maxVelocity));
     }
   }
+
+  @Test
+  void returnsCorrectAcceleration() {
+    TrapezoidProfile.Constraints constraints = new TrapezoidProfile.Constraints(1.0, 1.0);
+    TrapezoidProfile.State goal = new TrapezoidProfile.State(2.0, 0.0);
+    TrapezoidProfile.State state = new TrapezoidProfile.State(0.0, 0.0);
+
+    TrapezoidProfile profile = new TrapezoidProfile(constraints);
+    for (int i = 0; i < 100; ++i) {
+      state = profile.calculate(kDt, state, goal);
+      if (Math.abs(Math.abs(state.velocity) - constraints.maxVelocity) > 1e-5) {
+        // During acceleration, the acceleration should be equal to the max
+        // acceleration.
+        assertEquals(constraints.maxAcceleration, Math.abs(state.acceleration), 1e-5);
+      } else {
+        // Once the max velocity is reached, the acceleration should be zero.
+        assertEquals(0.0, state.acceleration, 1e-5);
+      }
+    }
+  }
 }


### PR DESCRIPTION
I know this is trivial to calculate but knowing what profiling phase you are in seems useful (especially when you are changing goals)