### PR TITLE
[ci] Avoid duplicate Windows debug build Bazel actions

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -23,14 +23,14 @@ jobs:
 
           - { name: "macOS", classifier: "osxuniversal,osxuniversaldebug,headers,sources,osxuniversalstatic,osxuniversalstaticdebug,linuxsystemcore,linuxsystemcoredebug,linuxsystemcorestatic,linuxsystemcorestaticdebug", os: macOS-15, action: "test" }
 
-          - { name: "Windows x86-64",      classifier: "windowsx86-64,windowsx86-64debug,headers,sources",   os: windows-2022, action: "test" }
-          - { name: "Windows x86-64 Static", classifier: "windowsx86-64static,windowsx86-64staticdebug",        os: windows-2022, action: "test" }
+          - { name: "Windows x86-64",      classifier: "windowsx86-64,windowsx86-64static,headers,sources",   os: windows-2022, action: "test" }
+          - { name: "Windows x86-64 Debug", classifier: "windowsx86-64debug,windowsx86-64staticdebug",        os: windows-2022, action: "test" }
 
-          - { name: "Windows ARM64",       classifier: "windowsarm64,windowsarm64debug",                    os: windows-2022, action: "build" }
-          - { name: "Windows ARM64 Static",  classifier: "windowsarm64static,windowsarm64staticdebug",         os: windows-2022, action: "build" }
+          - { name: "Windows ARM64",       classifier: "windowsarm64,windowsarm64static",                    os: windows-2022, action: "build" }
+          - { name: "Windows ARM64 Debug",  classifier: "windowsarm64debug,windowsarm64staticdebug",         os: windows-2022, action: "build" }
 
-          - { name: "Windows System Core", classifier: "linuxsystemcore,linuxsystemcoredebug", os: windows-2022, action: "build" }
-          - { name: "Windows System Core Static", classifier: "linuxsystemcorestatic,linuxsystemcorestaticdebug", os: windows-2022, action: "build" }
+          - { name: "Windows System Core", classifier: "linuxsystemcore,linuxsystemcorestatic", os: windows-2022, action: "build" }
+          - { name: "Windows System Core Debug", classifier: "linuxsystemcoredebug,linuxsystemcorestaticdebug", os: windows-2022, action: "build" }
 
     name: "${{ matrix.action == 'test' && 'Test' || 'Build' }} ${{ matrix.name }}"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Each Bazel Windows CI job is currently redundantly evaluating the build actions for both the `opt` and `dbg` compilation modes.

If we group the debug artifact builds together (instead of grouping by the shared/static library artifacts), the `dbg` compilation mode actions no longer need to be executed across multiple CI jobs in the matrix.

(Yes, the CI jobs are sharing the Bazel cache, but there's still overhead in checking the action cache for each action. It's also possible that two jobs will race to execute the same action.)

| Total actions per job      | [Before] | After |
|----------------------------|---------:|------:|
| Windows x86-64             |    12277 | 10179 |
| Windows x86-64 Static      |    11947 | n/a   |
| Windows x86-64 Debug       |   n/a    |  9895 |
| Windows ARM64              |     5518 |  3420 |
| Windows ARM64 Static       |     5304 | n/a   |
| Windows ARM64 Debug        |   n/a    |  3272 |
| Windows System Core        |     4836 |  2916 |
| Windows System Core Static |     4576 | n/a   |
| Windows System Core Debug  |   n/a    |  2916 |

[Before]: https://github.com/wpilibsuite/allwpilib/actions/runs/23781230818

This should hopefully translate to shorter wall-clock time Windows CI jobs.