### PR TITLE
[ci] Fix all warnings from clang-tidy 22

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -72,3 +72,4 @@ CheckOptions:
   - key: modernize-use-using.IgnoreExternC
     value: 'true'
 FormatStyle: file
+HeaderFilterRegex: '^((?!thirdparty/).)*$'

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install wpiformat
         run: |
           python -m venv ${{ runner.temp }}/wpiformat
-          ${{ runner.temp }}/wpiformat/bin/pip3 install wpiformat==2026.56
+          ${{ runner.temp }}/wpiformat/bin/pip3 install wpiformat==2026.57
       - name: Run
         run: ${{ runner.temp }}/wpiformat/bin/wpiformat -default-branch 2027
       - name: Check output
@@ -78,7 +78,7 @@ jobs:
       - name: Install wpiformat
         run: |
           python -m venv ${{ runner.temp }}/wpiformat
-          ${{ runner.temp }}/wpiformat/bin/pip3 install wpiformat==2026.56
+          ${{ runner.temp }}/wpiformat/bin/pip3 install wpiformat==2026.57
       - name: Create compile_commands.json
         run: |
           ./gradlew generateCompileCommands -Ptoolchain-optional-roboRio

--- a/hal/src/main/native/include/wpi/hal/.clang-tidy
+++ b/hal/src/main/native/include/wpi/hal/.clang-tidy
@@ -71,3 +71,4 @@ FormatStyle: file
 CheckOptions:
   - key: bugprone-dangling-handle
     value: 'std::string_view'
+HeaderFilterRegex: '^((?!thirdparty/).)*$'

--- a/ntcore/.clang-tidy
+++ b/ntcore/.clang-tidy
@@ -67,4 +67,8 @@ Checks:
   modernize-use-override,
   modernize-use-using,
   readability-braces-around-statements'
+CheckOptions:
+  - key: modernize-use-using.IgnoreExternC
+    value: 'true'
 FormatStyle: file
+HeaderFilterRegex: '^((?!thirdparty/).)*$'


### PR DESCRIPTION
I ran the following locally:
```bash
gradle generateCompileCommands
./.github/workflows/fix_compile_commands.py build/TargetedCompileCommands/linuxx86-64release/compile_commands.json
wpiformat -default-branch 2027 -no-format -tidy-all -compile-commands=build/TargetedCompileCommands/linuxx86-64release
```

The `HeaderFilterRegex` option is used to filter out warnings from thirdparty headers.