### PR TITLE
[robotpy] Improve debug information failures that require running scan-header, update-yaml, and update-build-info

### DIFF
--- a/shared/bazel/rules/robotpy/wrapper.py
+++ b/shared/bazel/rules/robotpy/wrapper.py
@@ -45,7 +45,7 @@ The 'header to dat file' step has failed. The most probable cause for this is th
 have yaml files that don't exist or are out of date called out in this project's
 pyproject.toml file, and need to be regenerated running a tool that looks like this:
 
-bazel run //<project>:write_<library_name>-update-yaml tool
+bazel run //<project>:write_<library_name>-update-yaml
 
 Please see this readme for more information:
 {README_LINK}#2-update-yaml
@@ -57,7 +57,7 @@ Please see this readme for more information:
 An auto generation error has occurred. The most probable cause for this that the bazel
 build scripts need to updated, running a tool that looks like this:
 
-bazel run //<project>:<library_name>-generator.generate_build_info tool.
+bazel run //<project>:<library_name>-generator.generate_build_info
 
 Please see this readme for more information:
 {README_LINK}#3-generate-build-info


### PR DESCRIPTION
Fixes #8386 

Was already working on this when more people started hitting issues so I prioritized getting this PR up. This updates the wrapper script to look for the 3 biggest categories of "everything should be fine if you run this step first" tool failures.

<details>

<summary>Scan headers example</summary>

```INFO: From Testing //hal:robotpy-hal-scan-headers:
==================== Test output for //hal:robotpy-hal-scan-headers:
# wpi/hal
I2CTypes = "wpi/hal/I2CTypes.h"

-------------------------------------
Failed to run wrapped tool.
CWD: /home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/1026/execroot/__main__/bazel-out/k8-opt/bin/hal/robotpy-hal-scan-headers.runfiles/__main__
Tool: semiwrap.tool, Args:
   scan-headers
   --pyproject=hal/src/main/python/pyproject.toml
   --check
-------------------------------------

#########################################################################################
The scan header test has failed. This likely means that you have removed header
files that are used by the project or have added new headers that aren't tracked 
(or explicity ignored) by the project. The text printed up above this message 
should tell you want needs to be added / removed from this projects pyproject.toml file.

Please see this readme for more information:
https://github.com/wpilibsuite/allwpilib/blob/2027/README-RobotPy.md#1-scan-headers
#########################################################################################
```
</details>



<details>

<summary>update-yaml example</summary>

