### PR TITLE
[ntcore] Release ListenerStorage mutex before stopping thread

### DIFF
--- a/ntcore/src/main/native/cpp/ListenerStorage.cpp
+++ b/ntcore/src/main/native/cpp/ListenerStorage.cpp
@@ -346,14 +346,16 @@ bool ListenerStorage::WaitForListenerQueue(double timeout) {
 }
 
 void ListenerStorage::Reset() {
-  std::scoped_lock lock{m_mutex};
-  m_pollers.clear();
-  m_listeners.clear();
-  m_connListeners.clear();
-  m_topicListeners.clear();
-  m_valueListeners.clear();
-  m_logListeners.clear();
-  m_timeSyncListeners.clear();
+  {
+    std::scoped_lock lock{m_mutex};
+    m_pollers.clear();
+    m_listeners.clear();
+    m_connListeners.clear();
+    m_topicListeners.clear();
+    m_valueListeners.clear();
+    m_logListeners.clear();
+    m_timeSyncListeners.clear();
+  }
   m_thread.Join();
 }
 


### PR DESCRIPTION
- If the thread is still running then it will deadlock
- Fixes #8561

The deadlock doesn't happen very often for me locally, but it happens in CI a lot. It's been running for a few minutes locally and I haven't seen a deadlock so it probably works?