### PR TITLE
Preferences Listener should not depend on mutable fields

### DIFF
--- a/ntcore/src/main/java/edu/wpi/first/networktables/Topic.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/Topic.java
@@ -330,8 +330,8 @@ public class Topic {
   }
 
   /** NetworkTables instance. */
-  protected NetworkTableInstance m_inst;
+  protected final NetworkTableInstance m_inst;
 
   /** NetworkTables handle. */
-  protected int m_handle;
+  protected final int m_handle;
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Preferences.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Preferences.java
@@ -83,6 +83,8 @@ public final class Preferences {
     if (m_listener != null) {
       m_listener.close();
     }
+
+    Topic typePublisherTopic = m_typePublisher.getTopic();
     m_listener =
         NetworkTableListener.createListener(
             m_tableSubscriber,
@@ -90,8 +92,8 @@ public final class Preferences {
             event -> {
               if (event.topicInfo != null) {
                 Topic topic = event.topicInfo.getTopic();
-                if (!topic.equals(m_typePublisher.getTopic())) {
-                  event.topicInfo.getTopic().setPersistent(true);
+                if (!topic.equals(typePublisherTopic)) {
+                  topic.setPersistent(true);
                 }
               }
             });


### PR DESCRIPTION
The Listener installed by Preferences was referencing m_typePublisher which
could be modified by a future call to setNetworkTableInstance(). Instead,
reference a local.

Also made Topic.m_handle final, to guarantee that Topic.equals() is thread-
safe, and still work after the publisher has been closed.