### PR TITLE
[ci] Specify exact OpenCV features in vcpkg manifest

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,22 @@
   "name": "main",
   "version-string": "latest",
   "dependencies": [
-    "opencv",
+    {
+      "name": "opencv4",
+      "default-features": false,
+      "features": [
+        "calib3d",
+        "dshow",
+        "fs",
+        "highgui",
+        "intrinsics",
+        "jpeg",
+        "msmf",
+        "png",
+        "thread",
+        "win32ui"
+      ]
+    },
     "fmt",
     "libuv",
     "libssh"


### PR DESCRIPTION
This allows us to skip building things we don't need, like the ML libraries or QR code scanning. This cuts the vcpkg configure time down by 50%.