### PR TITLE
[wpimath] Implement Rotation3d interpolation as slerp instead of lerp

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateSystem.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateSystem.java
@@ -86,7 +86,7 @@ public class CoordinateSystem {
   public static Translation3d convert(
       Translation3d translation, CoordinateSystem from, CoordinateSystem to) {
     // Convert to NWU, then convert to the new coordinate system
-    return translation.rotateBy(from.m_rotation).rotateBy(to.m_rotation.unaryMinus());
+    return translation.rotateBy(from.m_rotation).rotateBy(to.m_rotation.inverse());
   }
 
   /**
@@ -100,7 +100,7 @@ public class CoordinateSystem {
   public static Rotation3d convert(
       Rotation3d rotation, CoordinateSystem from, CoordinateSystem to) {
     // Convert to NWU, then convert to the new coordinate system
-    return rotation.rotateBy(from.m_rotation).rotateBy(to.m_rotation.unaryMinus());
+    return rotation.rotateBy(from.m_rotation).rotateBy(to.m_rotation.inverse());
   }
 
   /**
@@ -128,7 +128,7 @@ public class CoordinateSystem {
       Transform3d transform, CoordinateSystem from, CoordinateSystem to) {
     // coordRot is the rotation that converts between the coordinate systems when applied
     // extrinsically. It first converts to NWU, then converts to the new coordinate system.
-    var coordRot = from.m_rotation.rotateBy(to.m_rotation.unaryMinus());
+    var coordRot = from.m_rotation.rotateBy(to.m_rotation.inverse());
     // The new rotation is the extrinsic rotation from convert(zero) to
     // convert(transformRot). That is, applying convertedRot extrinsically to
     // convert(zero) produces convert(transformRot). In the below snippet, we
@@ -140,9 +140,9 @@ public class CoordinateSystem {
     //                = (coordRot transformRot) coordRot⁻¹
     //
     // In code, the equivalent for rotA rotB is rotB.rotateBy(rotA) (note the
-    // change in order), and the equivalent for rot⁻¹ is rot.unaryMinus().
+    // change in order).
     return new Transform3d(
         convert(transform.getTranslation(), from, to),
-        coordRot.unaryMinus().rotateBy(transform.getRotation().rotateBy(coordRot)));
+        coordRot.inverse().rotateBy(transform.getRotation().rotateBy(coordRot)));
   }
 }

--- a/wpimath/src/main/java/org/wpilib/math/geometry/Pose3d.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/Pose3d.java
@@ -338,7 +338,7 @@ public class Pose3d implements Interpolatable<Pose3d>, ProtobufSerializable, Str
         Comparator.comparing(
                 (Pose3d other) -> this.getTranslation().getDistance(other.getTranslation()))
             .thenComparing(
-                (Pose3d other) -> this.getRotation().minus(other.getRotation()).getAngle()));
+                (Pose3d other) -> this.getRotation().relativeTo(other.getRotation()).getAngle()));
   }
 
   @Override

--- a/wpimath/src/main/java/org/wpilib/math/geometry/Quaternion.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/Quaternion.java
@@ -219,16 +219,6 @@ public class Quaternion implements ProtobufSerializable, StructSerializable {
   /**
    * Matrix exponential of a quaternion.
    *
-   * @param adjustment the "Twist" that will be applied to this quaternion.
-   * @return The quaternion product of exp(adjustment) * this
-   */
-  public Quaternion exp(Quaternion adjustment) {
-    return adjustment.exp().times(this);
-  }
-
-  /**
-   * Matrix exponential of a quaternion.
-   *
    * <p>source: wpimath/algorithms.md
    *
    * <p>If this quaternion is in 𝖘𝖔(3) and you are looking for an element of SO(3), use {@link
@@ -258,16 +248,6 @@ public class Quaternion implements ProtobufSerializable, StructSerializable {
         getX() * axial_scalar * scalar,
         getY() * axial_scalar * scalar,
         getZ() * axial_scalar * scalar);
-  }
-
-  /**
-   * Log operator of a quaternion.
-   *
-   * @param end The quaternion to map this quaternion onto.
-   * @return The "Twist" that maps this quaternion to the argument.
-   */
-  public Quaternion log(Quaternion end) {
-    return end.times(this.inverse()).log();
   }
 
   /**

--- a/wpimath/src/main/java/org/wpilib/math/geometry/Rotation2d.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/Rotation2d.java
@@ -203,7 +203,7 @@ public class Rotation2d
   }
 
   /**
-   * Subtracts the new rotation from the current rotation and returns the new rotation.
+   * Returns this rotation relative to another rotation.
    *
    * <p>For example, <code>Rotation2d.fromDegrees(10).minus(Rotation2d.fromDegrees(100))</code>
    * equals <code>Rotation2d(-Math.PI/2.0)</code>

--- a/wpimath/src/main/java/org/wpilib/math/geometry/Transform3d.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/Transform3d.java
@@ -45,7 +45,7 @@ public class Transform3d implements ProtobufSerializable, StructSerializable {
     m_translation =
         last.getTranslation()
             .minus(initial.getTranslation())
-            .rotateBy(initial.getRotation().unaryMinus());
+            .rotateBy(initial.getRotation().inverse());
 
     m_rotation = last.getRotation().relativeTo(initial.getRotation());
   }
@@ -290,8 +290,7 @@ public class Transform3d implements ProtobufSerializable, StructSerializable {
     // using a clockwise rotation matrix. This transforms the global
     // delta into a local delta (relative to the initial pose).
     return new Transform3d(
-        getTranslation().unaryMinus().rotateBy(getRotation().unaryMinus()),
-        getRotation().unaryMinus());
+        getTranslation().unaryMinus().rotateBy(getRotation().inverse()), getRotation().inverse());
   }
 
   @Override

--- a/wpimath/src/main/java/org/wpilib/math/kinematics/Odometry3d.java
+++ b/wpimath/src/main/java/org/wpilib/math/kinematics/Odometry3d.java
@@ -57,7 +57,7 @@ public class Odometry3d<T> {
     m_pose = initialPose;
     // When applied extrinsically, m_gyroOffset cancels the current gyroAngle and
     // then rotates to m_poseMeters.getRotation()
-    m_gyroOffset = gyroAngle.unaryMinus().rotateBy(m_pose.getRotation());
+    m_gyroOffset = gyroAngle.inverse().rotateBy(m_pose.getRotation());
     m_previousAngle = m_pose.getRotation();
     m_previousWheelPositions = m_kinematics.copy(wheelPositions);
   }
@@ -76,7 +76,7 @@ public class Odometry3d<T> {
     m_pose = pose;
     // When applied extrinsically, m_gyroOffset cancels the current gyroAngle and
     // then rotates to m_poseMeters.getRotation()
-    m_gyroOffset = gyroAngle.unaryMinus().rotateBy(m_pose.getRotation());
+    m_gyroOffset = gyroAngle.inverse().rotateBy(m_pose.getRotation());
     m_previousAngle = m_pose.getRotation();
     m_kinematics.copyInto(wheelPositions, m_previousWheelPositions);
   }
@@ -89,7 +89,7 @@ public class Odometry3d<T> {
   public void resetPose(Pose3d pose) {
     // Cancel the previous m_pose.Rotation() and then rotate to the new angle
     m_gyroOffset =
-        m_gyroOffset.rotateBy(m_pose.getRotation().unaryMinus()).rotateBy(pose.getRotation());
+        m_gyroOffset.rotateBy(m_pose.getRotation().inverse()).rotateBy(pose.getRotation());
     m_pose = pose;
     m_previousAngle = m_pose.getRotation();
   }
@@ -110,7 +110,7 @@ public class Odometry3d<T> {
    */
   public void resetRotation(Rotation3d rotation) {
     // Cancel the previous m_pose.Rotation() and then rotate to the new angle
-    m_gyroOffset = m_gyroOffset.rotateBy(m_pose.getRotation().unaryMinus()).rotateBy(rotation);
+    m_gyroOffset = m_gyroOffset.rotateBy(m_pose.getRotation().inverse()).rotateBy(rotation);
     m_pose = new Pose3d(m_pose.getTranslation(), rotation);
     m_previousAngle = m_pose.getRotation();
   }
@@ -136,7 +136,7 @@ public class Odometry3d<T> {
    */
   public Pose3d update(Rotation3d gyroAngle, T wheelPositions) {
     var angle = gyroAngle.rotateBy(m_gyroOffset);
-    var angle_difference = angle.minus(m_previousAngle).toVector();
+    var angle_difference = angle.relativeTo(m_previousAngle).toVector();
 
     var twist2d = m_kinematics.toTwist2d(m_previousWheelPositions, wheelPositions);
     var twist =

--- a/wpimath/src/main/native/include/wpi/math/geometry/CoordinateSystem.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/CoordinateSystem.hpp
@@ -86,7 +86,8 @@ class WPILIB_DLLEXPORT CoordinateSystem {
                                          const CoordinateSystem& from,
                                          const CoordinateSystem& to) {
     // Convert to NWU, then convert to the new coordinate system
-    return translation.RotateBy(from.m_rotation).RotateBy(-to.m_rotation);
+    return translation.RotateBy(from.m_rotation)
+        .RotateBy(to.m_rotation.Inverse());
   }
 
   /**
@@ -101,7 +102,7 @@ class WPILIB_DLLEXPORT CoordinateSystem {
                                       const CoordinateSystem& from,
                                       const CoordinateSystem& to) {
     // Convert to NWU, then convert to the new coordinate system
-    return rotation.RotateBy(from.m_rotation).RotateBy(-to.m_rotation);
+    return rotation.RotateBy(from.m_rotation).RotateBy(to.m_rotation.Inverse());
   }
 
   /**
@@ -133,7 +134,7 @@ class WPILIB_DLLEXPORT CoordinateSystem {
     // coordRot is the rotation that converts between the coordinate systems
     // when applied extrinsically. It first converts to NWU, then converts to
     // the new coordinate system.
-    const auto coordRot = from.m_rotation.RotateBy(-to.m_rotation);
+    const auto coordRot = from.m_rotation.RotateBy(to.m_rotation.Inverse());
     // The new rotation is the extrinsic rotation from convert(zero) to
     // convert(transformRot). That is, applying convertedRot extrinsically to
     // convert(zero) produces convert(transformRot). In the below snippet, we
@@ -145,10 +146,10 @@ class WPILIB_DLLEXPORT CoordinateSystem {
     //                = (coordRot transformRot) coordRot⁻¹
     //
     // In code, the equivalent for rotA rotB is rotB.RotateBy(rotA) (note the
-    // change in order), and the equivalent for rot⁻¹ is -rot.
+    // change in order).
     return Transform3d{
         Convert(transform.Translation(), from, to),
-        (-coordRot).RotateBy(transform.Rotation().RotateBy(coordRot))};
+        coordRot.Inverse().RotateBy(transform.Rotation().RotateBy(coordRot))};
   }
 
  private:

--- a/wpimath/src/main/native/include/wpi/math/geometry/Pose3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Pose3d.hpp
@@ -256,9 +256,14 @@ class WPILIB_DLLEXPORT Pose3d {
 
           // If the distances are equal sort by difference in rotation
           if (aDistance == bDistance) {
-            return gcem::abs(
-                       (this->Rotation() - a.Rotation()).Angle().value()) <
-                   gcem::abs((this->Rotation() - b.Rotation()).Angle().value());
+            return gcem::abs(this->Rotation()
+                                 .RelativeTo(a.Rotation())
+                                 .Angle()
+                                 .value()) <
+                   gcem::abs(this->Rotation()
+                                 .RelativeTo(b.Rotation())
+                                 .Angle()
+                                 .value());
           }
           return aDistance < bDistance;
         });
@@ -281,9 +286,14 @@ class WPILIB_DLLEXPORT Pose3d {
 
           // If the distances are equal sort by difference in rotation
           if (aDistance == bDistance) {
-            return gcem::abs(
-                       (this->Rotation() - a.Rotation()).Angle().value()) <
-                   gcem::abs((this->Rotation() - b.Rotation()).Angle().value());
+            return gcem::abs(this->Rotation()
+                                 .RelativeTo(a.Rotation())
+                                 .Angle()
+                                 .value()) <
+                   gcem::abs(this->Rotation()
+                                 .RelativeTo(b.Rotation())
+                                 .Angle()
+                                 .value());
           }
           return aDistance < bDistance;
         });

--- a/wpimath/src/main/native/include/wpi/math/geometry/Quaternion.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Quaternion.hpp
@@ -160,15 +160,6 @@ class WPILIB_DLLEXPORT Quaternion {
   /**
    * Matrix exponential of a quaternion.
    *
-   * @param other the "Twist" that will be applied to this quaternion.
-   */
-  constexpr Quaternion Exp(const Quaternion& other) const {
-    return other.Exp() * *this;
-  }
-
-  /**
-   * Matrix exponential of a quaternion.
-   *
    * source: wpimath/algorithms.md
    *
    *  If this quaternion is in 𝖘𝖔(3) and you are looking for an element of
@@ -194,15 +185,6 @@ class WPILIB_DLLEXPORT Quaternion {
 
     return Quaternion(cosine * scalar, X() * axial_scalar * scalar,
                       Y() * axial_scalar * scalar, Z() * axial_scalar * scalar);
-  }
-
-  /**
-   * Log operator of a quaternion.
-   *
-   * @param other The quaternion to map this quaternion onto
-   */
-  constexpr Quaternion Log(const Quaternion& other) const {
-    return (other * Inverse()).Log();
   }
 
   /**

--- a/wpimath/src/main/native/include/wpi/math/geometry/Rotation2d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Rotation2d.hpp
@@ -118,8 +118,7 @@ class WPILIB_DLLEXPORT Rotation2d {
   }
 
   /**
-   * Subtracts the new rotation from the current rotation and returns the new
-   * rotation.
+   * Returns this rotation relative to another rotation.
    *
    * For example, <code>Rotation2d{10_deg} - Rotation2d{100_deg}</code> equals
    * <code>Rotation2d{wpi::units::radian_t{-std::numbers::pi/2.0}}</code>

--- a/wpimath/src/main/native/include/wpi/math/geometry/Transform3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Transform3d.hpp
@@ -153,7 +153,8 @@ class WPILIB_DLLEXPORT Transform3d {
     // We are rotating the difference between the translations
     // using a clockwise rotation matrix. This transforms the global
     // delta into a local delta (relative to the initial pose).
-    return Transform3d{(-Translation()).RotateBy(-Rotation()), -Rotation()};
+    return Transform3d{(-Translation()).RotateBy(Rotation().Inverse()),
+                       Rotation().Inverse()};
   }
 
   /**
@@ -207,7 +208,7 @@ constexpr Transform3d::Transform3d(const Pose3d& initial, const Pose3d& final) {
   // To transform the global translation delta to be relative to the initial
   // pose, rotate by the inverse of the initial pose's orientation.
   m_translation = (final.Translation() - initial.Translation())
-                      .RotateBy(-initial.Rotation());
+                      .RotateBy(initial.Rotation().Inverse());
 
   m_rotation = final.Rotation().RelativeTo(initial.Rotation());
 }

--- a/wpimath/src/main/python/semiwrap/Rotation3d.yml
+++ b/wpimath/src/main/python/semiwrap/Rotation3d.yml
@@ -26,15 +26,12 @@ classes:
             keepalive: []
           const Rotation2d&:
             keepalive: []
-      operator+:
-      operator-:
-        overloads:
-          const Rotation3d& [const]:
-          '[const]':
+      Inverse:
       operator*:
       operator/:
       operator==:
       RotateBy:
+      Interpolate:
       GetQuaternion:
       X:
       Y:

--- a/wpimath/src/test/java/org/wpilib/math/geometry/QuaternionTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/geometry/QuaternionTest.java
@@ -219,8 +219,8 @@ class QuaternionTest {
     var start = new Quaternion(1, 2, 3, 4);
     var expect = new Quaternion(5, 6, 7, 8);
 
-    var twist = start.log(expect);
-    var actual = start.exp(twist);
+    var twist = expect.times(start.inverse()).log();
+    var actual = twist.exp().times(start);
 
     assertEquals(expect, actual);
   }

--- a/wpimath/src/test/java/org/wpilib/math/geometry/Rotation3dTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/geometry/Rotation3dTest.java
@@ -24,7 +24,7 @@ class Rotation3dTest {
     var rot1 = new Rotation3d(0, 0, Math.PI / 2);
     var rot2 = new Rotation3d(Math.PI, 0, 0);
     var rot3 = new Rotation3d(-Math.PI / 2, 0, 0);
-    final var result1 = rot1.plus(rot2).plus(rot3);
+    final var result1 = rot1.rotateBy(rot2).rotateBy(rot3);
     final var expected1 = new Rotation3d(0, -Math.PI / 2, Math.PI / 2);
     assertAll(
         () -> assertEquals(expected1, result1),
@@ -34,7 +34,7 @@ class Rotation3dTest {
     rot1 = new Rotation3d(0, 0, Math.PI / 2);
     rot2 = new Rotation3d(-Math.PI, 0, 0);
     rot3 = new Rotation3d(Math.PI / 2, 0, 0);
-    final var result2 = rot1.plus(rot2).plus(rot3);
+    final var result2 = rot1.rotateBy(rot2).rotateBy(rot3);
     final var expected2 = new Rotation3d(0, Math.PI / 2, Math.PI / 2);
     assertAll(
         () -> assertEquals(expected2, result2),
@@ -44,7 +44,7 @@ class Rotation3dTest {
     rot1 = new Rotation3d(0, 0, Math.PI / 2);
     rot2 = new Rotation3d(0, Math.PI / 3, 0);
     rot3 = new Rotation3d(-Math.PI / 2, 0, 0);
-    final var result3 = rot1.plus(rot2).plus(rot3);
+    final var result3 = rot1.rotateBy(rot2).rotateBy(rot3);
     final var expected3 = new Rotation3d(0, Math.PI / 2, Math.PI / 6);
     assertAll(
         () -> assertEquals(expected3, result3),
@@ -196,22 +196,22 @@ class Rotation3dTest {
   void testRotationLoop() {
     var rot = Rotation3d.kZero;
 
-    rot = rot.plus(new Rotation3d(Units.degreesToRadians(90.0), 0.0, 0.0));
+    rot = rot.rotateBy(new Rotation3d(Units.degreesToRadians(90.0), 0.0, 0.0));
     var expected = new Rotation3d(Units.degreesToRadians(90.0), 0.0, 0.0);
     assertEquals(expected, rot);
 
-    rot = rot.plus(new Rotation3d(0.0, Units.degreesToRadians(90.0), 0.0));
+    rot = rot.rotateBy(new Rotation3d(0.0, Units.degreesToRadians(90.0), 0.0));
     expected =
         new Rotation3d(
             VecBuilder.fill(1.0 / Math.sqrt(3), 1.0 / Math.sqrt(3), -1.0 / Math.sqrt(3)),
             Units.degreesToRadians(120.0));
     assertEquals(expected, rot);
 
-    rot = rot.plus(new Rotation3d(0.0, 0.0, Units.degreesToRadians(90.0)));
+    rot = rot.rotateBy(new Rotation3d(0.0, 0.0, Units.degreesToRadians(90.0)));
     expected = new Rotation3d(0.0, Units.degreesToRadians(90.0), 0.0);
     assertEquals(expected, rot);
 
-    rot = rot.plus(new Rotation3d(0.0, Units.degreesToRadians(-90.0), 0.0));
+    rot = rot.rotateBy(new Rotation3d(0.0, Units.degreesToRadians(-90.0), 0.0));
     assertEquals(Rotation3d.kZero, rot);
   }
 
@@ -253,7 +253,7 @@ class Rotation3dTest {
     final var xAxis = VecBuilder.fill(1.0, 0.0, 0.0);
 
     var rot = new Rotation3d(xAxis, Units.degreesToRadians(90.0));
-    rot = rot.plus(new Rotation3d(xAxis, Units.degreesToRadians(30.0)));
+    rot = rot.rotateBy(new Rotation3d(xAxis, Units.degreesToRadians(30.0)));
 
     var expected = new Rotation3d(xAxis, Units.degreesToRadians(120.0));
     assertEquals(expected, rot);
@@ -264,7 +264,7 @@ class Rotation3dTest {
     final var yAxis = VecBuilder.fill(0.0, 1.0, 0.0);
 
     var rot = new Rotation3d(yAxis, Units.degreesToRadians(90.0));
-    rot = rot.plus(new Rotation3d(yAxis, Units.degreesToRadians(30.0)));
+    rot = rot.rotateBy(new Rotation3d(yAxis, Units.degreesToRadians(30.0)));
 
     var expected = new Rotation3d(yAxis, Units.degreesToRadians(120.0));
     assertEquals(expected, rot);
@@ -275,7 +275,7 @@ class Rotation3dTest {
     final var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var rot = new Rotation3d(zAxis, Units.degreesToRadians(90.0));
-    rot = rot.plus(new Rotation3d(zAxis, Units.degreesToRadians(30.0)));
+    rot = rot.rotateBy(new Rotation3d(zAxis, Units.degreesToRadians(30.0)));
 
     var expected = new Rotation3d(zAxis, Units.degreesToRadians(120.0));
     assertEquals(expected, rot);
@@ -295,16 +295,6 @@ class Rotation3dTest {
     var result = end.relativeTo(start);
 
     assertEquals(expected, result);
-  }
-
-  @Test
-  void testMinus() {
-    final var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
-
-    var rot1 = new Rotation3d(zAxis, Units.degreesToRadians(70.0));
-    var rot2 = new Rotation3d(zAxis, Units.degreesToRadians(30.0));
-
-    assertEquals(rot1.minus(rot2).getZ(), Units.degreesToRadians(40.0), kEpsilon);
   }
 
   @Test

--- a/wpimath/src/test/native/cpp/geometry/QuaternionTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/QuaternionTest.cpp
@@ -200,8 +200,8 @@ TEST(QuaternionTest, LogarithmAndExponentialInverse) {
   Quaternion start{1, 2, 3, 4};
   Quaternion expect{5, 6, 7, 8};
 
-  auto twist = start.Log(expect);
-  auto actual = start.Exp(twist);
+  auto twist = (expect * start.Inverse()).Log();
+  auto actual = twist.Exp() * start;
 
   EXPECT_EQ(expect, actual);
 }

--- a/wpimath/src/test/native/cpp/geometry/Rotation3dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Rotation3dTest.cpp
@@ -20,7 +20,7 @@ TEST(Rotation3dTest, GimbalLockAccuracy) {
   auto rot2 = Rotation3d{wpi::units::radian_t{std::numbers::pi}, 0_rad, 0_rad};
   auto rot3 =
       Rotation3d{-wpi::units::radian_t{std::numbers::pi / 2}, 0_rad, 0_rad};
-  const auto result1 = rot1 + rot2 + rot3;
+  const auto result1 = rot1.RotateBy(rot2).RotateBy(rot3);
   const auto expected1 =
       Rotation3d{0_rad, -wpi::units::radian_t{std::numbers::pi / 2},
                  wpi::units::radian_t{std::numbers::pi / 2}};
@@ -31,7 +31,7 @@ TEST(Rotation3dTest, GimbalLockAccuracy) {
   rot1 = Rotation3d{0_rad, 0_rad, wpi::units::radian_t{std::numbers::pi / 2}};
   rot2 = Rotation3d{wpi::units::radian_t{-std::numbers::pi}, 0_rad, 0_rad};
   rot3 = Rotation3d{wpi::units::radian_t{std::numbers::pi / 2}, 0_rad, 0_rad};
-  const auto result2 = rot1 + rot2 + rot3;
+  const auto result2 = rot1.RotateBy(rot2).RotateBy(rot3);
   const auto expected2 =
       Rotation3d{0_rad, wpi::units::radian_t{std::numbers::pi / 2},
                  wpi::units::radian_t{std::numbers::pi / 2}};
@@ -42,7 +42,7 @@ TEST(Rotation3dTest, GimbalLockAccuracy) {
   rot1 = Rotation3d{0_rad, 0_rad, wpi::units::radian_t{std::numbers::pi / 2}};
   rot2 = Rotation3d{0_rad, wpi::units::radian_t{std::numbers::pi / 3}, 0_rad};
   rot3 = Rotation3d{-wpi::units::radian_t{std::numbers::pi / 2}, 0_rad, 0_rad};
-  const auto result3 = rot1 + rot2 + rot3;
+  const auto result3 = rot1.RotateBy(rot2).RotateBy(rot3);
   const auto expected3 =
       Rotation3d{0_rad, wpi::units::radian_t{std::numbers::pi / 2},
                  wpi::units::radian_t{std::numbers::pi / 6}};
@@ -184,20 +184,20 @@ TEST(Rotation3dTest, DegreesToRadians) {
 TEST(Rotation3dTest, RotationLoop) {
   Rotation3d rot;
 
-  rot = rot + Rotation3d{90_deg, 0_deg, 0_deg};
+  rot = rot.RotateBy(Rotation3d{90_deg, 0_deg, 0_deg});
   Rotation3d expected{90_deg, 0_deg, 0_deg};
   EXPECT_EQ(expected, rot);
 
-  rot = rot + Rotation3d{0_deg, 90_deg, 0_deg};
+  rot = rot.RotateBy(Rotation3d{0_deg, 90_deg, 0_deg});
   expected = Rotation3d{
       {1.0 / std::sqrt(3), 1.0 / std::sqrt(3), -1.0 / std::sqrt(3)}, 120_deg};
   EXPECT_EQ(expected, rot);
 
-  rot = rot + Rotation3d{0_deg, 0_deg, 90_deg};
+  rot = rot.RotateBy(Rotation3d{0_deg, 0_deg, 90_deg});
   expected = Rotation3d{0_deg, 90_deg, 0_deg};
   EXPECT_EQ(expected, rot);
 
-  rot = rot + Rotation3d{0_deg, -90_deg, 0_deg};
+  rot = rot.RotateBy(Rotation3d{0_deg, -90_deg, 0_deg});
   EXPECT_EQ(Rotation3d{}, rot);
 }
 
@@ -205,7 +205,7 @@ TEST(Rotation3dTest, RotateByFromZeroX) {
   const Eigen::Vector3d xAxis{1.0, 0.0, 0.0};
 
   const Rotation3d zero;
-  auto rotated = zero + Rotation3d{xAxis, 90_deg};
+  auto rotated = zero.RotateBy(Rotation3d{xAxis, 90_deg});
 
   Rotation3d expected{xAxis, 90_deg};
   EXPECT_EQ(expected, rotated);
@@ -215,7 +215,7 @@ TEST(Rotation3dTest, RotateByFromZeroY) {
   const Eigen::Vector3d yAxis{0.0, 1.0, 0.0};
 
   const Rotation3d zero;
-  auto rotated = zero + Rotation3d{yAxis, 90_deg};
+  auto rotated = zero.RotateBy(Rotation3d{yAxis, 90_deg});
 
   Rotation3d expected{yAxis, 90_deg};
   EXPECT_EQ(expected, rotated);
@@ -225,7 +225,7 @@ TEST(Rotation3dTest, RotateByFromZeroZ) {
   const Eigen::Vector3d zAxis{0.0, 0.0, 1.0};
 
   const Rotation3d zero;
-  auto rotated = zero + Rotation3d{zAxis, 90_deg};
+  auto rotated = zero.RotateBy(Rotation3d{zAxis, 90_deg});
 
   Rotation3d expected{zAxis, 90_deg};
   EXPECT_EQ(expected, rotated);
@@ -235,7 +235,7 @@ TEST(Rotation3dTest, RotateByNonZeroX) {
   const Eigen::Vector3d xAxis{1.0, 0.0, 0.0};
 
   auto rot = Rotation3d{xAxis, 90_deg};
-  rot = rot + Rotation3d{xAxis, 30_deg};
+  rot = rot.RotateBy(Rotation3d{xAxis, 30_deg});
 
   Rotation3d expected{xAxis, 120_deg};
   EXPECT_EQ(expected, rot);
@@ -245,7 +245,7 @@ TEST(Rotation3dTest, RotateByNonZeroY) {
   const Eigen::Vector3d yAxis{0.0, 1.0, 0.0};
 
   auto rot = Rotation3d{yAxis, 90_deg};
-  rot = rot + Rotation3d{yAxis, 30_deg};
+  rot = rot.RotateBy(Rotation3d{yAxis, 30_deg});
 
   Rotation3d expected{yAxis, 120_deg};
   EXPECT_EQ(expected, rot);
@@ -255,7 +255,7 @@ TEST(Rotation3dTest, RotateByNonZeroZ) {
   const Eigen::Vector3d zAxis{0.0, 0.0, 1.0};
 
   auto rot = Rotation3d{zAxis, 90_deg};
-  rot = rot + Rotation3d{zAxis, 30_deg};
+  rot = rot.RotateBy(Rotation3d{zAxis, 30_deg});
 
   Rotation3d expected{zAxis, 120_deg};
   EXPECT_EQ(expected, rot);
@@ -274,15 +274,6 @@ TEST(Rotation3dTest, RelativeTo) {
   auto result = end.RelativeTo(start);
 
   EXPECT_EQ(expected, result);
-}
-
-TEST(Rotation3dTest, Minus) {
-  const Eigen::Vector3d zAxis{0.0, 0.0, 1.0};
-
-  const auto rot1 = Rotation3d{zAxis, 70_deg};
-  const auto rot2 = Rotation3d{zAxis, 30_deg};
-
-  EXPECT_DOUBLE_EQ(40.0, wpi::units::degree_t{(rot1 - rot2).Z()}.value());
 }
 
 TEST(Rotation3dTest, AxisAngle) {
@@ -376,7 +367,7 @@ TEST(Rotation3dTest, Interpolate) {
   rot2 = Rotation3d{yAxis, -160_deg};
   interpolated = wpi::util::Lerp(rot1, rot2, 0.5);
   EXPECT_DOUBLE_EQ(180.0, wpi::units::degree_t{interpolated.X()}.value());
-  EXPECT_DOUBLE_EQ(-5.0, wpi::units::degree_t{interpolated.Y()}.value());
+  EXPECT_NEAR(-5.0, wpi::units::degree_t{interpolated.Y()}.value(), 1e-9);
   EXPECT_DOUBLE_EQ(180.0, wpi::units::degree_t{interpolated.Z()}.value());
 
   // 50 + (70 - 50) * 0.5 = 60

--- a/wpimath/src/test/python/geometry/test_quaternion.py
+++ b/wpimath/src/test/python/geometry/test_quaternion.py
@@ -204,8 +204,8 @@ def test_logarithm_and_exponential_inverse():
     start = Quaternion(1, 2, 3, 4)
     expect = Quaternion(5, 6, 7, 8)
 
-    twist = start.log(expect)
-    actual = start.exp(twist)
+    twist = (expect * start.inverse()).log()
+    actual = twist.exp() * start
 
     assert actual == expect
 


### PR DESCRIPTION
Also replace arithmetic operators since they're not commutative, which is confusing for users.