### PR TITLE
Update github actions to use Node 24 versions

### DIFF
--- a/.github/actions/pregen/action.yml
+++ b/.github/actions/pregen/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
     - name: Install jinja and protobuf

--- a/.github/workflows/artifactory-nightly-cleanup.yml
+++ b/.github/workflows/artifactory-nightly-cleanup.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'wpilibsuite/allwpilib' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: jfrog/setup-jfrog-cli@v4
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'wpilibsuite/allwpilib' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: jfrog/setup-jfrog-cli@v4

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Check disk free space post-cleanup
         run: df -h
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
       - id: Setup_bazel_remote
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Set up Go 1.15.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           cache: false
           go-version: 1.15.x
@@ -117,7 +117,7 @@ jobs:
           cd $(mktemp -d)
           GO111MODULE=on go get github.com/bazelbuild/buildtools/buildifier@6.0.0
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
       - name: Run buildifier
@@ -130,7 +130,7 @@ jobs:
         run: git diff HEAD > bazel-lint-fixes.patch
         if: ${{ failure() }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.platform }}-bazel-lint-fixes
           path: bazel-lint-fixes.patch
@@ -140,7 +140,7 @@ jobs:
     name: "Robotpy Pregeneration"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
       - id: Setup_build_buddy
@@ -166,7 +166,7 @@ jobs:
         run: git diff HEAD > robotpy-pregeneration.patch
         if: ${{ failure() }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: robotpy-pregeneration-fixes
           path: robotpy-pregeneration.patch

--- a/.github/workflows/cmake-android.yml
+++ b/.github/workflows/cmake-android.yml
@@ -26,14 +26,14 @@ jobs:
     name: "Build - ${{ matrix.name }}"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
           ndk-version: r27c
           add-to-path: false
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 21

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run vcpkg (Windows only)
         if: runner.os == 'Windows'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,8 +11,8 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: actions/checkout@v6
+      - uses: gradle/actions/wrapper-validation@v5
 
   build-docker:
     strategy:
@@ -49,7 +49,7 @@ jobs:
       - name: Check disk free space post-cleanup
         run: df -h
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set release environment variable
@@ -65,7 +65,7 @@ jobs:
         env:
           ARTIFACTORY_PUBLISH_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PUBLISH_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact-name }}
           path: build/allOutputs
@@ -136,16 +136,16 @@ jobs:
       - name: Check disk free space post-cleanup
         run: df -h
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 21
           architecture: ${{ matrix.architecture }}
       - name: Import Developer ID Certificate
-        uses: wpilibsuite/import-signing-certificate@v2
+        uses: wpilibsuite/import-signing-certificate@v3
         with:
           certificate-data: ${{ secrets.APPLE_CERTIFICATE_DATA }}
           certificate-passphrase: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -172,7 +172,7 @@ jobs:
         if: |
           matrix.artifact-name == 'macOS' && (github.repository == 'wpilibsuite/allwpilib' &&
           (github.ref == 'refs/heads/2027' || startsWith(github.ref, 'refs/tags/v2027')))
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.outputs }}
@@ -186,10 +186,10 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [validation]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 21
@@ -201,7 +201,7 @@ jobs:
         env:
           ARTIFACTORY_PUBLISH_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PUBLISH_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: Documentation
           path: docs/build/outputs
@@ -213,12 +213,12 @@ jobs:
     needs: [build-documentation]
     concurrency: ci-docs-publish
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Download docs artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: Documentation
       - name: Make output directories
@@ -249,7 +249,7 @@ jobs:
           echo "BRANCH=2027" >> $GITHUB_ENV
         if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '2027')
       - name: Install SSH Client 🔑
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.9.1
         with:
           ssh-private-key: ${{ secrets.GH_DEPLOY_KEY }}
       - name: Deploy 🚀
@@ -262,7 +262,7 @@ jobs:
           single-commit: true
           folder: docs/tmp
       - name: Trigger Workflow
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.DISPATCH_PAT_TOKEN }}
           script: |
@@ -292,13 +292,13 @@ jobs:
           docker-images: false
           swap-storage: false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: |
           github.repository == 'wpilibsuite/allwpilib' &&
           (github.ref == 'refs/heads/2027' || startsWith(github.ref, 'refs/tags/v2027'))
         with:
           repository: wpilibsuite/build-tools
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         if: |
           github.repository == 'wpilibsuite/allwpilib' &&
           (github.ref == 'refs/heads/2027' || startsWith(github.ref, 'refs/tags/v2027'))
