### PR TITLE
[wpinet] Fix windows mDNS announcer long startup times

### DIFF
--- a/wpinet/src/main/native/windows/MulticastServiceAnnouncer.cpp
+++ b/wpinet/src/main/native/windows/MulticastServiceAnnouncer.cpp
@@ -163,7 +163,8 @@ void MulticastServiceAnnouncer::Start() {
   registerRequest.pServiceInstance = serviceInst;
   registerRequest.InterfaceIndex = 0;
 
-  if (DnsServiceRegister(&registerRequest, &pImpl->serviceCancel) != DNS_REQUEST_PENDING) {
+  if (DnsServiceRegister(&registerRequest, &pImpl->serviceCancel) !=
+      DNS_REQUEST_PENDING) {
     DnsServiceFreeInstance(serviceInst);
     CloseHandle(pImpl->registerEvent);
     pImpl->registerEvent = nullptr;


### PR DESCRIPTION
The existing code takes 750ms to start per resolver. This is too long, especially in mrccomm where we start 4 on initialize, and 3 any time the team number changes.

Solve this by handling the async setup more correctly. Assuming it returns pending, we're assuming the announcer is good. Then on stop(), we cancel the register in case its still pending, wait for the callback, and then deregister.
