### PR TITLE
[wpilib] Support disabling Preferences support for legacy dashboards

### DIFF
--- a/wpilibj/src/main/java/org/wpilib/util/Preferences.java
+++ b/wpilibj/src/main/java/org/wpilib/util/Preferences.java
@@ -44,6 +44,7 @@ public final class Preferences {
   private static StringPublisher m_typePublisher;
   private static MultiSubscriber m_tableSubscriber;
   private static NetworkTableListener m_listener;
+  private static boolean m_supportLegacyDashboards = true;
 
   /** Creates a preference class. */
   private Preferences() {}
@@ -59,7 +60,12 @@ public final class Preferences {
    * @param inst NetworkTable instance
    */
   public static synchronized void setNetworkTableInstance(NetworkTableInstance inst) {
-    m_table = inst.getTable(kTableName);
+    NetworkTable table = inst.getTable(kTableName);
+    if (table.equals(m_table)) {
+      return;
+    }
+    m_table = table;
+
     if (m_typePublisher != null) {
       m_typePublisher.close();
     }
@@ -70,18 +76,58 @@ public final class Preferences {
                 StringTopic.TYPE_STRING, "{\"SmartDashboard\":\"" + kSmartDashboardType + "\"}");
     m_typePublisher.set(kSmartDashboardType);
 
-    // Subscribe to all Preferences; this ensures we get the latest values
-    // ahead of a getter call.
+    if (m_supportLegacyDashboards) {
+      // Create listener to set all Preferences values to persistent
+      // (for backwards compatibility with old dashboards).
+      installTopicPersistingListener(true);
+    }
+  }
+
+  /**
+   * Enables or disables support for dashboards that create Preferences topics outside of the
+   * Preferences APIs.
+   *
+   * <p>Legacy dashboard support is enabled by default. In future releases of WPILIb, it might
+   * change to be disabled by default.
+   *
+   * @param enable Whether legacy dashboard support should be enabled
+   * @return Whether legacy dashboard support was enabled when this method was called
+   */
+  public static synchronized boolean enableLegacyDashboardSupport(boolean enable) {
+    boolean wasEnabled = m_supportLegacyDashboards;
+    if (wasEnabled != enable) {
+      installTopicPersistingListener(enable);
+      m_supportLegacyDashboards = enable;
+    }
+    return wasEnabled;
+  }
+
+  /**
+   * Creates a listener that update all Preference topics to be persistent.
+   *
+   * <p>Closes previously-installed listener and subscriber (if any).
+   *
+   * <p>This is done for backwards compatibility with old dashboards.
+   *
+   * @param install Whether to install a new listener.
+   */
+  private static synchronized void installTopicPersistingListener(boolean install) {
     if (m_tableSubscriber != null) {
       m_tableSubscriber.close();
     }
-    m_tableSubscriber = new MultiSubscriber(inst, new String[] {m_table.getPath() + "/"});
-
-    // Listener to set all Preferences values to persistent
-    // (for backwards compatibility with old dashboards).
     if (m_listener != null) {
       m_listener.close();
     }
+    if (!install) {
+      m_tableSubscriber = null;
+      m_listener = null;
+      return;
+    }
+
+    // Subscribe to all Preferences; this ensures we get the latest values
+    // ahead of a getter call.
+    NetworkTableInstance inst = m_table.getInstance();
+    m_tableSubscriber = new MultiSubscriber(inst, new String[] {m_table.getPath() + "/"});
 
     Topic typePublisherTopic = m_typePublisher.getTopic();
     m_listener =

--- a/wpilibj/src/test/java/org/wpilib/util/PreferencesTest.java
+++ b/wpilibj/src/test/java/org/wpilib/util/PreferencesTest.java
@@ -17,7 +17,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,8 +31,12 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.wpilib.networktables.NetworkTable;
+import org.wpilib.networktables.NetworkTableEntry;
+import org.wpilib.networktables.NetworkTableEvent;
 import org.wpilib.networktables.NetworkTableInstance;
+import org.wpilib.networktables.NetworkTableListener;
 import org.wpilib.networktables.Topic;
 
 @Execution(SAME_THREAD)
@@ -69,6 +76,7 @@ class PreferencesTest {
 
   @AfterEach
   void cleanup() {
+    m_inst.waitForListenerQueue(0.1);
     m_inst.close();
   }
 
@@ -119,6 +127,40 @@ class PreferencesTest {
         () -> assertEquals(2, Preferences.getInt("checkedValueInt", 0)),
         () -> assertEquals(3.4, Preferences.getFloat("checkedValueFloat", 0), 1e-6),
         () -> assertFalse(Preferences.getBoolean("checkedValueBoolean", true)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void enableLegacyDashboardSupportTest(boolean enable) throws InterruptedException {
+    // Publish a value, wait until we are sure the listener would have fired, and verify that the
+    // topic is persistent only if legacy dashboard support is enabled.
+    boolean wasEnabled = Preferences.enableLegacyDashboardSupport(enable);
+    Semaphore semaphore = new Semaphore(0);
+    NetworkTableEntry entry = m_table.getEntry("legacyDashboardValueLong");
+    try (NetworkTableListener listener =
+        NetworkTableListener.createListener(
+            entry,
+            EnumSet.of(NetworkTableEvent.Kind.IMMEDIATE, NetworkTableEvent.Kind.VALUE_ALL),
+            event -> {
+              if (event.valueData != null) {
+                semaphore.release();
+              }
+            })) {
+      // Publish a value, wait for listeners to fire, and do that again. This ensures any listener
+      // installed by Preferences would have been called at least once.
+      for (int value = 1; value < 3; value++) {
+        entry.setInteger(value);
+        m_inst.waitForListenerQueue(0.5);
+        if (!semaphore.tryAcquire(100, TimeUnit.MILLISECONDS)) {
+          fail("timed out waiting for event listener");
+        }
+      }
+      assertEquals(enable, entry.isPersistent());
+    } finally {
+      if (wasEnabled != enable) {
+        Preferences.enableLegacyDashboardSupport(wasEnabled);
+      }
+    }
   }
 
   @Nested


### PR DESCRIPTION
To support legacy dashboards, the Preferences code installed a listener that marked all new topics as persisted. Unfortunately, having a listener that updates new topics in the background can result in a closed NetworkTablesInstance being accessed (resulting in a SIGSEGV) when Preferences.setNetworkTableInstance() is called soon after values have been published for new topics (see https://github.com/wpilibsuite/allwpilib/issues/8215).

This change adds an API to disable the code that installs this listener.

The code to set new topics discovered under /Preferences as persistent was added back in 2015 in 1a8f94. Dashboards that want to want data for new keys to be saved should use the Preferences API so the topics are
marked as persistent.