### PR TITLE
[cmd3] Scope scheduled commands to the running opmode, if one exists

### DIFF
--- a/commandsv3/src/main/java/org/wpilib/command3/BindingScope.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/BindingScope.java
@@ -25,6 +25,14 @@ interface BindingScope {
     return new ForCommand(scheduler, command);
   }
 
+  static BindingScope forOpmode(long opmodeId) {
+    if (opmodeId == 0) {
+      throw new IllegalArgumentException("Invalid OpMode ID provided");
+    }
+
+    return new ForOpmode(opmodeId);
+  }
+
   /** A global binding scope. Bindings in this scope are always active. */
   final class Global implements BindingScope {
     // No reason not to be a singleton.
@@ -47,6 +55,18 @@ interface BindingScope {
     @Override
     public boolean active() {
       return scheduler.isRunning(command);
+    }
+  }
+
+  /**
+   * A binding scoped to a running opmode.
+   *
+   * @param opmodeId The ID of the opmode that the binding is scoped to.
+   */
+  record ForOpmode(long opmodeId) implements BindingScope {
+    @Override
+    public boolean active() {
+      return OpModeFetcher.getFetcher().getOpModeId() == opmodeId;
     }
   }
 }

--- a/commandsv3/src/main/java/org/wpilib/command3/OpModeFetcher.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/OpModeFetcher.java
@@ -1,0 +1,63 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.command3;
+
+import static org.wpilib.util.ErrorMessages.requireNonNullParam;
+
+import org.wpilib.driverstation.DriverStation;
+
+/**
+ * Helper class for fetching information about the current opmode. This is a package-private class
+ * so tests for this library don't need to hook into driverstation simulation and the HAL.
+ */
+abstract class OpModeFetcher {
+  private static volatile OpModeFetcher s_fetcher;
+
+  abstract long getOpModeId();
+
+  abstract String getOpModeName();
+
+  /**
+   * Gets the current fetcher implementation. If {@link #setFetcher(OpModeFetcher)} has not already
+   * been called to set an implementation, this will default to a {@link DriverStationOpModeFetcher}
+   * instance.
+   *
+   * @return The fetcher instance to use to get opmode information.
+   */
+  static OpModeFetcher getFetcher() {
+    // Default to pull from the DS unless otherwise specified
+    if (s_fetcher == null) {
+      synchronized (OpModeFetcher.class) {
+        if (s_fetcher == null) {
+          s_fetcher = new DriverStationOpModeFetcher();
+        }
+      }
+    }
+
+    return s_fetcher;
+  }
+
+  /**
+   * Sets the fetcher to use. In tests, this is reset before every test with an implementation that
+   * always returns an ID of 0 and an empty string for the opmode name.
+   *
+   * @param fetcher The fetcher implementation to set. Cannot be null.
+   */
+  static void setFetcher(OpModeFetcher fetcher) {
+    s_fetcher = requireNonNullParam(fetcher, "fetcher", "setFetcher");
+  }
+
+  static final class DriverStationOpModeFetcher extends OpModeFetcher {
+    @Override
+    public long getOpModeId() {
+      return DriverStation.getOpModeId();
+    }
+
+    @Override
+    public String getOpModeName() {
+      return DriverStation.getOpMode();
+    }
+  }
+}

--- a/commandsv3/src/test/java/org/wpilib/command3/MockHardwareExtension.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/MockHardwareExtension.java
@@ -1,0 +1,27 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.command3;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class MockHardwareExtension implements BeforeEachCallback {
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    OpModeFetcher.setFetcher(new MockOpModeFetcher());
+  }
+
+  private static final class MockOpModeFetcher extends OpModeFetcher {
+    @Override
+    long getOpModeId() {
+      return 0;
+    }
+
+    @Override
+    String getOpModeName() {
+      return "";
+    }
+  }
+}

--- a/commandsv3/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/commandsv3/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.wpilib.command3.MockHardwareExtension


### PR DESCRIPTION
This prevents commands from outliving the opmodes in which they were scheduled