### PR TITLE
Enable ExpansionHub motors and servos on any set

### DIFF
--- a/wpilibc/src/main/native/cpp/hardware/expansionhub/ExpansionHubMotor.cpp
+++ b/wpilibc/src/main/native/cpp/hardware/expansionhub/ExpansionHubMotor.cpp
@@ -93,21 +93,25 @@ ExpansionHubMotor::~ExpansionHubMotor() noexcept {
 }
 
 void ExpansionHubMotor::SetPercentagePower(double power) {
+  SetEnabled(true);
   m_modePublisher.Set(kPercentageMode);
   m_setpointPublisher.Set(power);
 }
 
 void ExpansionHubMotor::SetVoltage(wpi::units::volt_t voltage) {
+  SetEnabled(true);
   m_modePublisher.Set(kVoltageMode);
   m_setpointPublisher.Set(voltage.value());
 }
 
 void ExpansionHubMotor::SetPositionSetpoint(double setpoint) {
+  SetEnabled(true);
   m_modePublisher.Set(kPositionMode);
   m_setpointPublisher.Set(setpoint);
 }
 
 void ExpansionHubMotor::SetVelocitySetpoint(double setpoint) {
+  SetEnabled(true);
   m_modePublisher.Set(kVelocityMode);
   m_setpointPublisher.Set(setpoint);
 }

--- a/wpilibc/src/main/native/cpp/hardware/expansionhub/ExpansionHubServo.cpp
+++ b/wpilibc/src/main/native/cpp/hardware/expansionhub/ExpansionHubServo.cpp
@@ -76,6 +76,7 @@ void ExpansionHubServo::SetAngle(wpi::units::degree_t angle) {
 }
 
 void ExpansionHubServo::SetPulseWidth(wpi::units::microsecond_t pulseWidth) {
+  SetEnabled(true);
   m_pulseWidthPublisher.Set(pulseWidth.value());
 }
 

--- a/wpilibj/src/main/java/org/wpilib/hardware/expansionhub/ExpansionHubMotor.java
+++ b/wpilibj/src/main/java/org/wpilib/hardware/expansionhub/ExpansionHubMotor.java
@@ -158,6 +158,7 @@ public class ExpansionHubMotor implements AutoCloseable {
    * @param power The power to drive the motor at
    */
   public void setPercentagePower(double power) {
+    setEnabled(true);
     m_modePublisher.set(kPercentageMode);
     m_setpointPublisher.set(power);
   }
@@ -169,6 +170,7 @@ public class ExpansionHubMotor implements AutoCloseable {
    * @param voltage The voltage to drive the motor at
    */
   public void setVoltage(Voltage voltage) {
+    setEnabled(true);
     m_modePublisher.set(kVoltageMode);
     m_setpointPublisher.set(voltage.in(Volts));
   }
@@ -180,6 +182,7 @@ public class ExpansionHubMotor implements AutoCloseable {
    * @param setpoint The position setpoint to drive the motor to
    */
   public void setPositionSetpoint(double setpoint) {
+    setEnabled(true);
     m_modePublisher.set(kPositionMode);
     m_setpointPublisher.set(setpoint);
   }
@@ -191,6 +194,7 @@ public class ExpansionHubMotor implements AutoCloseable {
    * @param setpoint The velocity setpoint to drive the motor to
    */
   public void setVelocitySetpoint(double setpoint) {
+    setEnabled(true);
     m_modePublisher.set(kVelocityMode);
     m_setpointPublisher.set(setpoint);
   }

--- a/wpilibj/src/main/java/org/wpilib/hardware/expansionhub/ExpansionHubServo.java
+++ b/wpilibj/src/main/java/org/wpilib/hardware/expansionhub/ExpansionHubServo.java
@@ -107,6 +107,7 @@ public class ExpansionHubServo implements AutoCloseable {
 
     int rawValue = (int) ((value * getFullRangeScaleFactor()) + m_minPwm);
 
+    setEnabled(true);
     m_pulseWidthPublisher.set(rawValue);
   }
 
@@ -142,6 +143,7 @@ public class ExpansionHubServo implements AutoCloseable {
    * @param pulseWidth Pulse width
    */
   public void setPulseWidth(Time pulseWidth) {
+    setEnabled(true);
     m_pulseWidthPublisher.set((long) pulseWidth.in(Microseconds));
   }
 


### PR DESCRIPTION
This more matches the existing FTC SDK. And removes the footgun of needing to call set