### PR TITLE
Update Bazel resource-limiting commands

### DIFF
--- a/README-Bazel.md
+++ b/README-Bazel.md
@@ -23,6 +23,7 @@ Examples:
   build --local_resources=memory=HOST_RAM*.5 # Don't use more than half my RAM when building
   build --local_resources=cpu=HOST_CPUS-1 # Leave one core alone
   ```
+Bazel's RAM usage estimation is simplistic and hardcoded, so limiting the allowed number of CPU cores is the best way to reduce memory usage if it becomes a problem.
 
 The default settings build all the release artifact variants relevant for your platform.  The overall list of options ends up being, essentially, all the variants of (linux, osx, windows) x (debug, release) x (static, shared) x (aarch64, x86).  OSX and Windows are hard to compile for from any other OS, so we by default build for your local OS and the system core, with all the variants.
 


### PR DESCRIPTION
`--local_ram_resources=value` and `--local_cpu_resources=value` have been replaced by `--local_resources=[memory|cpu]=value`, so the Bazel README is updated to recommend the new form.