### PR TITLE
[glass] Fix color order for sim GUI LEDs

### DIFF
--- a/glass/src/lib/native/include/glass/hardware/LEDDisplay.h
+++ b/glass/src/lib/native/include/glass/hardware/LEDDisplay.h
@@ -20,9 +20,9 @@ namespace glass {
 class LEDDisplayModel : public glass::Model {
  public:
   struct Data {
-    uint8_t b;
-    uint8_t g;
     uint8_t r;
+    uint8_t g;
+    uint8_t b;
   };
 
   virtual std::span<const Data> GetData(wpi::SmallVectorImpl<Data>& buf) = 0;


### PR DESCRIPTION
The color order of the internal AddressableLED buffer changed from BGR to RGB on the 2027 branch, but the sim GUI was never updated to reflect this change. This causes red and blue to be swapped when visualizing LEDs in sim.