### PR TITLE
Clean up spotbugs excludes

### DIFF
--- a/styleguide/spotbugs-exclude.xml
+++ b/styleguide/spotbugs-exclude.xml
@@ -2,46 +2,18 @@
 <FindBugsFilter>
   <Match>
     <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE" />
-    <Class name="org.wpilib.driverstation.DriverStation" />
-  </Match>
-  <Match>
-    <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE" />
-    <Class name="org.wpilib.Ultrasonic" />
-  </Match>
-  <Match>
-    <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE" />
     <Class name="org.wpilib.system.Watchdog" />
   </Match>
   <Match>
     <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" />
-    <Class name="org.wpilib.ADIS16448_IMU" />
-  </Match>
-  <Match>
-    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" />
-    <Class name="org.wpilib.ADIS16470_IMU" />
-  </Match>
-  <Match>
-    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" />
-    <Class name="org.wpilib.driverstation.DriverStation" />
-  </Match>
-  <Match>
-    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" />
-    <Class name="org.wpilib.driverstation.GenericHID" />
-  </Match>
-  <Match>
-    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" />
-    <Class name="org.wpilib.Ultrasonic" />
-  </Match>
-  <Match>
-    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" />
-    <Class name="org.wpilib.command2.CommandScheduler" />
+    <Or>
+      <Class name="org.wpilib.driverstation.DriverStation" />
+      <Class name="org.wpilib.driverstation.GenericHID" />
+      <Class name="org.wpilib.command2.CommandScheduler" />
+    </Or>
   </Match>
   <Match>
     <Bug pattern="CT_CONSTRUCTOR_THROW" />
-  </Match>
-  <Match>
-    <Bug pattern="DCN_NULLPOINTER_EXCEPTION" />
-    <Class name="org.wpilib.test.TestSuite" />
   </Match>
   <Match>
     <Bug pattern="DE_MIGHT_IGNORE" />
@@ -49,16 +21,32 @@
   </Match>
   <Match>
     <Bug pattern="DM_DEFAULT_ENCODING" />
+    <Or>
+      <Class name="org.wpilib.epilogue.processor.EpilogueGenerator" />
+      <Class name="org.wpilib.examples.i2ccommunication.I2CCommunicationTest" />
+      <Class name="org.wpilib.command2.PrintCommandTest" />
+    </Or>
   </Match>
   <Match>
     <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME" />
+    <Or>
+      <Class name="org.wpilib.system.DataLogManager" />
+      <Class name="org.wpilib.system.Filesystem" />
+      <Class name="org.wpilib.util.runtime.CombinedRuntimeLoader" />
+      <Class name="org.wpilib.util.runtime.RuntimeDetector" />
+    </Or>
   </Match>
   <Match>
+    <!--
+    These are false positives where the Random instance is used multiple times in a loop. Futhermore, high randomness is not a
+    high priority because these are tests- In fact, the odometry tests seed the Random instance to guarantee repeatability.
+    -->
     <Bug pattern="DMI_RANDOM_USED_ONLY_ONCE" />
-  </Match>
-  <Match>
-    <Bug pattern="EC_BAD_ARRAY_COMPARE" />
-    <Class name="org.wpilib.math.estimator.SwerveDrivePoseEstimator$InterpolationRecord" />
+    <Or>
+      <Class name="org.wpilib.math.kinematics.SwerveDriveOdometry3dTest" />
+      <Class name="org.wpilib.math.kinematics.SwerveDriveOdometryTest" />
+      <Class name="org.wpilib.math.filter.LinearFilterTest" />
+    </Or>
   </Match>
   <Match>
     <Bug pattern="EI_EXPOSE_REP" />
@@ -77,6 +65,16 @@
   </Match>
   <Match>
     <Bug pattern="FL_FLOATS_AS_LOOP_COUNTERS" />
+    <Or>
+      <Class name="org.wpilib.math.controller.DifferentialDriveAccelerationLimiterTest" />
+      <Class name="org.wpilib.math.controller.ImplicitModelFollowerTest" />
+      <Class name="org.wpilib.math.controller.LinearSystemLoopTest" />
+      <Class name="~org\.wpilib\.math\.estimator\.[^.]*PoseEstimator(3d)?Test" />
+      <Class name="org.wpilib.math.filter.LinearFilterTest" />
+      <Class name="org.wpilib.math.kinematics.ChassisSpeedsTest" />
+      <Class name="org.wpilib.hardware.led.LEDPatternTest" />
+      <Class name="org.wpilib.simulation.AnalogInputSimTest" />
+    </Or>
   </Match>
   <Match>
     <Bug pattern="IS2_INCONSISTENT_SYNC" />
