### PR TITLE
[datalog] Add java entry map 

### DIFF
--- a/datalog/src/main/java/org/wpilib/datalog/DataLogReader.java
+++ b/datalog/src/main/java/org/wpilib/datalog/DataLogReader.java
@@ -67,9 +67,8 @@ public class DataLogReader implements Iterable<DataLogRecord> {
   /**
    * Gets the data log version. Returns 0 if data log is invalid.
    *
-   * @return Version number; most significant byte is major, least significant is
-   *         minor (so version
-   *         1.0 will be 0x0100)
+   * @return Version number; most significant byte is major, least significant is minor (so version
+   *     1.0 will be 0x0100)
    */
   public short getVersion() {
     if (m_buf.remaining() < 12) {
@@ -138,16 +137,16 @@ public class DataLogReader implements Iterable<DataLogRecord> {
       if (record.isStart()) {
         StartRecordData startData = record.getStartData();
         boolean isNew = m_entriesByName.containsKey(startData.name);
-        DataLogReaderEntry readerEntry = new DataLogReaderEntry(entry, startData.name,
-            startData.type, startData.metadata);
+        DataLogReaderEntry readerEntry =
+            new DataLogReaderEntry(entry, startData.name, startData.type, startData.metadata);
         if (isNew) {
-          readerEntry.m_ranges.add(new DataLogReaderRange(new DataLogIterator(this, pos),
-              new DataLogIterator(this, pos + m_buf.remaining())));
+          readerEntry.m_ranges.add(
+              new DataLogReaderRange(
+                  new DataLogIterator(this, pos),
+                  new DataLogIterator(this, pos + m_buf.remaining())));
         }
         m_entriesByName.put(startData.name, readerEntry);
-        m_entriesById.put(
-            entry,
-            readerEntry);
+        m_entriesById.put(entry, readerEntry);
       } else if (record.isFinish()) {
         // update range
         List<DataLogReaderRange> ranges = m_entriesById.get(record.getEntry()).m_ranges;
@@ -183,10 +182,22 @@ public class DataLogReader implements Iterable<DataLogRecord> {
     return m_buf.remaining();
   }
 
+  /**
+   * Fetches the entry with the given id.
+   *
+   * @param entry Id number of the desired entry, which is associated with all of its records.
+   * @return The DataLogReaderEntry associated with that entry id.
+   */
   DataLogReaderEntry getEntry(int entry) {
     return m_entriesById.get(entry);
   }
 
+  /**
+   * Fetches the entry with the given name.
+   *
+   * @param name Name string of an entry.
+   * @return The DataLogReaderEntry associated with that name.
+   */
   DataLogReaderEntry getEntry(String name) {
     return m_entriesByName.get(name);
   }
@@ -195,9 +206,18 @@ public class DataLogReader implements Iterable<DataLogRecord> {
   private HashMap<Integer, DataLogReaderEntry> m_entriesById;
   private HashMap<String, DataLogReaderEntry> m_entriesByName;
 
+  /**
+   * DataLogReader Entry class, which associates an entry's ID with its name, type, and metadata in
+   * a persistent way.
+   */
   public static class DataLogReaderEntry extends StartRecordData {
     private final List<DataLogReaderRange> m_ranges;
 
+    /**
+     * Returns the list of ranges for which this entry is valid.
+     *
+     * @return List of DataLogReaderRange for which this entry is valid
+     */
     public List<DataLogReaderRange> getRanges() {
       return m_ranges;
     }
@@ -208,6 +228,6 @@ public class DataLogReader implements Iterable<DataLogRecord> {
     }
   }
 
-  public record DataLogReaderRange(DataLogIterator begin, DataLogIterator end) {
-  }
+  /** Range of records during which an entry is valid. */
+  public record DataLogReaderRange(DataLogIterator begin, DataLogIterator end) {}
 }

--- a/datalog/src/main/java/org/wpilib/datalog/DataLogReaderThread.java
+++ b/datalog/src/main/java/org/wpilib/datalog/DataLogReaderThread.java
@@ -207,7 +207,7 @@ public class DataLogReaderThread implements AutoCloseable {
      * @return List of DataLogReaderRange for which this entry is valid
      */
     public List<DataLogReaderRange> getRanges() {
-      return m_ranges;
+      return List.copyOf(m_ranges);
     }
 
     public DataLogReaderEntry(int entry, String name, String type, String metadata) {
@@ -222,7 +222,7 @@ public class DataLogReaderThread implements AutoCloseable {
   }
 
   /** Range of records during which an entry is valid. */
-  public class DataLogReaderRange {
+  public static class DataLogReaderRange {
     DataLogIterator m_begin;
     DataLogIterator m_end;
 

--- a/datalog/src/main/java/org/wpilib/datalog/DataLogReaderThread.java
+++ b/datalog/src/main/java/org/wpilib/datalog/DataLogReaderThread.java
@@ -223,8 +223,8 @@ public class DataLogReaderThread implements AutoCloseable {
 
   /** Range of records during which an entry is valid. */
   public static class DataLogReaderRange {
-    DataLogIterator m_begin;
-    DataLogIterator m_end;
+    public DataLogIterator m_begin;
+    public DataLogIterator m_end;
 
     public DataLogReaderRange(DataLogIterator begin, DataLogIterator end) {
       m_begin = begin;

--- a/datalog/src/main/java/org/wpilib/datalog/DataLogReaderThread.java
+++ b/datalog/src/main/java/org/wpilib/datalog/DataLogReaderThread.java
@@ -41,7 +41,6 @@ public class DataLogReaderThread implements AutoCloseable {
   }
 
   private void readMain() {
-    // HashMap<Integer, Entry<DataLogReaderEntry, List<Character>>> schemaEntries = new HashMap<>();
     for (DataLogRecord record : m_reader) {
       if (!m_active.get()) {
         break;
@@ -62,20 +61,18 @@ public class DataLogReaderThread implements AutoCloseable {
                 new DataLogReaderRange(
                     m_reader.iterator(), new DataLogIterator(m_reader, Integer.MAX_VALUE)));
           }
-          // TODO: support struct schema database
         } finally {
           m_mutex.unlock();
         }
       } else if (record.isFinish()) {
-        int entry = record.getFinishEntry(); // can we not just use record.entry?
         m_mutex.lock();
         try {
-          var readerEntry = m_entriesById.get(entry);
+          var readerEntry = m_entriesById.get(record.getEntry());
           if (readerEntry == null) {
             System.out.println("...ID not found");
           } else {
             readerEntry.m_ranges.getLast().m_end = m_reader.iterator();
-            m_entriesById.remove(entry);
+            m_entriesById.remove(record.getEntry());
           }
         } finally {
           m_mutex.unlock();
@@ -141,10 +138,20 @@ public class DataLogReaderThread implements AutoCloseable {
     }
   }
 
+  /**
+   * Checks if the background thread has finished processing the entire log.
+   *
+   * @return A boolean representing if the background thread has finished processing the entire log.
+   */
   public boolean isDone() {
     return m_done.get();
   }
 
+  /**
+   * Returns the <code>DataLogReader</code> object associated with the log.
+   *
+   * @return The <code>DataLogReader</code> object associated with the log.
+   */
   public DataLogReader getReader() {
     return m_reader;
   }

--- a/datalog/src/main/java/org/wpilib/datalog/DataLogReaderThread.java
+++ b/datalog/src/main/java/org/wpilib/datalog/DataLogReaderThread.java
@@ -1,0 +1,209 @@
+package org.wpilib.datalog;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+
+import org.wpilib.datalog.DataLogRecord.MetadataRecordData;
+import org.wpilib.datalog.DataLogRecord.StartRecordData;
+
+public class DataLogReaderThread implements AutoCloseable {
+  private Thread m_thread;
+  private ReentrantLock m_mutex;
+  private DataLogReader m_reader;
+  private AtomicBoolean m_done = new AtomicBoolean(false);
+  private AtomicBoolean m_active = new AtomicBoolean(true);
+  private AtomicInteger m_numRecords = new AtomicInteger(0);
+
+  public DataLogReaderThread(DataLogReader reader) {
+    m_reader = reader;
+    m_entriesById = new HashMap<>();
+    m_entriesByName = new HashMap<>();
+    m_thread = new Thread(this::readMain);
+    m_thread.start();
+  }
+
+  private void readMain() {
+    // HashMap<Integer, Entry<DataLogReaderEntry, List<Character>>> schemaEntries = new HashMap<>();
+    for (DataLogRecord record : m_reader) {
+      if (!m_active.get()) {
+        break;
+      }
+      m_numRecords.incrementAndGet();
+      if (record.isStart()) {
+        DataLogReaderEntry data = new DataLogReaderEntry(record.getStartData());
+        m_mutex.lock();
+        try {
+          DataLogReaderEntry oldEntry = m_entriesById.put(data.entry, data);
+          if (oldEntry != null) {
+            System.out.println("...DUPLICATE entry ID, overriding");
+          }
+          boolean isNew = m_entriesByName.containsKey(data.name);
+          m_entriesByName.put(data.name, data);
+          if (isNew) {
+            data.m_ranges.add(new DataLogReaderRange(m_reader.iterator(), new DataLogIterator(m_reader, Integer.MAX_VALUE)));
+          }
+          oldEntry = data; // is this needed?
+          // if (data.type.equals("structschema") || 
+          //     data.type.equals("proto:FileDescriptorProto")) {
+          //
+          //   // TODO: figure out schema entries
+          // }
+        } finally {
+          m_mutex.unlock();
+        }
+      } else if (record.isFinish()) {
+        int entry = record.getFinishEntry(); // can we not just use record.entry?
+        m_mutex.lock();
+        try {
+          var readerEntry = m_entriesById.get(entry);
+          if (readerEntry == null) {
+            System.out.println("...ID not found");
+          } else {
+            readerEntry.m_ranges.getLast().m_end = m_reader.iterator();
+            m_entriesById.remove(entry);
+          }
+        } finally {
+          m_mutex.unlock();
+        }
+      } else if (record.isSetMetadata()) {
+        MetadataRecordData data = record.getSetMetadataData();
+        m_mutex.lock();
+        try {
+          var readerEntry = m_entriesById.get(data.entry);
+          if (readerEntry == null) {
+            System.out.println("...ID not found");
+          } else {
+            readerEntry.metadata = data.metadata;
+          }
+        } finally {
+          m_mutex.unlock();
+        }
+      } else if (record.isControl()) {
+        System.out.println("Unrecognized control record");
+      }
+    }
+
+    m_done.set(true);
+  }
+
+  public int getNumRecords() {
+    return m_numRecords.get();
+  }
+
+  public int getNumEntries() {
+    m_mutex.lock();
+    try {
+      return m_entriesByName.size();
+    } finally {
+      m_mutex.unlock();
+    }
+  }
+
+  public void forEachEntryName(Consumer<DataLogReaderEntry> func) {
+    m_mutex.lock();
+    try {
+      for (var kv : m_entriesByName.entrySet()) {
+        func.accept(kv.getValue());
+      }
+    } finally {
+      m_mutex.unlock();
+    }
+  }
+
+  public boolean isDone() {
+    return m_done.get();
+  }
+
+  public DataLogReader getReader() {
+    return m_reader;
+  }
+
+  /**
+   * Fetches the entry with the given id.
+   *
+   * @param entry Id number of the desired entry, which is associated with all of its records.
+   * @return The DataLogReaderEntry associated with that entry id.
+   */
+  DataLogReaderEntry getEntry(int entry) {
+    m_mutex.lock();
+    try {
+      if (m_entriesById.containsKey(entry)) {
+        return m_entriesById.get(entry);
+      } else return null;
+    } finally {
+      m_mutex.unlock();
+    }
+  }
+
+  /**
+   * Fetches the entry with the given name.
+   *
+   * @param name Name string of an entry.
+   * @return The DataLogReaderEntry associated with that name.
+   */
+  DataLogReaderEntry getEntry(String name) {
+    m_mutex.lock();
+    try {
+      if (m_entriesByName.containsKey(name)) {
+        return m_entriesByName.get(name);
+      } else return null;
+    } finally {
+      m_mutex.unlock();
+    }
+  }
+
+  private HashMap<Integer, DataLogReaderEntry> m_entriesById;
+  private HashMap<String, DataLogReaderEntry> m_entriesByName;
+
+  /**
+   * DataLogReader Entry class, which associates an entry's ID with its name, type, and metadata in
+   * a persistent way.
+   */
+  public static class DataLogReaderEntry extends StartRecordData {
+    private final List<DataLogReaderRange> m_ranges;
+
+    /**
+     * Returns the list of ranges for which this entry is valid.
+     *
+     * @return List of DataLogReaderRange for which this entry is valid
+     */
+    public List<DataLogReaderRange> getRanges() {
+      return m_ranges;
+    }
+
+    public DataLogReaderEntry(int entry, String name, String type, String metadata) {
+      super(entry, name, type, metadata);
+      m_ranges = new ArrayList<>();
+    }
+    
+    public DataLogReaderEntry(StartRecordData startData) {
+      super(startData.entry, startData.name, startData.type, startData.metadata);
+      m_ranges = new ArrayList<>();
+    }
+  }
+
+  /** Range of records during which an entry is valid. */
+  public class DataLogReaderRange {
+    DataLogIterator m_begin;
+    DataLogIterator m_end;
+
+    public DataLogReaderRange(DataLogIterator begin, DataLogIterator end) {
+      m_begin = begin;
+      m_end = end;
+    }
+  }
+
+  public void close() {
+    m_active.set(false);
+    try {
+      m_thread.join();
+    } catch (InterruptedException e) {
+      System.out.println("DataLog Reader Thread was interrupted");
+    }
+  }
+}

--- a/datalog/src/main/java/org/wpilib/datalog/DataLogReaderThread.java
+++ b/datalog/src/main/java/org/wpilib/datalog/DataLogReaderThread.java
@@ -62,6 +62,7 @@ public class DataLogReaderThread implements AutoCloseable {
                 new DataLogReaderRange(
                     m_reader.iterator(), new DataLogIterator(m_reader, Integer.MAX_VALUE)));
           }
+          // TODO: support struct schema database
         } finally {
           m_mutex.unlock();
         }

--- a/datalog/src/main/java/org/wpilib/datalog/DataLogReaderThread.java
+++ b/datalog/src/main/java/org/wpilib/datalog/DataLogReaderThread.java
@@ -62,11 +62,6 @@ public class DataLogReaderThread implements AutoCloseable {
                 new DataLogReaderRange(
                     m_reader.iterator(), new DataLogIterator(m_reader, Integer.MAX_VALUE)));
           }
-          // if (data.type.equals("structschema") ||
-          //     data.type.equals("proto:FileDescriptorProto")) {
-          //
-          //   // TODO: figure out schema entries
-          // }
         } finally {
           m_mutex.unlock();
         }

--- a/datalog/src/main/java/org/wpilib/datalog/DataLogRecord.java
+++ b/datalog/src/main/java/org/wpilib/datalog/DataLogRecord.java
@@ -143,7 +143,7 @@ public class DataLogRecord {
     public final String type;
 
     /** Initial metadata. */
-    public final String metadata;
+    public String metadata;
   }
 
   /**

--- a/datalog/src/main/java/org/wpilib/datalog/DataLogRecord.java
+++ b/datalog/src/main/java/org/wpilib/datalog/DataLogRecord.java
@@ -13,6 +13,8 @@ import java.nio.LongBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.InputMismatchException;
 
+import org.wpilib.datalog.DataLogReader.DataLogReaderEntry;
+
 /**
  * A record in the data log. May represent either a control record (entry == 0) or a data record.
  * Used only for reading (e.g. with DataLogReader).
@@ -27,6 +29,23 @@ public class DataLogRecord {
     m_timestamp = timestamp;
     m_data = data;
     m_data.order(ByteOrder.LITTLE_ENDIAN);
+
+    if (isStart()) {
+      var startData = getStartData();
+      m_readerEntry = new DataLogReaderEntry(entry, startData.name, startData.type, startData.metadata);   
+    } else {
+      m_readerEntry = null; // TODO: initialize m_readerEntry properly on non-start records without using a setter because thats nasty
+    }
+  }
+
+  public void setReaderEntry(DataLogReaderEntry entry) {
+    if (m_readerEntry == null) {
+      m_readerEntry = entry;
+    }
+  }
+
+  public DataLogReaderEntry getReaderEntry() {
+    return m_readerEntry;
   }
 
   /**
@@ -427,4 +446,5 @@ public class DataLogRecord {
   private final int m_entry;
   private final long m_timestamp;
   private final ByteBuffer m_data;
+  private DataLogReaderEntry m_readerEntry; // TODO: make m_readerEntry final
 }

--- a/datalog/src/main/java/org/wpilib/datalog/DataLogRecord.java
+++ b/datalog/src/main/java/org/wpilib/datalog/DataLogRecord.java
@@ -13,8 +13,6 @@ import java.nio.LongBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.InputMismatchException;
 
-import org.wpilib.datalog.DataLogReader.DataLogReaderEntry;
-
 /**
  * A record in the data log. May represent either a control record (entry == 0) or a data record.
  * Used only for reading (e.g. with DataLogReader).
@@ -29,23 +27,6 @@ public class DataLogRecord {
     m_timestamp = timestamp;
     m_data = data;
     m_data.order(ByteOrder.LITTLE_ENDIAN);
-
-    if (isStart()) {
-      var startData = getStartData();
-      m_readerEntry = new DataLogReaderEntry(entry, startData.name, startData.type, startData.metadata);   
-    } else {
-      m_readerEntry = null; // TODO: initialize m_readerEntry properly on non-start records without using a setter because thats nasty
-    }
-  }
-
-  public void setReaderEntry(DataLogReaderEntry entry) {
-    if (m_readerEntry == null) {
-      m_readerEntry = entry;
-    }
-  }
-
-  public DataLogReaderEntry getReaderEntry() {
-    return m_readerEntry;
   }
 
   /**
@@ -446,5 +427,4 @@ public class DataLogRecord {
   private final int m_entry;
   private final long m_timestamp;
   private final ByteBuffer m_data;
-  private DataLogReaderEntry m_readerEntry; // TODO: make m_readerEntry final
 }


### PR DESCRIPTION
The C++ `DataLogReader` classes allow the user to get the name, type, metadata, etc. of any entry in a log given only its entry id using an internal map. The java library does not expose this functionality, so this is a proof of concept at one way this could be added. There are some very obvious warts but I want to get feedback if I am even barking up the right tree to begin with. 

Closes #8126 

TODO:

- [x] Implement DataLogReaderRange usages
- [x] Javadoc