### PR TITLE
[robotpy] Fix maven coordinates for native downloads

### DIFF
--- a/apriltag/src/main/python/native-pyproject.toml
+++ b/apriltag/src/main/python/native-pyproject.toml
@@ -24,7 +24,7 @@ packages = ["src/native"]
 
 [[tool.hatch.build.hooks.robotpy.maven_lib_download]]
 artifact_id = "apriltag-cpp"
-group_id = "edu.wpi.first.apriltag"
+group_id = "org.wpilib.apriltag"
 repo_url = "https://frcmaven.wpi.edu/artifactory/release-2027"
 version = "0.0.0"
 

--- a/datalog/src/main/python/native-pyproject.toml
+++ b/datalog/src/main/python/native-pyproject.toml
@@ -23,7 +23,7 @@ packages = ["src/native"]
 
 [[tool.hatch.build.hooks.robotpy.maven_lib_download]]
 artifact_id = "datalog-cpp"
-group_id = "edu.wpi.first.datalog"
+group_id = "org.wpilib.datalog"
 repo_url = "https://frcmaven.wpi.edu/artifactory/release-2027"
 version = "0.0.0"
 

--- a/hal/src/main/python/native-pyproject.toml
+++ b/hal/src/main/python/native-pyproject.toml
@@ -24,7 +24,7 @@ packages = ["src/native"]
 
 [[tool.hatch.build.hooks.robotpy.maven_lib_download]]
 artifact_id = "hal-cpp"
-group_id = "edu.wpi.first.hal"
+group_id = "org.wpilib.hal"
 repo_url = "https://frcmaven.wpi.edu/artifactory/release-2027"
 version = "0.0.0"
 

--- a/ntcore/src/main/python/native-pyproject.toml
+++ b/ntcore/src/main/python/native-pyproject.toml
@@ -26,7 +26,7 @@ packages = ["src/native"]
 
 [[tool.hatch.build.hooks.robotpy.maven_lib_download]]
 artifact_id = "ntcore-cpp"
-group_id = "edu.wpi.first.ntcore"
+group_id = "org.wpilib.ntcore"
 repo_url = "https://frcmaven.wpi.edu/artifactory/release-2027"
 version = "0.0.0"
 

--- a/romiVendordep/src/main/python/native-pyproject.toml
+++ b/romiVendordep/src/main/python/native-pyproject.toml
@@ -22,7 +22,7 @@ packages = ["src/native"]
 
 [[tool.hatch.build.hooks.robotpy.maven_lib_download]]
 artifact_id = "romiVendordep-cpp"
-group_id = "edu.wpi.first.romiVendordep"
+group_id = "org.wpilib.romiVendordep"
 repo_url = "https://frcmaven.wpi.edu/artifactory/release-2027"
 version = "0.0.0"
 

--- a/wpilibc/src/main/python/native-pyproject.toml
+++ b/wpilibc/src/main/python/native-pyproject.toml
@@ -30,7 +30,7 @@ packages = ["src/native"]
 
 [[tool.hatch.build.hooks.robotpy.maven_lib_download]]
 artifact_id = "wpilibc-cpp"
-group_id = "edu.wpi.first.wpilibc"
+group_id = "org.wpilib.wpilibc"
 repo_url = "https://frcmaven.wpi.edu/artifactory/release-2027"
 version = "0.0.0"
 

--- a/wpimath/src/main/python/native-pyproject.toml
+++ b/wpimath/src/main/python/native-pyproject.toml
@@ -22,7 +22,7 @@ packages = ["src/native"]
 
 [[tool.hatch.build.hooks.robotpy.maven_lib_download]]
 artifact_id = "wpimath-cpp"
-group_id = "edu.wpi.first.wpimath"
+group_id = "org.wpilib.wpimath"
 repo_url = "https://frcmaven.wpi.edu/artifactory/release-2027"
 version = "0.0.0"
 

--- a/wpinet/src/main/python/native-pyproject.toml
+++ b/wpinet/src/main/python/native-pyproject.toml
@@ -22,7 +22,7 @@ packages = ["src/native"]
 
 [[tool.hatch.build.hooks.robotpy.maven_lib_download]]
 artifact_id = "wpinet-cpp"
-group_id = "edu.wpi.first.wpinet"
+group_id = "org.wpilib.wpinet"
 repo_url = "https://frcmaven.wpi.edu/artifactory/release-2027"
 version = "0.0.0"
 

--- a/wpiutil/src/main/python/native-pyproject.toml
+++ b/wpiutil/src/main/python/native-pyproject.toml
@@ -21,7 +21,7 @@ packages = ["src/native"]
 
 [[tool.hatch.build.hooks.robotpy.maven_lib_download]]
 artifact_id = "wpiutil-cpp"
-group_id = "edu.wpi.first.wpiutil"
+group_id = "org.wpilib.wpiutil"
 repo_url = "https://frcmaven.wpi.edu/artifactory/release-2027"
 version = "0.0.0"
 

--- a/xrpVendordep/src/main/python/native-pyproject.toml
+++ b/xrpVendordep/src/main/python/native-pyproject.toml
@@ -22,7 +22,7 @@ packages = ["src/native"]
 
 [[tool.hatch.build.hooks.robotpy.maven_lib_download]]
 artifact_id = "xrpVendordep-cpp"
-group_id = "edu.wpi.first.xrpVendordep"
+group_id = "org.wpilib.xrpVendordep"
 repo_url = "https://frcmaven.wpi.edu/artifactory/release-2027"
 version = "0.0.0"
 

--- a/xrpVendordep/src/main/python/pyproject.toml
+++ b/xrpVendordep/src/main/python/pyproject.toml
@@ -32,7 +32,7 @@ version_file = "xrp/version.py"
 
 [[tool.hatch.build.hooks.robotpy.maven_lib_download]]
 artifact_id = "halsim_xrp"
-group_id = "edu.wpi.first.halsim"
+group_id = "org.wpilib.halsim"
 repo_url = "https://frcmaven.wpi.edu/artifactory/release-2027"
 version = "0.0.0"
 use_headers = false


### PR DESCRIPTION
This got missed in the reorg, and these values aren't actually used for anything when building in `allwpilb`, but we might as well fix them here to make the copybara process easier.