@@ -89,35 +87,20 @@
     <Bug pattern="MS_MUTABLE_ARRAY" />
   </Match>
   <Match>
+    <!--
+    This seems to be a false positive from the &= used by these command compositions to determine runsWhenDisabled
+    -->
     <Bug pattern="NS_DANGEROUS_NON_SHORT_CIRCUIT" />
-    <Class name="org.wpilib.command2.ParallelCommandGroup" />
-  </Match>
-  <Match>
-    <Bug pattern="NS_DANGEROUS_NON_SHORT_CIRCUIT" />
-    <Class name="org.wpilib.command2.ParallelDeadlineGroup" />
-  </Match>
-  <Match>
-    <Bug pattern="NS_DANGEROUS_NON_SHORT_CIRCUIT" />
-    <Class name="org.wpilib.command2.ParallelRaceGroup" />
-  </Match>
-  <Match>
-    <Bug pattern="NS_DANGEROUS_NON_SHORT_CIRCUIT" />
-    <Class name="org.wpilib.command2.ProxyScheduleCommand" />
-  </Match>
-  <Match>
-    <Bug pattern="NS_DANGEROUS_NON_SHORT_CIRCUIT" />
-    <Class name="org.wpilib.command2.SequentialCommandGroup" />
-  </Match>
-  <Match>
-    <Bug pattern="NS_DANGEROUS_NON_SHORT_CIRCUIT" />
-    <Class name="org.wpilib.command2.SelectCommand" />
+    <Or>
+      <Class name="org.wpilib.command2.ParallelCommandGroup" />
+      <Class name="org.wpilib.command2.ParallelDeadlineGroup" />
+      <Class name="org.wpilib.command2.ParallelRaceGroup" />
+      <Class name="org.wpilib.command2.SequentialCommandGroup" />
+      <Class name="org.wpilib.command2.SelectCommand" />
+    </Or>
   </Match>
   <Match>
     <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE" />
-  </Match>
-  <Match>
-    <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
-    <Class name="org.wpilib.test.AntJunitLauncher" />
   </Match>
   <Match>
     <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
@@ -129,70 +112,37 @@
   </Match>
   <Match>
     <Bug pattern="SC_START_IN_CTOR" />
+    <Class name="org.wpilib.hardware.motor.MotorSafety" />
   </Match>
   <Match>
     <Bug pattern="SF_SWITCH_FALLTHROUGH" />
     <Class name="org.wpilib.vision.stream.CameraServer$PropertyPublisher" />
   </Match>
   <Match>
-    <Bug pattern="SING_SINGLETON_GETTER_NOT_SYNCHRONIZED" />
-    <Class name="org.wpilib.test.TestSuite" />
-  </Match>
-  <Match>
     <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR" />
-    <Class name="org.wpilib.test.TestSuite" />
+    <Or>
+      <Class name="org.wpilib.command2.CommandScheduler" />
+      <Class name="org.wpilib.math.geometry.CoordinateAxis" />
+      <Class name="org.wpilib.math.geometry.CoordinateSystem" />
+    </Or>
   </Match>
   <Match>
-    <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR" />
-    <Class name="org.wpilib.command2.CommandScheduler" />
-  </Match>
-  <Match>
-    <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR" />
-    <Class name="org.wpilib.math.geometry.CoordinateAxis" />
-  </Match>
-  <Match>
-    <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR" />
-    <Class name="org.wpilib.math.geometry.CoordinateSystem" />
-  </Match>
-  <Match>
+    <!--
+    Many false positives from instance reporting.
+    -->
     <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
   </Match>
   <Match>
-    <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION" />
-  </Match>
-  <Match>
-    <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE" />
-  </Match>
-  <Match>
-    <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION" />
-  </Match>
-  <Match>
+    <!--
+    False positives because the users are supposed to fill in the code.
+    -->
     <Bug pattern="UC_USELESS_VOID_METHOD" />
