### PR TITLE
[wpiutil] Fix cmake build on windows when only MulticastServiceAnnouncer is used

### DIFF
--- a/wpinet/src/main/native/windows/MulticastServiceAnnouncer.cpp
+++ b/wpinet/src/main/native/windows/MulticastServiceAnnouncer.cpp
@@ -22,6 +22,8 @@
 #include "wpi/util/SmallVector.hpp"
 #include "wpi/util/StringExtras.hpp"
 
+#pragma comment(lib, "dnsapi")
+
 using namespace wpi::net;
 
 struct ImplBase {


### PR DESCRIPTION
The pragma lib was only in the resolver. But if you had a statically linked library that only used the announcer, the import wouldn't get resolved.