### PR TITLE
[bazel] Build with LLVM

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -35,6 +35,18 @@ jobs:
     name: "${{ matrix.action == 'test' && 'Test' || 'Build' }} ${{ matrix.name }}"
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Free disk space (Linux)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+        if: startsWith(matrix.os, 'ubuntu')
+
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -12,14 +12,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: "Linux System Core", classifier: "linuxsystemcore",                 os: ubuntu-24.04, container: "wpilib/systemcore-cross-ubuntu:2027-24.04", action: "build" }
-          - { name: "Linux System Core Debug", classifier: "linuxsystemcoredebug",            os: ubuntu-24.04, container: "wpilib/systemcore-cross-ubuntu:2027-24.04", action: "build" }
-          - { name: "Linux System Core Static", classifier: "linuxsystemcorestatic",           os: ubuntu-24.04, container: "wpilib/systemcore-cross-ubuntu:2027-24.04", action: "build" }
-          - { name: "Linux System Core Static Debug", classifier: "linuxsystemcorestaticdebug",    os: ubuntu-24.04, container: "wpilib/systemcore-cross-ubuntu:2027-24.04", action: "build" }
-          - { name: "Linux x86-64",      classifier: "linuxx86-64,headers,sources",     os: ubuntu-24.04, container: "wpilib/systemcore-cross-ubuntu:2027-24.04", action: "test" }
-          - { name: "Linux x86-64 Debug",  classifier: "linuxx86-64debug",                os: ubuntu-24.04, container: "wpilib/systemcore-cross-ubuntu:2027-24.04", action: "test" }
-          - { name: "Linux x86-64 Static", classifier: "linuxx86-64static",               os: ubuntu-24.04, container: "wpilib/systemcore-cross-ubuntu:2027-24.04", action: "test" }
-          - { name: "Linux x86-64 Static Debug", classifier: "linuxx86-64staticdebug",        os: ubuntu-24.04, container: "wpilib/systemcore-cross-ubuntu:2027-24.04", action: "test" }
+          - { name: "Linux System Core", classifier: "linuxsystemcore",                 os: ubuntu-24.04, action: "build" }
+          - { name: "Linux System Core Debug", classifier: "linuxsystemcoredebug",            os: ubuntu-24.04, action: "build" }
+          - { name: "Linux System Core Static", classifier: "linuxsystemcorestatic",           os: ubuntu-24.04, action: "build" }
+          - { name: "Linux System Core Static Debug", classifier: "linuxsystemcorestaticdebug",    os: ubuntu-24.04, action: "build" }
+          - { name: "Linux x86-64",      classifier: "linuxx86-64,headers,sources",     os: ubuntu-24.04, action: "test" }
+          - { name: "Linux x86-64 Debug",  classifier: "linuxx86-64debug",                os: ubuntu-24.04, action: "test" }
+          - { name: "Linux x86-64 Static", classifier: "linuxx86-64static",               os: ubuntu-24.04, action: "test" }
+          - { name: "Linux x86-64 Static Debug", classifier: "linuxx86-64staticdebug",        os: ubuntu-24.04, action: "test" }
 
           - { name: "macOS", classifier: "osxuniversal,osxuniversaldebug,headers,sources,osxuniversalstatic,osxuniversalstaticdebug,linuxsystemcore,linuxsystemcoredebug,linuxsystemcorestatic,linuxsystemcorestaticdebug", os: macOS-15, action: "test" }
 
@@ -34,7 +34,6 @@ jobs:
 
     name: "${{ matrix.action == 'test' && 'Test' || 'Build' }} ${{ matrix.name }}"
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -44,6 +44,10 @@ jobs:
           username: ${{ secrets.BAZEL_CACHE_USERNAME }}
           password: ${{ secrets.BAZEL_CACHE_PASSWORD }}
 
+      - name: Install apt dependencies
+        if: matrix.os == 'ubuntu-24.04'
+        run: sudo apt-get install -y libgl1-mesa-dev libx11-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev
+
       - if: matrix.os == 'ubuntu-24.04'
         uses: bazel-contrib/setup-bazel@0.15.0
         with:
