### PR TITLE
[ci] Build only publish artifacts in Bazel cross-compile jobs

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -54,10 +54,16 @@ jobs:
 
       - name: bazel ${{ matrix.action }}
         run: |
-          if [[ "${{ matrix.os }}" == "windows-2022" ]]; then
-            bazel --output_user_root=C:\\bazelroot ${{ matrix.action }} ... --config=ci -c opt --repo_env=WPI_PUBLISH_CLASSIFIER_FILTER='${{ matrix.classifier }}'
+          ACTION='${{ matrix.action }}'
+          if [[ "${ACTION}" == "build" ]]; then
+            TARGETS=:publish
           else
-            bazel ${{ matrix.action }} ... --config=ci -c opt --repo_env=WPI_PUBLISH_CLASSIFIER_FILTER='${{ matrix.classifier }}'
+            TARGETS=...
+          fi
+          if [[ "${{ matrix.os }}" == "windows-2022" ]]; then
+            bazel --output_user_root=C:\\bazelroot ${ACTION} ${TARGETS} --config=ci -c opt --repo_env=WPI_PUBLISH_CLASSIFIER_FILTER='${{ matrix.classifier }}'
+          else
+            bazel ${ACTION} ${TARGETS} --config=ci -c opt --repo_env=WPI_PUBLISH_CLASSIFIER_FILTER='${{ matrix.classifier }}'
           fi
         shell: bash
 


### PR DESCRIPTION
#8363 split all the cross-compilation into separate jobs, however these jobs are still also building the world (including the tests) targeting the host.

Since `//:publish` and its dependencies are transitioned to target the desired platforms for each artifact, `bazel build //:publish` in the CI jobs that aren't running tests to only build what we actually care about in these jobs.

This saves around 1 to 1.5 minutes for each cross-compile job with 100% cache hit rates.