### PR TITLE
[robotpy][cmd2] Fix opmodes merge

### DIFF
--- a/commandsv2/src/main/python/commands2/commandscheduler.py
+++ b/commandsv2/src/main/python/commands2/commandscheduler.py
@@ -10,7 +10,7 @@ import hal
 from typing_extensions import Self
 from wpilib import (
     RobotBase,
-    RobotState,
+    DriverStation,
     TimedRobot,
     Watchdog,
     reportWarning,
@@ -191,7 +191,7 @@ class CommandScheduler(Sendable):
         if self.isScheduled(command):
             return
 
-        if RobotState.isDisabled() and not command.runsWhenDisabled():
+        if DriverStation.isDisabled() and not command.runsWhenDisabled():
             return
 
         requirements = command.getRequirements()
@@ -249,7 +249,7 @@ class CommandScheduler(Sendable):
         self._watchdog.addEpoch("buttons.run()")
 
         self._inRunLoop = True
-        isDisabled = RobotState.isDisabled()
+        isDisabled = DriverStation.isDisabled()
 
         # Run scheduled commands, remove finished commands.
         for command in self._scheduledCommands.copy():

--- a/commandsv2/src/test/python/test_robotdisabledcommand.py
+++ b/commandsv2/src/test/python/test_robotdisabledcommand.py
@@ -7,7 +7,6 @@ if TYPE_CHECKING:
     from .util import *
 
 import pytest
-from wpilib import RobotState
 
 
 def test_robotDisabledCommandCancel(scheduler: commands2.CommandScheduler):


### PR DESCRIPTION
Looks like a build failure got lost in the landing order of python commands and the big opmode change. This makes it compile again, based on the java / C++ changes from the opmode pr