### PR TITLE
[ntcore] Fix local client behavior

### DIFF
--- a/ntcore/src/main/native/cpp/NetworkServer.cpp
+++ b/ntcore/src/main/native/cpp/NetworkServer.cpp
@@ -59,7 +59,6 @@ class NetworkServer::ServerConnection {
   void SetupOutgoingTimer();
   void UpdateOutgoingTimer(uint32_t repeatMs);
   void ConnectionClosed();
-  uv::Loop& GetLoopRef() const { return m_outgoingTimer->GetLoopRef(); }
 
   NetworkServer& m_server;
   ConnectionInfo m_info;
@@ -239,13 +238,11 @@ void NetworkServer::ServerConnection4::ProcessWsUpgrade() {
       if (m_server.m_serverImpl.ProcessIncomingText(m_clientId, data)) {
         m_server.m_idle->Start();
       }
-      m_server.m_serverImpl.SendAllLocalOutgoing(GetLoopRef().Now().count());
     });
     m_websocket->binary.connect([this](std::span<const uint8_t> data, bool) {
       if (m_server.m_serverImpl.ProcessIncomingBinary(m_clientId, data)) {
         m_server.m_idle->Start();
       }
-      m_server.m_serverImpl.SendAllLocalOutgoing(GetLoopRef().Now().count());
     });
 
     SetupOutgoingTimer();
@@ -425,7 +422,6 @@ void NetworkServer::Init() {
         DEBUG4("Stopping idle processing");
         m_idle->Stop();  // go back to sleep
       }
-      m_serverImpl.SendAllLocalOutgoing(m_loop.Now().count());
     });
   }
 

--- a/ntcore/src/main/native/cpp/server/ServerImpl.cpp
+++ b/ntcore/src/main/native/cpp/server/ServerImpl.cpp
@@ -152,14 +152,6 @@ void ServerImpl::SendOutgoing(int clientId, uint64_t curTimeMs) {
   }
 }
 
-void ServerImpl::SendAllLocalOutgoing(uint64_t curTimeMs) {
-  for (auto&& client : m_clients) {
-    if (client && client->IsLocal()) {
-      client->SendOutgoing(curTimeMs, true);
-    }
-  }
-}
-
 void ServerImpl::SetLocal(net::ServerMessageHandler* local,
                           net::ClientMessageQueue* queue) {
   DEBUG4("SetLocal()");

--- a/ntcore/src/main/native/cpp/server/ServerImpl.hpp
+++ b/ntcore/src/main/native/cpp/server/ServerImpl.hpp
@@ -43,7 +43,6 @@ class ServerImpl final {
 
   void SendAllOutgoing(uint64_t curTimeMs, bool flush);
   void SendOutgoing(int clientId, uint64_t curTimeMs);
-  void SendAllLocalOutgoing(uint64_t curTimeMs);
 
   void SetLocal(net::ServerMessageHandler* local,
                 net::ClientMessageQueue* queue);


### PR DESCRIPTION
Fixes local clients receiving inconsistent data updates. Data was only flushed to local clients on incoming websocket data (or when explicitly flushed), so local clients on a quiet server would stop receiving updates.

Revert some changes from #7997.
Instead of relying on periodic sends, always immediately send local data updates to the wire for lower latency. This means that on local clients, the periodic update rate and sendAll settings will be ignored, as all data updates will be sent immediately.