@@ -63,12 +67,7 @@ jobs:
       - name: Free Space
         if: always()
         shell: bash
-        run: |
-          if [[ "${{ matrix.os }}" == "windows-2022" ]]; then
-            fsutil volume diskfree C:
-          else
-            df -h /
-          fi
+        run: df -h
 
   buildifier:
     name: "buildifier"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -186,29 +186,29 @@ llvm_toolchain(
     name = "llvm_toolchain",
     cxx_standard = {"": "c++20"},
     extra_compile_flags = {
+        "darwin-aarch64": MACOS_EXTRA_COMPILE_FLAGS,
+        "darwin-x86_64": MACOS_EXTRA_COMPILE_FLAGS,
         "linux-aarch64": LINUX_EXTRA_COMPILE_FLAGS,
         "linux-x86_64": LINUX_EXTRA_COMPILE_FLAGS,
-        "macos-aarch64": MACOS_EXTRA_COMPILE_FLAGS,
-        "macos-x86_64": MACOS_EXTRA_COMPILE_FLAGS,
     },
     extra_cxx_flags = {
+        "darwin-aarch64": MACOS_EXTRA_CXX_FLAGS,
+        "darwin-x86_64": MACOS_EXTRA_CXX_FLAGS,
         "linux-aarch64": LINUX_EXTRA_CXX_FLAGS,
         "linux-x86_64": LINUX_EXTRA_CXX_FLAGS,
-        "macos-aarch64": MACOS_EXTRA_CXX_FLAGS,
-        "macos-x86_64": MACOS_EXTRA_CXX_FLAGS,
     },
     extra_link_flags = {
+        "darwin-aarch64": MACOS_EXTRA_LINK_FLAGS,
+        "darwin-x86_64": MACOS_EXTRA_LINK_FLAGS,
         "linux-aarch64": LINUX_EXTRA_LINK_FLAGS,
         "linux-x86_64": LINUX_EXTRA_LINK_FLAGS,
-        "macos-aarch64": MACOS_EXTRA_LINK_FLAGS,
-        "macos-x86_64": MACOS_EXTRA_LINK_FLAGS,
     },
     llvm_version = "20.1.7",
     stdlib = {
+        "darwin-aarch64": "builtin-libc++",
+        "darwin-x86_64": "builtin-libc++",
         "linux-aarch64": "stdc++",
         "linux-x86_64": "stdc++",
-        "macos-aarch64": "builtin-libc++",
-        "macos-x86_64": "builtin-libc++",
     },
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,6 +78,14 @@ http_archive(
     url = "https://github.com/wpilibsuite/rules_bzlmodrio_toolchains/releases/download/2025-1.bcr6/rules_bzlmodrio_toolchains-2025-1.bcr6.tar.gz",
 )
 
+# TODO(davo): update version after the next release of toolchains_llvm after 1.5.0
+http_archive(
+    name = "toolchains_llvm",
+    integrity = "sha256-Ht0UsdgsySFX+H7AU3TS992uZr8nV5TP60lADgKeP7s=",
+    strip_prefix = "toolchains_llvm-cebf1ed19db1521bcaae489a40dd736d50e9302f",
+    url = "https://github.com/bazel-contrib/toolchains_llvm/archive/cebf1ed19db1521bcaae489a40dd736d50e9302f.tar.gz",
+)
+
 http_archive(
     name = "pybind11_bazel",
     integrity = "sha256-iwRj1wuX2pDS6t6DqiCfhIXisv4y+7CvxSJtZoSAzGw=",
@@ -128,9 +136,85 @@ load("@bazel_features//:deps.bzl", "bazel_features_deps")
 
 bazel_features_deps()
 
+load("@toolchains_llvm//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+
+bazel_toolchain_dependencies()
+
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
 
 apple_support_dependencies()
+
+load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
+
+COMMON_EXTRA_COMPILE_FLAGS = [
+    "-Wextra",
+    "-Werror",
+    "-pedantic",
+    "-Wno-unused-parameter",
+    "-fPIC",
+]
+
+LINUX_EXTRA_COMPILE_FLAGS = COMMON_EXTRA_COMPILE_FLAGS + ["-gz=zlib"]
+
+MACOS_EXTRA_COMPILE_FLAGS = COMMON_EXTRA_COMPILE_FLAGS + [
+    "-Wno-shorten-64-to-32",
+    "-Wno-gcc-compat",
+    "-Wno-missing-field-initializers",
+    "-Wno-unused-private-field",
+]
+
+COMMON_EXTRA_CXX_FLAGS = [
+    "-Wformat=2",
+    "-Wno-unused-parameter",
+    "-pthread",
+    "-Wno-deprecated-enum-enum-conversion",
+]
+
+LINUX_EXTRA_CXX_FLAGS = COMMON_EXTRA_CXX_FLAGS + ["-Wno-psabi"]
+
+MACOS_EXTRA_CXX_FLAGS = COMMON_EXTRA_CXX_FLAGS + [
+    "-Wno-unused-const-variable",
+    "-Wno-error=c11-extensions",
+    "-Wno-deprecated-anon-enum-enum-conversion",
+]
+
+LINUX_EXTRA_LINK_FLAGS = ["-Wl,-rpath,$ORIGIN"]
+
+MACOS_EXTRA_LINK_FLAGS = ["-Wl,-rpath,@loader_path"]
+
+llvm_toolchain(
+    name = "llvm_toolchain",
+    cxx_standard = {"": "c++20"},
+    extra_compile_flags = {
+        "linux-aarch64": LINUX_EXTRA_COMPILE_FLAGS,
+        "linux-x86_64": LINUX_EXTRA_COMPILE_FLAGS,
+        "macos-aarch64": MACOS_EXTRA_COMPILE_FLAGS,
+        "macos-x86_64": MACOS_EXTRA_COMPILE_FLAGS,
+    },
+    extra_cxx_flags = {
+        "linux-aarch64": LINUX_EXTRA_CXX_FLAGS,
+        "linux-x86_64": LINUX_EXTRA_CXX_FLAGS,
+        "macos-aarch64": MACOS_EXTRA_CXX_FLAGS,
+        "macos-x86_64": MACOS_EXTRA_CXX_FLAGS,
+    },
+    extra_link_flags = {
+        "linux-aarch64": LINUX_EXTRA_LINK_FLAGS,
+        "linux-x86_64": LINUX_EXTRA_LINK_FLAGS,
+        "macos-aarch64": MACOS_EXTRA_LINK_FLAGS,
+        "macos-x86_64": MACOS_EXTRA_LINK_FLAGS,
+    },
+    llvm_version = "19.1.7",
+    stdlib = {
+        "linux-aarch64": "stdc++",
+        "linux-x86_64": "stdc++",
+        "macos-aarch64": "builtin-libc++",
+        "macos-x86_64": "builtin-libc++",
+    },
+)
+
+load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+
+llvm_register_toolchains()
 
 load("@rules_cc//cc:repositories.bzl", "rules_cc_toolchains")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -168,6 +168,7 @@ COMMON_EXTRA_CXX_FLAGS = [
     "-Wno-unused-parameter",
     "-pthread",
     "-Wno-deprecated-enum-enum-conversion",
+    "-Wno-nontrivial-memcall",  # warning in imgui.h inline functions
 ]
 
 LINUX_EXTRA_CXX_FLAGS = COMMON_EXTRA_CXX_FLAGS + ["-Wno-psabi"]

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -203,7 +203,7 @@ llvm_toolchain(
         "macos-aarch64": MACOS_EXTRA_LINK_FLAGS,
         "macos-x86_64": MACOS_EXTRA_LINK_FLAGS,
     },
-    llvm_version = "19.1.7",
+    llvm_version = "20.1.7",
     stdlib = {
         "linux-aarch64": "stdc++",
         "linux-x86_64": "stdc++",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -163,6 +163,8 @@ MACOS_EXTRA_COMPILE_FLAGS = COMMON_EXTRA_COMPILE_FLAGS + [
     "-Wno-unused-private-field",
 ]
 
+CONLY_FLAGS = ["-Wno-c23-extensions"]
+
 COMMON_EXTRA_CXX_FLAGS = [
     "-Wformat=2",
     "-Wno-unused-parameter",
@@ -185,6 +187,12 @@ MACOS_EXTRA_LINK_FLAGS = ["-Wl,-rpath,@loader_path"]
 
 llvm_toolchain(
     name = "llvm_toolchain",
+    conly_flags = {
+        "darwin-aarch64": CONLY_FLAGS,
+        "darwin-x86_64": CONLY_FLAGS,
+        "linux-aarch64": CONLY_FLAGS,
+        "linux-x86_64": CONLY_FLAGS,
+    },
     cxx_standard = {"": "c++20"},
     extra_compile_flags = {
         "darwin-aarch64": MACOS_EXTRA_COMPILE_FLAGS,

--- a/apriltag/BUILD.bazel
+++ b/apriltag/BUILD.bazel
@@ -33,10 +33,9 @@ cc_library(
     srcs = glob(["src/main/native/thirdparty/apriltag/src/**"]),
     hdrs = glob(["src/main/native/thirdparty/apriltag/include/**"]),
     copts = select({
-        "@platforms//os:osx": [
+        "@bazel_tools//tools/cpp:gcc": [
             "-Wno-format-nonliteral",
-            "-Wno-gnu-zero-variadic-macro-arguments",
-            "-Wno-uninitialized",
+            "-Wno-maybe-uninitialized",
             "-Wno-sign-compare",
             "-Wno-type-limits",
         ],
@@ -47,9 +46,10 @@ cc_library(
             "/wd4267",
             "/wd4996",
         ],
-        "@rules_bzlmodrio_toolchains//constraints/combined:is_linux": [
+        "//conditions:default": [
             "-Wno-format-nonliteral",
-            "-Wno-maybe-uninitialized",
+            "-Wno-gnu-zero-variadic-macro-arguments",
+            "-Wno-uninitialized",
             "-Wno-sign-compare",
             "-Wno-type-limits",
         ],

--- a/shared/bazel/compiler_flags/linux_flags.rc
+++ b/shared/bazel/compiler_flags/linux_flags.rc
@@ -25,7 +25,7 @@ build:linux --host_cxxopt=-Wno-attributes
 # Ignore potential issues in third party code on the host
 build:linux --host_cxxopt=-Wno-pedantic
 build:linux --host_cxxopt=-Wno-format-nonliteral
-build:linux --host_cxxopt=-Wno-missing-requires
+#build:linux --host_cxxopt=-Wno-missing-requires
 build:linux --host_cxxopt=-Wno-implicit-fallthrough
 
 build:linux --host_per_file_copt=external/zlib/.*\.c@-Wno-deprecated-non-prototype

--- a/tools/wpical/BUILD.bazel
+++ b/tools/wpical/BUILD.bazel
@@ -85,7 +85,7 @@ osx_copts = unix_copts
 
 copts = select({
     "@platforms//os:linux": unix_copts + [
-        # "-Wno-maybe-uninitialized",
+        "-Wno-sometimes-uninitialized",
     ],
     "@platforms//os:osx": osx_copts,
     "@platforms//os:windows": [

--- a/tools/wpical/BUILD.bazel
+++ b/tools/wpical/BUILD.bazel
@@ -85,7 +85,7 @@ osx_copts = unix_copts
 
 copts = select({
     "@platforms//os:linux": unix_copts + [
-        "-Wno-maybe-uninitialized",
+        # "-Wno-maybe-uninitialized",
     ],
     "@platforms//os:osx": osx_copts,
     "@platforms//os:windows": [


### PR DESCRIPTION
This pulls a hermetic LLVM toolchain into the Bazel workspace, for use in our Linux x86-64 builds. This removes our dependency on the host OS C++ toolchain, and hence makes building in a container largely redundant.

Since we no longer build in a container, this also frees up some disk space for our CI builds, however this is somewhat displaced by the size of the toolchain download.

Note that this doesn't register the toolchain with an isolated sysroot, so this now relies on the host image for its sysroot.