### PR TITLE
Fix Gradle 9 `archives` deprecation warning

### DIFF
--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -39,11 +39,13 @@ task outputJavadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 artifacts {
-    archives sourcesJar
-    archives javadocJar
-    archives outputJar
-    archives outputSourcesJar
-    archives outputJavadocJar
+    tasks.named("assemble") {
+        dependsOn(sourcesJar)
+        dependsOn(javadocJar)
+        dependsOn(outputJar)
+        dependsOn(outputSourcesJar)
+        dependsOn(outputJavadocJar)
+    }
 }
 
 addTaskToCopyAllOutputs(outputSourcesJar)

--- a/shared/javacpp/publish.gradle
+++ b/shared/javacpp/publish.gradle
@@ -47,8 +47,10 @@ task cppHeadersZip(type: Zip) {
 }
 
 artifacts {
-    archives cppHeadersZip
-    archives cppSourcesZip
+    tasks.named("assemble") {
+        dependsOn(cppHeadersZip)
+        dependsOn(cppSourcesZip)
+    }
 }
 
 addTaskToCopyAllOutputs(cppSourcesZip)

--- a/shared/jni/publish.gradle
+++ b/shared/jni/publish.gradle
@@ -62,8 +62,10 @@ task cppHeadersZip(type: Zip) {
 }
 
 artifacts {
-    archives cppHeadersZip
-    archives cppSourcesZip
+    tasks.named("assemble") {
+        dependsOn(cppHeadersZip)
+        dependsOn(cppSourcesZip)
+    }
 }
 
 addTaskToCopyAllOutputs(cppSourcesZip)


### PR DESCRIPTION
The deprecation message was:
```
The `archives` configuration added by the `base` plugin has been
deprecated and will be removed in Gradle 10.0.0. Adding artifacts to the
`archives` configuration will now result in a deprecation warning. If
you want the artifact built when running the `assemble` task, you should
add the artifact (or the task that produces it) as a dependency of the
`assemble` task directly.

val specialJar = tasks.register<Jar>("specialJar") {
    archiveBaseName.set("special")
    from("build/special")
}
tasks.named("assemble") {
    dependsOn(specialJar)
}
```