### PR TITLE
[wpiunits] Make RPM an alias of RotationsPerMinute

### DIFF
--- a/wpiunits/src/main/java/edu/wpi/first/units/Units.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/Units.java
@@ -167,7 +167,7 @@ public final class Units {
    * per {@link #Minute}. Motor spec sheets often list maximum speeds in terms of RPM.
    */
   public static final AngularVelocityUnit RotationsPerMinute = Rotations.per(Minute);
-  
+
   /**
    * A unit of angular velocity equivalent to spinning at a rate of one {@link #Rotations Rotation}
    * per {@link #Minute}. Motor spec sheets often list maximum speeds in terms of RPM.


### PR DESCRIPTION
Currently the only name for this unit is `RPM`. This caused a bit of confusion for a couple of my team members when we failed to find an RPM unit, assuming it would be named `RotationsPerMinute` as is the standard for almost all other units, such as `RotationsPerSecond`.

No corresponding changes have been made to wpilibc as it seems to already work this way, with `rpm` being the abbreviation for `revolutions_per_minute`.