### PR TITLE
[build] Migrate to Gradle version catalogs

### DIFF
--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -57,8 +57,8 @@ dependencies {
     implementation project(':wpiunits')
     implementation project(':wpiutil')
     annotationProcessor project(':epilogue-processor')
-    implementation "org.openjdk.jmh:jmh-core:1.37"
-    annotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:1.37"
+    implementation libs.jmh.core
+    annotationProcessor libs.jmh.annotationprocessor
 }
 
 tasks.withType(com.github.spotbugs.snom.SpotBugsTask).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -10,17 +10,23 @@ buildscript {
 
 plugins {
     id 'base'
-    id 'org.wpilib.WPILibVersioningPlugin' version '2027.0.1'
-    id 'org.wpilib.WPILibRepositoriesPlugin' version '2027.0.0'
-    id 'org.wpilib.NativeUtils' apply false
-    id 'org.wpilib.GradleJni' version '2027.0.0'
-    id 'org.wpilib.GradleVsCode'
     id 'idea'
     id 'visual-studio'
-    id 'net.ltgt.errorprone' version '4.3.0' apply false
-    id 'com.gradleup.shadow' version '9.1.0' apply false
-    id 'com.diffplug.spotless' version '8.0.0' apply false
-    id 'com.github.spotbugs' version '6.4.2' apply false
+
+    alias(libs.plugins.wpilib.versioning)
+    alias(libs.plugins.wpilib.repositories)
+    // NativeUtils and GradleVsCode are on the classpath for buildSrc, which doesn't carry version information.
+    // We're forced to use the string-based syntax here instead.
+    id 'org.wpilib.NativeUtils' apply false
+    id 'org.wpilib.GradleVsCode' apply false
+    // alias(libs.plugins.wpilib.native.utils) apply false
+    // alias(libs.plugins.wpilib.gradle.vscode)
+    alias(libs.plugins.wpilib.gradle.jni)
+
+    alias(libs.plugins.build.shadow) apply false
+    alias(libs.plugins.lint.errorprone) apply false
+    alias(libs.plugins.lint.spotbugs) apply false
+    alias(libs.plugins.lint.spotless) apply false
 }
 
 wpilibVersioning.buildServerMode = project.hasProperty('buildServer')

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,6 +8,8 @@ repositories {
         url = "https://plugins.gradle.org/m2/"
     }
 }
+
 dependencies {
-    implementation "org.wpilib:native-utils:2027.1.1"
+    implementation libs.wpilib.native.utils
+    implementation libs.wpilib.gradle.vscode
 }

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/cameraserver/multiCameraServer/build.gradle
+++ b/cameraserver/multiCameraServer/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.google.code.gson:gson:2.13.1'
+    implementation libs.gson
 
     implementation project(':wpiutil')
     implementation project(':wpinet')

--- a/commandsv2/build.gradle
+++ b/commandsv2/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation project(':wpilibj')
     implementation project(':wpiannotations')
     api project(':datalog')
-    testImplementation 'org.mockito:mockito-core:4.1.0'
+    testImplementation libs.bundles.mockito
     annotationProcessor project(':javacPlugin')
     testAnnotationProcessor project(':javacPlugin')
 }

--- a/commandsv3/build.gradle
+++ b/commandsv3/build.gradle
@@ -25,10 +25,10 @@ dependencies {
     implementation project(':hal')
     implementation project(':wpimath')
     implementation project(':wpilibj')
-    api("us.hebi.quickbuf:quickbuf-runtime:1.4")
+    api(libs.quickbuf.runtime)
     testAnnotationProcessor project(':javacPlugin')
     testAnnotationProcessor project(':epilogue-processor')
-    testImplementation 'org.mockito:mockito-core:4.1.0'
+    testImplementation(libs.bundles.mockito)
     testImplementation project(':epilogue-runtime')
 }
 

--- a/epilogue-processor/build.gradle
+++ b/epilogue-processor/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     implementation(project(':epilogue-runtime'))
     api project(':commandsv2')
 
-    testImplementation 'com.google.testing.compile:compile-testing:+'
+    testImplementation libs.compile.testing
 }

