### PR TITLE
[hal] Notifier: Reset signal object on ack

### DIFF
--- a/hal/src/main/native/sim/Notifier.cpp
+++ b/hal/src/main/native/sim/Notifier.cpp
@@ -259,6 +259,7 @@ void HAL_SetNotifierAlarm(HAL_NotifierHandle notifierHandle, uint64_t alarmTime,
 
   if (ack) {
     notifier->handlerSignaled.clear();
+    wpi::util::ResetSignalObject(notifierHandle);
   }
 
   if (!absolute) {
@@ -291,6 +292,7 @@ void HAL_CancelNotifierAlarm(HAL_NotifierHandle notifierHandle, HAL_Bool ack,
 
   if (ack) {
     notifier->handlerSignaled.clear();
+    wpi::util::ResetSignalObject(notifierHandle);
   }
 
   thr->m_alarmQueue.remove({notifierHandle, notifier});
@@ -305,6 +307,7 @@ void HAL_AcknowledgeNotifierAlarm(HAL_NotifierHandle notifierHandle,
     return;
   }
   notifier->handlerSignaled.clear();
+  wpi::util::ResetSignalObject(notifierHandle);
 }
 
 int32_t HAL_GetNotifierOverrun(HAL_NotifierHandle notifierHandle,

--- a/hal/src/main/native/systemcore/Notifier.cpp
+++ b/hal/src/main/native/systemcore/Notifier.cpp
@@ -185,6 +185,7 @@ void HAL_SetNotifierAlarm(HAL_NotifierHandle notifierHandle, uint64_t alarmTime,
 
   if (ack) {
     notifier->handlerSignaled.clear();
+    wpi::util::ResetSignalObject(notifierHandle);
   }
 
   if (!absolute) {
@@ -217,6 +218,7 @@ void HAL_CancelNotifierAlarm(HAL_NotifierHandle notifierHandle, HAL_Bool ack,
 
   if (ack) {
     notifier->handlerSignaled.clear();
+    wpi::util::ResetSignalObject(notifierHandle);
   }
 
   thr->m_alarmQueue.remove({notifierHandle, notifier});
@@ -231,6 +233,7 @@ void HAL_AcknowledgeNotifierAlarm(HAL_NotifierHandle notifierHandle,
     return;
   }
   notifier->handlerSignaled.clear();
+  wpi::util::ResetSignalObject(notifierHandle);
 }
 
 int32_t HAL_GetNotifierOverrun(HAL_NotifierHandle notifierHandle,


### PR DESCRIPTION
This is needed to avoid spurious wakeups in WaitForObject due to a previous alarm having set the signal object.