### PR TITLE
[wpilibc,j] Fixup alerts

### DIFF
--- a/wpilibc/src/main/python/semiwrap/simulation/AlertSim.yml
+++ b/wpilibc/src/main/python/semiwrap/simulation/AlertSim.yml
@@ -11,6 +11,7 @@ classes:
       text:
       activeStartTime:
       level:
+        # use inline code to fix crash
         ignore: true
     methods:
       isActive:

--- a/wpilibc/src/test/native/cpp/simulation/AlertSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/AlertSimTest.cpp
@@ -108,6 +108,11 @@ TEST_F(AlertSimTest, SetIsIdempotent) {
   c.Set(true);
 
   const auto startState = GetActiveAlerts(Alert::Level::LOW);
+  std::vector<std::string> expected;
+  expected.emplace_back("A");
+  expected.emplace_back("B");
+  expected.emplace_back("C");
+  EXPECT_EQ(expected, startState);
 
   b.Set(true);
   EXPECT_STATE(Alert::Level::LOW, startState);

--- a/wpilibc/src/test/python/test_alert.py
+++ b/wpilibc/src/test/python/test_alert.py
@@ -81,7 +81,6 @@ def test_set_unset_multiple(group_name):
 
 
 def test_set_is_idempotent(group_name):
-    group_name = group_name
     with (
         Alert(group_name, "A", Alert.Level.LOW) as a,
         Alert(group_name, "B", Alert.Level.LOW) as b,
@@ -103,7 +102,6 @@ def test_set_is_idempotent(group_name):
 
 
 def test_close_unsets_alert(group_name):
-    group_name = group_name
     with Alert(group_name, "alert", Alert.Level.MEDIUM) as alert:
         alert.set(True)
         assert is_alert_active("alert", Alert.Level.MEDIUM)
@@ -111,7 +109,6 @@ def test_close_unsets_alert(group_name):
 
 
 def test_set_text_while_unset(group_name):
-    group_name = group_name
     with Alert(group_name, "BEFORE", Alert.Level.LOW) as alert:
         assert alert.getText() == "BEFORE"
         alert.set(True)

--- a/wpilibc/src/test/python/test_alert.py
+++ b/wpilibc/src/test/python/test_alert.py
@@ -21,7 +21,7 @@ def get_active_alerts(group_name: str, level: Alert.Level) -> T.List[str]:
     return [
         a.text
         for a in AlertSim.getAll()
-        if a.group == group_name and a.level == level and a.isActive()
+        if a.level == level and a.isActive()
     ]
 
 
@@ -29,10 +29,7 @@ def is_alert_active(group_name: str, text: str, level: Alert.Level):
     matches = [
         a
         for a in AlertSim.getAll()
-        if a.group == group_name
-        and a.level == level
-        and a.text == text
-        and a.isActive()
+        if a.level == level and a.text == text and a.isActive()
     ]
     return len(matches) > 0
 

--- a/wpilibc/src/test/python/test_alert.py
+++ b/wpilibc/src/test/python/test_alert.py
@@ -17,7 +17,7 @@ def group_name(request):
     AlertSim.resetData()
 
 
-def get_active_alerts(group_name: str, level: Alert.Level) -> T.List[str]:
+def get_active_alerts(level: Alert.Level) -> T.List[str]:
     return [
         a.text
         for a in AlertSim.getAll()
@@ -25,7 +25,7 @@ def get_active_alerts(group_name: str, level: Alert.Level) -> T.List[str]:
     ]
 
 
-def is_alert_active(group_name: str, text: str, level: Alert.Level):
+def is_alert_active(text: str, level: Alert.Level):
     matches = [
         a
         for a in AlertSim.getAll()
@@ -35,27 +35,26 @@ def is_alert_active(group_name: str, text: str, level: Alert.Level):
 
 
 def assert_state(
-    group_name: str,
     level: Alert.Level,
     expected_state: T.List[str],
 ):
-    assert expected_state == get_active_alerts(group_name, level)
+    assert expected_state == get_active_alerts(level)
 
 
 def test_set_unset_single(group_name):
     with Alert(group_name, "one", Alert.Level.HIGH) as one:
 
-        assert not is_alert_active(group_name, "one", Alert.Level.HIGH)
-        assert not is_alert_active(group_name, "two", Alert.Level.LOW)
+        assert not is_alert_active("one", Alert.Level.HIGH)
+        assert not is_alert_active("two", Alert.Level.LOW)
 
         one.set(True)
-        assert is_alert_active(group_name, "one", Alert.Level.HIGH)
+        assert is_alert_active("one", Alert.Level.HIGH)
 
         one.set(True)
-        assert is_alert_active(group_name, "one", Alert.Level.HIGH)
+        assert is_alert_active("one", Alert.Level.HIGH)
 
         one.set(False)
-        assert not is_alert_active(group_name, "one", Alert.Level.HIGH)
+        assert not is_alert_active("one", Alert.Level.HIGH)
 
 
 def test_set_unset_multiple(group_name):
@@ -64,21 +63,21 @@ def test_set_unset_multiple(group_name):
         Alert(group_name, "two", Alert.Level.LOW) as two,
     ):
 
-        assert not is_alert_active(group_name, "one", Alert.Level.HIGH)
-        assert not is_alert_active(group_name, "two", Alert.Level.LOW)
+        assert not is_alert_active("one", Alert.Level.HIGH)
+        assert not is_alert_active("two", Alert.Level.LOW)
 
         one.set(True)
-        assert is_alert_active(group_name, "one", Alert.Level.HIGH)
-        assert not is_alert_active(group_name, "two", Alert.Level.LOW)
+        assert is_alert_active("one", Alert.Level.HIGH)
+        assert not is_alert_active("two", Alert.Level.LOW)
 
         one.set(True)
         two.set(True)
-        assert is_alert_active(group_name, "one", Alert.Level.HIGH)
-        assert is_alert_active(group_name, "two", Alert.Level.LOW)
+        assert is_alert_active("one", Alert.Level.HIGH)
+        assert is_alert_active("two", Alert.Level.LOW)
 
         one.set(False)
-        assert not is_alert_active(group_name, "one", Alert.Level.HIGH)
-        assert is_alert_active(group_name, "two", Alert.Level.LOW)
+        assert not is_alert_active("one", Alert.Level.HIGH)
+        assert is_alert_active("two", Alert.Level.LOW)
 
 
 def test_set_is_idempotent(group_name):
@@ -93,22 +92,22 @@ def test_set_is_idempotent(group_name):
         b.set(True)
         c.set(True)
 
-        start_state = get_active_alerts(group_name, Alert.Level.LOW)
+        start_state = get_active_alerts(Alert.Level.LOW)
         assert set(start_state) == {"A", "B", "C"}
 
         b.set(True)
-        assert_state(group_name, Alert.Level.LOW, start_state)
+        assert_state(Alert.Level.LOW, start_state)
 
         a.set(True)
-        assert_state(group_name, Alert.Level.LOW, start_state)
+        assert_state(Alert.Level.LOW, start_state)
 
 
 def test_close_unsets_alert(group_name):
     group_name = group_name
     with Alert(group_name, "alert", Alert.Level.MEDIUM) as alert:
         alert.set(True)
-        assert is_alert_active(group_name, "alert", Alert.Level.MEDIUM)
-    assert not is_alert_active(group_name, "alert", Alert.Level.MEDIUM)
+        assert is_alert_active("alert", Alert.Level.MEDIUM)
+    assert not is_alert_active("alert", Alert.Level.MEDIUM)
 
 
 def test_set_text_while_unset(group_name):
@@ -116,22 +115,22 @@ def test_set_text_while_unset(group_name):
     with Alert(group_name, "BEFORE", Alert.Level.LOW) as alert:
         assert alert.getText() == "BEFORE"
         alert.set(True)
-        assert is_alert_active(group_name, "BEFORE", Alert.Level.LOW)
+        assert is_alert_active("BEFORE", Alert.Level.LOW)
         alert.set(False)
-        assert not is_alert_active(group_name, "BEFORE", Alert.Level.LOW)
+        assert not is_alert_active("BEFORE", Alert.Level.LOW)
         alert.setText("AFTER")
         assert alert.getText() == "AFTER"
         alert.set(True)
-        assert not is_alert_active(group_name, "BEFORE", Alert.Level.LOW)
-        assert is_alert_active(group_name, "AFTER", Alert.Level.LOW)
+        assert not is_alert_active("BEFORE", Alert.Level.LOW)
+        assert is_alert_active("AFTER", Alert.Level.LOW)
 
 
 def test_set_text_while_set(group_name):
     with Alert(group_name, "BEFORE", Alert.Level.LOW) as alert:
         assert alert.getText() == "BEFORE"
         alert.set(True)
-        assert is_alert_active(group_name, "BEFORE", Alert.Level.LOW)
+        assert is_alert_active("BEFORE", Alert.Level.LOW)
         alert.setText("AFTER")
         assert alert.getText() == "AFTER"
-        assert not is_alert_active(group_name, "BEFORE", Alert.Level.LOW)
-        assert is_alert_active(group_name, "AFTER", Alert.Level.LOW)
+        assert not is_alert_active("BEFORE", Alert.Level.LOW)
+        assert is_alert_active("AFTER", Alert.Level.LOW)

--- a/wpilibc/src/test/python/test_alert.py
+++ b/wpilibc/src/test/python/test_alert.py
@@ -41,14 +41,26 @@ def assert_state(
     assert expected_state == get_active_alerts(level)
 
 
+def test_no_alerts_initially(group_name):
+    assert AlertSim.getCount() == 0
+    assert not AlertSim.getAll()
+
+
+def test_no_alerts_after_reset(group_name):
+    with Alert(group_name, "alert", Alert.Level.HIGH) as alert:
+
+        alert.set(True)
+        assert is_alert_active("alert", Alert.Level.HIGH)
+
+        AlertSim.resetData()
+        assert AlertSim.getCount() == 0
+        assert not AlertSim.getAll()
+
+
 def test_set_unset_single(group_name):
     with Alert(group_name, "one", Alert.Level.HIGH) as one:
 
         assert not is_alert_active("one", Alert.Level.HIGH)
-        assert not is_alert_active("two", Alert.Level.LOW)
-
-        one.set(True)
-        assert is_alert_active("one", Alert.Level.HIGH)
 
         one.set(True)
         assert is_alert_active("one", Alert.Level.HIGH)

--- a/wpilibj/src/main/java/org/wpilib/driverstation/Alert.java
+++ b/wpilibj/src/main/java/org/wpilib/driverstation/Alert.java
@@ -43,9 +43,6 @@ public class Alert implements AutoCloseable {
      */
     HIGH(AlertJNI.LEVEL_HIGH),
 
-    /** Alternate name for a high priority alert. */
-    ERROR(HIGH.m_value),
-
     /**
      * Medium priority alert - displayed second with a yellow "!" symbol. Use this type for problems
      * which could affect the robot's functionality but do not necessarily require immediate
@@ -53,18 +50,21 @@ public class Alert implements AutoCloseable {
      */
     MEDIUM(AlertJNI.LEVEL_MEDIUM),
 
-    /** Alternate name for a medium priority alert. */
-    WARNING(MEDIUM.m_value),
-
     /**
      * Low priority alert - displayed last with a green "i" symbol. Use this type for problems which
      * are unlikely to affect the robot's functionality, or any other alerts which do not fall under
      * the other categories.
      */
-    LOW(AlertJNI.LEVEL_LOW),
+    LOW(AlertJNI.LEVEL_LOW);
+
+    /** Alternate name for a high priority alert. */
+    public static final Level ERROR = HIGH;
+
+    /** Alternate name for a medium priority alert. */
+    public static final Level WARNING = MEDIUM;
 
     /** Alternate name for a low priority alert. */
-    INFO(LOW.m_value);
+    public static final Level INFO = LOW;
 
     private final int m_value;
 

--- a/wpilibj/src/test/java/org/wpilib/simulation/AlertSimTest.java
+++ b/wpilibj/src/test/java/org/wpilib/simulation/AlertSimTest.java
@@ -54,19 +54,20 @@ class AlertSimTest {
   }
 
   @Test
-  void testInitialization() {
+  void testNoAlertsInitially() {
     assertEquals(0, AlertSim.getCount());
     assertEquals(0, AlertSim.getAll().length);
   }
 
   @Test
-  void testReset() {
+  void testNoAlertsAfterReset() {
     try (var alert = makeAlert("alert", Level.HIGH)) {
       alert.set(true);
       assertTrue(isAlertActive("alert", Level.HIGH));
+      AlertSim.resetData();
+      assertEquals(0, AlertSim.getCount());
+      assertEquals(0, AlertSim.getAll().length);
     }
-    AlertSim.resetData();
-    assertFalse(isAlertActive("alert", Level.HIGH));
   }
 
   @Test
@@ -109,6 +110,7 @@ class AlertSimTest {
       c.set(true);
 
       var startState = List.of(getActiveAlerts(Level.LOW));
+      assertEquals(List.of("A", "B", "C"), startState);
 
       b.set(true);
       assertState(Level.LOW, startState);


### PR DESCRIPTION
Makes Java `Alert.Level.ERROR`, `Alert.Level.WARNING`,  and `Alert.Level.INFO` proper aliases (instead of separate enum constants with the same value).
Cleans up Python tests.
Makes the Alert tests more consistent between languages.