### PR TITLE
Fix deprecated gradle warning in catch2 publish.gradle

### DIFF
--- a/thirdparty/catch2/publish.gradle
+++ b/thirdparty/catch2/publish.gradle
@@ -54,8 +54,8 @@ model {
                 artifact cppSourcesZip
 
                 artifactId = baseArtifactId
-                groupId artifactGroupId
-                version wpilibVersioning.version.get()
+                groupId = artifactGroupId
+                version = wpilibVersioning.version.get()
             }
         }
     }


### PR DESCRIPTION
Need to use assignment operator rather than generated methods.