### PR TITLE
Fix eclipse compiler generating bad class files in wpilibExamples

### DIFF
--- a/wpilibjExamples/build.gradle
+++ b/wpilibjExamples/build.gradle
@@ -31,6 +31,19 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+// Prevent the eclipse compiler (used by the VS Code extension for intellisense and debugging)
+// from generating bad class files from annotation processors like Epilogue
+eclipse {
+    classpath {
+        containers 'org.eclipse.buildship.core.gradleclasspathcontainer'
+        file.whenMerged { cp ->
+            def entries = cp.entries;
+            def src = new org.gradle.plugins.ide.eclipse.model.SourceFolder('build/generated/sources/annotationProcessor/java/main/', null)
+            entries.add(src)
+        }
+    }
+}
+
 jacoco {
     toolVersion = "0.8.13"
 }


### PR DESCRIPTION
Small code snippet written by @Gold856 added to wpilibExamples, fixes errors generated by VSCode intellisense (which uses the eclipse compiler). No changes made otherwise