### PR TITLE
[hal] Simplify monotonic_clock

### DIFF
--- a/hal/src/main/native/include/wpi/hal/monotonic_clock.hpp
+++ b/hal/src/main/native/include/wpi/hal/monotonic_clock.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <chrono>
-#include <limits>
 
 #include "wpi/hal/HAL.h"
 
@@ -22,17 +21,12 @@ class monotonic_clock {
   using duration = std::chrono::microseconds;
   using time_point = std::chrono::time_point<monotonic_clock>;
 
-  static time_point now() noexcept {
-    uint64_t currentTime = HAL_GetMonotonicTime();
-    return time_point(std::chrono::microseconds(currentTime));
-  }
   static constexpr bool is_steady = true;
 
-  static time_point epoch() noexcept { return time_point(zero()); }
-
-  static duration zero() noexcept { return duration(0); }
-
-  static constexpr time_point min_time =
-      time_point(duration(std::numeric_limits<duration::rep>::min()));
+  static time_point now() noexcept {
+    uint64_t currentTime = HAL_GetMonotonicTime();
+    return time_point{std::chrono::microseconds{currentTime}};
+  }
 };
+
 }  // namespace wpi::hal

--- a/wpilibc/src/main/native/include/wpi/system/Tracer.hpp
+++ b/wpilibc/src/main/native/include/wpi/system/Tracer.hpp
@@ -66,8 +66,7 @@ class Tracer {
   static constexpr std::chrono::milliseconds kMinPrintPeriod{1000};
 
   wpi::hal::monotonic_clock::time_point m_startTime;
-  wpi::hal::monotonic_clock::time_point m_lastEpochsPrintTime =
-      wpi::hal::monotonic_clock::epoch();
+  wpi::hal::monotonic_clock::time_point m_lastEpochsPrintTime;
 
   wpi::util::StringMap<std::chrono::nanoseconds> m_epochs;
 };


### PR DESCRIPTION
The epoch() function, zero() function, and min_time member are all not part of the std::chrono clock interface.

The default constructor of time_point is [documented](https://en.cppreference.com/w/cpp/chrono/time_point/time_point.html) to initialize to the clock's epoch.