### PR TITLE
bazel: Use lowercase repo name

### DIFF
--- a/shared/bazel/patches/rules_cc_windows.patch
+++ b/shared/bazel/patches/rules_cc_windows.patch
@@ -182,7 +182,7 @@ index ce0dac5..ec68ab9 100644
      should_detect_cpp_toolchain = "BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN" not in env or env["BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN"] != "1"
  
      if should_detect_cpp_toolchain:
-+        if repository_ctx.os.name.find("windows") != -1:
++        if repository_ctx.os.name.lower().find("windows") != -1:
 +            build_path = "@rules_cc//cc/private/toolchain:BUILD.windows_toolchains.tpl"
 +        else:
 +            build_path = "@rules_cc//cc/private/toolchain:BUILD.toolchains.tpl"


### PR DESCRIPTION
Comments from https://github.com/bazelbuild/rules_cc/pull/432 suggested lower casing, let's make sure that works.