### PR TITLE
[epilogue-processor] Fix naive tests in prep for huge refactor

### DIFF
--- a/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java
@@ -2320,7 +2320,8 @@ class AnnotationProcessorTest {
   private void assertLoggerGenerates(String loggedClassContent, String loggerClassContent) {
     // Extract the expected logger file name from the class declaration so we can find the correct
     // generated file.
-    var pattern = Pattern.compile(".*public class (.*) extends ClassSpecificLogger.*", Pattern.DOTALL);
+    var pattern =
+        Pattern.compile(".*public class (.*) extends ClassSpecificLogger.*", Pattern.DOTALL);
     var matcher = pattern.matcher(loggerClassContent);
     var className = "ExampleLogger";
     if (matcher.matches()) {

--- a/epilogue-runtime/BUILD.bazel
+++ b/epilogue-runtime/BUILD.bazel
@@ -11,6 +11,7 @@ wpilib_java_library(
         "//ntcore:ntcore-java",
         "//wpiunits:wpiunits-java",
         "//wpiutil:wpiutil-java",
+        "@maven//:us_hebi_quickbuf_quickbuf_runtime",
     ],
 )
 
@@ -19,6 +20,7 @@ wpilib_java_junit5_test(
     srcs = glob(["src/test/java/**/*.java"]),
     deps = [
         ":epilogue-java",
+        "//wpimath:wpimath-java",
         "//wpiutil:wpiutil-java",
         "@maven//:us_hebi_quickbuf_quickbuf_runtime",
     ],


### PR DESCRIPTION
This was encountered during the great refactoring of 2027. The changing of the package names seems to affect the order in which  entries are sorted in [here](https://github.com/wpilibsuite/allwpilib/blob/main/epilogue-processor/src/test/java/edu/wpi/first/epilogue/processor/AnnotationProcessorTest.java#L2330-L2334), which causes the base class codegen to be returned instead of the concrete class.

This (equally naively) prevents this by changing the name of the base class to not have "Example" in it.

Example of the failure

```
> Task :epilogue-processor:test

AnnotationProcessorTest > complexSuperclass() FAILED
    org.opentest4j.AssertionFailedError: expected: <package org.wpilib.epilogue;

    import org.wpilib.epilogue.Logged;
    import org.wpilib.epilogue.Epilogue;
    import org.wpilib.epilogue.logging.ClassSpecificLogger;
    import org.wpilib.epilogue.logging.EpilogueBackend;
    import java.lang.invoke.MethodHandles;
    import java.lang.invoke.VarHandle;

    public class ExampleLogger extends ClassSpecificLogger<Example> {
      // Accesses private or superclass field org.wpilib.epilogue.Example.i
      private static final VarHandle $org_wpilib_epilogue_Example_i;
      // Accesses private or superclass field org.wpilib.epilogue.BaseExample.d
      private static final VarHandle $org_wpilib_epilogue_BaseExample_d;
      // Accesses private or superclass field org.wpilib.epilogue.BaseExample.f
      private static final VarHandle $org_wpilib_epilogue_BaseExample_f;
      // Accesses private or superclass field org.wpilib.epilogue.BaseExample.g
      private static final VarHandle $org_wpilib_epilogue_BaseExample_g;

      static {
        try {
          var rootLookup = MethodHandles.lookup();
          var lookup$$org_wpilib_epilogue_BaseExample = MethodHandles.privateLookupIn(org.wpilib.epilogue.BaseExample.class, rootLookup);
          $org_wpilib_epilogue_BaseExample_d = lookup$$org_wpilib_epilogue_BaseExample.findVarHandle(org.wpilib.epilogue.BaseExample.class, "d", double.class);
          $org_wpilib_epilogue_BaseExample_f = lookup$$org_wpilib_epilogue_BaseExample.findVarHandle(org.wpilib.epilogue.BaseExample.class, "f", double.class);
          $org_wpilib_epilogue_BaseExample_g = lookup$$org_wpilib_epilogue_BaseExample.findVarHandle(org.wpilib.epilogue.BaseExample.class, "g", double.class);
          var lookup$$org_wpilib_epilogue_Example = MethodHandles.privateLookupIn(org.wpilib.epilogue.Example.class, rootLookup);
          $org_wpilib_epilogue_Example_i = lookup$$org_wpilib_epilogue_Example.findVarHandle(org.wpilib.epilogue.Example.class, "i", double.class);
        } catch (ReflectiveOperationException e) {
          throw new RuntimeException("[EPILOGUE] Could not load private fields for logging!", e);
        }
      }

      public ExampleLogger() {
        super(Example.class);
      }

      @Override
      public void update(EpilogueBackend backend, Example object) {
        if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
          backend.log("h", object.h);
          backend.log("i", ((double) $org_wpilib_epilogue_Example_i.get(object)));
          backend.log("d", ((double) $org_wpilib_epilogue_BaseExample_d.get(object)));
          backend.log("e", object.e);
          backend.log("f", ((double) $org_wpilib_epilogue_BaseExample_f.get(object)));
          backend.log("g", ((double) $org_wpilib_epilogue_BaseExample_g.get(object)));
          backend.log("a", object.a);
          backend.log("getValue", object.getValue());
          backend.log("getB", object.getB());
        }
      }
    }
    > but was: <package org.wpilib.epilogue;

    import org.wpilib.epilogue.Logged;
    import org.wpilib.epilogue.Epilogue;
    import org.wpilib.epilogue.logging.ClassSpecificLogger;
    import org.wpilib.epilogue.logging.EpilogueBackend;
    import java.lang.invoke.MethodHandles;
    import java.lang.invoke.VarHandle;

    public class BaseExampleLogger extends ClassSpecificLogger<BaseExample> {
      // Accesses private or superclass field org.wpilib.epilogue.BaseExample.f
      private static final VarHandle $org_wpilib_epilogue_BaseExample_f;

      static {
        try {
          var rootLookup = MethodHandles.lookup();
          var lookup$$org_wpilib_epilogue_BaseExample = MethodHandles.privateLookupIn(org.wpilib.epilogue.BaseExample.class, rootLookup);
          $org_wpilib_epilogue_BaseExample_f = lookup$$org_wpilib_epilogue_BaseExample.findVarHandle(org.wpilib.epilogue.BaseExample.class, "f", double.class);
        } catch (ReflectiveOperationException e) {
          throw new RuntimeException("[EPILOGUE] Could not load private fields for logging!", e);
        }
      }

      public BaseExampleLogger() {
        super(BaseExample.class);
      }

      @Override
      public void update(EpilogueBackend backend, BaseExample object) {
        if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
          backend.log("d", object.d);
          backend.log("e", object.e);
          backend.log("f", ((double) $org_wpilib_epilogue_BaseExample_f.get(object)));
          backend.log("g", object.g);
          backend.log("a", object.a);
          backend.log("getValue", object.getValue());
          backend.log("getB", object.getB());
        }
      }
    }
    >
        at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at app//org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
        at app//org.wpilib.epilogue.processor.AnnotationProcessorTest.assertLoggerGenerates(AnnotationProcessorTest.java:2266)
        at app//org.wpilib.epilogue.processor.AnnotationProcessorTest.complexSuperclass(AnnotationProcessorTest.java:654)

AnnotationProcessorTest > simpleSuperclass() FAILED
    org.opentest4j.AssertionFailedError: expected: <package org.wpilib.epilogue;

    import org.wpilib.epilogue.Logged;
    import org.wpilib.epilogue.Epilogue;
    import org.wpilib.epilogue.logging.ClassSpecificLogger;
    import org.wpilib.epilogue.logging.EpilogueBackend;
    import java.lang.invoke.MethodHandles;
    import java.lang.invoke.VarHandle;

    public class ExampleLogger extends ClassSpecificLogger<Example> {
      // Accesses private or superclass field org.wpilib.epilogue.BaseExample.b
      private static final VarHandle $org_wpilib_epilogue_BaseExample_b;
      // Accesses private or superclass field org.wpilib.epilogue.BaseExample.c
      private static final VarHandle $org_wpilib_epilogue_BaseExample_c;
      // Accesses private or superclass field org.wpilib.epilogue.BaseExample.d
      private static final VarHandle $org_wpilib_epilogue_BaseExample_d;

      static {
        try {
          var rootLookup = MethodHandles.lookup();
          var lookup$$org_wpilib_epilogue_BaseExample = MethodHandles.privateLookupIn(org.wpilib.epilogue.BaseExample.class, rootLookup);
          $org_wpilib_epilogue_BaseExample_b = lookup$$org_wpilib_epilogue_BaseExample.findVarHandle(org.wpilib.epilogue.BaseExample.class, "b", double.class);
          $org_wpilib_epilogue_BaseExample_c = lookup$$org_wpilib_epilogue_BaseExample.findVarHandle(org.wpilib.epilogue.BaseExample.class, "c", double.class);
          $org_wpilib_epilogue_BaseExample_d = lookup$$org_wpilib_epilogue_BaseExample.findVarHandle(org.wpilib.epilogue.BaseExample.class, "d", double.class);
        } catch (ReflectiveOperationException e) {
          throw new RuntimeException("[EPILOGUE] Could not load private fields for logging!", e);
        }
      }

      public ExampleLogger() {
        super(Example.class);
      }

      @Override
      public void update(EpilogueBackend backend, Example object) {
        if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
          backend.log("e", object.e);
          backend.log("a", object.a);
          backend.log("b", ((double) $org_wpilib_epilogue_BaseExample_b.get(object)));
          backend.log("c", ((double) $org_wpilib_epilogue_BaseExample_c.get(object)));
          backend.log("d", ((double) $org_wpilib_epilogue_BaseExample_d.get(object)));
        }
      }
    }
    > but was: <package org.wpilib.epilogue;

    import org.wpilib.epilogue.Logged;
    import org.wpilib.epilogue.Epilogue;
    import org.wpilib.epilogue.logging.ClassSpecificLogger;
    import org.wpilib.epilogue.logging.EpilogueBackend;
    import java.lang.invoke.MethodHandles;
    import java.lang.invoke.VarHandle;

    public class BaseExampleLogger extends ClassSpecificLogger<BaseExample> {
      // Accesses private or superclass field org.wpilib.epilogue.BaseExample.c
      private static final VarHandle $org_wpilib_epilogue_BaseExample_c;

      static {
        try {
          var rootLookup = MethodHandles.lookup();
          var lookup$$org_wpilib_epilogue_BaseExample = MethodHandles.privateLookupIn(org.wpilib.epilogue.BaseExample.class, rootLookup);
          $org_wpilib_epilogue_BaseExample_c = lookup$$org_wpilib_epilogue_BaseExample.findVarHandle(org.wpilib.epilogue.BaseExample.class, "c", double.class);
        } catch (ReflectiveOperationException e) {
          throw new RuntimeException("[EPILOGUE] Could not load private fields for logging!", e);
        }
      }

      public BaseExampleLogger() {
        super(BaseExample.class);
      }

      @Override
      public void update(EpilogueBackend backend, BaseExample object) {
        if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
          backend.log("a", object.a);
          backend.log("b", object.b);
          backend.log("c", ((double) $org_wpilib_epilogue_BaseExample_c.get(object)));
          backend.log("d", object.d);
        }
      }
    }
    >
        at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at app//org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
        at app//org.wpilib.epilogue.processor.AnnotationProcessorTest.assertLoggerGenerates(AnnotationProcessorTest.java:2266)
        at app//org.wpilib.epilogue.processor.AnnotationProcessorTest.simpleSuperclass(AnnotationProcessorTest.java:565)

51 tests completed, 2 failed
```