### PR TITLE
[wpinet] Fix port having incorrect endian on windows resolver

### DIFF
--- a/wpinet/src/main/native/windows/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/windows/MulticastServiceResolver.cpp
@@ -186,7 +186,7 @@ static _Function_class_(DNS_QUERY_COMPLETION_ROUTINE) VOID WINAPI
         wpi::util::convertUTF16ToUTF8String(wideServiceName, storage);
 
         data.serviceName = std::string{storage};
-        data.port = ntohs(foundSrv->Data.Srv.wPort);
+        data.port = foundSrv->Data.Srv.wPort;
         data.ipv4Address = ntohl(A->Data.A.IpAddress);
 
         impl->onFound(std::move(data));


### PR DESCRIPTION
For some reason, ip is in network order, but port is in host order. And I've verified this with a known good iphone app showing the systemcore announcer is properly sending the correct port.