### PR TITLE
Fix order of Swerve Modules in Odometry Update

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/subsystems/DriveSubsystem.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/subsystems/DriveSubsystem.cpp
@@ -45,8 +45,8 @@ DriveSubsystem::DriveSubsystem()
 void DriveSubsystem::Periodic() {
   // Implementation of subsystem periodic method goes here.
   m_odometry.Update(m_gyro.GetRotation2d(),
-                    {m_frontLeft.GetPosition(), m_rearLeft.GetPosition(),
-                     m_frontRight.GetPosition(), m_rearRight.GetPosition()});
+                    {m_frontLeft.GetPosition(), m_frontRight.GetPosition(),
+                     m_rearLeft.GetPosition(), m_rearRight.GetPosition()});
 }
 
 void DriveSubsystem::Drive(units::meters_per_second_t xSpeed,


### PR DESCRIPTION
The order of the Swerve Modules in the m_odometry.Update call needs to match the order they are defined in the creation of the kDriveKinematics object.