### PR TITLE
[robotpy][build] Run robotpy gen steps in series instead of simultaneously

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -135,8 +135,11 @@ jobs:
         run: bazel test //... -k --test_tag_filters=robotpy_scan_headers --build_tests_only
         shell: bash
 
-      - name: Run robotpy pregeneration
-        run: bazel run //:write_robotpy_files
+      - name: Run yaml file generation
+        run: bazel run //:write_robotpy_update_yaml_files
+
+      - name: Run build file generation
+        run: bazel run //:write_robotpy_generated_pybind_files
 
       - name: Check Output
         run: git --no-pager diff --exit-code HEAD


### PR DESCRIPTION
The update yaml step _might_ cause changes that would affect the build file generation. Since `bazel run //:write_robotpy_update_yaml_files` runs them all at once, user that was using the github action to fix their python stuff would end up having to run it twice.

By running the steps individually in series, this should be able to get it in one swoop.