### PR TITLE
[javac] Fix javadoc warnings

### DIFF
--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationValidator.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationValidator.java
@@ -28,9 +28,9 @@ import javax.tools.Diagnostic;
  * <p>Requirements:
  *
  * <ul>
- *   <li>Name must be <= 32 characters
- *   <li>Group must be <= 12 characters
- *   <li>Description must be <= 64 characters
+ *   <li>Name must be &lt;= 32 characters
+ *   <li>Group must be &lt;= 12 characters
+ *   <li>Description must be &lt;= 64 characters
  * </ul>
  */
 public class OpModeAnnotationValidator implements TaskListener {


### PR DESCRIPTION
```
> Task :javacPlugin:javadoc
/home/tav/frc/wpilib/allwpilib/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationValidator.java:31: warning: invalid input: '<'
 *   <li>Name must be <= 32 characters
                      ^
/home/tav/frc/wpilib/allwpilib/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationValidator.java:32: warning: invalid input: '<'
 *   <li>Group must be <= 12 characters
                       ^
/home/tav/frc/wpilib/allwpilib/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationValidator.java:33: warning: invalid input: '<'
 *   <li>Description must be <= 64 characters
                             ^
3 warnings
```

These weren't caught by the `docs:generateJavaDocs` task because the javacPlugin docs aren't included there.