### PR TITLE
[ci] Remove Java and deprecated Bazelisk setup from Bazel workflow

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -39,16 +39,6 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
-      - if: matrix.os == 'windows-2022' || matrix.os == 'macOS-15'
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 21
-          architecture: x64
-
-      - if: matrix.os == 'ubuntu-24.04'
-        uses: bazelbuild/setup-bazelisk@v3
-
       - id: Setup_bazel_remote
         uses: ./.github/actions/setup-bazel-remote
         with:


### PR DESCRIPTION
We download the JDK in the workspace and tell Bazel to use it for all Java actions in our config, so we don't need to download another one.

https://github.com/wpilibsuite/allwpilib/blob/99af9d775c97341a84b9f4d22296cc3a76f8de61/.bazelrc#L12-L15

The [bazelbuild/setup-bazelisk](https://github.com/bazelbuild/setup-bazelisk) action is deprecated, and is redundant with the [bazel-contrib/setup-bazel](https://github.com/bazel-contrib/setup-bazel) action we use after it.