### PR TITLE
[ci] Upgrade to wpiformat 2025.79

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install wpiformat
         run: |
           python -m venv ${{ runner.temp }}/wpiformat
-          ${{ runner.temp }}/wpiformat/bin/pip3 install wpiformat==2025.78
+          ${{ runner.temp }}/wpiformat/bin/pip3 install wpiformat==2025.79
       - name: Run
         run: ${{ runner.temp }}/wpiformat/bin/wpiformat -default-branch 2027
       - name: Check output
@@ -78,7 +78,7 @@ jobs:
       - name: Install wpiformat
         run: |
           python -m venv ${{ runner.temp }}/wpiformat
-          ${{ runner.temp }}/wpiformat/bin/pip3 install wpiformat==2025.78
+          ${{ runner.temp }}/wpiformat/bin/pip3 install wpiformat==2025.79
       - name: Create compile_commands.json
         run: |
           ./gradlew generateCompileCommands -Ptoolchain-optional-roboRio

--- a/.wpiformat
+++ b/.wpiformat
@@ -28,10 +28,6 @@ generatedFileExclude {
 }
 
 modifiableFileExclude {
-  \.icns$
-  \.ico$
-  \.jinja$
-  gradlew
   objcpp/
   wpimath/src/test/native/cpp/UnitsTest\.cpp$
   wpiutil/src/main/native/cpp/fs\.cpp$


### PR DESCRIPTION
wpiformat now skips binary files matching a list of extensions.

https://github.com/wpilibsuite/styleguide/blob/main/wpiformat/wpiformat/__init__.py#L483-L504