### PR TITLE
[wpimath] Rename variables in Twist tests

### DIFF
--- a/wpimath/src/test/java/org/wpilib/math/geometry/Twist2dTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/geometry/Twist2dTest.java
@@ -13,28 +13,28 @@ class Twist2dTest {
   @Test
   void testStraight() {
     var straight = new Twist2d(5.0, 0.0, 0.0);
-    var straightPose = straight.exp();
+    var straightTransform = straight.exp();
 
     var expected = new Transform2d(5.0, 0.0, Rotation2d.kZero);
-    assertEquals(expected, straightPose);
+    assertEquals(expected, straightTransform);
   }
 
   @Test
   void testQuarterCircle() {
     var quarterCircle = new Twist2d(5.0 / 2.0 * Math.PI, 0, Math.PI / 2.0);
-    var quarterCirclePose = quarterCircle.exp();
+    var quarterCircleTransform = quarterCircle.exp();
 
     var expected = new Transform2d(5.0, 5.0, Rotation2d.kCCW_Pi_2);
-    assertEquals(expected, quarterCirclePose);
+    assertEquals(expected, quarterCircleTransform);
   }
 
   @Test
   void testDiagonalNoDtheta() {
     var diagonal = new Twist2d(2.0, 2.0, 0.0);
-    var diagonalPose = diagonal.exp();
+    var diagonalTransform = diagonal.exp();
 
     var expected = new Transform2d(2.0, 2.0, Rotation2d.kZero);
-    assertEquals(expected, diagonalPose);
+    assertEquals(expected, diagonalTransform);
   }
 
   @Test

--- a/wpimath/src/test/java/org/wpilib/math/geometry/Twist3dTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/geometry/Twist3dTest.java
@@ -15,28 +15,28 @@ class Twist3dTest {
   @Test
   void testStraightX() {
     var straight = new Twist3d(5.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-    var straightPose = straight.exp();
+    var straightTransform = straight.exp();
 
     var expected = new Transform3d(5.0, 0.0, 0.0, Rotation3d.kZero);
-    assertEquals(expected, straightPose);
+    assertEquals(expected, straightTransform);
   }
 
   @Test
   void testStraightY() {
     var straight = new Twist3d(0.0, 5.0, 0.0, 0.0, 0.0, 0.0);
-    var straightPose = straight.exp();
+    var straightTransform = straight.exp();
 
     var expected = new Transform3d(0.0, 5.0, 0.0, Rotation3d.kZero);
-    assertEquals(expected, straightPose);
+    assertEquals(expected, straightTransform);
   }
 
   @Test
   void testStraightZ() {
     var straight = new Twist3d(0.0, 0.0, 5.0, 0.0, 0.0, 0.0);
-    var straightPose = straight.exp();
+    var straightTransform = straight.exp();
 
     var expected = new Transform3d(0.0, 0.0, 5.0, Rotation3d.kZero);
-    assertEquals(expected, straightPose);
+    assertEquals(expected, straightTransform);
   }
 
   @Test
@@ -44,20 +44,20 @@ class Twist3dTest {
     var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var quarterCircle = new Twist3d(5.0 / 2.0 * Math.PI, 0.0, 0.0, 0.0, 0.0, Math.PI / 2.0);
-    var quarterCirclePose = quarterCircle.exp();
+    var quarterCircleTransform = quarterCircle.exp();
 
     var expected =
         new Transform3d(5.0, 5.0, 0.0, new Rotation3d(zAxis, Units.degreesToRadians(90.0)));
-    assertEquals(expected, quarterCirclePose);
+    assertEquals(expected, quarterCircleTransform);
   }
 
   @Test
   void testDiagonalNoDtheta() {
     var diagonal = new Twist3d(2.0, 2.0, 0.0, 0.0, 0.0, 0.0);
-    var diagonalPose = diagonal.exp();
+    var diagonalTransform = diagonal.exp();
 
     var expected = new Transform3d(2.0, 2.0, 0.0, Rotation3d.kZero);
-    assertEquals(expected, diagonalPose);
+    assertEquals(expected, diagonalTransform);
   }
 
   @Test

--- a/wpimath/src/test/native/cpp/geometry/Twist2dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Twist2dTest.cpp
@@ -2,7 +2,6 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include <cmath>
 #include <numbers>
 
 #include <gtest/gtest.h>
@@ -13,30 +12,30 @@ using namespace wpi::math;
 
 TEST(Twist2dTest, Straight) {
   const Twist2d straight{5_m, 0_m, 0_rad};
-  const auto straightPose = straight.Exp();
+  const auto straightTransform = straight.Exp();
 
-  EXPECT_DOUBLE_EQ(5.0, straightPose.X().value());
-  EXPECT_DOUBLE_EQ(0.0, straightPose.Y().value());
-  EXPECT_DOUBLE_EQ(0.0, straightPose.Rotation().Radians().value());
+  EXPECT_DOUBLE_EQ(5.0, straightTransform.X().value());
+  EXPECT_DOUBLE_EQ(0.0, straightTransform.Y().value());
+  EXPECT_DOUBLE_EQ(0.0, straightTransform.Rotation().Radians().value());
 }
 
 TEST(Twist2dTest, QuarterCircle) {
   const Twist2d quarterCircle{5_m / 2.0 * std::numbers::pi, 0_m,
                               wpi::units::radian_t{std::numbers::pi / 2.0}};
-  const auto quarterCirclePose = quarterCircle.Exp();
+  const auto quarterCircleTransform = quarterCircle.Exp();
 
-  EXPECT_DOUBLE_EQ(5.0, quarterCirclePose.X().value());
-  EXPECT_DOUBLE_EQ(5.0, quarterCirclePose.Y().value());
-  EXPECT_DOUBLE_EQ(90.0, quarterCirclePose.Rotation().Degrees().value());
+  EXPECT_DOUBLE_EQ(5.0, quarterCircleTransform.X().value());
+  EXPECT_DOUBLE_EQ(5.0, quarterCircleTransform.Y().value());
+  EXPECT_DOUBLE_EQ(90.0, quarterCircleTransform.Rotation().Degrees().value());
 }
 
 TEST(Twist2dTest, DiagonalNoDtheta) {
   const Twist2d diagonal{2_m, 2_m, 0_deg};
-  const auto diagonalPose = diagonal.Exp();
+  const auto diagonalTransform = diagonal.Exp();
 
-  EXPECT_DOUBLE_EQ(2.0, diagonalPose.X().value());
-  EXPECT_DOUBLE_EQ(2.0, diagonalPose.Y().value());
-  EXPECT_DOUBLE_EQ(0.0, diagonalPose.Rotation().Degrees().value());
+  EXPECT_DOUBLE_EQ(2.0, diagonalTransform.X().value());
+  EXPECT_DOUBLE_EQ(2.0, diagonalTransform.Y().value());
+  EXPECT_DOUBLE_EQ(0.0, diagonalTransform.Rotation().Degrees().value());
 }
 
 TEST(Twist2dTest, Equality) {

--- a/wpimath/src/test/native/cpp/geometry/Twist3dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Twist3dTest.cpp
@@ -2,7 +2,6 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include <cmath>
 #include <numbers>
 
 #include <gtest/gtest.h>
@@ -13,26 +12,26 @@ using namespace wpi::math;
 
 TEST(Twist3dTest, StraightX) {
   const Twist3d straight{5_m, 0_m, 0_m, 0_rad, 0_rad, 0_rad};
-  const auto straightPose = straight.Exp();
+  const auto straightTransform = straight.Exp();
 
   Transform3d expected{5_m, 0_m, 0_m, Rotation3d{}};
-  EXPECT_EQ(expected, straightPose);
+  EXPECT_EQ(expected, straightTransform);
 }
 
 TEST(Twist3dTest, StraightY) {
   const Twist3d straight{0_m, 5_m, 0_m, 0_rad, 0_rad, 0_rad};
-  const auto straightPose = straight.Exp();
+  const auto straightTransform = straight.Exp();
 
   Transform3d expected{0_m, 5_m, 0_m, Rotation3d{}};
-  EXPECT_EQ(expected, straightPose);
+  EXPECT_EQ(expected, straightTransform);
 }
 
 TEST(Twist3dTest, StraightZ) {
   const Twist3d straight{0_m, 0_m, 5_m, 0_rad, 0_rad, 0_rad};
-  const auto straightPose = straight.Exp();
+  const auto straightTransform = straight.Exp();
 
   Transform3d expected{0_m, 0_m, 5_m, Rotation3d{}};
-  EXPECT_EQ(expected, straightPose);
+  EXPECT_EQ(expected, straightTransform);
 }
 
 TEST(Twist3dTest, QuarterCircle) {
@@ -44,18 +43,18 @@ TEST(Twist3dTest, QuarterCircle) {
                               0_rad,
                               0_rad,
                               wpi::units::radian_t{std::numbers::pi / 2.0}};
-  const auto quarterCirclePose = quarterCircle.Exp();
+  const auto quarterCircleTransform = quarterCircle.Exp();
 
   Transform3d expected{5_m, 5_m, 0_m, Rotation3d{zAxis, 90_deg}};
-  EXPECT_EQ(expected, quarterCirclePose);
+  EXPECT_EQ(expected, quarterCircleTransform);
 }
 
 TEST(Twist3dTest, DiagonalNoDtheta) {
   const Twist3d diagonal{2_m, 2_m, 0_m, 0_rad, 0_rad, 0_rad};
-  const auto diagonalPose = diagonal.Exp();
+  const auto diagonalTransform = diagonal.Exp();
 
   Transform3d expected{2_m, 2_m, 0_m, Rotation3d{}};
-  EXPECT_EQ(expected, diagonalPose);
+  EXPECT_EQ(expected, diagonalTransform);
 }
 
 TEST(Twist3dTest, Equality) {


### PR DESCRIPTION
Exp() now returns a transform instead of a pose.