```
ERROR: /home/pjreiniger/git/allwpilib/wpiutil/BUILD.bazel:387:18: Executing genrule //wpiutil:wpiutil.header_to_dat.SendableBuilder [for tool] failed: (Exit 1): bash failed: error executing Genrule command (from target //wpiutil:wpiutil.header_to_dat.SendableBuilder) /bin/bash -c ... (remaining 1 argument skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
Traceback (most recent call last):
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/allwpilib_pip_deps_cxxheaderparser/site-packages/cxxheaderparser/parser.py", line 351, in parse
    self._parse_declarations(tok, doxygen)
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/allwpilib_pip_deps_cxxheaderparser/site-packages/cxxheaderparser/parser.py", line 2633, in _parse_declarations
    and self._maybe_parse_class_enum_decl(
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/allwpilib_pip_deps_cxxheaderparser/site-packages/cxxheaderparser/parser.py", line 2749, in _maybe_parse_class_enum_decl
    self._parse_class_decl(
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/allwpilib_pip_deps_cxxheaderparser/site-packages/cxxheaderparser/parser.py", line 1316, in _parse_class_decl
    if self.visitor.on_class_start(state) is False:
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/allwpilib_pip_deps_semiwrap/site-packages/semiwrap/autowrap/cxxparser.py", line 607, in on_class_start
    raise ValueError(f"'{cls_key}' must be in {self.gendata.data_fname}")
ValueError: 'wpi::util::SendableBuilder' must be in wpiutil/src/main/python/semiwrap/SendableBuilder.yml

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/allwpilib_pip_deps_semiwrap/site-packages/semiwrap/cmd/header2dat.py", line 91, in generate_wrapper
    hctx = parse_header(
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/allwpilib_pip_deps_semiwrap/site-packages/semiwrap/autowrap/cxxparser.py", line 2090, in parse_header
    parser.parse()
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/allwpilib_pip_deps_cxxheaderparser/site-packages/cxxheaderparser/parser.py", line 369, in parse
    raise CxxParseError(msg) from e
cxxheaderparser.errors.CxxParseError: bazel-out/k8-opt-exec-ST-a828a81199fe/bin/wpiutil/native/wpiutil/include/wpi/util/sendable/SendableBuilder.hpp:21: parse error evaluating 'class'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/__main__/shared/bazel/rules/robotpy/_wrapper_stage2_bootstrap.py", line 499, in <module>
    main()
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/__main__/shared/bazel/rules/robotpy/_wrapper_stage2_bootstrap.py", line 493, in main
    _run_py_path(main_filename, args=sys.argv[1:])
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/__main__/shared/bazel/rules/robotpy/_wrapper_stage2_bootstrap.py", line 287, in _run_py_path
    runpy.run_path(main_filename, run_name="__main__")
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/execroot/__main__/external/python_3_10_x86_64-unknown-linux-gnu/lib/python3.10/runpy.py", line 289, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/execroot/__main__/external/python_3_10_x86_64-unknown-linux-gnu/lib/python3.10/runpy.py", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/execroot/__main__/external/python_3_10_x86_64-unknown-linux-gnu/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/__main__/shared/bazel/rules/robotpy/wrapper.py", line 110, in <module>
    main()
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/__main__/shared/bazel/rules/robotpy/wrapper.py", line 98, in main
    tool_main()
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/allwpilib_pip_deps_semiwrap/site-packages/semiwrap/cmd/header2dat.py", line 164, in main
    missing = generate_wrapper(
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/allwpilib_pip_deps_semiwrap/site-packages/semiwrap/cmd/header2dat.py", line 101, in generate_wrapper
    raise ValueError(f"processing {src_h}") from e
ValueError: processing bazel-out/k8-opt-exec-ST-a828a81199fe/bin/wpiutil/native/wpiutil/include/wpi/util/sendable/SendableBuilder.hpp
-------------------------------------
Failed to run wrapped tool.
CWD: /home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/652/execroot/__main__
Tool: semiwrap.cmd.header2dat, Args:
   --cpp
   202002L
   SendableBuilder
   wpiutil/src/main/python/semiwrap/SendableBuilder.yml
   -I
   bazel-out/k8-opt-exec-ST-a828a81199fe/bin/wpiutil/native/wpiutil/include
   -I
   bazel-out/k8-opt-exec-ST-a828a81199fe/bin/wpiutil/native/wpiutil/include
   bazel-out/k8-opt-exec-ST-a828a81199fe/bin/wpiutil/native/wpiutil/include/wpi/util/sendable/SendableBuilder.hpp
   bazel-out/k8-opt-exec-ST-a828a81199fe/bin/wpiutil/native/wpiutil/include
   bazel-out/k8-opt-exec-ST-a828a81199fe/bin/wpiutil/generated/resolve_casters/wpiutil.casters.pkl
   bazel-out/k8-opt-exec-ST-a828a81199fe/bin/wpiutil/generated/header_to_dat/SendableBuilder.dat
   bazel-out/k8-opt-exec-ST-a828a81199fe/bin/wpiutil/generated/header_to_dat/SendableBuilder.d
   bogus
   c++20
   ccache
   c++
   --
   -std=c++20
-------------------------------------

#########################################################################################
The 'header to dat file' step has failed. The most probable cause for this is that you
have yaml files that don't exist or are out of date called out in this projects
pyproject.toml file, and need to be regenerated using the 

bazel run //<project>:write_<library_name>-update-yaml tool

Please see this readme for more information:
https://github.com/wpilibsuite/allwpilib/blob/2027/README-RobotPy.md#2-update-yaml
#########################################################################################
```

