### PR TITLE
Update Android NDK version to R27D in CMake workflow

### DIFF
--- a/.github/workflows/cmake-android.yml
+++ b/.github/workflows/cmake-android.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r27c
+          ndk-version: r27d
           add-to-path: false
 
       - uses: actions/setup-java@v4


### PR DESCRIPTION
https://github.com/android/ndk/wiki#release-schedule