### PR TITLE
[epilogue] Support logging of protobuf-serializable types

### DIFF
--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/AnnotationProcessor.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/AnnotationProcessor.java
@@ -112,7 +112,8 @@ public class AnnotationProcessor extends AbstractProcessor {
             new MeasureHandler(processingEnv),
             new PrimitiveHandler(processingEnv),
             new SupplierHandler(processingEnv),
-            new StructHandler(processingEnv), // prioritize struct over sendable
+            new StructHandler(processingEnv), // prioritize struct over sendable and protobuf
+            new ProtobufHandler(processingEnv), // then protobuf
             new SendableHandler(processingEnv));
 
     m_epiloguerGenerator = new EpilogueGenerator(processingEnv, customLoggers);

--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
@@ -1142,6 +1142,76 @@ class AnnotationProcessorTest {
   }
 
   @Test
+  void protobuf() {
+    String source =
+        """
+      package edu.wpi.first.epilogue;
+
+      import edu.wpi.first.util.protobuf.Protobuf;
+      import edu.wpi.first.util.protobuf.ProtobufSerializable;
+      import java.util.List;
+      import us.hebi.quickbuf.*;
+
+      class ProtobufType implements ProtobufSerializable {
+        // Message type is necessary - Epilogue can't log with a wildcard message type in the proto
+        public static final Protobuf<ProtobufType, Message> proto = null; // value doesn't matter
+
+        static class Message extends ProtoMessage<Message> {
+          // Implement stubs for the abstract base class.
+          // This code never runs so actual implementations are unnecessary.
+          @Override
+          public Message copyFrom(Message other) { return null; }
+          @Override
+          public Message clear() { return null; }
+          @Override
+          public int computeSerializedSize() { return 0; }
+          @Override
+          public void writeTo(ProtoSink output) {}
+          @Override
+          public Message mergeFrom(ProtoSource input) { return null; }
+          @Override
+          public boolean equals(Object obj) { return false; }
+          @Override
+          public Message clone() { return null; }
+        }
+      }
+
+      @Logged
+      class Example {
+        ProtobufType x;          // Should be logged
+        ProtobufType[] arr1;     // Should not be logged
+        ProtobufType[][] arr2;   // Should not be logged
+        List<ProtobufType> list; // Should not be logged
+      }
+      """;
+
+    String expectedGeneratedSource =
+        """
+      package edu.wpi.first.epilogue;
+
+      import edu.wpi.first.epilogue.Logged;
+      import edu.wpi.first.epilogue.Epilogue;
+      import edu.wpi.first.epilogue.logging.ClassSpecificLogger;
+      import edu.wpi.first.epilogue.logging.EpilogueBackend;
+
+      public class ExampleLogger extends ClassSpecificLogger<Example> {
+        public ExampleLogger() {
+          super(Example.class);
+        }
+
+        @Override
+        public void update(EpilogueBackend backend, Example object) {
+          if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
+            backend.log("x", object.x, edu.wpi.first.epilogue.ProtobufType.proto);
+          }
+        }
+      }
+      """;
+
+    assertLoggerGenerates(source, expectedGeneratedSource);
+  }
+
+  @Test
   void lists() {
     String source =
         """

--- a/epilogue-runtime/BUILD.bazel
+++ b/epilogue-runtime/BUILD.bazel
@@ -8,5 +8,6 @@ java_library(
         "//ntcore:networktables-java",
         "//wpiunits",
         "//wpiutil:wpiutil-java",
+        "@maven//:us_hebi_quickbuf_quickbuf_runtime",
     ],
 )

--- a/epilogue-runtime/build.gradle
+++ b/epilogue-runtime/build.gradle
@@ -13,4 +13,5 @@ dependencies {
     api(project(':ntcore'))
     api(project(':wpiutil'))
     api(project(':wpiunits'))
+    testImplementation(project(':wpimath')) // for convenient protobuf types
 }

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/EpilogueBackend.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/EpilogueBackend.java
@@ -6,8 +6,10 @@ package edu.wpi.first.epilogue.logging;
 
 import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.Unit;
+import edu.wpi.first.util.protobuf.Protobuf;
 import edu.wpi.first.util.struct.Struct;
 import java.util.Collection;
+import us.hebi.quickbuf.ProtoMessage;
 
 /** A backend is a generic interface for Epilogue to log discrete data points. */
 public interface EpilogueBackend {
@@ -192,6 +194,17 @@ public interface EpilogueBackend {
     S[] array = (S[]) value.toArray(Object[]::new);
     log(identifier, array, struct);
   }
+
+  /**
+   * Logs a protobuf-serializable object.
+   *
+   * @param identifier the identifier of the data point
+   * @param value the value of the data point
+   * @param proto the protobuf to use to serialize the data
+   * @param <P> the protobuf-serializable type
+   * @param <M> the protobuf message type
+   */
+  <P, M extends ProtoMessage<M>> void log(String identifier, P value, Protobuf<P, M> proto);
 
   /**
    * Logs a measurement's value in terms of its base unit.

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/LazyBackend.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/LazyBackend.java
@@ -4,11 +4,13 @@
 
 package edu.wpi.first.epilogue.logging;
 
+import edu.wpi.first.util.protobuf.Protobuf;
 import edu.wpi.first.util.struct.Struct;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import us.hebi.quickbuf.ProtoMessage;
 
 /**
  * A backend implementation that only logs data when it changes. Useful for keeping bandwidth and
@@ -242,5 +244,18 @@ public class LazyBackend implements EpilogueBackend {
 
     m_previousValues.put(identifier, value.clone());
     m_backend.log(identifier, value, struct);
+  }
+
+  @Override
+  public <P, M extends ProtoMessage<M>> void log(String identifier, P value, Protobuf<P, M> proto) {
+    var previous = m_previousValues.get(identifier);
+
+    if (Objects.equals(previous, value)) {
+      // no change
+      return;
+    }
+
+    m_previousValues.put(identifier, value);
+    m_backend.log(identifier, value, proto);
   }
 }

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/MultiBackend.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/MultiBackend.java
@@ -4,10 +4,12 @@
 
 package edu.wpi.first.epilogue.logging;
 
+import edu.wpi.first.util.protobuf.Protobuf;
 import edu.wpi.first.util.struct.Struct;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import us.hebi.quickbuf.ProtoMessage;
 
 /**
  * A backend implementation that delegates to other backends. Helpful for simultaneous logging to
@@ -135,6 +137,13 @@ public class MultiBackend implements EpilogueBackend {
   public <S> void log(String identifier, S[] value, Struct<S> struct) {
     for (EpilogueBackend backend : m_backends) {
       backend.log(identifier, value, struct);
+    }
+  }
+
+  @Override
+  public <P, M extends ProtoMessage<M>> void log(String identifier, P value, Protobuf<P, M> proto) {
+    for (EpilogueBackend backend : m_backends) {
+      backend.log(identifier, value, proto);
     }
   }
 }

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/NestedBackend.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/NestedBackend.java
@@ -4,9 +4,11 @@
 
 package edu.wpi.first.epilogue.logging;
 
+import edu.wpi.first.util.protobuf.Protobuf;
 import edu.wpi.first.util.struct.Struct;
 import java.util.HashMap;
 import java.util.Map;
+import us.hebi.quickbuf.ProtoMessage;
 
 /**
  * A backend that logs to an underlying backend, prepending all logged data with a specific prefix.
@@ -146,5 +148,10 @@ public class NestedBackend implements EpilogueBackend {
   @Override
   public <S> void log(String identifier, S[] value, Struct<S> struct) {
     m_impl.log(withPrefix(identifier), value, struct);
+  }
+
+  @Override
+  public <P, M extends ProtoMessage<M>> void log(String identifier, P value, Protobuf<P, M> proto) {
+    m_impl.log(m_prefix + identifier, value, proto);
   }
 }

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/NullBackend.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/logging/NullBackend.java
@@ -4,7 +4,9 @@
 
 package edu.wpi.first.epilogue.logging;
 
+import edu.wpi.first.util.protobuf.Protobuf;
 import edu.wpi.first.util.struct.Struct;
+import us.hebi.quickbuf.ProtoMessage;
 
 /** Null backend implementation that logs nothing. */
 public class NullBackend implements EpilogueBackend {
@@ -62,4 +64,8 @@ public class NullBackend implements EpilogueBackend {
 
   @Override
   public <S> void log(String identifier, S[] value, Struct<S> struct) {}
+
+  @Override
+  public <P, M extends ProtoMessage<M>> void log(
+      String identifier, P value, Protobuf<P, M> proto) {}
 }

--- a/epilogue-runtime/src/test/java/edu/wpi/first/epilogue/logging/LazyBackendTest.java
+++ b/epilogue-runtime/src/test/java/edu/wpi/first/epilogue/logging/LazyBackendTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import edu.wpi.first.math.geometry.Rotation2d;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -184,5 +185,18 @@ class LazyBackendTest {
         new byte[] {0x00, 0x00, 0x00, 0x00}, (byte[]) backend.getEntries().get(0).value());
     assertArrayEquals(
         new byte[] {0x01, 0x00, 0x00, 0x00}, (byte[]) backend.getEntries().get(1).value());
+  }
+
+  @Test
+  void lazyProtobuf() {
+    var backend = new TestBackend();
+    var lazy = new LazyBackend(backend);
+
+    var rotation = Rotation2d.kZero;
+    lazy.log("rotation", rotation, Rotation2d.proto);
+    assertEquals(1, backend.getEntries().size());
+    var entry = backend.getEntries().get(0);
+    assertEquals("rotation", entry.identifier());
+    assertArrayEquals(new byte[] {9, 0, 0, 0, 0, 0, 0, 0, 0}, (byte[]) entry.value());
   }
 }

--- a/epilogue-runtime/src/test/java/edu/wpi/first/epilogue/logging/TestBackend.java
+++ b/epilogue-runtime/src/test/java/edu/wpi/first/epilogue/logging/TestBackend.java
@@ -4,12 +4,14 @@
 
 package edu.wpi.first.epilogue.logging;
 
+import edu.wpi.first.util.protobuf.Protobuf;
 import edu.wpi.first.util.struct.Struct;
 import edu.wpi.first.util.struct.StructBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import us.hebi.quickbuf.ProtoMessage;
 
 @SuppressWarnings("PMD.TestClassWithoutTestCases") // This is not a test class!
 public class TestBackend implements EpilogueBackend {
@@ -112,6 +114,14 @@ public class TestBackend implements EpilogueBackend {
       serialized[i] = buffer.get();
     }
 
+    m_entries.add(new LogEntry<>(identifier, serialized));
+  }
+
+  @Override
+  public <P, M extends ProtoMessage<M>> void log(String identifier, P value, Protobuf<P, M> proto) {
+    var msg = proto.createMessage();
+    proto.pack(msg, value);
+    var serialized = msg.toByteArray();
     m_entries.add(new LogEntry<>(identifier, serialized));
   }
 }


### PR DESCRIPTION
For parity with struct-serializable types

Change struct serialization to only apply to types with a `public static final <type> struct` field, instead of relying only on the marker interface (which is not always followed). Doing this allows fallthrough to the protobuf handler for types with dynamic structs but static protobuf serializers