### PR TITLE
[glass] Add correct time for rebuilt

### DIFF
--- a/glass/src/lib/native/cpp/other/FMS.cpp
+++ b/glass/src/lib/native/cpp/other/FMS.cpp
@@ -71,11 +71,11 @@ void glass::DisplayFMS(FMSModel* model, bool editableDsAttached) {
     }
     ImGui::SameLine();
     if (ImGui::Button("Auto") && !enabled) {
-      model->SetMatchTime(15.0);
+      model->SetMatchTime(20.0);
     }
     ImGui::SameLine();
     if (ImGui::Button("Teleop") && !enabled) {
-      model->SetMatchTime(135.0);
+      model->SetMatchTime(140.0);
     }
   }
 


### PR DESCRIPTION
The timer has changed for rebuilt's auto and teleop so here's the correct timer