### PR TITLE
[build] Fix doxygen builds on apple CPUs

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -52,12 +52,16 @@ doxygen {
     // See below maven and https://doxygen.nl/download.html for provided binaries
     // Ensure theme.css (from https://github.com/jothepro/doxygen-awesome-css) is compatible with
     // doxygen version when updating
+    executables {
+        doxygen {
+            // Note: has no effect if not on an x86_64 platform - you need to have a global install available on your
+            // PATH for the doxygen plugin to run
+            executableByVersion('1.12.0')
 
-    String arch = System.getProperty("os.arch");
-    if (arch.equals("x86_64") || arch.equals("amd64")) {
-        executables {
-            doxygen {
-                executableByVersion('1.12.0')
+            String arch = System.getProperty("os.arch");
+            if (!(arch.equals("x86_64") || arch.equals("amd64"))) {
+                // Search for a local doxygen install
+                executableBySearchPath('doxygen')
             }
         }
     }


### PR DESCRIPTION
Caused by the doxygen gradle plugin attempting to download 1.10.0 (presumably its default version) from artifactory because the 1.12.0 config is only applied on x86_64 platforms. Just fixing that isn't enough, however; on mac, the plugin would fail to extract the dmg. We need to fall back to a global installation on the PATH for the plugin to find, preferentially using that instead of a failed attempt to download and extract the dmg.

Builds on mac (and presumably linux and windows on ARM) will need `doxygen` in the PATH, or the build will fail with a "Could not locate doxygen in search path" error message.

I found this while setting up a new macbook (M4, sequoia 15.5). It's also reproducible on my older macbook (M1, sequoia 15.6.1)