### PR TITLE
[build] Build JNI and benchmarks as release by default

### DIFF
--- a/.github/workflows/fix_compile_commands.py
+++ b/.github/workflows/fix_compile_commands.py
@@ -31,6 +31,9 @@ def main():
             # Replace GCC warning argument with one Clang recognizes
             elif arg == "-Wno-maybe-uninitialized":
                 out_args.append("-Wno-uninitialized")
+            # Skip GCC-specific warning argument
+            elif arg == "-Wno-error=restrict":
+                pass
             else:
                 out_args.append(arg)
 

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -181,7 +181,11 @@ tasks.register('deployStatic') {
 model {
     components {
         benchmarkCpp(NativeExecutableSpec) {
-            targetBuildTypes 'debug'
+            if (project.hasProperty('ciDebugOnly')) {
+                targetBuildTypes 'debug'
+            } else {
+                targetBuildTypes 'release'
+            }
             sources {
                 cpp {
                     source {
@@ -235,7 +239,11 @@ model {
             }
         }
         benchmarkCppStatic(NativeExecutableSpec) {
-            targetBuildTypes 'debug'
+            if (project.hasProperty('ciDebugOnly')) {
+                targetBuildTypes 'debug'
+            } else {
+                targetBuildTypes 'release'
+            }
             nativeUtils.excludeBinariesFromStrip(it)
             sources {
                 cpp {

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -39,12 +39,14 @@ nativeUtils.platformConfigs.each {
     }
 }
 
-// Compress debug info on Linux
 nativeUtils.platformConfigs.each {
   if (it.name.contains('linux')) {
+    // Compress debug info on Linux
     it.cppCompiler.debugArgs.add("-gz=zlib")
     // Make warning in OpenCV 4.10 from GCC 15 not an error
     it.cppCompiler.args.add("-Wno-error=overloaded-virtual")
+    // Make warning from Google Benchmark not an error
+    it.cppCompiler.args.add("-Wno-error=restrict")
   }
 }
 

--- a/shared/jni/setupBuild.gradle
+++ b/shared/jni/setupBuild.gradle
@@ -148,7 +148,11 @@ model {
         // By default, a development executable will be generated. This is to help the case of
         // testing specific functionality of the library.
         "${nativeName}Dev"(NativeExecutableSpec) {
-            targetBuildTypes 'debug'
+            if (project.hasProperty('ciDebugOnly') || project.hasProperty('debugJNI')) {
+                targetBuildTypes 'debug'
+            } else {
+                targetBuildTypes 'release'
+            }
             sources {
                 cpp {
                     source {


### PR DESCRIPTION
It doesn't make sense to benchmark debug binaries. Also, wpimath JNI performance in unit tests is drastically impacted by debug vs release.