### PR TITLE
[bazel] Update rules_jvm_external to version 6.8

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,11 +54,13 @@ http_archive(
 )
 
 # Download Extra java rules
+RULES_JVM_EXTERNAL_TAG = "6.8"
+
 http_archive(
     name = "rules_jvm_external",
-    sha256 = "4f55980c25d0783b9fe43b049362018d8d79263476b5340a5491893ffcc06ab6",
-    strip_prefix = "rules_jvm_external-30899314873b6ec69dc7d02c4457fbe52a6e535d",
-    url = "https://github.com/bazel-contrib/rules_jvm_external/archive/30899314873b6ec69dc7d02c4457fbe52a6e535d.tar.gz",
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    sha256 = "704a0197e4e966f96993260418f2542568198490456c21814f647ae7091f56f2",
+    url = "https://github.com/bazel-contrib/rules_jvm_external/releases/download/{v}/rules_jvm_external-{v}.tar.gz".format(v = RULES_JVM_EXTERNAL_TAG)
 )
 
 # Setup aspect lib

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,9 +58,9 @@ RULES_JVM_EXTERNAL_TAG = "6.8"
 
 http_archive(
     name = "rules_jvm_external",
-    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     sha256 = "704a0197e4e966f96993260418f2542568198490456c21814f647ae7091f56f2",
-    url = "https://github.com/bazel-contrib/rules_jvm_external/releases/download/{v}/rules_jvm_external-{v}.tar.gz".format(v = RULES_JVM_EXTERNAL_TAG)
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    url = "https://github.com/bazel-contrib/rules_jvm_external/releases/download/{v}/rules_jvm_external-{v}.tar.gz".format(v = RULES_JVM_EXTERNAL_TAG),
 )
 
 # Setup aspect lib


### PR DESCRIPTION
The commit we were pinned to (https://github.com/bazel-contrib/rules_jvm_external/commit/30899314873b6ec69dc7d02c4457fbe52a6e535d) ended up in a release.

https://github.com/bazel-contrib/rules_jvm_external/releases/tag/6.8