### PR TITLE
Replace internal usages of getAverageVoltage for Analog

### DIFF
--- a/wpilibc/src/main/native/cpp/AnalogAccelerometer.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogAccelerometer.cpp
@@ -35,7 +35,7 @@ AnalogAccelerometer::AnalogAccelerometer(std::shared_ptr<AnalogInput> channel)
 }
 
 double AnalogAccelerometer::GetAcceleration() const {
-  return (m_analogInput->GetAverageVoltage() - m_zeroGVoltage) / m_voltsPerG;
+  return (m_analogInput->GetVoltage() - m_zeroGVoltage) / m_voltsPerG;
 }
 
 void AnalogAccelerometer::SetSensitivity(double sensitivity) {

--- a/wpilibc/src/main/native/cpp/AnalogPotentiometer.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogPotentiometer.cpp
@@ -38,7 +38,7 @@ AnalogPotentiometer::AnalogPotentiometer(std::shared_ptr<AnalogInput> input,
 }
 
 double AnalogPotentiometer::Get() const {
-  return (m_analog_input->GetAverageVoltage() /
+  return (m_analog_input->GetVoltage() /
           RobotController::GetVoltage3V3()) *
              m_fullRange +
          m_offset;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogAccelerometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogAccelerometer.java
@@ -83,7 +83,7 @@ public class AnalogAccelerometer implements Sendable, AutoCloseable {
     if (m_analogChannel == null) {
       return 0.0;
     }
-    return (m_analogChannel.getAverageVoltage() - m_zeroGVoltage) / m_voltsPerG;
+    return (m_analogChannel.getVoltage() - m_zeroGVoltage) / m_voltsPerG;
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometer.java
@@ -125,7 +125,7 @@ public class AnalogPotentiometer implements Sendable, AutoCloseable {
     if (m_analogInput == null) {
       return m_offset;
     }
-    return (m_analogInput.getAverageVoltage() / RobotController.getVoltage3V3()) * m_fullRange
+    return (m_analogInput.getVoltage() / RobotController.getVoltage3V3()) * m_fullRange
         + m_offset;
   }
 


### PR DESCRIPTION
Any usages of these will currently crash. For now at least replace the usages with just getVoltage()