### PR TITLE
[wpilib] Replace unit .to<double>() with .value()

### DIFF
--- a/wpilibc/src/main/native/cpp/hardware/expansionhub/ExpansionHubMotor.cpp
+++ b/wpilibc/src/main/native/cpp/hardware/expansionhub/ExpansionHubMotor.cpp
@@ -99,7 +99,7 @@ void ExpansionHubMotor::SetPercentagePower(double power) {
 
 void ExpansionHubMotor::SetVoltage(wpi::units::volt_t voltage) {
   m_modePublisher.Set(kVoltageMode);
-  m_setpointPublisher.Set(voltage.to<double>());
+  m_setpointPublisher.Set(voltage.value());
 }
 
 void ExpansionHubMotor::SetPositionSetpoint(double setpoint) {

--- a/wpilibc/src/main/native/cpp/hardware/expansionhub/ExpansionHubServo.cpp
+++ b/wpilibc/src/main/native/cpp/hardware/expansionhub/ExpansionHubServo.cpp
@@ -76,7 +76,7 @@ void ExpansionHubServo::SetAngle(wpi::units::degree_t angle) {
 }
 
 void ExpansionHubServo::SetPulseWidth(wpi::units::microsecond_t pulseWidth) {
-  m_pulseWidthPublisher.Set(pulseWidth.to<double>());
+  m_pulseWidthPublisher.Set(pulseWidth.value());
 }
 
 void ExpansionHubServo::SetEnabled(bool enabled) {
@@ -84,7 +84,7 @@ void ExpansionHubServo::SetEnabled(bool enabled) {
 }
 
 void ExpansionHubServo::SetFramePeriod(wpi::units::microsecond_t framePeriod) {
-  m_framePeriodPublisher.Set(framePeriod.to<double>());
+  m_framePeriodPublisher.Set(framePeriod.value());
 }
 
 wpi::units::microsecond_t ExpansionHubServo::GetFullRangeScaleFactor() {

--- a/wpilibc/src/main/native/cpp/hardware/motor/PWMMotorController.cpp
+++ b/wpilibc/src/main/native/cpp/hardware/motor/PWMMotorController.cpp
@@ -148,12 +148,12 @@ void PWMMotorController::SetSpeed(double speed) {
   if (speed == 0.0) {
     rawValue = m_centerPwm;
   } else if (speed > 0.0) {
-    rawValue = wpi::units::microsecond_t{static_cast<double>(std::lround(
-                   (speed * GetPositiveScaleFactor()).to<double>()))} +
+    rawValue = wpi::units::microsecond_t{static_cast<double>(
+                   std::lround((speed * GetPositiveScaleFactor()).value()))} +
                GetMinPositivePwm();
   } else {
-    rawValue = wpi::units::microsecond_t{static_cast<double>(std::lround(
-                   (speed * GetNegativeScaleFactor()).to<double>()))} +
+    rawValue = wpi::units::microsecond_t{static_cast<double>(
+                   std::lround((speed * GetNegativeScaleFactor()).value()))} +
                GetMaxNegativePwm();
   }
 
@@ -171,10 +171,10 @@ double PWMMotorController::GetSpeed() const {
     return -1.0;
   } else if (rawValue > GetMinPositivePwm()) {
     return ((rawValue - GetMinPositivePwm()) / GetPositiveScaleFactor())
-        .to<double>();
+        .value();
   } else if (rawValue < GetMaxNegativePwm()) {
     return ((rawValue - GetMaxNegativePwm()) / GetNegativeScaleFactor())
-        .to<double>();
+        .value();
   } else {
     return 0.0;
   }

--- a/wpimath/src/main/native/include/wpi/math/system/NumericalIntegration.hpp
+++ b/wpimath/src/main/native/include/wpi/math/system/NumericalIntegration.hpp
@@ -61,7 +61,7 @@ T RK4(F&& f, T x, U u, wpi::units::second_t dt) {
  */
 template <typename F, typename T>
 T RK4(F&& f, wpi::units::second_t t, T y, wpi::units::second_t dt) {
-  const auto h = dt.to<double>();
+  const auto h = dt.value();
 
   T k1 = f(t, y);
   T k2 = f(t + dt * 0.5, y + h * k1 * 0.5);
@@ -198,13 +198,13 @@ T RKDP(F&& f, wpi::units::second_t t, T y, wpi::units::second_t dt,
   double truncationError;
 
   double dtElapsed = 0.0;
-  double h = dt.to<double>();
+  double h = dt.value();
 
   // Loop until we've gotten to our desired dt
-  while (dtElapsed < dt.to<double>()) {
+  while (dtElapsed < dt.value()) {
     do {
       // Only allow us to advance up to the dt remaining
-      h = std::min(h, dt.to<double>() - dtElapsed);
+      h = std::min(h, dt.value() - dtElapsed);
 
       // clang-format off
       T k1 = f(t, y);


### PR DESCRIPTION
This is consistent with the rest of the library. I left instances alone which intended a specific typecast.