### PR TITLE
[wpiunit] Add `hypot` method for calculating the hypotenuse between two distances

### DIFF
--- a/wpiunits/generate_units.py
+++ b/wpiunits/generate_units.py
@@ -138,16 +138,26 @@ UNIT_CONFIGURATIONS = {
         "divide": {"Time": "LinearVelocity", "LinearVelocity": "Time"},
         "extra": inspect.cleandoc(
             """
-          /** Returns the hypotenuse (sqrt(a^2 + b^2)) between two Distances.
-           * The result is returned in the units of the first parameter.
-           */
-          static Distance hypot(Measure<? extends DistanceUnit> a, Measure<? extends DistanceUnit> b) {
-            return (Distance) a.unit().ofBaseUnits(Math.hypot(a.baseUnitMagnitude(), b.baseUnitMagnitude()));
-          }
+                /** Returns the hypotenuse (sqrt(a^2 + b^2)) between two Distances.
+                * The result is returned in the units of the first parameter.
+                * @param a the first distance
+                * @param b the second distance
+                * @return the hypotenuse between a and b
+                */
+                static Distance hypot(Distance a, Distance b) {
+                    return a.unit().ofBaseUnits(
+                        Math.hypot(a.in(a.unit().getBaseUnit()), b.in(b.unit().getBaseUnit()))
+                    );
+                }
 
-          default Distance hypot(Measure<? extends DistanceUnit> other) {
-            return hypot(this, other);
-          }
+                /** Returns the hypotenuse (sqrt(this^2 + other^2)) between two Distances.
+                * The result is returned in the units of the first parameter.
+                * @param other the second distance
+                * @return the hypotenuse between this and other
+                */
+                default Distance hypot(Distance other) {
+                    return hypot(this, other);
+                }
         """ 
         ),
     },

--- a/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Distance.java
+++ b/wpiunits/src/generated/main/java/edu/wpi/first/units/measure/Distance.java
@@ -780,14 +780,25 @@ public interface Distance extends Measure<DistanceUnit> {
   default Per<DistanceUnit, VoltageUnit> per(VoltageUnit divisorUnit) {
     return div(divisorUnit.one());
   }
+
   /** Returns the hypotenuse (sqrt(a^2 + b^2)) between two Distances.
-   * The result is returned in the units of the first parameter.
-   */
-  static Distance hypot(Measure<? extends DistanceUnit> a, Measure<? extends DistanceUnit> b) {
-    return (Distance) a.unit().ofBaseUnits(Math.hypot(a.baseUnitMagnitude(), b.baseUnitMagnitude()));
+  * The result is returned in the units of the first parameter.
+  * @param a the first distance
+  * @param b the second distance
+  * @return the hypotenuse between a and b
+  */
+  static Distance hypot(Distance a, Distance b) {
+      return a.unit().ofBaseUnits(
+        Math.hypot(a.in(a.unit().getBaseUnit()), b.in(b.unit().getBaseUnit()))
+      );
   }
 
-  default Distance hypot(Measure<? extends DistanceUnit> other) {
-    return hypot(this, other);
+  /** Returns the hypotenuse (sqrt(this^2 + other^2)) between two Distances.
+  * The result is returned in the units of the first parameter.
+  * @param other the second distance
+  * @return the hypotenuse between this and other
+  */
+  default Distance hypot(Distance other) {
+      return hypot(this, other);
   }
 }

--- a/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
@@ -1777,15 +1777,6 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
     return max;
   }
 
-  /**
-   * Returns the hypotenuse of two distances, computed in base units. The resulting distance is
-   * expressed in the unit of the first argument.
-   *
-   * <p>Equivalent to creating a distance using sqrt(a^2 + b^2) in base units.
-   */
-  static Distance hypot(Measure<? extends DistanceUnit> a, Measure<? extends DistanceUnit> b) {
-    return a.unit().ofBaseUnits(Math.hypot(a.baseUnitMagnitude(), b.baseUnitMagnitude()));
-  }
 
   /**
    * Returns a string representation of this measurement in a shorthand form. The symbol of the

--- a/wpiunits/src/test/java/edu/wpi/first/units/MeasureTest.java
+++ b/wpiunits/src/test/java/edu/wpi/first/units/MeasureTest.java
@@ -93,37 +93,6 @@ class MeasureTest {
   }
 
   @Test
-  void testHypot() {
-    Distance a = Units.Meters.of(6);
-    Distance b = Units.Meters.of(8);
-
-    // Static method on Measure
-    Distance resStatic = Measure.hypot(a, b);
-    assertEquals(Units.Meters.of(10), resStatic);
-
-    // Static method on Distance (generated)
-    Distance resStatic2 = Distance.hypot(a, b);
-    assertEquals(Units.Meters.of(10), resStatic2);
-
-    // Instance method on Distance delegating to static
-    Distance resInstance = a.hypot(b);
-    assertEquals(Units.Meters.of(10), resInstance);
-
-    // Mixed units: 3 feet and 48 inches (4 feet) -> hypot = 5 feet
-    Distance f3 = Units.Feet.of(3);
-    Distance in48 = Units.Inches.of(48);
-    Distance mixed = Measure.hypot(f3, in48);
-    assertTrue(mixed.isEquivalent(Units.Feet.of(5)));
-
-    // Generated static and instance variants with mixed units
-    Distance mixed2 = Distance.hypot(f3, in48);
-    assertTrue(mixed2.isEquivalent(Units.Feet.of(5)));
-
-    Distance mixedInstance = f3.hypot(in48);
-    assertTrue(mixedInstance.isEquivalent(Units.Feet.of(5)));
-  }
-
-  @Test
   void testUnaryMinus() {
     Distance m = Units.Feet.of(123);
     Distance negated = m.unaryMinus();
@@ -143,6 +112,30 @@ class MeasureTest {
   void testAs() {
     Distance m = Units.Inches.of(12);
     assertEquals(1, m.in(Units.Feet), Measure.EQUIVALENCE_THRESHOLD);
+  }
+
+  @Test
+  void testHypot() {
+    Distance a = Units.Meters.of(6);
+    Distance b = Units.Meters.of(8);
+
+    // Static method on Distance
+    Distance resStatic = Distance.hypot(a, b);
+    assertEquals(Units.Meters.of(10), resStatic);
+
+    // Instance method on Distance delegating to static
+    Distance resInstance = a.hypot(b);
+    assertEquals(Units.Meters.of(10), resInstance);
+
+    // Mixed units: 3 feet and 48 inches (4 feet) -> hypot = 5 feet
+    Distance f3 = Units.Feet.of(3);
+    Distance in48 = Units.Inches.of(48);
+
+    Distance mixed = Distance.hypot(f3, in48);
+    assertTrue(mixed.isEquivalent(Units.Feet.of(5)));
+
+    Distance mixedInstance = f3.hypot(in48);
+    assertTrue(mixedInstance.isEquivalent(Units.Feet.of(5)));
   }
 
   @Test


### PR DESCRIPTION
Adds a simple ``.hplot()`` method with tests that gets the hypothenuse between two distances. Contains both static and instance versions. Fixes #7666 