### PR TITLE
[ntcore] Change ntcore_test to just exit on tsan error

### DIFF
--- a/ntcore/src/test/native/cpp/main.cpp
+++ b/ntcore/src/test/native/cpp/main.cpp
@@ -30,6 +30,7 @@ void __asan_on_error(void) {
   FAIL() << "Encountered an address sanitizer error";
 }
 void __tsan_on_report(void) {
-  FAIL() << "Encountered a thread sanitizer error";
+  std::puts("Encountered a thread sanitizer error");
+  std::_Exit(EXIT_FAILURE);
 }
 }  // extern "C"


### PR DESCRIPTION
In shutdown situations, calling FAIL() can deadlock in tsan.

Fixes #8214 (this is the only place we do this).