### PR TITLE
[datalog] Add dev targets to Bazel builds

### DIFF
--- a/datalog/BUILD.bazel
+++ b/datalog/BUILD.bazel
@@ -121,7 +121,7 @@ java_binary(
 )
 
 java_binary(
-    name = "DevMain-java",
+    name = "DevMain-Java",
     srcs = ["src/dev/java/org/wpilib/datalog/DevMain.java"],
     main_class = "org.wpilib.datalog.DevMain",
     deps = [
@@ -130,7 +130,7 @@ java_binary(
 )
 
 cc_binary(
-    name = "DevMain-cpp",
+    name = "DevMain-Cpp",
     srcs = ["src/dev/native/cpp/main.cpp"],
     deps = [
         ":datalog",


### PR DESCRIPTION
There is currently no way to build Datalog's DevMain binaries for developer testing when using Bazel. It appeared to be a simple oversight so I just added them directly.