### PR TITLE
[cmd2] CommandScheduler::Cancel(): Don't mutate in for loop

### DIFF
--- a/commandsv2/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/commandsv2/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -315,10 +315,14 @@ void CommandScheduler::Cancel(Command* command,
   for (auto&& action : m_impl->interruptActions) {
     action(*command, interruptor);
   }
+  wpi::util::SmallVector<Subsystem*, 8> toErase;
   for (auto&& requirement : m_impl->requirements) {
     if (requirement.second == command) {
-      m_impl->requirements.erase(requirement.first);
+      toErase.push_back(requirement.first);
     }
+  }
+  for (auto* subsystem : toErase) {
+    m_impl->requirements.erase(subsystem);
   }
   m_watchdog.AddEpoch(command->GetName() + ".End(true)");
 }


### PR DESCRIPTION
Erasing elements from a container while iterating over the container may not be well-defined.