### PR TITLE
Explicitly set Documentation archiveVersion

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -168,6 +168,7 @@ doxygen.sourceSets.main {
 
 tasks.register("zipCppDocs", Zip) {
     archiveBaseName = zipBaseNameCpp
+    archiveVersion = ""
     destinationDirectory = outputsFolder
     dependsOn doxygenDox
     from ("$buildDir/docs/doxygen/html")
@@ -247,6 +248,7 @@ task generateJavaDocs(type: Javadoc) {
 
 tasks.register("zipJavaDocs", Zip) {
     archiveBaseName = zipBaseNameJava
+    archiveVersion = ""
     destinationDirectory = outputsFolder
     dependsOn generateJavaDocs
     from ("$buildDir/docs/javadoc")


### PR DESCRIPTION
In the recent gradle or gradle dependencies update, the documentation zips were being published as documentation-version-unspecified, where the unspecified was coming from archiveVersion. It looks like we use a different method of setting the version, so make sure that archiveVersion is empty