### PR TITLE
Remove PMD.RedundantFieldInitializer rule

### DIFF
--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/ClassSpecificLogger.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/ClassSpecificLogger.java
@@ -27,7 +27,6 @@ public abstract class ClassSpecificLogger<T> {
   // Linked hashmap to maintain insert order
   private final Map<Sendable, SendableBuilder> m_sendables = new LinkedHashMap<>();
 
-  @SuppressWarnings("PMD.RedundantFieldInitializer")
   private boolean m_disabled = false;
 
   /**

--- a/styleguide/pmd-ruleset.xml
+++ b/styleguide/pmd-ruleset.xml
@@ -97,6 +97,12 @@
 
   <rule ref="category/java/performance.xml">
     <exclude name="AvoidInstantiatingObjectsInLoops" />
+    <!--
+      This rule is in place to save three (!) bytecode instructions when initializing a field to its default value.
+      Code that's more readable due to having explicit initial values is more important than reducing class size by a
+      few bytes.
+    -->
+    <exclude name="RedundantFieldInitializer" />
   </rule>
 
   <rule name="UnnecessaryCastRule" language="java"

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
@@ -33,7 +33,7 @@ public final class SmartDashboard {
   /** The executor for listener tasks; calls listener tasks synchronously from main thread. */
   private static final ListenerExecutor listenerExecutor = new ListenerExecutor();
 
-  private static boolean m_reported = false; // NOPMD redundant field initializer
+  private static boolean m_reported = false;
 
   static {
     setNetworkTableInstance(NetworkTableInstance.getDefault());

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/elevatorprofiledpid/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/elevatorprofiledpid/Robot.java
@@ -12,7 +12,6 @@ import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.motorcontrol.PWMSparkMax;
 
-@SuppressWarnings("PMD.RedundantFieldInitializer")
 public class Robot extends TimedRobot {
   private static double kDt = 0.02;
   private static double kMaxVelocity = 1.75;

--- a/wpiunits/src/main/java/edu/wpi/first/units/collections/ReadOnlyPrimitiveLongSet.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/collections/ReadOnlyPrimitiveLongSet.java
@@ -110,7 +110,6 @@ public class ReadOnlyPrimitiveLongSet implements Iterable<Long> {
   @Override
   public Iterator<Long> iterator() {
     return new Iterator<>() {
-      @SuppressWarnings("PMD.RedundantFieldInitializer")
       private int m_index = 0;
 
       @Override


### PR DESCRIPTION
Code readability is much more important than saving three bytes per redundantly-initialized field