### PR TITLE
[wpilib] Color: Improve string support

### DIFF
--- a/wpilibc/src/main/python/semiwrap/Color.yml
+++ b/wpilibc/src/main/python/semiwrap/Color.yml
@@ -168,7 +168,7 @@ classes:
               b:
                 name: blue
           int, int, int:
-          std::string_view:
+      FromString:
       FromHSV:
       HexString:
       operator==:

--- a/wpilibc/src/test/native/cpp/util/ColorTest.cpp
+++ b/wpilibc/src/test/native/cpp/util/ColorTest.cpp
@@ -43,21 +43,43 @@ TEST(ColorTest, ConstructFromInts) {
   EXPECT_NEAR(0.25, color.blue, 1e-2);
 }
 
-TEST(ColorTest, ConstructFromHexString) {
-  constexpr wpi::Color color{"#FF8040"};
+TEST(ColorTest, FromHexString) {
+  constexpr wpi::Color color = wpi::Color::FromString("#FF8040");
 
   EXPECT_NEAR(1.0, color.red, 1e-2);
   EXPECT_NEAR(0.5, color.green, 1e-2);
   EXPECT_NEAR(0.25, color.blue, 1e-2);
 
   // No leading #
-  EXPECT_THROW(wpi::Color{"112233"}, std::invalid_argument);
+  EXPECT_THROW(wpi::Color::FromString("112233"), std::invalid_argument);
 
   // Too long
-  EXPECT_THROW(wpi::Color{"#11223344"}, std::invalid_argument);
+  EXPECT_THROW(wpi::Color::FromString("#11223344"), std::invalid_argument);
 
   // Invalid hex characters
-  EXPECT_THROW(wpi::Color{"#$$$$$$"}, std::invalid_argument);
+  EXPECT_THROW(wpi::Color::FromString("#$$$$$$"), std::invalid_argument);
+}
+
+TEST(ColorTest, FromRGBString) {
+  constexpr wpi::Color color = wpi::Color::FromString("rgb(255, 128, 64)");
+
+  EXPECT_NEAR(1.0, color.red, 1e-2);
+  EXPECT_NEAR(0.5, color.green, 1e-2);
+  EXPECT_NEAR(0.25, color.blue, 1e-2);
+
+  // Missing rgb()
+  EXPECT_THROW(wpi::Color::FromString("255, 128, 64"), std::invalid_argument);
+
+  // Too few components
+  EXPECT_THROW(wpi::Color::FromString("rgb(255, 128)"), std::invalid_argument);
+
+  // Too many components
+  EXPECT_THROW(wpi::Color::FromString("rgb(255, 128, 64, 32)"),
+               std::invalid_argument);
+
+  // Non-integer component
+  EXPECT_THROW(wpi::Color::FromString("rgb(255, abc, 64)"),
+               std::invalid_argument);
 }
 
 TEST(ColorTest, FromHSV) {

--- a/wpilibj/src/test/java/org/wpilib/util/ColorTest.java
+++ b/wpilibj/src/test/java/org/wpilib/util/ColorTest.java
@@ -55,21 +55,55 @@ class ColorTest {
   }
 
   @Test
-  void testConstructFromHexString() {
-    var color = new Color("#FF8040");
+  void testFromHexString() {
+    var color = Color.fromString("#FF8040");
 
     assertEquals(1.0, color.red, 1e-2);
     assertEquals(0.5, color.green, 1e-2);
     assertEquals(0.25, color.blue, 1e-2);
 
     // No leading #
-    assertThrows(IllegalArgumentException.class, () -> new Color("112233"));
+    assertThrows(IllegalArgumentException.class, () -> Color.fromString("112233"));
 
     // Too long
-    assertThrows(IllegalArgumentException.class, () -> new Color("#11223344"));
+    assertThrows(IllegalArgumentException.class, () -> Color.fromString("#11223344"));
 
     // Invalid hex characters
-    assertThrows(IllegalArgumentException.class, () -> new Color("#$$$$$$"));
+    assertThrows(IllegalArgumentException.class, () -> Color.fromString("#$$$$$$"));
+  }
+
+  @Test
+  void testFromRGBString() {
+    var color = Color.fromString("rgb(255,128,64)");
+
+    assertEquals(1.0, color.red, 1e-2);
+    assertEquals(0.5, color.green, 1e-2);
+    assertEquals(0.25, color.blue, 1e-2);
+
+    // Wrong number of components
+    assertThrows(IllegalArgumentException.class, () -> Color.fromString("rgb(255,128)"));
+
+    // Invalid integer
+    assertThrows(IllegalArgumentException.class, () -> Color.fromString("rgb(255,xx,64)"));
+  }
+
+  @Test
+  void testFromConstantName() {
+    var color = Color.fromString("red");
+
+    assertEquals(1.0, color.red, 1e-2);
+    assertEquals(0.0, color.green, 1e-2);
+    assertEquals(0.0, color.blue, 1e-2);
+
+    // with k prefix
+    color = Color.fromString("kRed");
+
+    assertEquals(1.0, color.red, 1e-2);
+    assertEquals(0.0, color.green, 1e-2);
+    assertEquals(0.0, color.blue, 1e-2);
+
+    // Unknown name
+    assertThrows(IllegalArgumentException.class, () -> Color.fromString("unknowncolor"));
   }
 
   @Test


### PR DESCRIPTION
Now rgb() and color constants are supported.

Changed from constructor to fromString() factory function to enable directly returning color constant values.