### PR TITLE
Make bazel test names more consistent

### DIFF
--- a/romiVendordep/BUILD.bazel
+++ b/romiVendordep/BUILD.bazel
@@ -25,7 +25,7 @@ java_library(
 )
 
 cc_test(
-    name = "romi-test",
+    name = "romi-cpp-test",
     size = "small",
     srcs = glob(["src/test/native/cpp/**"]),
     deps = [

--- a/wpilibc/BUILD.bazel
+++ b/wpilibc/BUILD.bazel
@@ -56,7 +56,7 @@ cc_library(
 )
 
 cc_test(
-    name = "wpilibc-test",
+    name = "wpilibc-cpp-test",
     size = "small",
     srcs = glob(["src/test/native/cpp/**"]),
     tags = [


### PR DESCRIPTION
Consistently using `-cpp-test` makes it easier to remember how to run tests.