### PR TITLE
[wpilib] Remove MotorController::StopMotor()

### DIFF
--- a/wpilibc/src/main/native/cpp/hardware/motor/PWMMotorController.cpp
+++ b/wpilibc/src/main/native/cpp/hardware/motor/PWMMotorController.cpp
@@ -54,6 +54,10 @@ bool PWMMotorController::GetInverted() const {
 void PWMMotorController::Disable() {
   m_pwm.SetDisabled();
 
+  if (m_simSpeed) {
+    m_simSpeed.Set(0.0);
+  }
+
   for (auto& follower : m_nonowningFollowers) {
     follower->Disable();
   }
@@ -63,19 +67,7 @@ void PWMMotorController::Disable() {
 }
 
 void PWMMotorController::StopMotor() {
-  // Don't use Set(0) as that will feed the watch kitty
-  m_pwm.SetPulseTime(0_us);
-
-  if (m_simSpeed) {
-    m_simSpeed.Set(0.0);
-  }
-
-  for (auto& follower : m_nonowningFollowers) {
-    follower->StopMotor();
-  }
-  for (auto& follower : m_owningFollowers) {
-    follower->StopMotor();
-  }
+  Disable();
 }
 
 std::string PWMMotorController::GetDescription() const {

--- a/wpilibc/src/main/native/include/wpi/hardware/motor/MotorController.hpp
+++ b/wpilibc/src/main/native/include/wpi/hardware/motor/MotorController.hpp
@@ -61,11 +61,6 @@ class MotorController {
    * Common interface for disabling a motor.
    */
   virtual void Disable() = 0;
-
-  /**
-   * Common interface to stop the motor until Set is called again.
-   */
-  virtual void StopMotor() = 0;
 };
 
 }  // namespace wpi

--- a/wpilibc/src/main/python/semiwrap/MotorController.yml
+++ b/wpilibc/src/main/python/semiwrap/MotorController.yml
@@ -10,4 +10,3 @@ classes:
       SetInverted:
       GetInverted:
       Disable:
-      StopMotor:

--- a/wpilibc/src/main/python/semiwrap/MotorControllerGroup.yml
+++ b/wpilibc/src/main/python/semiwrap/MotorControllerGroup.yml
@@ -39,5 +39,4 @@ classes:
       SetInverted:
       GetInverted:
       Disable:
-      StopMotor:
       InitSendable:

--- a/wpilibc/src/main/python/wpilib/src/rpy/MotorControllerGroup.cpp
+++ b/wpilibc/src/main/python/wpilib/src/rpy/MotorControllerGroup.cpp
@@ -48,12 +48,6 @@ void PyMotorControllerGroup::Disable() {
   }
 }
 
-void PyMotorControllerGroup::StopMotor() {
-  for (auto motorController : m_motorControllers) {
-    motorController->StopMotor();
-  }
-}
-
 void PyMotorControllerGroup::InitSendable(wpi::util::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Motor Controller");
   builder.SetActuator(true);

--- a/wpilibc/src/main/python/wpilib/src/rpy/MotorControllerGroup.h
+++ b/wpilibc/src/main/python/wpilib/src/rpy/MotorControllerGroup.h
@@ -32,7 +32,6 @@ class PyMotorControllerGroup : public wpi::util::Sendable,
   void SetInverted(bool isInverted) override;
   bool GetInverted() const override;
   void Disable() override;
-  void StopMotor() override;
 
   void InitSendable(wpi::util::SendableBuilder& builder) override;
 

--- a/wpilibc/src/test/native/cpp/motorcontrol/MockMotorController.cpp
+++ b/wpilibc/src/test/native/cpp/motorcontrol/MockMotorController.cpp
@@ -25,7 +25,3 @@ bool MockMotorController::GetInverted() const {
 void MockMotorController::Disable() {
   m_speed = 0;
 }
-
-void MockMotorController::StopMotor() {
-  Disable();
-}

--- a/wpilibc/src/test/native/include/motorcontrol/MockMotorController.hpp
+++ b/wpilibc/src/test/native/include/motorcontrol/MockMotorController.hpp
@@ -18,7 +18,6 @@ class MockMotorController : public MotorController {
   void SetInverted(bool isInverted) override;
   bool GetInverted() const override;
   void Disable() override;
-  void StopMotor() override;
 
  private:
   double m_speed = 0.0;

--- a/wpilibj/src/main/java/org/wpilib/hardware/motor/MotorController.java
+++ b/wpilibj/src/main/java/org/wpilib/hardware/motor/MotorController.java
@@ -71,10 +71,4 @@ public interface MotorController {
 
   /** Disable the motor controller. */
   void disable();
-
-  /**
-   * Stops motor movement. Motor can be moved again by calling set without having to re-enable the
-   * motor.
-   */
-  void stopMotor();
 }

--- a/wpilibj/src/main/java/org/wpilib/hardware/motor/PWMMotorController.java
+++ b/wpilibj/src/main/java/org/wpilib/hardware/motor/PWMMotorController.java
@@ -225,12 +225,7 @@ public abstract class PWMMotorController extends MotorSafety
 
   @Override
   public void stopMotor() {
-    // Don't use set(0) as that will feed the watch kitty
-    m_pwm.setPulseTimeMicroseconds(0);
-
-    for (var follower : m_followers) {
-      follower.stopMotor();
-    }
+    disable();
   }
 
   @Override

--- a/wpilibj/src/test/java/org/wpilib/hardware/motor/MockMotorController.java
+++ b/wpilibj/src/test/java/org/wpilib/hardware/motor/MockMotorController.java
@@ -33,9 +33,4 @@ public class MockMotorController implements MotorController {
   public void disable() {
     m_speed = 0;
   }
-
-  @Override
-  public void stopMotor() {
-    disable();
-  }
 }

--- a/xrpVendordep/src/main/java/org/wpilib/xrp/XRPMotor.java
+++ b/xrpVendordep/src/main/java/org/wpilib/xrp/XRPMotor.java
@@ -103,9 +103,4 @@ public class XRPMotor implements MotorController {
   public void disable() {
     set(0.0);
   }
-
-  @Override
-  public void stopMotor() {
-    set(0.0);
-  }
 }


### PR DESCRIPTION
It does the same thing as Disable() in practice, and MotorSafety has its own StopMotor() function.