@@ -316,7 +316,7 @@ jobs:
         run: |
           cat combiner/products/build/allOutputs/version.txt
           test -s combiner/products/build/allOutputs/version.txt
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: |
           github.repository == 'wpilibsuite/allwpilib' &&
           (github.ref == 'refs/heads/2027' || startsWith(github.ref, 'refs/tags/v2027'))
@@ -341,7 +341,7 @@ jobs:
           RUN_AZURE_ARTIFACTORY_RELEASE: "TRUE"
           ARTIFACTORY_PUBLISH_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PUBLISH_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: |
           github.repository == 'wpilibsuite/allwpilib' &&
           (github.ref == 'refs/heads/2027' || startsWith(github.ref, 'refs/tags/v2027'))

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           sync-labels: true

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -15,14 +15,14 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: actions/checkout@v6
+      - uses: gradle/actions/wrapper-validation@v5
 
   wpiformat:
     name: "wpiformat"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Fetch all history and metadata
@@ -30,7 +30,7 @@ jobs:
           git checkout -b pr
           git branch -f 2027 origin/2027
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Install wpiformat
@@ -44,7 +44,7 @@ jobs:
       - name: Generate diff
         run: git diff HEAD > wpiformat-fixes.patch
         if: ${{ failure() }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: wpiformat fixes
           path: wpiformat-fixes.patch
@@ -63,7 +63,7 @@ jobs:
     needs: [validation]
     container: wpilib/ubuntu-base:24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Fetch all history and metadata
@@ -72,7 +72,7 @@ jobs:
           git checkout -b pr
           git branch -f 2027 origin/2027
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Install wpiformat
@@ -96,7 +96,7 @@ jobs:
     needs: [validation]
     container: wpilib/systemcore-cross-ubuntu:2027-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Fetch all history and metadata
@@ -111,7 +111,7 @@ jobs:
       - name: Generate diff
         run: git diff HEAD > javaformat-fixes.patch
         if: ${{ failure() }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: javaformat fixes
           path: javaformat-fixes.patch

--- a/.github/workflows/pregenerate.yml
+++ b/.github/workflows/pregenerate.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Update"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Run pregen
@@ -27,7 +27,7 @@ jobs:
       - name: Generate diff
         run: git diff HEAD > pregenerated-files-fixes.patch
         if: ${{ failure() }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pregenerated-files-fixes
           path: pregenerated-files-fixes.patch

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: configure
         run: mkdir build && cd build && cmake -G Ninja -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER:FILEPATH=/usr/bin/clang-18 -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/clang++-18 -DWITH_JAVA=OFF ${{ matrix.cmake-flags }} ..

--- a/.github/workflows/sentinel-build.yml
+++ b/.github/workflows/sentinel-build.yml
@@ -14,8 +14,8 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: actions/checkout@v6
+      - uses: gradle/actions/wrapper-validation@v5
 
   build-docker:
     if: (github.repository_owner == 'wpilibsuite' && github.ref == 'refs/heads/main') || github.event_name != 'schedule'
@@ -46,7 +46,7 @@ jobs:
           large-packages: false
           docker-images: false
           swap-storage: false
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build with Gradle
@@ -58,7 +58,7 @@ jobs:
           run: ./gradlew build -PbuildServer -PskipJavaFormat ${{ matrix.build-options }}
       - name: Check free disk space
         run: df .
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact-name }}
           path: build/allOutputs
@@ -110,16 +110,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [validation]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 21
           architecture: ${{ matrix.architecture }}
       - name: Import Developer ID Certificate
-        uses: wpilibsuite/import-signing-certificate@v2
+        uses: wpilibsuite/import-signing-certificate@v3
         with:
           certificate-data: ${{ secrets.APPLE_CERTIFICATE_DATA }}
           certificate-passphrase: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -160,7 +160,7 @@ jobs:
       - name: Check disk free space (macOS)
         run: df -h .
         if: matrix.os == 'macOS-15'
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.outputs }}

--- a/.github/workflows/upstream-utils.yml
+++ b/.github/workflows/upstream-utils.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Update"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Fetch all history and metadata
@@ -23,7 +23,7 @@ jobs:
           git checkout -b pr
           git branch -f main origin/main
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Configure committer identity


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/ 
Depends on https://github.com/wpilibsuite/import-signing-certificate/pull/7 
Done on the 2027 branch since the force change to Node 24 should (tm) happen after the last 2026 release. And in case it breaks something and we do need to backport to 2026, the release timeline on 2027 is not as strict