### PR TITLE
[ci] Decrease CI verbosity

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -33,7 +33,7 @@ jobs:
           password: ${{ secrets.BAZEL_CACHE_PASSWORD }}
 
       - name: bazel ${{ matrix.action }}
-        run: bazel --output_user_root=C:\\bazelroot ${{ matrix.action }} ... --config=ci ${{ matrix.config }} --verbose_failures
+        run: bazel --output_user_root=C:\\bazelroot ${{ matrix.action }} ... --config=ci ${{ matrix.config }}
         shell: bash
 
   build-mac:
@@ -55,7 +55,7 @@ jobs:
           password: ${{ secrets.BAZEL_CACHE_PASSWORD }}
 
       - name: bazel test (release)
-        run: bazel test ...   --config=ci -c opt --nojava_header_compilation --verbose_failures
+        run: bazel test ...   --config=ci -c opt --nojava_header_compilation
         shell: bash
 
   build-linux:
@@ -85,7 +85,7 @@ jobs:
           bazelisk-version: 1.x
 
       - name: bazel ${{ matrix.action }} (release)
-        run: bazel ${{ matrix.action }} ... --config=ci -c opt ${{ matrix.config }} --verbose_failures
+        run: bazel ${{ matrix.action }} ... --config=ci -c opt ${{ matrix.config }}
 
   buildifier:
     name: "buildifier"

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -87,9 +87,9 @@ jobs:
       - name: List changed files
         run: ${{ runner.temp }}/wpiformat/bin/wpiformat -list-changed-files
       - name: Run clang-tidy release
-        run: ${{ runner.temp }}/wpiformat/bin/wpiformat -no-format -tidy-changed -compile-commands=build/TargetedCompileCommands/linuxx86-64release -vv
+        run: ${{ runner.temp }}/wpiformat/bin/wpiformat -no-format -tidy-changed -compile-commands=build/TargetedCompileCommands/linuxx86-64release
       - name: Run clang-tidy debug
-        run: ${{ runner.temp }}/wpiformat/bin/wpiformat -no-format -tidy-changed -compile-commands=build/TargetedCompileCommands/linuxx86-64debug -vv
+        run: ${{ runner.temp }}/wpiformat/bin/wpiformat -no-format -tidy-changed -compile-commands=build/TargetedCompileCommands/linuxx86-64debug
   javaformat:
     name: "Java format"
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Offline conversations have pointed out that the bazel output is very noisy upon a failure. The `-k` that was there for a while was recently deleted in another PR, and this one removes `--verbose_failures`. `--verbose_failures` prints all of the command line arguments, which can be quite lengthy and make it harder to find the actual compiler error.

This also removes the `-vv` from the `clang-tidy` step. I have found it very hard to find the actual errors when its printing out all of the debug information.