### PR TITLE
[copybara] Zero out high churn 'repo_url' in .toml files

### DIFF
--- a/copy.bara.sky
+++ b/copy.bara.sky
@@ -74,10 +74,19 @@ def define_mostrobotpy_to_allwpilib():
     transformations = []
 
     rename_transforms = []
+
+    # "Zero Out" high churn values. These get replaced automatically in the
+    # allwpilib -> mostrobotpy direction
     rename_transforms.append(core.replace(
         before = 'version = "${version}"',
         after = 'version = "0.0.0"',
         regex_groups = {"version": ".*"},
+        paths = glob(["**/*.toml"]),
+    ))
+    rename_transforms.append(core.replace(
+        before = 'repo_url = "${repo_url}"',
+        after = 'repo_url = ""',
+        regex_groups = {"repo_url": ".*"},
         paths = glob(["**/*.toml"]),
     ))
 


### PR DESCRIPTION
This is a high churn change whenever `mostrobotpy` switches from pointing to `release-2027` to `development-2027`. The value isn't used by the bazel build scripts, so there is no reason to have a zero impact change on ~11 files muddying up the synchronization diffs.

In the `allwpilib -> mostrobotpy` direction, we update [this ](https://github.com/robotpy/mostrobotpy/blob/main/rdev.toml) config file and run [this](https://github.com/robotpy/mostrobotpy/blob/main/rdev.sh) script which updates it in that repo during.

I manually did this change in #8503, but this will do it automatically in the future