--- a/fields/build.gradle
+++ b/fields/build.gradle
@@ -14,9 +14,7 @@ if (OperatingSystem.current().isWindows()) {
 }
 
 dependencies {
-    implementation "com.fasterxml.jackson.core:jackson-annotations:2.15.2"
-    implementation "com.fasterxml.jackson.core:jackson-core:2.15.2"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.15.2"
+    implementation libs.bundles.jackson
 }
 
 ext {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,52 @@
+[versions]
+ejml = "0.44.0"
+jackson = "2.19.2"
+jmh = "1.37"
+opencv = "4.10.0-3"
+quickbuf = "1.4"
+
+[libraries]
+# General runtime dependencies
+ejml-simple = { module = "org.ejml:ejml-simple", version.ref = "ejml" } # also pulls in other EJML modules as transitive dependencies
+gson = { module = "com.google.code.gson:gson", version = "2.13.1" }
+jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
+jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+quickbuf-runtime = { module = "us.hebi.quickbuf:quickbuf-runtime", version.ref = "quickbuf" }
+thirdparty-opencv = { module = "edu.wpi.first.thirdparty.frc2025.opencv:opencv-java", version.ref = "opencv" }
+
+# General test dependencies
+compile-testing = { module = "com.google.testing.compile:compile-testing", version = "0.23.0" }
+jmh-annotationprocessor = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.ref = "jmh" }
+jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
+junit-api = { module = "org.junit.jupiter:junit-jupiter", version = "5.13.4" }
+junit-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "1.10.1" }
+mockito-core = { module = "org.mockito:mockito-core", version = "4.1.0" }
+
+# buildsrc dependencies
+# Note that these are also Gradle plugins and cannot be used with the plugin specification
+# due to their presence on the classpath without version information.
+wpilib-gradle-vscode = { module = "org.wpilib:gradle-cpp-vscode", version = "2027.0.0" }
+wpilib-native-utils = { module = "org.wpilib:native-utils", version = "2027.1.1" }
+
+[bundles]
+ejml = ["ejml-simple"]
+jackson = ["jackson-annotations", "jackson-core", "jackson-databind"]
+mockito = ["mockito-core"]
+# junit api and launcher artifacts are different dependency types (implementation and runtime, respectively),
+# so it doesn't make sense to bundle them in a single "junit" bundle
+# Similar logic applies for JMH
+
+[plugins]
+build-shadow = { id = "com.gradleup.shadow", version = "9.1.0" }
+lint-errorprone = { id = "net.ltgt.errorprone", version = "4.3.0" }
+lint-spotbugs = { id = "com.github.spotbugs", version = "6.4.2" }
+lint-spotless = { id = "com.diffplug.spotless", version = "8.0.0" }
+
+wpilib-gradle-jni = { id = "org.wpilib.GradleJni", version = "2027.0.0" }
+# Note: these plugins can't be used. Their JARs are on the classpath for buildSrc,
+# which doesn't retain version information.
+# wpilib-gradle-vscode = { id = "org.wpilib.GradleVsCode", version = "2027.0.0" }
+# wpilib-native-utils = { id = "org.wpilib.NativeUtils", version = "2027.1.1" }
+wpilib-repositories = { id = "org.wpilib.WPILibRepositoriesPlugin", version = "2027.0.0" }
+wpilib-versioning = { id = "org.wpilib.WPILibVersioningPlugin", version = "2027.0.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ ejml = "0.44.0"
 jackson = "2.19.2"
 jmh = "1.37"
 opencv = "4.10.0-3"
+thirdparty-year = "frc2025" # Note: this also appears in the opencv module name in the libraries section
 quickbuf = "1.4"
 
 [libraries]

--- a/javacPlugin/build.gradle
+++ b/javacPlugin/build.gradle
@@ -12,6 +12,6 @@ apply from: "${rootDir}/shared/java/javacommon.gradle"
 
 dependencies {
     implementation project(':wpiannotations')
-    testImplementation 'com.google.testing.compile:compile-testing:+'
+    testImplementation libs.compile.testing
     testImplementation project(':commandsv2')
 }

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -1,5 +1,3 @@
-import org.gradle.internal.os.OperatingSystem
-
 nativeUtils.skipInstallPdb = project.hasProperty('buildServer')
 
 if (project.hasProperty('ciDebugOnly')) {
@@ -13,7 +11,7 @@ nativeUtils {
     wpi {
         configureDependencies {
             opencvYear = "frc2025"
-            opencvVersion = "4.10.0-3"
+            opencvVersion = libs.versions.opencv
         }
     }
 }

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -10,7 +10,7 @@ nativeUtils.withCrossSystemCore()
 nativeUtils {
     wpi {
         configureDependencies {
-            opencvYear = "frc2025"
+            opencvYear = libs.versions.thirdparty.year
             opencvVersion = libs.versions.opencv
         }
     }

--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -121,8 +121,8 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation libs.junit.api
+    testRuntimeOnly libs.junit.launcher
 
     devImplementation sourceSets.main.output
 }

--- a/shared/opencv.gradle
+++ b/shared/opencv.gradle
@@ -1,5 +1,3 @@
-def opencvVersion = '4.10.0-3'
-
 if (project.hasProperty('useCpp') && project.useCpp) {
     model {
         binaries {
@@ -22,12 +20,12 @@ if (project.hasProperty('useCpp') && project.useCpp) {
 
 if (project.hasProperty('useJava') && project.useJava) {
     dependencies {
-        implementation "edu.wpi.first.thirdparty.frc2025.opencv:opencv-java:${opencvVersion}"
+        implementation libs.thirdparty.opencv
         if (!project.hasProperty('skipDev') || !project.skipDev) {
-            devImplementation "edu.wpi.first.thirdparty.frc2025.opencv:opencv-java:${opencvVersion}"
+            devImplementation libs.thirdparty.opencv
         }
         if (project.hasProperty('useDocumentation') && project.useDocumentation) {
-            javaSource "edu.wpi.first.thirdparty.frc2025.opencv:opencv-java:${opencvVersion}:sources"
+            javaSource(variantOf(libs.thirdparty.opencv) { classifier("sources") })
         }
     }
 }

--- a/wpilibj/build.gradle
+++ b/wpilibj/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation project(':cscore')
     api project(':datalog')
     implementation project(':cameraserver')
-    testImplementation 'org.mockito:mockito-core:4.1.0'
+    testImplementation(libs.bundles.mockito)
     devImplementation sourceSets.main.output
 }
 

--- a/wpilibjExamples/build.gradle
+++ b/wpilibjExamples/build.gradle
@@ -30,8 +30,8 @@ dependencies {
     annotationProcessor project(':javacPlugin')
     annotationProcessor project(':wpiannotations')
 
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation libs.junit.api
+    testRuntimeOnly libs.junit.launcher
 }
 
 // Prevent the eclipse compiler (used by the VS Code extension for intellisense and debugging)

--- a/wpimath/build.gradle
+++ b/wpimath/build.gradle
@@ -89,11 +89,9 @@ nativeUtils.exportsConfigs {
 
 dependencies {
     api project(":wpiunits")
-    api "org.ejml:ejml-simple:0.44.0"
-    api "com.fasterxml.jackson.core:jackson-annotations:2.19.2"
-    api "com.fasterxml.jackson.core:jackson-core:2.19.2"
-    api "com.fasterxml.jackson.core:jackson-databind:2.19.2"
-    api "us.hebi.quickbuf:quickbuf-runtime:1.4"
+    api libs.bundles.ejml
+    api libs.bundles.jackson
+    api libs.quickbuf.runtime
 }
 
 sourceSets.main.java.srcDir "${projectDir}/src/generated/main/java"

--- a/wpiutil/build.gradle
+++ b/wpiutil/build.gradle
@@ -275,8 +275,6 @@ model {
 }
 
 dependencies {
-    api "com.fasterxml.jackson.core:jackson-annotations:2.19.2"
-    api "com.fasterxml.jackson.core:jackson-core:2.19.2"
-    api "com.fasterxml.jackson.core:jackson-databind:2.19.2"
-    api 'us.hebi.quickbuf:quickbuf-runtime:1.4'
+    api libs.bundles.jackson
+    api libs.quickbuf.runtime
 }


### PR DESCRIPTION
Also fixes the google compile-testing library to 0.23.0 (the latest available at time of writing) instead of a wildcard

Jackson versions were inconsistent across projects; most were on 2.19.2, but the fields subproject was on 2.15.2. All projects are now on 2.19.2 for consistency