</details>


<details>

<summary>update build files example</summary>

```
================================================================================
ERROR: /home/pjreiniger/git/allwpilib/wpiutil/BUILD.bazel:387:18: Executing genrule //wpiutil:wpiutil.dat2trampoline.src/main/python/wpiutil/trampolines/wpi__util__XSendableBuilder.hpp failed: (Exit 1): bash failed: error executing Genrule command (from target //wpiutil:wpiutil.dat2trampoline.src/main/python/wpiutil/trampolines/wpi__util__XSendableBuilder.hpp) /bin/bash -c ... (remaining 1 argument skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
Traceback (most recent call last):
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/661/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/__main__/shared/bazel/rules/robotpy/_wrapper_stage2_bootstrap.py", line 499, in <module>
    main()
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/661/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/__main__/shared/bazel/rules/robotpy/_wrapper_stage2_bootstrap.py", line 493, in main
    _run_py_path(main_filename, args=sys.argv[1:])
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/661/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/__main__/shared/bazel/rules/robotpy/_wrapper_stage2_bootstrap.py", line 287, in _run_py_path
    runpy.run_path(main_filename, run_name="__main__")
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/execroot/__main__/external/python_3_10_x86_64-unknown-linux-gnu/lib/python3.10/runpy.py", line 289, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/execroot/__main__/external/python_3_10_x86_64-unknown-linux-gnu/lib/python3.10/runpy.py", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/execroot/__main__/external/python_3_10_x86_64-unknown-linux-gnu/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/661/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/__main__/shared/bazel/rules/robotpy/wrapper.py", line 110, in <module>
    main()
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/661/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/__main__/shared/bazel/rules/robotpy/wrapper.py", line 98, in main
    tool_main()
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/661/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/allwpilib_pip_deps_semiwrap/site-packages/semiwrap/cmd/dat2trampoline.py", line 61, in main
    _write_wrapper_cpp(pathlib.Path(input_dat), yml_id, pathlib.Path(output_hpp))
  File "/home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/661/execroot/__main__/bazel-out/k8-opt-exec-ST-a828a81199fe/bin/shared/bazel/rules/robotpy/wrapper.runfiles/allwpilib_pip_deps_semiwrap/site-packages/semiwrap/cmd/dat2trampoline.py", line 48, in _write_wrapper_cpp
    raise ValueError("\n".join(msg))
ValueError: cannot find wpi::util::SendableBuilderX in wpi/util/sendable/SendableBuilder.hpp
- config: wpiutil/src/main/python/semiwrap/SendableBuilder.yml
- found wpi::util::SendableBuilder
-------------------------------------
Failed to run wrapped tool.
CWD: /home/pjreiniger/.cache/bazel/_bazel_pjreiniger/3820437f09d5d4cc513fa74e2d198f91/sandbox/linux-sandbox/661/execroot/__main__
Tool: semiwrap.cmd.dat2trampoline, Args:
   bazel-out/k8-opt-exec-ST-a828a81199fe/bin/wpiutil/generated/header_to_dat/SendableBuilder.dat
   wpi::util::SendableBuilderX
   bazel-out/k8-opt/bin/wpiutil/src/main/python/wpiutil/trampolines/wpi__util__XSendableBuilder.hpp
-------------------------------------

#########################################################################################
An auto generation error has occured. The most probable cause for this that the bazel
build scripts need to updated, using the 

bazel run //<project>:<library_name>-generator.generate_build_info tool.

Please see this readme for more information:
https://github.com/wpilibsuite/allwpilib/blob/2027/README-RobotPy.md#3-generate-build-info
#########################################################################################
```

</details>
