### PR TITLE
[wpilibj] Watchdog: handle callback throwing an exception

### DIFF
--- a/wpilibj/src/main/java/org/wpilib/system/Watchdog.java
+++ b/wpilibj/src/main/java/org/wpilib/system/Watchdog.java
@@ -274,8 +274,11 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
         watchdog.m_isExpired = true;
 
         m_queueMutex.unlock();
-        watchdog.m_callback.run();
-        m_queueMutex.lock();
+        try {
+          watchdog.m_callback.run();
+        } finally {
+          m_queueMutex.lock();
+        }
 
         updateAlarm();
       } finally {


### PR DESCRIPTION
Ensure mutex is re-locked.