### PR TITLE
Feature/detailed trigger dependencies

### DIFF
--- a/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/AnnotationProcessor.java
+++ b/epilogue-processor/src/main/java/edu/wpi/first/epilogue/processor/AnnotationProcessor.java
@@ -38,7 +38,8 @@ import javax.tools.Diagnostic;
 
 @SupportedAnnotationTypes({
   "edu.wpi.first.epilogue.CustomLoggerFor",
-  "edu.wpi.first.epilogue.Logged"
+  "edu.wpi.first.epilogue.Logged",
+  "edu.wpi.first.epilogue.DependsOn"
 })
 @SupportedSourceVersion(SourceVersion.RELEASE_17)
 public class AnnotationProcessor extends AbstractProcessor {

--- a/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/DependsOn.java
+++ b/epilogue-runtime/src/main/java/edu/wpi/first/epilogue/DependsOn.java
@@ -1,0 +1,62 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.epilogue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a logged field or method as dependent on other data points. This annotation is used to
+ * provide metadata for analysis tools like AdvantageScope, allowing them to understand
+ * relationships between different logged values.
+ *
+ * <p>This annotation is particularly useful for triggers and other composite conditions where
+ * understanding the component values is important for debugging.
+ *
+ * <pre><code>
+ * {@literal @}Logged
+ * class Arm {
+ *   {@literal @}DependsOn("getPosition()")
+ *   {@literal @}DependsOn("getTargetPosition()")
+ *   {@literal @}DependsOn("getTolerance()")
+ *   public final Trigger exampleTrigger =
+ *     new Trigger(() -> getPosition().isNear(getTargetPosition(), getTolerance()));
+ *
+ *   public Angle getPosition() { ... }
+ *   public Angle getTargetPosition() { ... }
+ *   public Angle getTolerance() { ... }
+ * }
+ * </code></pre>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Repeatable(DependsOn.Container.class)
+public @interface DependsOn {
+  /**
+   * The name of the method or field that this item depends on. This should match the actual name of
+   * a method or field in the same class that provides data relevant to understanding this item.
+   *
+   * <p>For methods, include the parentheses (e.g., "getPosition()"). For fields, use just the field
+   * name (e.g., "position").
+   *
+   * @return the name of the dependency
+   */
+  String value();
+
+  /** Container annotation for multiple {@link DependsOn} annotations. */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.FIELD, ElementType.METHOD})
+  @interface Container {
+    /**
+     * Array of {@link DependsOn} annotations.
+     *
+     * @return the array of dependencies
+     */
+    DependsOn[] value();
+  }
+}


### PR DESCRIPTION
Add `@DependsOn` annotation to hopefully resolve the following issue: https://github.com/wpilibsuite/allwpilib/issues/8233

`@DependsOn` is on the Epilogue logging framework, allowing fields and methods marked with `@Logged` to declare dependencies on other data points in the same class. 

The changes include annotation processor updates, logger code generation updates, and new tests to verify the behavior.

Let me know what you all think!