### PR TITLE
[wpimath] Add typedefs for LQR and Kalman filters

### DIFF
--- a/wpimath/src/main/native/include/wpi/math/controller/LinearQuadraticRegulator.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/LinearQuadraticRegulator.hpp
@@ -311,6 +311,9 @@ class LinearQuadraticRegulator {
   Matrixd<Inputs, States> m_K;
 };
 
+template <int States, int Inputs>
+using LQR = LinearQuadraticRegulator<States, Inputs>;
+
 extern template class EXPORT_TEMPLATE_DECLARE(WPILIB_DLLEXPORT)
     LinearQuadraticRegulator<1, 1>;
 extern template class EXPORT_TEMPLATE_DECLARE(WPILIB_DLLEXPORT)

--- a/wpimath/src/main/native/include/wpi/math/estimator/ExtendedKalmanFilter.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/ExtendedKalmanFilter.hpp
@@ -428,4 +428,7 @@ class ExtendedKalmanFilter {
   StateMatrix m_initP;
 };
 
+template <int States, int Inputs, int Outputs>
+using EKF = ExtendedKalmanFilter<States, Inputs, Outputs>;
+
 }  // namespace wpi::math

--- a/wpimath/src/main/native/include/wpi/math/estimator/KalmanFilter.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/KalmanFilter.hpp
@@ -262,6 +262,9 @@ class KalmanFilter {
   StateMatrix m_initP;
 };
 
+template <int States, int Inputs, int Outputs>
+using KF = KalmanFilter<States, Inputs, Outputs>;
+
 extern template class EXPORT_TEMPLATE_DECLARE(WPILIB_DLLEXPORT)
     KalmanFilter<1, 1, 1>;
 extern template class EXPORT_TEMPLATE_DECLARE(WPILIB_DLLEXPORT)

--- a/wpimath/src/main/native/include/wpi/math/estimator/SteadyStateKalmanFilter.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/SteadyStateKalmanFilter.hpp
@@ -237,6 +237,9 @@ class SteadyStateKalmanFilter {
   StateVector m_xHat;
 };
 
+template <int States, int Inputs, int Outputs>
+using SteadyStateKF = SteadyStateKalmanFilter<States, Inputs, Outputs>;
+
 extern template class EXPORT_TEMPLATE_DECLARE(WPILIB_DLLEXPORT)
     SteadyStateKalmanFilter<1, 1, 1>;
 extern template class EXPORT_TEMPLATE_DECLARE(WPILIB_DLLEXPORT)

--- a/wpimath/src/main/native/include/wpi/math/estimator/UnscentedKalmanFilter.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/UnscentedKalmanFilter.hpp
@@ -496,4 +496,7 @@ class UnscentedKalmanFilter {
   SigmaPoints m_pts;
 };
 
+template <int States, int Inputs, int Outputs, SigmaPoints<States> SigmaPoints>
+using UKF = UnscentedKalmanFilter<States, Inputs, Outputs, SigmaPoints>;
+
 }  // namespace wpi::math


### PR DESCRIPTION
These are industry-standard initialisms. The original class names were left as is so they're more googleable, but I could be convinced otherwise.