### PR TITLE
Add ProfiledPIDController with feedforward snippets

### DIFF
--- a/wpilibcExamples/src/main/cpp/snippets/ProfiledPIDFeedforward/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/snippets/ProfiledPIDFeedforward/cpp/Robot.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <frc/Encoder.h>
+#include <frc/TimedRobot.h>
+#include <frc/controller/ProfiledPIDController.h>
+#include <frc/controller/SimpleMotorFeedforward.h>
+#include <frc/motorcontrol/PWMSparkMax.h>
+#include <units/acceleration.h>
+#include <units/length.h>
+#include <units/velocity.h>
+#include <units/voltage.h>
+
+/**
+ * ProfiledPIDController with feedforward snippets for frc-docs.
+ * https://docs.wpilib.org/en/stable/docs/software/advanced-controls/controllers/profiled-pidcontroller.html
+ */
+class Robot : public frc::TimedRobot {
+ public:
+  Robot() { m_encoder.SetDistancePerPulse(1.0 / 256.0); }
+
+  // Controls a simple motor's position using a SimpleMotorFeedforward
+  // and a ProfiledPIDController
+  void GoToPosition(units::meter_t goalPosition) {
+    auto pidVal = m_controller.Calculate(units::meter_t{m_encoder.GetDistance()}, goalPosition);
+    m_motor.SetVoltage(
+         pidVal +
+        m_feedforward.Calculate(m_lastSpeed, m_controller.GetSetpoint().velocity));
+    m_lastSpeed = m_controller.GetSetpoint().velocity;
+  }
+
+  void TeleopPeriodic() override {
+    // Example usage: move to position 10.0 meters
+    GoToPosition(10.0_m);
+  }
+
+ private:
+  frc::ProfiledPIDController<units::meters> m_controller{
+      1.0, 0.0, 0.0, {5_mps, 10_mps_sq}};
+  frc::SimpleMotorFeedforward<units::meters> m_feedforward{0.5_V, 1.5_V / 1_mps,
+                                                            0.3_V / 1_mps_sq};
+  frc::Encoder m_encoder{0, 1};
+  frc::PWMSparkMax m_motor{0};
+
+  units::meters_per_second_t m_lastSpeed = 0_mps;
+};
+
+#ifndef RUNNING_FRC_TESTS
+int main() {
+  return frc::StartRobot<Robot>();
+}
+#endif

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/snippets/profiledpidfeedforward/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/snippets/profiledpidfeedforward/Robot.java
@@ -1,0 +1,47 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.snippets.profiledpidfeedforward;
+
+import edu.wpi.first.math.controller.ProfiledPIDController;
+import edu.wpi.first.math.controller.SimpleMotorFeedforward;
+import edu.wpi.first.math.trajectory.TrapezoidProfile;
+import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj.motorcontrol.PWMSparkMax;
+
+/**
+ * ProfiledPIDController with feedforward snippets for frc-docs.
+ * https://docs.wpilib.org/en/stable/docs/software/advanced-controls/controllers/profiled-pidcontroller.html
+ */
+public class Robot extends TimedRobot {
+  private final ProfiledPIDController m_controller =
+      new ProfiledPIDController(1.0, 0.0, 0.0, new TrapezoidProfile.Constraints(5.0, 10.0));
+  private final SimpleMotorFeedforward m_feedforward = new SimpleMotorFeedforward(0.5, 1.5, 0.3);
+  private final Encoder m_encoder = new Encoder(0, 1);
+  private final PWMSparkMax m_motor = new PWMSparkMax(0);
+
+  double m_lastSpeed = 0;
+
+  /** Called once at the beginning of the robot program. */
+  public Robot() {
+    m_encoder.setDistancePerPulse(1.0 / 256.0);
+  }
+
+  // Controls a simple motor's position using a SimpleMotorFeedforward
+  // and a ProfiledPIDController
+  public void goToPosition(double goalPosition) {
+    double pidVal = m_controller.calculate(m_encoder.getDistance(), goalPosition);
+    m_motor.setVoltage(
+        pidVal
+            + m_feedforward.calculate(m_lastSpeed, m_controller.getSetpoint().velocity));
+    m_lastSpeed = m_controller.getSetpoint().velocity;
+  }
+
+  @Override
+  public void teleopPeriodic() {
+    // Example usage: move to position 10.0
+    goToPosition(10.0);
+  }
+}


### PR DESCRIPTION
Adds snippets demonstrating `ProfiledPIDController` usage with `SimpleMotorFeedforward` using the two-parameter `calculate(currentVelocity, nextVelocity)` method.

## Changes
- Added Java snippet: `wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/snippets/profiledpidfeedforward/Robot.java`
- Added C++ snippet: `wpilibcExamples/src/main/cpp/snippets/ProfiledPIDFeedforward/cpp/Robot.cpp`

## Purpose
These snippets will be used in frc-docs (wpilibsuite/frc-docs#3117) to document the recommended feedforward pattern with ProfiledPIDController, replacing deprecated inline code examples.

The snippets demonstrate:
- Using `ProfiledPIDController` to control motor position
- Tracking previous velocity with a member variable
- Using `feedforward.calculate(lastSpeed, controller.getSetpoint().velocity)` pattern
- Complete, compilable robot code

## Related
- frc-docs PR: wpilibsuite/frc-docs#3117
- frc-docs issue: wpilibsuite/frc-docs#2963