-    <Class name="org.wpilib.templates.romitimed.Robot" />
-  </Match>
-  <Match>
-    <Bug pattern="UC_USELESS_VOID_METHOD" />
-    <Class name="org.wpilib.templates.xrptimed.Robot" />
-  </Match>
-  <Match>
-    <Bug pattern="UC_USELESS_VOID_METHOD" />
-    <Class name="org.wpilib.templates.timed.Robot" />
-  </Match>
-  <Match>
-    <Bug pattern="UC_USELESS_VOID_METHOD" />
-    <Class name="org.wpilib.templates.timeslice.Robot" />
-  </Match>
-  <Match>
-    <Bug pattern="UC_USELESS_VOID_METHOD" />
-    <Class name="org.wpilib.templates.timesliceskeleton.Robot" />
-  </Match>
-  <Match>
-    <Bug pattern="URF_UNREAD_FIELD" />
-    <Class name="org.wpilib.ADIS16448_IMU" />
-  </Match>
-  <Match>
-    <Bug pattern="URF_UNREAD_FIELD" />
-    <Class name="org.wpilib.ADIS16470_IMU" />
+    <Or>
+      <Class name="org.wpilib.templates.romitimed.Robot" />
+      <Class name="org.wpilib.templates.xrptimed.Robot" />
+      <Class name="org.wpilib.templates.timed.Robot" />
+      <Class name="org.wpilib.templates.timeslice.Robot" />
+    </Or>
   </Match>
   <Match>
     <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
@@ -208,5 +158,15 @@
   </Match>
   <Match>
     <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE" />
+    <Or>
+      <Class name="org.wpilib.epilogue.processor.LoggableHandler" />
+      <Class name="org.wpilib.util.runtime.MsvcRuntimeException" />
+      <Class name="org.wpilib.util.runtime.RuntimeLoader" />
+      <Class name="org.wpilib.system.Tracer" />
+      <Class name="org.wpilib.system.Watchdog" />
+      <Class name="org.wpilib.math.system.LinearSystem" />
+      <Class name="org.wpilib.math.trajectory.Trajectory" />
+      <Class name="org.wpilib.command3.SchedulerTelemetryTests" />
+    </Or>
   </Match>
 </FindBugsFilter>


### PR DESCRIPTION
2027 counterpart to #8332. Not sure what the actual merge process will look like, but I wanted to note what the final 2027 result should look like, since it's significantly different from a simple merge (with conflicts fixed).

Change list:
* Multiple matches with the same bug pattern are collapsed into a single match with an `<Or>` for the different classes
  * This is applied to `AT_STALE_THREAD_WRITE_OF_PRIMITIVE`, `DMI_HARDCODED_ABSOLUTE_FILENAME`, `DMI_RANDOM_USED_ONLY_ONCE`, `NS_DANGEROUS_NON_SHORT_CIRCUIT`, `SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR`, `UC_USELESS_VOID_METHOD`
* When reasonable, matches are restricted from global matches to enumerated classes
  * This is applied to `DM_DEFAULT_ENCODING`, `FL_FLOATS_AS_LOOP_COUNTERS`, `SC_START_IN_CTOR`, `VA_FORMAT_STRING_USES_NEWLINE`
  * Due to the large number of cases, it's questionable whether `FL_FLOATS_AS_LOOP_COUNTERS` and `VA_FORMAT_STRING_USES_NEWLINE` should have enumerated cases or be blanket suppressions- Open to feedback about this
  * `CT_CONSTRUCTOR_THROW` is left as a blanket suppression because the reason it's a bug is because people could use finalizers to access partially initialized objects, which is not something we need to worry about
  * `EI_EXPOSE_REP`, `EI_EXPOSE_REP2`, `MS_EXPOSE_REP`, `MS_MUTABLE_ARRAY`, `PA_PUBLIC_PRIMITIVE_ATTRIBUTE`, and `URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD` are left as blanket suppressions since many of our classes are intentionally designed in different ways due to other considerations
  * As commented, `ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD` is a blanket suppression because that's how we track the number of instances for instance reporting
* Outdated matches are removed:
  * `DriverStation` and `Ultrasonic` no longer causes `AT_NONATOMIC_64BIT_PRIMITIVE`
  * `ADIS16448_IMU`, `ADIS16470_IMU`, `Ultrasonic`, `TestSuite`, `SwerveDrivePoseEstimator$InterpolationRecord`, `AntJunitLauncher`, `templates.timesliceskeleton.Robot` were deleted
  * `THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION`, `THROWS_METHOD_THROWS_CLAUSE_THROWABLE`, `THROWS_METHOD_THROWS_RUNTIMEEXCEPTION` no longer match anything