### PR TITLE
[commandsv3] implement command contexts

### DIFF
--- a/commandsv3/src/generate/main/java/commandhid.java.jinja
+++ b/commandsv3/src/generate/main/java/commandhid.java.jinja
@@ -8,6 +8,7 @@
 {%- endmacro %}
 package org.wpilib.command3.button;
 
+import org.wpilib.command3.Context;
 import org.wpilib.command3.Scheduler;
 import org.wpilib.command3.Trigger;
 import org.wpilib.driverstation.{{ ConsoleName }}Controller;
@@ -26,10 +27,11 @@ public class Command{{ ConsoleName }}Controller extends CommandGenericHID {
    * Construct an instance of a controller. Commands bound to buttons on the controller will be
    * scheduled on the {@link Scheduler#getDefault() default scheduler} using its default event loop.
    *
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the controller is plugged into.
    */
-  public Command{{ ConsoleName }}Controller(int port) {
-    super(port);
+  public Command{{ ConsoleName }}Controller(Context context, int port) {
+    super(context, port);
     m_hid = new {{ ConsoleName }}Controller(port);
   }
 
@@ -38,10 +40,11 @@ public class Command{{ ConsoleName }}Controller extends CommandGenericHID {
    * scheduled on the given scheduler using its default event loop.
    *
    * @param scheduler The scheduler that should execute the triggered commands.
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the controller is plugged into.
    */
-  public Command{{ ConsoleName }}Controller(Scheduler scheduler, int port) {
-    super(scheduler, port);
+  public Command{{ ConsoleName }}Controller(Scheduler scheduler, Context context, int port) {
+    super(scheduler, context, port);
     m_hid = new {{ ConsoleName }}Controller(port);
   }
 

--- a/commandsv3/src/generated/main/java/org/wpilib/command3/button/CommandNiDsPS4Controller.java
+++ b/commandsv3/src/generated/main/java/org/wpilib/command3/button/CommandNiDsPS4Controller.java
@@ -6,6 +6,7 @@
 
 package org.wpilib.command3.button;
 
+import org.wpilib.command3.Context;
 import org.wpilib.command3.Scheduler;
 import org.wpilib.command3.Trigger;
 import org.wpilib.driverstation.NiDsPS4Controller;
@@ -24,10 +25,11 @@ public class CommandNiDsPS4Controller extends CommandGenericHID {
    * Construct an instance of a controller. Commands bound to buttons on the controller will be
    * scheduled on the {@link Scheduler#getDefault() default scheduler} using its default event loop.
    *
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the controller is plugged into.
    */
-  public CommandNiDsPS4Controller(int port) {
-    super(port);
+  public CommandNiDsPS4Controller(Context context, int port) {
+    super(context, port);
     m_hid = new NiDsPS4Controller(port);
   }
 
@@ -36,10 +38,11 @@ public class CommandNiDsPS4Controller extends CommandGenericHID {
    * scheduled on the given scheduler using its default event loop.
    *
    * @param scheduler The scheduler that should execute the triggered commands.
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the controller is plugged into.
    */
-  public CommandNiDsPS4Controller(Scheduler scheduler, int port) {
-    super(scheduler, port);
+  public CommandNiDsPS4Controller(Scheduler scheduler, Context context, int port) {
+    super(scheduler, context, port);
     m_hid = new NiDsPS4Controller(port);
   }
 

--- a/commandsv3/src/generated/main/java/org/wpilib/command3/button/CommandNiDsPS5Controller.java
+++ b/commandsv3/src/generated/main/java/org/wpilib/command3/button/CommandNiDsPS5Controller.java
@@ -6,6 +6,7 @@
 
 package org.wpilib.command3.button;
 
+import org.wpilib.command3.Context;
 import org.wpilib.command3.Scheduler;
 import org.wpilib.command3.Trigger;
 import org.wpilib.driverstation.NiDsPS5Controller;
@@ -24,10 +25,11 @@ public class CommandNiDsPS5Controller extends CommandGenericHID {
    * Construct an instance of a controller. Commands bound to buttons on the controller will be
    * scheduled on the {@link Scheduler#getDefault() default scheduler} using its default event loop.
    *
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the controller is plugged into.
    */
-  public CommandNiDsPS5Controller(int port) {
-    super(port);
+  public CommandNiDsPS5Controller(Context context, int port) {
+    super(context, port);
     m_hid = new NiDsPS5Controller(port);
   }
 
@@ -36,10 +38,11 @@ public class CommandNiDsPS5Controller extends CommandGenericHID {
    * scheduled on the given scheduler using its default event loop.
    *
    * @param scheduler The scheduler that should execute the triggered commands.
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the controller is plugged into.
    */
-  public CommandNiDsPS5Controller(Scheduler scheduler, int port) {
-    super(scheduler, port);
+  public CommandNiDsPS5Controller(Scheduler scheduler, Context context, int port) {
+    super(scheduler, context, port);
     m_hid = new NiDsPS5Controller(port);
   }
 

--- a/commandsv3/src/generated/main/java/org/wpilib/command3/button/CommandNiDsStadiaController.java
+++ b/commandsv3/src/generated/main/java/org/wpilib/command3/button/CommandNiDsStadiaController.java
@@ -6,6 +6,7 @@
 
 package org.wpilib.command3.button;
 
+import org.wpilib.command3.Context;
 import org.wpilib.command3.Scheduler;
 import org.wpilib.command3.Trigger;
 import org.wpilib.driverstation.NiDsStadiaController;
@@ -24,10 +25,11 @@ public class CommandNiDsStadiaController extends CommandGenericHID {
    * Construct an instance of a controller. Commands bound to buttons on the controller will be
    * scheduled on the {@link Scheduler#getDefault() default scheduler} using its default event loop.
    *
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the controller is plugged into.
    */
-  public CommandNiDsStadiaController(int port) {
-    super(port);
+  public CommandNiDsStadiaController(Context context, int port) {
+    super(context, port);
     m_hid = new NiDsStadiaController(port);
   }
 
@@ -36,10 +38,11 @@ public class CommandNiDsStadiaController extends CommandGenericHID {
    * scheduled on the given scheduler using its default event loop.
    *
    * @param scheduler The scheduler that should execute the triggered commands.
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the controller is plugged into.
    */
-  public CommandNiDsStadiaController(Scheduler scheduler, int port) {
-    super(scheduler, port);
+  public CommandNiDsStadiaController(Scheduler scheduler, Context context, int port) {
+    super(scheduler, context, port);
     m_hid = new NiDsStadiaController(port);
   }
 

--- a/commandsv3/src/generated/main/java/org/wpilib/command3/button/CommandNiDsXboxController.java
+++ b/commandsv3/src/generated/main/java/org/wpilib/command3/button/CommandNiDsXboxController.java
@@ -6,6 +6,7 @@
 
 package org.wpilib.command3.button;
 
+import org.wpilib.command3.Context;
 import org.wpilib.command3.Scheduler;
 import org.wpilib.command3.Trigger;
 import org.wpilib.driverstation.NiDsXboxController;
@@ -24,10 +25,11 @@ public class CommandNiDsXboxController extends CommandGenericHID {
    * Construct an instance of a controller. Commands bound to buttons on the controller will be
    * scheduled on the {@link Scheduler#getDefault() default scheduler} using its default event loop.
    *
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the controller is plugged into.
    */
-  public CommandNiDsXboxController(int port) {
-    super(port);
+  public CommandNiDsXboxController(Context context, int port) {
+    super(context, port);
     m_hid = new NiDsXboxController(port);
   }
 
@@ -36,10 +38,11 @@ public class CommandNiDsXboxController extends CommandGenericHID {
    * scheduled on the given scheduler using its default event loop.
    *
    * @param scheduler The scheduler that should execute the triggered commands.
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the controller is plugged into.
    */
-  public CommandNiDsXboxController(Scheduler scheduler, int port) {
-    super(scheduler, port);
+  public CommandNiDsXboxController(Scheduler scheduler, Context context, int port) {
+    super(scheduler, context, port);
     m_hid = new NiDsXboxController(port);
   }
 

--- a/commandsv3/src/main/java/org/wpilib/command3/Conditions.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Conditions.java
@@ -1,0 +1,52 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.command3;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * Utility class for composing BooleanSupplier conditions with logical operations.
+ *
+ * <p>This class provides static methods for combining multiple boolean conditions using logical
+ * AND, OR, and NOT operations. It is commonly used for creating complex trigger conditions and
+ * context compositions.
+ */
+public final class Conditions {
+  private Conditions() {
+    throw new UnsupportedOperationException("This is a utility class!");
+  }
+
+  /**
+   * Creates a BooleanSupplier that returns true when both input conditions are true.
+   *
+   * @param a the first condition
+   * @param b the second condition
+   * @return a BooleanSupplier that performs logical AND on the two conditions
+   */
+  public static BooleanSupplier and(BooleanSupplier a, BooleanSupplier b) {
+    return () -> a.getAsBoolean() && b.getAsBoolean();
+  }
+
+  /**
+   * Creates a BooleanSupplier that returns true when either input condition is true.
+   *
+   * @param a the first condition
+   * @param b the second condition
+   * @return a BooleanSupplier that performs logical OR on the two conditions
+   */
+  public static BooleanSupplier or(BooleanSupplier a, BooleanSupplier b) {
+    return () -> a.getAsBoolean() || b.getAsBoolean();
+  }
+
+  /**
+   * Creates a BooleanSupplier that returns the opposite of the input condition.
+   *
+   * @param a the condition to negate
+   * @return a BooleanSupplier that performs logical NOT on the condition
+   */
+  public static BooleanSupplier not(BooleanSupplier a) {
+    return () -> !a.getAsBoolean();
+  }
+}

--- a/commandsv3/src/main/java/org/wpilib/command3/Context.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Context.java
@@ -1,0 +1,103 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.command3;
+
+import java.util.function.BooleanSupplier;
+import org.wpilib.driverstation.DriverStation;
+import org.wpilib.event.EventLoop;
+
+/**
+ * A Context represents a condition that determines when Trigger edges should be considered.
+ *
+ * <p>Contexts are used to scope when triggers are active. For example, joystick button triggers
+ * might use {@link #allTeleop} to ensure they only fire during teleop mode, preventing accidental
+ * input during autonomous.
+ *
+ * <p>Contexts can be composed using logical operations to create more complex conditions:
+ *
+ * <pre>{@code
+ * Context myContext = Context.allTeleop.and(() -> robot.isReady());
+ * Trigger myTrigger = new Trigger(myContext, controller.a()::get);
+ * }</pre>
+ *
+ * <p>When a trigger's context evaluates to false, edge detection is paused and will resume when the
+ * context becomes true again.
+ */
+public class Context implements BooleanSupplier {
+  /** A context that is always true. */
+  public static final Context all = new Context(() -> true);
+
+  /** A context that is true when the robot is in autonomous mode (enabled or disabled). */
+  public static final Context allAuto = all.and(DriverStation::isAutonomous);
+
+  /** A context that is true when the robot is in teleop mode (enabled or disabled). */
+  public static final Context allTeleop = all.and(DriverStation::isTeleop);
+
+  /** A context that is true when the robot is in test mode (enabled or disabled). */
+  public static final Context allTest = all.and(DriverStation::isTest);
+
+  private final BooleanSupplier m_condition;
+
+  /**
+   * Creates a new Context with the given condition.
+   *
+   * <p>This constructor is protected and intended for internal use and subclassing. Use the static
+   * factory methods or composition methods to create contexts.
+   *
+   * @param condition the boolean condition that determines when this context is active
+   */
+  protected Context(BooleanSupplier condition) {
+    m_condition = condition;
+  }
+
+  /**
+   * Creates a Trigger with this context and the given condition.
+   *
+   * <p>The resulting trigger will only fire edges when both this context and the provided condition
+   * change, and only when this context is true.
+   *
+   * @param condition the trigger condition
+   * @return a new Trigger that combines this context with the given condition
+   */
+  public Trigger trigger(BooleanSupplier condition) {
+    return new Trigger(Scheduler.getDefault(), this, Conditions.and(this, condition));
+  }
+
+  /**
+   * Creates a Trigger with this context, the given condition, and a specific event loop.
+   *
+   * @param loop the event loop to attach the trigger to
+   * @param condition the trigger condition
+   * @return a new Trigger that combines this context with the given condition
+   */
+  public Trigger trigger(EventLoop loop, BooleanSupplier condition) {
+    return new Trigger(Scheduler.getDefault(), this, loop, Conditions.and(this, condition));
+  }
+
+  /**
+   * Creates a new Context that is true when both this context and the given condition are true.
+   *
+   * @param condition the condition to combine with this context
+   * @return a new Context representing the logical AND of this context and the condition
+   */
+  public Context and(BooleanSupplier condition) {
+    return new Context(Conditions.and(this, condition));
+  }
+
+  /**
+   * Creates a new Context that is true when either this context or the given context is true.
+   *
+   * @param condition the context to combine with this context
+   * @return a new Context representing the logical OR of this context and the other context
+   */
+  public Context or(Context condition) {
+    return new Context(Conditions.or(this, condition));
+  }
+
+  @Override
+  public boolean getAsBoolean() {
+    return m_condition.getAsBoolean();
+  }
+}

--- a/commandsv3/src/main/java/org/wpilib/command3/Trigger.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Trigger.java
@@ -43,6 +43,7 @@ import org.wpilib.units.measure.Time;
  */
 public class Trigger implements BooleanSupplier {
   private final BooleanSupplier m_condition;
+  private final Context m_context;
   private final EventLoop m_loop;
   private final Scheduler m_scheduler;
   private Signal m_previousSignal;
@@ -62,39 +63,39 @@ public class Trigger implements BooleanSupplier {
   }
 
   /**
+   * Creates a new trigger based on the given condition. Uses the default scheduler and is polled by
+   * the scheduler's {@link Scheduler#getDefaultEventLoop() default event loop}.
+   *
+   * @param context the context that must be true for edges to be considered
+   * @param condition the condition represented by this trigger
+   */
+  public Trigger(Context context, BooleanSupplier condition) {
+    this(Scheduler.getDefault(), context, condition);
+  }
+
+  /**
    * Creates a new trigger based on the given condition. Polled by the scheduler's {@link
    * Scheduler#getDefaultEventLoop() default event loop}.
    *
    * @param scheduler The scheduler that should execute triggered commands.
+   * @param context the context that must be true for edges to be considered
    * @param condition the condition represented by this trigger
    */
-  public Trigger(Scheduler scheduler, BooleanSupplier condition) {
-    m_scheduler = requireNonNullParam(scheduler, "scheduler", "Trigger");
-    m_loop = scheduler.getDefaultEventLoop();
-    m_condition = requireNonNullParam(condition, "condition", "Trigger");
+  public Trigger(Scheduler scheduler, Context context, BooleanSupplier condition) {
+    this(scheduler, context, scheduler.getDefaultEventLoop(), condition);
   }
 
   /**
-   * Creates a new trigger based on the given condition. Triggered commands are executed by the
-   * {@link Scheduler#getDefault() default scheduler}.
-   *
-   * <p>Polled by the default scheduler button loop.
-   *
-   * @param condition the condition represented by this trigger
-   */
-  public Trigger(BooleanSupplier condition) {
-    this(Scheduler.getDefault(), condition);
-  }
-
-  /**
-   * Creates a new trigger based on the given condition.
+   * Creates a new trigger based on the given condition with a context.
    *
    * @param scheduler The scheduler that should execute triggered commands.
+   * @param context the context that must be true for edges to be considered
    * @param loop The event loop to poll the trigger.
    * @param condition the condition represented by this trigger
    */
-  public Trigger(Scheduler scheduler, EventLoop loop, BooleanSupplier condition) {
+  public Trigger(Scheduler scheduler, Context context, EventLoop loop, BooleanSupplier condition) {
     m_scheduler = requireNonNullParam(scheduler, "scheduler", "Trigger");
+    m_context = requireNonNullParam(context, "context", "Trigger");
     m_loop = requireNonNullParam(loop, "loop", "Trigger");
     m_condition = requireNonNullParam(condition, "condition", "Trigger");
   }
@@ -190,7 +191,7 @@ public class Trigger implements BooleanSupplier {
    */
   public Trigger and(BooleanSupplier trigger) {
     return new Trigger(
-        m_scheduler, m_loop, () -> m_condition.getAsBoolean() && trigger.getAsBoolean());
+        m_scheduler, m_context, m_loop, () -> m_condition.getAsBoolean() && trigger.getAsBoolean());
   }
 
   /**
@@ -201,7 +202,7 @@ public class Trigger implements BooleanSupplier {
    */
   public Trigger or(BooleanSupplier trigger) {
     return new Trigger(
-        m_scheduler, m_loop, () -> m_condition.getAsBoolean() || trigger.getAsBoolean());
+        m_scheduler, m_context, m_loop, () -> m_condition.getAsBoolean() || trigger.getAsBoolean());
   }
 
   /**
@@ -211,7 +212,7 @@ public class Trigger implements BooleanSupplier {
    * @return the negated trigger
    */
   public Trigger negate() {
-    return new Trigger(m_scheduler, m_loop, () -> !m_condition.getAsBoolean());
+    return new Trigger(m_scheduler, m_context, m_loop, () -> !m_condition.getAsBoolean());
   }
 
   /**
@@ -235,7 +236,8 @@ public class Trigger implements BooleanSupplier {
    */
   public Trigger debounce(Time duration, Debouncer.DebounceType type) {
     var debouncer = new Debouncer(duration.in(Seconds), type);
-    return new Trigger(m_scheduler, m_loop, () -> debouncer.calculate(m_condition.getAsBoolean()));
+    return new Trigger(
+        m_scheduler, m_context, m_loop, () -> debouncer.calculate(m_condition.getAsBoolean()));
   }
 
   private void poll() {
@@ -243,6 +245,13 @@ public class Trigger implements BooleanSupplier {
     // This should always be checked, regardless of signal change, since bindings may be scoped
     // and those scopes may become inactive.
     clearStaleBindings();
+
+    // Check if context is active - edges are only considered when context is true
+    if (!m_context.getAsBoolean()) {
+      // Context is false, reset previous signal so edges can be detected when context becomes true
+      m_previousSignal = null;
+      return;
+    }
 
     var signal = readSignal();
 

--- a/commandsv3/src/main/java/org/wpilib/command3/button/CommandGamepad.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/button/CommandGamepad.java
@@ -4,6 +4,7 @@
 
 package org.wpilib.command3.button;
 
+import org.wpilib.command3.Context;
 import org.wpilib.command3.Scheduler;
 import org.wpilib.command3.Trigger;
 import org.wpilib.driverstation.Gamepad;
@@ -21,10 +22,11 @@ public class CommandGamepad extends CommandGenericHID {
   /**
    * Construct an instance of a controller.
    *
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the controller is plugged into.
    */
-  public CommandGamepad(int port) {
-    super(port);
+  public CommandGamepad(Context context, int port) {
+    super(context, port);
     m_hid = new Gamepad(port);
   }
 
@@ -32,10 +34,11 @@ public class CommandGamepad extends CommandGenericHID {
    * Construct an instance of a controller.
    *
    * @param scheduler The scheduler that should execute the triggered commands.
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the controller is plugged into.
    */
-  public CommandGamepad(Scheduler scheduler, int port) {
-    super(scheduler, port);
+  public CommandGamepad(Scheduler scheduler, Context context, int port) {
+    super(scheduler, context, port);
     m_hid = new Gamepad(port);
   }
 

--- a/commandsv3/src/main/java/org/wpilib/command3/button/CommandGenericHID.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/button/CommandGenericHID.java
@@ -6,6 +6,7 @@ package org.wpilib.command3.button;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.wpilib.command3.Context;
 import org.wpilib.command3.Scheduler;
 import org.wpilib.command3.Trigger;
 import org.wpilib.driverstation.DriverStation.POVDirection;
@@ -20,6 +21,7 @@ import org.wpilib.math.util.Pair;
  */
 public class CommandGenericHID {
   private final Scheduler m_scheduler;
+  private final Context m_context;
   private final GenericHID m_hid;
   private final Map<EventLoop, Map<Integer, Trigger>> m_buttonCache = new HashMap<>();
   private final Map<EventLoop, Map<Pair<Integer, Double>, Trigger>> m_axisLessThanCache =
@@ -34,20 +36,23 @@ public class CommandGenericHID {
    * Construct an instance of a device.
    *
    * @param scheduler The scheduler that should execute the triggered commands.
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the device is plugged into.
    */
-  public CommandGenericHID(Scheduler scheduler, int port) {
+  public CommandGenericHID(Scheduler scheduler, Context context, int port) {
     m_scheduler = scheduler;
+    m_context = context;
     m_hid = new GenericHID(port);
   }
 
   /**
    * Construct an instance of a device.
    *
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the device is plugged into.
    */
-  public CommandGenericHID(int port) {
-    this(Scheduler.getDefault(), port);
+  public CommandGenericHID(Context context, int port) {
+    this(Scheduler.getDefault(), context, port);
   }
 
   /**
@@ -81,7 +86,7 @@ public class CommandGenericHID {
   public Trigger button(int button, EventLoop loop) {
     var cache = m_buttonCache.computeIfAbsent(loop, k -> new HashMap<>());
     return cache.computeIfAbsent(
-        button, k -> new Trigger(m_scheduler, loop, () -> m_hid.getRawButton(k)));
+        button, k -> new Trigger(m_scheduler, m_context, loop, () -> m_hid.getRawButton(k)));
   }
 
   /**
@@ -109,7 +114,7 @@ public class CommandGenericHID {
     // angle.value is a 4 bit bitfield
     return cache.computeIfAbsent(
         pov * 16 + angle.value,
-        k -> new Trigger(m_scheduler, loop, () -> m_hid.getPOV(pov) == angle));
+        k -> new Trigger(m_scheduler, m_context, loop, () -> m_hid.getPOV(pov) == angle));
   }
 
   /**
@@ -238,7 +243,7 @@ public class CommandGenericHID {
     var cache = m_axisLessThanCache.computeIfAbsent(loop, k -> new HashMap<>());
     return cache.computeIfAbsent(
         Pair.of(axis, threshold),
-        k -> new Trigger(m_scheduler, loop, () -> getRawAxis(axis) < threshold));
+        k -> new Trigger(m_scheduler, m_context, loop, () -> getRawAxis(axis) < threshold));
   }
 
   /**
@@ -268,7 +273,7 @@ public class CommandGenericHID {
     var cache = m_axisGreaterThanCache.computeIfAbsent(loop, k -> new HashMap<>());
     return cache.computeIfAbsent(
         Pair.of(axis, threshold),
-        k -> new Trigger(m_scheduler, loop, () -> getRawAxis(axis) > threshold));
+        k -> new Trigger(m_scheduler, m_context, loop, () -> getRawAxis(axis) > threshold));
   }
 
   /**
@@ -285,7 +290,9 @@ public class CommandGenericHID {
     var cache = m_axisMagnitudeGreaterThanCache.computeIfAbsent(loop, k -> new HashMap<>());
     return cache.computeIfAbsent(
         Pair.of(axis, threshold),
-        k -> new Trigger(m_scheduler, loop, () -> Math.abs(getRawAxis(axis)) > threshold));
+        k ->
+            new Trigger(
+                m_scheduler, m_context, loop, () -> Math.abs(getRawAxis(axis)) > threshold));
   }
 
   /**

--- a/commandsv3/src/main/java/org/wpilib/command3/button/CommandJoystick.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/button/CommandJoystick.java
@@ -4,6 +4,7 @@
 
 package org.wpilib.command3.button;
 
+import org.wpilib.command3.Context;
 import org.wpilib.command3.Scheduler;
 import org.wpilib.command3.Trigger;
 import org.wpilib.driverstation.Joystick;
@@ -20,10 +21,11 @@ public class CommandJoystick extends CommandGenericHID {
   /**
    * Construct an instance of a controller.
    *
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the controller is plugged into.
    */
-  public CommandJoystick(int port) {
-    super(port);
+  public CommandJoystick(Context context, int port) {
+    super(context, port);
     m_hid = new Joystick(port);
   }
 
@@ -31,10 +33,11 @@ public class CommandJoystick extends CommandGenericHID {
    * Construct an instance of a controller.
    *
    * @param scheduler The scheduler that should execute the triggered commands.
+   * @param context The context that must be true for trigger edges to be considered.
    * @param port The port index on the Driver Station that the controller is plugged into.
    */
-  public CommandJoystick(Scheduler scheduler, int port) {
-    super(scheduler, port);
+  public CommandJoystick(Scheduler scheduler, Context context, int port) {
+    super(scheduler, context, port);
     m_hid = new Joystick(port);
   }
 

--- a/commandsv3/src/main/java/org/wpilib/command3/button/InternalButton.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/button/InternalButton.java
@@ -5,6 +5,8 @@
 package org.wpilib.command3.button;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.wpilib.command3.Context;
+import org.wpilib.command3.Scheduler;
 import org.wpilib.command3.Trigger;
 
 /**
@@ -16,27 +18,56 @@ public class InternalButton extends Trigger {
   private final AtomicBoolean m_pressed;
   private final AtomicBoolean m_inverted;
 
-  /** Creates an InternalButton that is not inverted. */
+  /**
+   * Creates an InternalButton with the given scheduler and context.
+   *
+   * @param scheduler The scheduler that should execute triggered commands.
+   * @param context The context that must be true for edges to be considered
+   * @param inverted if false, then this button is pressed when set to true, otherwise it is pressed
+   *     when set to false.
+   */
+  public InternalButton(Scheduler scheduler, Context context, boolean inverted) {
+    this(scheduler, context, new AtomicBoolean(), new AtomicBoolean(inverted));
+  }
+
+  /**
+   * Creates an InternalButton that is not inverted. Uses the default scheduler and universal
+   * context.
+   */
   public InternalButton() {
     this(false);
   }
 
   /**
-   * Creates an InternalButton which is inverted depending on the input.
+   * Creates an InternalButton which is inverted depending on the input. Uses the default scheduler
+   * and universal context.
    *
    * @param inverted if false, then this button is pressed when set to true, otherwise it is pressed
    *     when set to false.
    */
   public InternalButton(boolean inverted) {
-    this(new AtomicBoolean(), new AtomicBoolean(inverted));
+    this(Context.all, inverted);
+  }
+
+  /**
+   * Creates an InternalButton with the given context and inversion setting. Uses the default
+   * scheduler.
+   *
+   * @param context The context that must be true for edges to be considered
+   * @param inverted if false, then this button is pressed when set to true, otherwise it is pressed
+   *     when set to false.
+   */
+  public InternalButton(Context context, boolean inverted) {
+    this(Scheduler.getDefault(), context, inverted);
   }
 
   /*
    * Mock constructor so the AtomicBoolean objects can be constructed before the super
    * constructor invocation.
    */
-  private InternalButton(AtomicBoolean state, AtomicBoolean inverted) {
-    super(() -> state.get() != inverted.get());
+  private InternalButton(
+      Scheduler scheduler, Context context, AtomicBoolean state, AtomicBoolean inverted) {
+    super(scheduler, context, () -> state.get() != inverted.get());
     m_pressed = state;
     m_inverted = inverted;
   }

--- a/commandsv3/src/main/java/org/wpilib/command3/button/JoystickButton.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/button/JoystickButton.java
@@ -6,6 +6,8 @@ package org.wpilib.command3.button;
 
 import static org.wpilib.util.ErrorMessages.requireNonNullParam;
 
+import org.wpilib.command3.Context;
+import org.wpilib.command3.Scheduler;
 import org.wpilib.command3.Trigger;
 import org.wpilib.driverstation.GenericHID;
 
@@ -14,11 +16,38 @@ public class JoystickButton extends Trigger {
   /**
    * Creates a joystick button for triggering commands.
    *
+   * @param scheduler The scheduler that should execute triggered commands.
+   * @param context The context that must be true for edges to be considered
+   * @param joystick The GenericHID object that has the button (e.g. Joystick, KinectStick, etc)
+   * @param buttonNumber The button number (see {@link GenericHID#getRawButton(int) }
+   */
+  public JoystickButton(
+      Scheduler scheduler, Context context, GenericHID joystick, int buttonNumber) {
+    super(scheduler, context, () -> joystick.getRawButton(buttonNumber));
+    requireNonNullParam(joystick, "joystick", "JoystickButton");
+  }
+
+  /**
+   * Creates a joystick button for triggering commands. Uses the default scheduler and teleop
+   * context.
+   *
    * @param joystick The GenericHID object that has the button (e.g. Joystick, KinectStick, etc)
    * @param buttonNumber The button number (see {@link GenericHID#getRawButton(int) }
    */
   public JoystickButton(GenericHID joystick, int buttonNumber) {
-    super(() -> joystick.getRawButton(buttonNumber));
+    this(Context.allTeleop, joystick, buttonNumber);
+  }
+
+  /**
+   * Creates a joystick button for triggering commands with the given context. Uses the default
+   * scheduler.
+   *
+   * @param context The context that must be true for edges to be considered
+   * @param joystick The GenericHID object that has the button (e.g. Joystick, KinectStick, etc)
+   * @param buttonNumber The button number (see {@link GenericHID#getRawButton(int) }
+   */
+  public JoystickButton(Context context, GenericHID joystick, int buttonNumber) {
+    super(context, () -> joystick.getRawButton(buttonNumber));
     requireNonNullParam(joystick, "joystick", "JoystickButton");
   }
 }

--- a/commandsv3/src/main/java/org/wpilib/command3/button/NetworkButton.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/button/NetworkButton.java
@@ -6,6 +6,8 @@ package org.wpilib.command3.button;
 
 import static org.wpilib.util.ErrorMessages.requireNonNullParam;
 
+import org.wpilib.command3.Context;
+import org.wpilib.command3.Scheduler;
 import org.wpilib.command3.Trigger;
 import org.wpilib.networktables.BooleanSubscriber;
 import org.wpilib.networktables.BooleanTopic;
@@ -17,6 +19,19 @@ public class NetworkButton extends Trigger {
   /**
    * Creates a NetworkButton that commands can be bound to.
    *
+   * @param scheduler The scheduler that should execute triggered commands.
+   * @param context The context that must be true for edges to be considered
+   * @param sub The boolean subscriber that provides the value.
+   */
+  public NetworkButton(Scheduler scheduler, Context context, BooleanSubscriber sub) {
+    super(scheduler, context, () -> sub.getTopic().getInstance().isConnected() && sub.get());
+    requireNonNullParam(sub, "sub", "NetworkButton");
+  }
+
+  /**
+   * Creates a NetworkButton that commands can be bound to. Uses the default scheduler and universal
+   * context.
+   *
    * @param topic The boolean topic that contains the value.
    */
   public NetworkButton(BooleanTopic topic) {
@@ -24,17 +39,30 @@ public class NetworkButton extends Trigger {
   }
 
   /**
-   * Creates a NetworkButton that commands can be bound to.
+   * Creates a NetworkButton that commands can be bound to. Uses the default scheduler and universal
+   * context.
    *
    * @param sub The boolean subscriber that provides the value.
    */
   public NetworkButton(BooleanSubscriber sub) {
-    super(() -> sub.getTopic().getInstance().isConnected() && sub.get());
+    this(Context.all, sub);
+  }
+
+  /**
+   * Creates a NetworkButton that commands can be bound to with the given context. Uses the default
+   * scheduler.
+   *
+   * @param context The context that must be true for edges to be considered
+   * @param sub The boolean subscriber that provides the value.
+   */
+  public NetworkButton(Context context, BooleanSubscriber sub) {
+    super(context, () -> sub.getTopic().getInstance().isConnected() && sub.get());
     requireNonNullParam(sub, "sub", "NetworkButton");
   }
 
   /**
-   * Creates a NetworkButton that commands can be bound to.
+   * Creates a NetworkButton that commands can be bound to. Uses the default scheduler and universal
+   * context.
    *
    * @param table The table where the networktable value is located.
    * @param field The field that is the value.
@@ -44,7 +72,8 @@ public class NetworkButton extends Trigger {
   }
 
   /**
-   * Creates a NetworkButton that commands can be bound to.
+   * Creates a NetworkButton that commands can be bound to. Uses the default scheduler and universal
+   * context.
    *
    * @param table The table where the networktable value is located.
    * @param field The field that is the value.
@@ -54,7 +83,8 @@ public class NetworkButton extends Trigger {
   }
 
   /**
-   * Creates a NetworkButton that commands can be bound to.
+   * Creates a NetworkButton that commands can be bound to. Uses the default scheduler and universal
+   * context.
    *
    * @param inst The NetworkTable instance to use
    * @param table The table where the networktable value is located.

--- a/commandsv3/src/main/java/org/wpilib/command3/button/POVButton.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/button/POVButton.java
@@ -6,6 +6,8 @@ package org.wpilib.command3.button;
 
 import static org.wpilib.util.ErrorMessages.requireNonNullParam;
 
+import org.wpilib.command3.Context;
+import org.wpilib.command3.Scheduler;
 import org.wpilib.command3.Trigger;
 import org.wpilib.driverstation.DriverStation.POVDirection;
 import org.wpilib.driverstation.GenericHID;
@@ -15,22 +17,55 @@ public class POVButton extends Trigger {
   /**
    * Creates a POV button for triggering commands.
    *
+   * @param scheduler The scheduler that should execute triggered commands.
+   * @param context The context that must be true for edges to be considered
+   * @param joystick The GenericHID object that has the POV
+   * @param angle The desired angle
+   * @param povNumber The POV number (see {@link GenericHID#getPOV(int)})
+   */
+  public POVButton(
+      Scheduler scheduler,
+      Context context,
+      GenericHID joystick,
+      POVDirection angle,
+      int povNumber) {
+    super(scheduler, context, () -> joystick.getPOV(povNumber) == angle);
+    requireNonNullParam(joystick, "joystick", "POVButton");
+  }
+
+  /**
+   * Creates a POV button for triggering commands. Uses the default scheduler and teleop context.
+   *
    * @param joystick The GenericHID object that has the POV
    * @param angle The desired angle
    * @param povNumber The POV number (see {@link GenericHID#getPOV(int)})
    */
   public POVButton(GenericHID joystick, POVDirection angle, int povNumber) {
-    super(() -> joystick.getPOV(povNumber) == angle);
-    requireNonNullParam(joystick, "joystick", "POVButton");
+    this(Context.allTeleop, joystick, angle, povNumber);
   }
 
   /**
-   * Creates a POV button for triggering commands. By default, acts on POV 0
+   * Creates a POV button for triggering commands. By default, acts on POV 0. Uses the default
+   * scheduler and teleop context.
    *
    * @param joystick The GenericHID object that has the POV
    * @param angle The desired angle
    */
   public POVButton(GenericHID joystick, POVDirection angle) {
     this(joystick, angle, 0);
+  }
+
+  /**
+   * Creates a POV button for triggering commands with the given context. Uses the default
+   * scheduler.
+   *
+   * @param context The context that must be true for edges to be considered
+   * @param joystick The GenericHID object that has the POV
+   * @param angle The desired angle
+   * @param povNumber The POV number (see {@link GenericHID#getPOV(int)})
+   */
+  public POVButton(Context context, GenericHID joystick, POVDirection angle, int povNumber) {
+    super(context, () -> joystick.getPOV(povNumber) == angle);
+    requireNonNullParam(joystick, "joystick", "POVButton");
   }
 }

--- a/commandsv3/src/main/java/org/wpilib/command3/button/RobotModeTriggers.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/button/RobotModeTriggers.java
@@ -4,6 +4,7 @@
 
 package org.wpilib.command3.button;
 
+import org.wpilib.command3.Context;
 import org.wpilib.command3.Trigger;
 import org.wpilib.driverstation.DriverStation;
 
@@ -21,7 +22,7 @@ public final class RobotModeTriggers {
    * @return A trigger that is true when the robot is enabled in autonomous mode.
    */
   public static Trigger autonomous() {
-    return new Trigger(DriverStation::isAutonomousEnabled);
+    return new Trigger(Context.allAuto, DriverStation::isAutonomousEnabled);
   }
 
   /**
@@ -30,7 +31,7 @@ public final class RobotModeTriggers {
    * @return A trigger that is true when the robot is enabled in teleop mode.
    */
   public static Trigger teleop() {
-    return new Trigger(DriverStation::isTeleopEnabled);
+    return new Trigger(Context.allTeleop, DriverStation::isTeleopEnabled);
   }
 
   /**
@@ -39,7 +40,7 @@ public final class RobotModeTriggers {
    * @return A trigger that is true when the robot is disabled.
    */
   public static Trigger disabled() {
-    return new Trigger(DriverStation::isDisabled);
+    return new Trigger(Context.all, DriverStation::isDisabled);
   }
 
   /**
@@ -48,6 +49,6 @@ public final class RobotModeTriggers {
    * @return A trigger that is true when the robot is enabled in test mode.
    */
   public static Trigger test() {
-    return new Trigger(DriverStation::isTestEnabled);
+    return new Trigger(Context.allTest, DriverStation::isTestEnabled);
   }
 }

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerErrorHandlingTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerErrorHandlingTests.java
@@ -25,7 +25,7 @@ class SchedulerErrorHandlingTests extends CommandTestBase {
                 })
             .named("Bad Behavior");
 
-    new Trigger(m_scheduler, () -> true).onTrue(command);
+    new Trigger(m_scheduler, Context.all, () -> true).onTrue(command);
 
     var e = assertThrows(RuntimeException.class, m_scheduler::run);
     assertEquals("The exception", e.getMessage());
@@ -50,7 +50,7 @@ class SchedulerErrorHandlingTests extends CommandTestBase {
                       Command.noRequirements()
                           .executing(
                               c2 -> {
-                                new Trigger(m_scheduler, () -> true)
+                                new Trigger(m_scheduler, Context.all, () -> true)
                                     .onTrue(
                                         Command.noRequirements()
                                             .executing(

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerSideloadFunctionTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerSideloadFunctionTests.java
@@ -88,7 +88,7 @@ class SchedulerSideloadFunctionTests extends CommandTestBase {
   @Test
   void sideloadAffectsStateForTriggerInSameCycle() {
     AtomicBoolean signal = new AtomicBoolean(false);
-    var trigger = new Trigger(m_scheduler, signal::get);
+    var trigger = new Trigger(m_scheduler, Context.all, signal::get);
     var command = Command.noRequirements().executing(Coroutine::park).named("Command");
     trigger.onTrue(command);
     m_scheduler.sideload(co -> signal.set(true));

--- a/commandsv3/src/test/java/org/wpilib/command3/TriggerTest.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/TriggerTest.java
@@ -16,7 +16,7 @@ class TriggerTest extends CommandTestBase {
   @Test
   void onTrue() {
     var signal = new AtomicBoolean(false);
-    var trigger = new Trigger(m_scheduler, signal::get);
+    var trigger = new Trigger(m_scheduler, Context.all, signal::get);
     var command = Command.noRequirements().executing(Coroutine::park).named("Command");
     trigger.onTrue(command);
 
@@ -33,7 +33,7 @@ class TriggerTest extends CommandTestBase {
   @Test
   void onFalse() {
     var signal = new AtomicBoolean(false);
-    var trigger = new Trigger(m_scheduler, signal::get);
+    var trigger = new Trigger(m_scheduler, Context.all, signal::get);
     var command = Command.noRequirements().executing(Coroutine::park).named("Command");
     trigger.onFalse(command);
 
@@ -50,7 +50,7 @@ class TriggerTest extends CommandTestBase {
   @Test
   void whileTrue() {
     var signal = new AtomicBoolean(false);
-    var trigger = new Trigger(m_scheduler, signal::get);
+    var trigger = new Trigger(m_scheduler, Context.all, signal::get);
     var command = Command.noRequirements().executing(Coroutine::park).named("Command");
     trigger.whileTrue(command);
 
@@ -67,7 +67,7 @@ class TriggerTest extends CommandTestBase {
   @Test
   void whileFalse() {
     var signal = new AtomicBoolean(false);
-    var trigger = new Trigger(m_scheduler, signal::get);
+    var trigger = new Trigger(m_scheduler, Context.all, signal::get);
     var command = Command.noRequirements().executing(Coroutine::park).named("Command");
     trigger.whileFalse(command);
 
@@ -83,7 +83,7 @@ class TriggerTest extends CommandTestBase {
   @Test
   void toggleOnTrue() {
     var signal = new AtomicBoolean(false);
-    var trigger = new Trigger(m_scheduler, signal::get);
+    var trigger = new Trigger(m_scheduler, Context.all, signal::get);
     var command = Command.noRequirements().executing(Coroutine::park).named("Command");
     trigger.toggleOnTrue(command);
 
@@ -106,7 +106,7 @@ class TriggerTest extends CommandTestBase {
   @Test
   void toggleOnFalse() {
     var signal = new AtomicBoolean(false);
-    var trigger = new Trigger(m_scheduler, signal::get);
+    var trigger = new Trigger(m_scheduler, Context.all, signal::get);
     var command = Command.noRequirements().executing(Coroutine::park).named("Command");
     trigger.toggleOnFalse(command);
 
@@ -142,7 +142,7 @@ class TriggerTest extends CommandTestBase {
         Command.noRequirements()
             .executing(
                 co -> {
-                  new Trigger(m_scheduler, innerSignal::get).onTrue(inner);
+                  new Trigger(m_scheduler, Context.all, innerSignal::get).onTrue(inner);
                   // If we yield, then the outer command exits and immediately cancels the
                   // on-deck inner command before it can run
                   co.park();
@@ -168,7 +168,7 @@ class TriggerTest extends CommandTestBase {
     BindingScope scope = activeScope::get;
 
     var triggerSignal = new AtomicBoolean(false);
-    var trigger = new Trigger(m_scheduler, triggerSignal::get);
+    var trigger = new Trigger(m_scheduler, Context.all, triggerSignal::get);
 
     var command = Command.noRequirements().executing(Coroutine::park).named("Command");
     trigger.addBinding(scope, BindingType.RUN_WHILE_HIGH, command);
@@ -207,7 +207,7 @@ class TriggerTest extends CommandTestBase {
     OpModeFetcher.setFetcher(fetcher);
 
     var triggerSignal = new AtomicBoolean(false);
-    var trigger = new Trigger(m_scheduler, triggerSignal::get);
+    var trigger = new Trigger(m_scheduler, Context.all, triggerSignal::get);
 
     var command = Command.noRequirements().executing(Coroutine::park).named("Command");
     trigger.whileTrue(command);
@@ -251,7 +251,7 @@ class TriggerTest extends CommandTestBase {
         Command.noRequirements()
             .executing(
                 co -> {
-                  new Trigger(m_scheduler, condition::get).onTrue(inner);
+                  new Trigger(m_scheduler, Context.all, condition::get).onTrue(inner);
                   co.await(awaited);
                 })
             .named("Outer");

--- a/design-docs/command-contexts.md
+++ b/design-docs/command-contexts.md
@@ -1,0 +1,182 @@
+# Summary
+
+This document describes how command contexts are implemented in command-based projects.
+
+# Motivation
+
+Command OpModes will significantly increase the number of command bindings that need to be restricted to particular conditions.  In addition, it should be a conscious decision to make bindings that are active regardless of opmode- Unknowingly doing so can be a major safety risk.
+
+This document proposes a solution to both easily specify restrictions for command bindings and require such restrictions.
+
+# Background
+
+Both FTC and FRC historically have had ways to automatically schedule commands in response to conditions such as driver inputs, but due to the different robot program setups, the methods and behaviors are different.  To provide context, a brief summary of these behaviors (as of 2025) is below:
+- In FRC, state naturally persists throughout the entire robot program, so command bindings last for the entire robot program execution.  (They are created when the robot program starts and last until the robot program ends.)
+- In FTC, opmodes should be as self contained as possible to avoid buggy behavior, so bindings are local to their opmode.  (They are created when the opmode starts and destroyed when the opmode ends)
+
+# Design
+
+Core concepts:
+- A `BooleanSupplier` represents a condition.
+- A `Context` describes when a set of `Trigger`s should be active.
+- A `Trigger` represents a condition to use for command bindings.
+- A `Trigger`’s *context condition* is the condition of the `Context` associated with the `Trigger`.
+- A `Trigger`’s *base condition* is the original condition used for the `Trigger`, without the context condition applied.
+
+Relevant library classes:
+- `BooleanSupplier` (described above) is provided by the Java Standard Environment.
+- `Context` is described above.  Although it contains a boolean condition, it should only be used for making `Trigger`s with that context condition, so it does _not_ implement `BooleanSupplier`.
+- `Trigger` is described above.  It is made by a `Context` from a `BooleanSupplier` and implements `BooleanSupplier`.
+- `Conditions` provides static utility methods for performing logical operations on `BooleanSupplier`s.
+- `CommandOpModes` is part of [command opmodes](opmodes-commandbased.md), and provides some common `Context` instances.
+- `CommandOpMode` is part of [command opmodes](opmodes-commandbased.md) and inherits from `Context`.
+- `CommandGenericHID` is the base class of all command controller classes (described below).
+- Command controller classes (such as `CommandXboxController`) are used to create `Trigger`s associated with a controller's inputs.
+
+Robot code outline:
+- Controllers are created with particular `Context`s to restrict the controller’s `Trigger` bindings to particular opmodes, optionally imposing additional conditions on the `Context`s.
+- Subsystems provide `BooleanSupplier`s to indicate state. (e.g., arm at angle)
+- Static methods in `Conditions` perform any necessary logic operations on the `BooleanSupplier`s.
+- `Context`s are used to create `Trigger`s from `BooleanSupplier`s to make bindings for any automatic actions.
+
+## Context
+
+The `Context` class describes when a set of `Trigger`s should be active.
+
+To avoid inadvertently making bindings that are active in more opmodes than expected, `Context`s can only be made from opmodes, or from an opmode type such as all opmodes or all teleop opmodes.
+
+To prevent making `Context`s which can be true regardless of opmode (aside from `Context.all` and `Context`s built from it), the only ways to create a `Context` are from the static `Context`s, a `CommandOpMode`, a logical OR of existing `Context`s, and a logical AND of a `Context` with an arbitrary condition.  (Note that allowing a logical OR of a `Context` with an arbitrary condition would defeat this goal.)
+
+```java
+public class Context {
+  // used by CommandOpMode and the internals of CommandOpModes
+  protected Context(BooleanSupplier);
+
+  // creates a Trigger with the given base condition
+  public Trigger trigger(BooleanSupplier);
+  public Trigger trigger(EventLoop, BooleanSupplier);
+
+  public Context and(BooleanSupplier);
+  public Context or(Context);
+}
+```
+
+Open question: Should we add `Context.trigger()` and `Context.trigger(EventLoop)` to create `Trigger`s whose context condition is the context and whose base condition is the context being active?  (Note that a constant true base condition would not have any rising or falling edges to trigger Commands.)
+
+The `Context` also has the following static fields:
+
+```java
+public class Context {
+  // always true
+  public static final Context all;
+
+  // true when the given robot mode is selected, regardless of enabled/disabled state
+  public static final Context allAuto;
+  public static final Context allTeleop;
+  public static final Context allTest;
+}
+```
+
+Open question: Are allAuto, allTeleop, and allTest worth defining for users?
+Open question: Should allTeleop be renamed to allTeleoperated to match the CommandOpMode factory?
+
+## CommandOpMode
+
+The `CommandOpMode` class extends `Context`, allowing any opmode to be used wherever a context is expected.  The condition of the `Context` is when the opmode is selected (regardless of enabled/disabled status).
+
+Note that the `selected` trigger must have a base condition that has rising and falling edges.
+
+```java
+public class CommandOpMode extends Context implements OpMode {
+  public final Trigger selected = trigger(...is selected...);
+  public final Trigger disabled = selected.and(RobotState::isDisabled);
+  public final Trigger enabled = selected.and(RobotState::isEnabled);
+}
+```
+
+Other details of `CommandOpMode` will be provided in the CommandOpModes design documentation.
+
+## Conditions
+
+To help with operations on `BooleanSupplier`s, a `Conditions` class provides static utility methods.
+
+Previously, these operations would be done by creating a `Trigger` and using the instance methods on that class.  However, using a `Trigger` for conditions not meant to trigger commands is not proper usage, especially with the new requirement that `Trigger`s always have an associated `Context`.  Defining a `Condition` functional interface with the appropriate utility methods was considered, but was decided against due to the confusion it would cause about when to use it instead of `Context`, `Trigger`, or `BooleanEvent`.
+
+```java
+public class Conditions {
+  public static BooleanSupplier and(BooleanSupplier, BooleanSupplier);
+  public static BooleanSupplier or(BooleanSupplier, BooleanSupplier);
+  public static BooleanSupplier negate(BooleanSupplier);
+  public static BooleanSupplier debounce(BooleanSupplier, double);
+  public static BooleanSupplier debounce(BooleanSupplier, double, Debouncer.DebounceType);
+}
+```
+
+## Trigger
+
+A `Trigger` is a combination of a *context condition* and a *base condition* that can make command bindings.
+
+Every `Trigger` is associated with a `Context`.  A `Trigger` with an inactive `Context` does not evaluate its base condition and does not activate any bindings.
+
+Not evaluating the base condition is important for the controller classes, where evaluating the base condition leads to warnings if the controller is not connected.  Not evaluating the base condition when the context condition is false is a natural way to suppress those warnings when the controller is not used.
+
+Previously, `Trigger`s would sometimes be used to indicate subsystem state.  Such usage is no longer appropriate because `Trigger`s should only be used to trigger commands.  Furthermore, `Trigger`s can only be made by `Context`s, but associating a `Context` with subsystem is inappropriate.  Instead, use `BooleanSupplier`s and the static utility methods provided by `Conditions`.  (Note that a static import allows simple usage as `and(cond1, cond2)` without needings `Conditions.` at the beginning.)
+
+```java
+public class Trigger implements BooleanSupplier {
+  // package private for use by Context
+  Trigger(Context, BooleanSupplier);
+  Trigger(Context, EventLoop, BooleanSupplier);
+
+  @Override
+  public boolean getAsBoolean();
+
+  public Trigger and(BooleanSupplier);
+  public Trigger or(Trigger);
+  public Trigger negate();
+  public Trigger debounce(double);
+  public Trigger debounce(double, Debouncer.DebounceType);
+
+  // below are the existing methods to create command bindings
+  public Trigger onChange(Command);
+  public Trigger onTrue(Command);
+  public Trigger onFalse(Command);
+  public Trigger whileTrue(Command);
+  public Trigger whileFalse(Command);
+  public Trigger toggleOnTrue(Command);
+  public Trigger toggleOnFalse(Command);
+}
+```
+
+The Trigger created by `Trigger.or` has a context condition that is *both* the context condition of the original `Trigger` and the context condition of the `Trigger` passed to `or`.
+
+Missing detail: Should `onFalse()` schedule the command if the context condition has a falling edge while the base condition is true?
+Missing detail: Should `whileTrue()` cancel the command if the context condition has a falling edge while the base condition is true?
+
+Open question: Should we allow `Trigger or(BooleanSupplier)`?  Note that only the base condition would be OR'd, and the context condition would remain the same.  This may be confusing, and may have weird interactions with a) how we resolve combining `Trigger`s with different contexts and b) the return value of `getAsBoolean()` when the context condition is false.
+
+## Command controllers
+
+The command controller classes (e.g., `CommandXboxController`) have a mandatory context parameter for their constructors.  Otherwise, they have the same overload set as before.
+
+```java
+public class CommandGenericHID {
+  // this replaces public CommandGenericHID(int);
+  // otherwise, the API is the same, with the Context being used to create the Triggers
+  public CommandGenericHID(int, Context);
+}
+
+public class CommandXboxController {
+  // this replaces public CommandXboxController(int);
+  // otherwise, the API is the same, with the Context being used to create the Triggers
+  public CommandXboxController(int, Context);
+}
+```
+
+## Sharing bindings across opmodes
+
+There are two recommended structures for bindings that are common to multiple opmodes:
+- Define a method with an opmode parameter that uses that parameter for all contexts, and invoke/call that method for each opmode with the shared bindings.
+- Separate from opmode-specific bindings, make the bindings with the context being a combination of all opmodes with the shared bindings.
+
+Robot code examples will be provided in the CommandOpModes design documentation.


### PR DESCRIPTION
The motivations of command contexts are described in the design document in this PR (which is slightly modified from the [design document in Peter's PR](https://github.com/PeterJohnson/allwpilib/blob/opmode-design-doc/design-docs/command-contexts.md)).

This PR also only adds contexts to Commands v3; if this API is approved, a future PR will add them to Commands v2 (in both Java and C++). 

Command OpModes for both v2 and v3 will be added in a future PR following #8652.