### PR TITLE
[ci] Use Java headers for macOS Bazel build

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -39,16 +39,6 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
-      - if: matrix.os == 'windows-2022' || matrix.os == 'macOS-15'
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 21
-          architecture: x64
-
-      - if: matrix.os == 'ubuntu-24.04'
-        uses: bazelbuild/setup-bazelisk@v3
-
       - id: Setup_bazel_remote
         uses: ./.github/actions/setup-bazel-remote
         with:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -56,8 +56,6 @@ jobs:
         run: |
           if [[ "${{ matrix.os }}" == "windows-2022" ]]; then
             bazel --output_user_root=C:\\bazelroot ${{ matrix.action }} ... --config=ci -c opt --repo_env=WPI_PUBLISH_CLASSIFIER_FILTER='${{ matrix.classifier }}'
-          elif [[ "${{ matrix.os }}" == "macOS-15" ]]; then
-            bazel ${{ matrix.action }} ... --config=ci -c opt --nojava_header_compilation --repo_env=WPI_PUBLISH_CLASSIFIER_FILTER='${{ matrix.classifier }}'
           else
             bazel ${{ matrix.action }} ... --config=ci -c opt --repo_env=WPI_PUBLISH_CLASSIFIER_FILTER='${{ matrix.classifier }}'
           fi


### PR DESCRIPTION
I'm not entirely sure why Java header compilation is disabled for the macOS build. But this option will be causing rebuilds to happen more often than strictly necessary.

[Turbine](https://github.com/google/turbine) takes Java class sources and spits out .class files with all method bodies, and private fields and methods stripped. This provides a .jar with sufficient information on the classpath to build dependent Java libraries without depending on the implementation in the build graph.

Currently stacked on:

- #8412