### PR TITLE
[ntcore] Update InstanceImpl::Destroy() to wait for listener callback completion

### DIFF
--- a/ntcore/src/main/native/cpp/InstanceImpl.cpp
+++ b/ntcore/src/main/native/cpp/InstanceImpl.cpp
@@ -77,12 +77,13 @@ int InstanceImpl::AllocImpl() {
 }
 
 void InstanceImpl::Destroy(int inst) {
-  std::scoped_lock lock(s_mutex);
-  if (inst < 0 || inst >= kNumInstances) {
-    return;
-  }
+  if (auto impl = Get(inst)) {
+    // If a callback is currently running, wait for it to complete.
+    impl->listenerStorage.Reset();
 
-  delete s_instances[inst].exchange(nullptr);
+    std::scoped_lock lock{s_mutex};
+    delete s_instances[inst].exchange(nullptr);
+  }
 }
 
 void InstanceImpl::StartLocal() {
@@ -222,6 +223,11 @@ void InstanceImpl::AddTimeSyncListener(NT_Listener listener,
 }
 
 void InstanceImpl::Reset() {
+  // Listeners sometimes call NetworkTables APIs, so reset listenerStorage
+  // first. Note that if a listener callback is running, this will wait until
+  // that callback completes.
+  listenerStorage.Reset();
+
   std::scoped_lock lock{m_mutex};
   m_networkServer.reset();
   m_networkClient.reset();
@@ -230,7 +236,6 @@ void InstanceImpl::Reset() {
   m_serverTimeOffset.reset();
   m_rtt2 = 0;
 
-  listenerStorage.Reset();
   // connectionList should have been cleared by destroying networkClient/server
   localStorage.Reset();
 }

--- a/ntcore/src/main/native/cpp/InstanceImpl.cpp
+++ b/ntcore/src/main/native/cpp/InstanceImpl.cpp
@@ -77,12 +77,13 @@ int InstanceImpl::AllocImpl() {
 }
 
 void InstanceImpl::Destroy(int inst) {
-  std::scoped_lock lock(s_mutex);
-  if (inst < 0 || inst >= NUM_INSTANCES) {
-    return;
-  }
+  if (auto impl = Get(inst)) {
+    // If a callback is currently running, wait for it to complete.
+    impl->listenerStorage.Reset();
 
-  delete s_instances[inst].exchange(nullptr);
+    std::scoped_lock lock{s_mutex};
+    delete s_instances[inst].exchange(nullptr);
+  }
 }
 
 void InstanceImpl::StartLocal() {
@@ -236,6 +237,11 @@ void InstanceImpl::AddTimeSyncListener(NT_Listener listener,
 }
 
 void InstanceImpl::Reset() {
+  // Listeners sometimes call NetworkTables APIs, so reset listenerStorage
+  // first. Note that if a listener callback is running, this will wait until
+  // that callback completes.
+  listenerStorage.Reset();
+
   std::scoped_lock lock{m_mutex};
   m_networkServer.reset();
   m_networkClient.reset();
@@ -245,7 +251,6 @@ void InstanceImpl::Reset() {
   m_serverTimeOffset.reset();
   m_rtt2 = 0;
 
-  listenerStorage.Reset();
   // connectionList should have been cleared by destroying networkClient/server
   localStorage.Reset();
 }

--- a/ntcore/src/main/native/cpp/ListenerStorage.cpp
+++ b/ntcore/src/main/native/cpp/ListenerStorage.cpp
@@ -346,17 +346,32 @@ bool ListenerStorage::WaitForListenerQueue(double timeout) {
 }
 
 void ListenerStorage::Reset() {
+  // If a callback is currently running, wait for it to complete.
   {
     std::scoped_lock lock{m_mutex};
-    m_pollers.clear();
-    m_listeners.clear();
-    m_connListeners.clear();
-    m_topicListeners.clear();
-    m_valueListeners.clear();
-    m_logListeners.clear();
-    m_timeSyncListeners.clear();
+    if (auto thr = m_thread.GetThread()) {
+      // Prevent future callbacks from running.
+      thr->m_callbacks.clear();
+    } else {
+      DoReset();
+      return;
+    }
   }
+
   m_thread.Join();
+
+  std::scoped_lock lock{m_mutex};
+  DoReset();
+}
+
+void ListenerStorage::DoReset() {
+  m_pollers.clear();
+  m_listeners.clear();
+  m_connListeners.clear();
+  m_topicListeners.clear();
+  m_valueListeners.clear();
+  m_logListeners.clear();
+  m_timeSyncListeners.clear();
 }
 
 std::vector<std::pair<NT_Listener, unsigned int>>

--- a/ntcore/src/main/native/cpp/ListenerStorage.cpp
+++ b/ntcore/src/main/native/cpp/ListenerStorage.cpp
@@ -27,6 +27,9 @@ void ListenerStorage::Thread::Main() {
     if (!events.empty()) {
       std::unique_lock lock{m_mutex};
       for (auto&& event : events) {
+        if (m_shutdown) {
+          break;
+        }
         auto callbackIt = m_callbacks.find(event.listener);
         if (callbackIt != m_callbacks.end()) {
           auto callback = callbackIt->second;
@@ -351,7 +354,7 @@ void ListenerStorage::Reset() {
     std::scoped_lock lock{m_mutex};
     if (auto thr = m_thread.GetThread()) {
       // Prevent future callbacks from running.
-      thr->m_callbacks.clear();
+      thr->m_shutdown = true;
     } else {
       DoReset();
       return;

--- a/ntcore/src/main/native/cpp/ListenerStorage.hpp
+++ b/ntcore/src/main/native/cpp/ListenerStorage.hpp
@@ -70,6 +70,7 @@ class ListenerStorage final : public IListenerStorage {
   NT_Listener DoAddListener(NT_ListenerPoller pollerHandle);
   std::vector<std::pair<NT_Listener, unsigned int>> DoRemoveListeners(
       std::span<const NT_Listener> handles);
+  void DoReset();
 
   int m_inst;
   mutable wpi::util::mutex m_mutex;

--- a/ntcore/src/main/native/cpp/ListenerStorage.hpp
+++ b/ntcore/src/main/native/cpp/ListenerStorage.hpp
@@ -114,6 +114,7 @@ class ListenerStorage final : public IListenerStorage {
     wpi::util::DenseMap<NT_Listener, ListenerCallback> m_callbacks;
     wpi::util::Event m_waitQueueWakeup;
     wpi::util::Event m_waitQueueWaiter;
+    bool m_shutdown{false};
   };
   wpi::util::SafeThreadOwner<Thread> m_thread;
 };

--- a/ntcore/src/main/native/include/wpi/nt/ntcore_cpp.hpp
+++ b/ntcore/src/main/native/include/wpi/nt/ntcore_cpp.hpp
@@ -416,13 +416,16 @@ NT_Inst CreateInstance();
 /**
  * Reset the internals of an instance. Every handle previously associated
  * with this instance will no longer be valid, except for the instance
- * handle.
+ * handle. This should not be called from a listener callback.
  */
 void ResetInstance(NT_Inst inst);
 
 /**
  * Destroy an instance.
  * The default instance cannot be destroyed.
+ * This should not be called from a listener callback.
+ * The behavior of concurrent calls of this function on the same instance is
+ * undefined.
  *
  * @param inst Instance handle
  */

--- a/ntcore/src/test/native/cpp/TableListenerTest.cpp
+++ b/ntcore/src/test/native/cpp/TableListenerTest.cpp
@@ -2,14 +2,22 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include <catch2/catch_test_macros.hpp>
+#include "InstanceImpl.hpp"
+#undef INFO
+#undef WARN
 
-#include "TestPrinters.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_templated.hpp>
+
+#include "Handle.hpp"
 #include "wpi/nt/DoubleTopic.hpp"
+#include "wpi/nt/IntegerTopic.hpp"
 #include "wpi/nt/NetworkTableInstance.hpp"
 #include "wpi/nt/ntcore_cpp.hpp"
 
@@ -32,6 +40,48 @@ void TableListenerTest::PublishTopics() {
   m_foovalue = m_inst.GetDoubleTopic("/foo/foovalue").Publish();
   m_barvalue = m_inst.GetDoubleTopic("/foo/bar/barvalue").Publish();
   m_bazvalue = m_inst.GetDoubleTopic("/baz/bazvalue").Publish();
+}
+
+// Matchers for checking the validity of a NetworkTableInstance.
+//
+// Note: These tests cannot simply rely on inst.m_handle since
+// NetworkTableInstance::Destroy() zeroeds it after it calls
+// DestroyInstance().
+
+template <typename T>
+class Matcher
+    : public Catch::Matchers::MatcherBase<wpi::nt::NetworkTableInstance> {
+ public:
+  std::string description() const { return describe(); }
+};
+
+struct HasHandleMatcher : public Matcher<wpi::nt::NetworkTableInstance> {
+ public:
+  bool match(const wpi::nt::NetworkTableInstance& arg) const override {
+    return !!arg.GetHandle();
+  }
+
+  std::string describe() const override { return "has a valid handle"; }
+};
+HasHandleMatcher HasHandle() {
+  return {};
+}
+
+struct MapsToInstanceImplMatcher
+    : public Matcher<wpi::nt::NetworkTableInstance> {
+  bool match(const wpi::nt::NetworkTableInstance& arg) const override {
+    auto handle = arg.GetHandle();
+    if (!handle) {
+      return false;
+    }
+    int inst = wpi::nt::Handle{handle}.GetTypedInst(wpi::nt::Handle::INSTANCE);
+    return wpi::nt::InstanceImpl::Get(inst) != nullptr;
+  }
+
+  std::string describe() const override { return "maps to an InstanceImpl"; }
+};
+MapsToInstanceImplMatcher MapsToInstanceImpl() {
+  return {};
 }
 
 TEST_CASE_METHOD(TableListenerTest, "TableListenerTest AddListener",
@@ -74,4 +124,208 @@ TEST_CASE_METHOD(TableListenerTest, "TableListenerTest AddSubTableListener",
   REQUIRE(listenerCalls.size() == 1u);
   CHECK(listenerCalls[0].parent == table.get());
   CHECK(listenerCalls[0].name == "bar");
+}
+
+// Thread-safe assertions.
+class Assertions {
+ public:
+  struct Event {
+    std::string m_msg;
+    bool m_isFailure;
+  };
+
+  struct Shared {
+    wpi::util::mutex m_mutex;
+    std::vector<Event> m_events;
+  };
+
+  Assertions() : m_shared{std::make_shared<Shared>()} {}
+
+  Assertions(const Assertions& other)
+      : m_shared{other.m_shared}, m_isChild{true} {}
+
+  ~Assertions() {
+    if (!m_isChild) {
+      LogEvents();
+    }
+  }
+
+  void Info(const char* message, const char* file, int line) {
+    std::unique_lock lock{m_shared->m_mutex};
+    m_shared->m_events.push_back(
+        {std::format("{}:{} {}", file, line, message), false});
+  }
+
+  void Check(bool predicate, const char* message, const char* file, int line) {
+    if (!predicate) {
+      std::unique_lock lock{m_shared->m_mutex};
+      m_shared->m_events.push_back(
+          {std::format("{}:{} {}", file, line, message), true});
+    }
+  }
+
+  void Fail(const char* message, const char* file, int line) {
+    Check(false, message, file, line);
+  }
+
+  template <typename T>
+  void CheckThat(T arg, const Matcher<T>& matcher, const char* file, int line) {
+    if (!matcher.match(arg)) {
+      std::unique_lock lock{m_shared->m_mutex};
+      m_shared->m_events.push_back(
+          {std::format("{}:{} {}", file, line, matcher.description()), true});
+    }
+  }
+
+ private:
+  mutable std::shared_ptr<Shared> m_shared;
+  bool m_isChild = false;
+
+  void LogEvents() {
+    std::unique_lock lock{m_shared->m_mutex};
+    bool hasFailures = false;
+    for (auto& event : m_shared->m_events) {
+      if (event.m_isFailure) {
+        WARN("CHECK failed: " + event.m_msg);
+        hasFailures = true;
+      } else {
+        INFO(event.m_msg);
+      }
+    }
+    CHECK_FALSE(hasFailures);
+  }
+};
+
+// Thread-safe assertion macros.
+// Assumes a variable named "assertions" of type Assertions.
+
+#define T_CHECK(predicate, message) \
+  assertions.Check(predicate, message, __FILE__, __LINE__)
+
+#define T_CHECK_THAT(arg, matcher) \
+  assertions.CheckThat(arg, matcher, __FILE__, __LINE__)
+
+#define T_FAIL(message) assertions.Fail(message, __FILE__, __LINE__)
+
+#define T_INFO(message) assertions.Info(message, __FILE__, __LINE__)
+
+// Verifies that a call to NetworkTableInstance::Destroy() made while a listener
+// is being called does not result in a crash (see
+// https://github.com/wpilibsuite/allwpilib/issues/8215).
+TEST_CASE_METHOD(TableListenerTest,
+                 "TableListenerTest DestroyInstanceWhileInCallack",
+                 "[ntcore][table-listener]") {
+  std::atomic_bool destroyCalled(false);
+  std::atomic_bool destroyReturned(false);
+  std::atomic_bool callbackWokeUp(false);
+  std::atomic_bool callbackSuccessful(false);
+  std::atomic_bool destroyerSuccessful(false);
+  auto listenerCalledEvent = wpi::util::MakeEvent(false, false);
+  auto listenerDoneEvent = wpi::util::MakeEvent(false, false);
+  auto destroyerThreadReadyEvent = wpi::util::MakeEvent(false, false);
+  auto destroyerThreadDoneEvent = wpi::util::MakeEvent(false, false);
+  auto exitListenerEvent = wpi::util::MakeEvent(false, false);
+  auto table = m_inst.GetTable("/Preferences");
+  Assertions assertions;
+
+  // Add a listener that blocks while Destroy() is called.
+  //
+  // Events;
+  // - Sets listenerCalledEvent when called
+  // - Waits for exitListenerEvent
+  // - Sets listenerDoneEvent before exiting
+  table->AddListener(
+      NT_EVENT_TOPIC | NT_EVENT_IMMEDIATE,
+      [&, assertions, inst = m_inst](auto table, auto key,
+                                     auto& event) mutable {
+        T_CHECK_THAT(inst, HasHandle());
+        T_CHECK_THAT(inst, MapsToInstanceImpl());
+        wpi::util::SetEvent(listenerCalledEvent);
+        T_INFO(
+            "[Listener] Sent listenerCalledEvent; waiting for "
+            "exitListenerEvent");
+
+        // Block the listener. This should block Destroy() from exiting.
+        bool timedOut;
+        T_CHECK(wpi::util::WaitForObject(exitListenerEvent, 1.0, &timedOut),
+                "[Listener] WaitForObject(exitListenerEvent)");
+        callbackWokeUp = true;
+        if (!timedOut) {
+          // Assert that the instance is still valid.
+          T_INFO("[Listener] Received exitListenerEvent");
+          T_CHECK(destroyCalled, "[Listener] destroyCalled");
+          if (destroyCalled) {
+            T_CHECK(!destroyReturned, "[Listener] !destroyReturned");
+            if (!destroyReturned) {
+              T_CHECK_THAT(inst, HasHandle());
+              T_CHECK_THAT(inst, MapsToInstanceImpl());
+            }
+          }
+        }
+
+        wpi::util::SetEvent(listenerDoneEvent);
+        T_INFO("[Listener] Sent listenerDoneEvent; exiting");
+        T_CHECK(!timedOut, "[Listener] !timedOut");
+        callbackSuccessful = true;
+      });
+
+  auto publisher = m_inst.GetIntegerTopic("/Preferences/key").Publish();
+  T_CHECK(wpi::util::WaitForObject(listenerCalledEvent, 1.0, NULL),
+          "[Test thread] WaitForObject(listenerCalledEvent)");
+
+  // Check preconditions.
+  T_CHECK_THAT(m_inst, HasHandle());
+  T_CHECK_THAT(m_inst, MapsToInstanceImpl());
+
+  // Call Destroy() in a separate thread, in case in hangs.
+  //
+  // Events:
+  // - Sets destroyerThreadReadyEvent when ready
+  // - Sets destroyerThreadDoneEvent before exiting
+  T_INFO("[Test thread] Starting destroyer thread");
+  auto destroyerThread = std::thread([&, assertions]() mutable {
+    T_CHECK(!callbackWokeUp, "[Destroyer thread] !callbackWokeUp");
+    destroyCalled = true;
+    wpi::util::SetEvent(destroyerThreadReadyEvent);
+    T_INFO("[Destroyer thread] Calling Destroy()");
+
+    wpi::nt::NetworkTableInstance::Destroy(m_inst);
+    T_INFO("[Destroyer thread] Returned from Destroy()");
+    destroyReturned = true;
+
+    // Verify Destroy() deleted the instance.
+    T_CHECK(!m_inst, "[Destroyer thread] !m_inst");
+    T_CHECK(callbackWokeUp, "[Destroyer thread] callbackWokeUp");
+    destroyerSuccessful = callbackWokeUp && !m_inst;
+    wpi::util::SetEvent(destroyerThreadDoneEvent);
+  });
+
+  bool timedOut = false;
+  T_CHECK(wpi::util::WaitForObject(destroyerThreadReadyEvent, 2.0, &timedOut),
+          "[Test thread] WaitForObject(destroyerThreadReadyEvent)");
+  if (timedOut) {
+    T_INFO("[Test thread] Timed out waiting for destroyerThreadReadyEvent");
+    wpi::util::SetEvent(exitListenerEvent);
+    wpi::util::WaitForObject(listenerDoneEvent, 3.0, NULL);
+    T_FAIL("Timed out waiting for destroyerThreadReadyEvent");
+    return;
+  }
+  T_INFO("[Test thread] Received destroyerThreadReadyEvent");
+
+  // Wait long enough to ensure destroyerThread is blocked inside Destroy()
+  std::this_thread::sleep_for(std::chrono::milliseconds(4));
+  T_INFO("[Test thread] Sending exitListenerEvent");
+  wpi::util::SetEvent(exitListenerEvent);
+
+  T_CHECK(wpi::util::WaitForObject(listenerDoneEvent, 3.0, NULL),
+          "[Test thread] Timed out waiting for listenerDoneEvent");
+  T_CHECK(wpi::util::WaitForObject(destroyerThreadDoneEvent, 1.0, &timedOut),
+          "[Test thread] Timed out waiting for destroyerThreadDoneEvent");
+  if (!timedOut && destroyerThread.joinable()) {
+    destroyerThread.join();
+  }
+
+  T_CHECK(callbackSuccessful, "[Test thread] callbackSuccessful");
+  T_CHECK(destroyerSuccessful, "[Test thread] destroyerSuccessfull");
+  T_CHECK(!m_inst, "[Test thread] !m_inst");
 }

--- a/ntcore/src/test/native/cpp/TableListenerTest.cpp
+++ b/ntcore/src/test/native/cpp/TableListenerTest.cpp
@@ -321,8 +321,12 @@ TEST_CASE_METHOD(TableListenerTest,
           "[Test thread] Timed out waiting for listenerDoneEvent");
   T_CHECK(wpi::util::WaitForObject(destroyerThreadDoneEvent, 1.0, &timedOut),
           "[Test thread] Timed out waiting for destroyerThreadDoneEvent");
-  if (!timedOut && destroyerThread.joinable()) {
-    destroyerThread.join();
+  if (destroyerThread.joinable()) {
+    if (timedOut) {
+      destroyerThread.detach();
+    } else {
+      destroyerThread.join();
+    }
   }
 
   T_CHECK(callbackSuccessful, "[Test thread] callbackSuccessful");

--- a/ntcore/src/test/native/cpp/TableListenerTest.cpp
+++ b/ntcore/src/test/native/cpp/TableListenerTest.cpp
@@ -308,6 +308,10 @@ TEST_CASE_METHOD(TableListenerTest,
     wpi::util::SetEvent(exitListenerEvent);
     wpi::util::WaitForObject(listenerDoneEvent, 3.0, NULL);
     T_FAIL("Timed out waiting for destroyerThreadReadyEvent");
+
+    if (destroyerThread.joinable()) {
+      destroyerThread.detach();
+    }
     return;
   }
   T_INFO("[Test thread] Received destroyerThreadReadyEvent");

--- a/ntcore/src/test/native/cpp/TableListenerTest.cpp
+++ b/ntcore/src/test/native/cpp/TableListenerTest.cpp
@@ -109,9 +109,9 @@ TEST_CASE_METHOD(TableListenerTest,
 
   table->AddListener(
       NT_EVENT_TOPIC | NT_EVENT_IMMEDIATE,
-      [&](auto table, auto key, auto& event) {
-        CHECK_THAT(m_inst, HasHandle());
-        CHECK_THAT(m_inst, MapsToInstanceImpl());
+      [&, inst = m_inst](auto table, auto key, auto& event) {
+        CHECK_THAT(inst, HasHandle());
+        CHECK_THAT(inst, MapsToInstanceImpl());
         wpi::util::SetEvent(listenerCalledEvent);
         INFO(
             "[Listener] Sent listenerCalledEvent; waiting for "
@@ -135,8 +135,8 @@ TEST_CASE_METHOD(TableListenerTest,
             if (destroyCalled) {
               CHECK(!destroyReturned);
               if (!destroyReturned) {
-                CHECK_THAT(m_inst, HasHandle());
-                CHECK_THAT(m_inst, MapsToInstanceImpl());
+                CHECK_THAT(inst, HasHandle());
+                CHECK_THAT(inst, MapsToInstanceImpl());
               }
             }
           }

--- a/ntcore/src/test/native/cpp/TableListenerTest.cpp
+++ b/ntcore/src/test/native/cpp/TableListenerTest.cpp
@@ -93,12 +93,12 @@ TEST_CASE_METHOD(TableListenerTest, "TableListenerTest AddListener",
 TEST_CASE_METHOD(TableListenerTest,
                  "TableListenerTest DestroyInstanceWhileInCallack",
                  "[ntcore][table-listener]") {
-  std::atomic_bool destroyCalled;
-  std::atomic_bool destroyReturned;
-  std::atomic_bool majorFailureDetected;
-  std::atomic_bool callbackWokeUp;
-  std::atomic_bool callbackSuccessful;
-  std::atomic_bool destroyerSuccessful;
+  std::atomic_bool destroyCalled(false);
+  std::atomic_bool destroyReturned(false);
+  std::atomic_bool majorFailureDetected(false);
+  std::atomic_bool callbackWokeUp(false);
+  std::atomic_bool callbackSuccessful(false);
+  std::atomic_bool destroyerSuccessful(false);
   auto listenerCalledEvent = wpi::util::MakeEvent(false, false);
   auto listenerDoneEvent = wpi::util::MakeEvent(false, false);
   auto destroyerThreadStartedEvent = wpi::util::MakeEvent(false, false);
@@ -144,8 +144,8 @@ TEST_CASE_METHOD(TableListenerTest,
 
         wpi::util::SetEvent(listenerDoneEvent);
         INFO("[Listener] Sent listenerDoneEvent; exiting");
-        REQUIRE(!timedOut);
-        REQUIRE(!majorFailureDetected);
+        CHECK(!timedOut);
+        CHECK(!majorFailureDetected);
         callbackSuccessful = true;
       });
 
@@ -176,14 +176,14 @@ TEST_CASE_METHOD(TableListenerTest,
     wpi::util::SetEvent(destroyerThreadDoneEvent);
   });
 
-  bool timedOut;
+  bool timedOut = false;
   CHECK(wpi::util::WaitForObject(destroyerThreadReadyEvent, 2.0, &timedOut));
   if (timedOut) {
     INFO("[Test thread] Timed out waiting for destroyerThreadReadyEvent");
     majorFailureDetected = true;  // Ensure traces from the listener are shown
     wpi::util::SetEvent(exitListenerEvent);
     wpi::util::WaitForObject(listenerDoneEvent, 3.0, NULL);
-    REQUIRE(majorFailureDetected);
+    FAIL("Timed out waiting for destroyerThreadReadyEvent");
     return;
   }
   INFO("[Test thread] Received destroyerThreadReadyEvent");

--- a/ntcore/src/test/native/cpp/TableListenerTest.cpp
+++ b/ntcore/src/test/native/cpp/TableListenerTest.cpp
@@ -2,14 +2,22 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include <catch2/catch_test_macros.hpp>
+#include "InstanceImpl.hpp"
+#undef INFO
+#undef WARN
 
-#include "TestPrinters.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_templated.hpp>
+
+#include "Handle.hpp"
 #include "wpi/nt/DoubleTopic.hpp"
+#include "wpi/nt/IntegerTopic.hpp"
 #include "wpi/nt/NetworkTableInstance.hpp"
 #include "wpi/nt/ntcore_cpp.hpp"
 
@@ -34,6 +42,33 @@ void TableListenerTest::PublishTopics() {
   m_bazvalue = m_inst.GetDoubleTopic("/baz/bazvalue").Publish();
 }
 
+// Matchers for checking the validity of a NetworkTableInstance.
+//
+// Note: These tests cannot simply rely on inst.m_handle since
+// NetworkTableInstance::Destroy() zeroeds it after it calls
+// DestroyInstance().
+
+struct HasHandle : Catch::Matchers::MatcherGenericBase {
+  bool match(const wpi::nt::NetworkTableInstance& arg) const {
+    return !!arg.GetHandle();
+  }
+
+  std::string describe() const override { return "has a valid handle"; }
+};
+
+struct MapsToInstanceImpl : Catch::Matchers::MatcherGenericBase {
+  bool match(const wpi::nt::NetworkTableInstance& arg) const {
+    auto handle = arg.GetHandle();
+    if (!handle) {
+      return false;
+    }
+    int inst = wpi::nt::Handle{handle}.GetTypedInst(wpi::nt::Handle::INSTANCE);
+    return wpi::nt::InstanceImpl::Get(inst) != nullptr;
+  }
+
+  std::string describe() const override { return "maps to an InstanceImpl"; }
+};
+
 TEST_CASE_METHOD(TableListenerTest, "TableListenerTest AddListener",
                  "[ntcore][table-listener]") {
   auto table = m_inst.GetTable("/foo");
@@ -53,6 +88,120 @@ TEST_CASE_METHOD(TableListenerTest, "TableListenerTest AddListener",
   REQUIRE(listenerCalls.size() == 1u);
   CHECK(listenerCalls[0].table == table.get());
   CHECK(listenerCalls[0].key == "foovalue");
+}
+
+TEST_CASE_METHOD(TableListenerTest,
+                 "TableListenerTest DestroyInstanceWhileInCallack",
+                 "[ntcore][table-listener]") {
+  std::atomic_bool destroyCalled;
+  std::atomic_bool destroyReturned;
+  std::atomic_bool majorFailureDetected;
+  std::atomic_bool callbackWokeUp;
+  std::atomic_bool callbackSuccessful;
+  std::atomic_bool destroyerSuccessful;
+  auto listenerCalledEvent = wpi::util::MakeEvent(false, false);
+  auto listenerDoneEvent = wpi::util::MakeEvent(false, false);
+  auto destroyerThreadStartedEvent = wpi::util::MakeEvent(false, false);
+  auto destroyerThreadReadyEvent = wpi::util::MakeEvent(false, false);
+  auto destroyerThreadDoneEvent = wpi::util::MakeEvent(false, false);
+  auto exitListenerEvent = wpi::util::MakeEvent(false, false);
+  auto table = m_inst.GetTable("/Preferences");
+
+  table->AddListener(
+      NT_EVENT_TOPIC | NT_EVENT_IMMEDIATE,
+      [&](auto table, auto key, auto& event) {
+        CHECK_THAT(m_inst, HasHandle());
+        CHECK_THAT(m_inst, MapsToInstanceImpl());
+        wpi::util::SetEvent(listenerCalledEvent);
+        INFO(
+            "[Listener] Sent listenerCalledEvent; waiting for "
+            "destroyerThreadStartedEvent");
+
+        bool timedOut;
+        CHECK(wpi::util::WaitForObject(destroyerThreadStartedEvent, 1.0,
+                                       &timedOut));
+        if (!timedOut) {
+          INFO(
+              "[Listener] Received destroyerThreadStartedEvent; waiting for "
+              "exitListenerEvent");
+
+          // Block Destroy()
+          CHECK(wpi::util::WaitForObject(exitListenerEvent, 2.0, &timedOut));
+          callbackWokeUp = true;
+
+          if (!timedOut) {
+            INFO("[Listener] Received exitListenerEvent");
+            CHECK(destroyCalled);
+            if (destroyCalled) {
+              CHECK(!destroyReturned);
+              if (!destroyReturned) {
+                CHECK_THAT(m_inst, HasHandle());
+                CHECK_THAT(m_inst, MapsToInstanceImpl());
+              }
+            }
+          }
+        }
+
+        wpi::util::SetEvent(listenerDoneEvent);
+        INFO("[Listener] Sent listenerDoneEvent; exiting");
+        REQUIRE(!timedOut);
+        REQUIRE(!majorFailureDetected);
+        callbackSuccessful = true;
+      });
+
+  auto publisher = m_inst.GetIntegerTopic("/Preferences/key").Publish();
+  REQUIRE(wpi::util::WaitForObject(listenerCalledEvent, 1.0, NULL));
+
+  REQUIRE_THAT(m_inst, HasHandle());
+  REQUIRE_THAT(m_inst, MapsToInstanceImpl());
+
+  // Call Destroy() in a separate thread, in case in hangs.
+  // Note: After the thread is created, use EXPECT_*() tests until thread
+  // joined.
+  INFO("[Test thread] Starting destroyer thread");
+  auto destroyerThread = std::thread([&]() {
+    wpi::util::SetEvent(destroyerThreadStartedEvent);
+    CHECK(!callbackWokeUp);
+    destroyCalled = true;
+    wpi::util::SetEvent(destroyerThreadReadyEvent);
+    INFO("[Destroyer thread] Calling Destroy()");
+
+    wpi::nt::NetworkTableInstance::Destroy(m_inst);
+    INFO("[Destroyer thread] Returned from Destroy()");
+    destroyReturned = true;
+
+    CHECK(!m_inst);
+    CHECK(callbackWokeUp);
+    destroyerSuccessful = callbackWokeUp && !m_inst;
+    wpi::util::SetEvent(destroyerThreadDoneEvent);
+  });
+
+  bool timedOut;
+  CHECK(wpi::util::WaitForObject(destroyerThreadReadyEvent, 2.0, &timedOut));
+  if (timedOut) {
+    INFO("[Test thread] Timed out waiting for destroyerThreadReadyEvent");
+    majorFailureDetected = true;  // Ensure traces from the listener are shown
+    wpi::util::SetEvent(exitListenerEvent);
+    wpi::util::WaitForObject(listenerDoneEvent, 3.0, NULL);
+    REQUIRE(majorFailureDetected);
+    return;
+  }
+  INFO("[Test thread] Received destroyerThreadReadyEvent");
+
+  // Wait long enough to ensure destroyerThread is blocked inside Destroy()
+  std::this_thread::sleep_for(std::chrono::milliseconds(4));
+  INFO("[Test thread] Sending exitListenerEvent");
+  wpi::util::SetEvent(exitListenerEvent);
+
+  CHECK(wpi::util::WaitForObject(listenerDoneEvent, 3.0, NULL));
+  CHECK(wpi::util::WaitForObject(destroyerThreadDoneEvent, 1.0, &timedOut));
+  if (!timedOut && destroyerThread.joinable()) {
+    destroyerThread.join();
+  }
+
+  CHECK(callbackSuccessful);
+  CHECK(destroyerSuccessful);
+  CHECK(!m_inst);
 }
 
 TEST_CASE_METHOD(TableListenerTest, "TableListenerTest AddSubTableListener",


### PR DESCRIPTION
This can add a delay if NetworkTableInstance::Destroy() is called while a
Listener callback is running.

Fixes #8215