### PR TITLE
Remove gfortran mention in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ Using Gradle makes building WPILib very straightforward. It only has a few depen
 
 On macOS ARM, run `softwareupdate --install-rosetta`. This is necessary to be able to use the macOS x86 roboRIO toolchain on ARM.
 
-On linux, run `sudo apt install gfortran`. This is necessary to be able to build WPIcal on linux platforms.
-
 On linux, run `sudo apt install libx11-dev libgl-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev` to be able to build things depending on glfw.
 
 ## Setup


### PR DESCRIPTION
Accidentally dropped in merge commit ed7982563bfeb09ffdcb128284a77eb587629d5c due to 3b7d0e7bf5423a667b9657c91b06d92d9660d9fb also modifying adjacent lines.