### PR TITLE
Fixup deleted function that was left in header file

### DIFF
--- a/wpilibc/src/main/native/include/frc/simulation/GenericHIDSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/GenericHIDSim.h
@@ -112,14 +112,6 @@ class GenericHIDSim {
   void SetName(const char* name);
 
   /**
-   * Set the type of an axis.
-   *
-   * @param axis the axis
-   * @param type the type
-   */
-  void SetAxisType(int axis, int type);
-
-  /**
    * Read the output of a button.
    *
    * @param outputNumber the button number


### PR DESCRIPTION
This function was supposed to be removed in #8302, but the declaration in the class was seemingly accidentally left. All usages and the definition in the cpp file were removed. 

Leaving this in causes missing symbols problems with robotpy's auto header parsing witchcraft