### PR TITLE
[cmd] Fix WaitUntilCommand for match time counting down

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/WaitUntilCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/WaitUntilCommand.java
@@ -35,14 +35,14 @@ public class WaitUntilCommand extends Command {
    * referees. When in doubt, add a safety factor or time the action manually.
    *
    * <p>The match time counts down when connected to FMS or the DS is in practice mode for the
-   * current mode. When the DS is not connected to FMS or in practice mode, this will immediately
-   * return.
+   * current mode. When the DS is not connected to FMS or in practice mode, the command will not
+   * wait.
    *
    * @param time the match time after which to end, in seconds
    * @see edu.wpi.first.wpilibj.DriverStation#getMatchTime()
    */
   public WaitUntilCommand(double time) {
-    this(() -> Timer.getMatchTime() - time < 0);
+    this(() -> Timer.getMatchTime() < time);
   }
 
   @Override

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/WaitUntilCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/WaitUntilCommand.cpp
@@ -14,7 +14,7 @@ WaitUntilCommand::WaitUntilCommand(std::function<bool()> condition)
     : m_condition{std::move(condition)} {}
 
 WaitUntilCommand::WaitUntilCommand(units::second_t time)
-    : m_condition{[=] { return frc::Timer::GetMatchTime() - time < 0_s; }} {}
+    : m_condition{[=] { return frc::Timer::GetMatchTime() < time; }} {}
 
 bool WaitUntilCommand::IsFinished() {
   return m_condition();

--- a/wpilibNewCommands/src/main/native/include/frc2/command/WaitUntilCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/WaitUntilCommand.h
@@ -38,7 +38,7 @@ class WaitUntilCommand : public CommandHelper<Command, WaitUntilCommand> {
    *
    * The match time counts down when connected to FMS or the DS is in practice
    * mode for the current mode. When the DS is not connected to FMS or in
-   * practice mode, this will immediately return.
+   * practice mode, the command will not wait.
    *
    * @param time the match time after which to end, in seconds
    * @see frc::DriverStation::GetMatchTime()


### PR DESCRIPTION
Fixes #8631
Documents that it will return immediately if FMS isn't attached or DS isn't in practice mode.
Related to change in DS match time behavior that was documented in #8606