### PR TITLE
[ci] Remove archival for lint patches

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -127,20 +127,20 @@ jobs:
         run: git --no-pager diff --exit-code HEAD
 
       - name: Generate diff
-        run: git diff HEAD > bazel-lint-fixes.patch
+        run: git diff HEAD > ${{ matrix.platform }}-bazel-lint-fixes.patch
         if: ${{ failure() }}
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.platform }}-bazel-lint-fixes
-          path: bazel-lint-fixes.patch
+          archive: false
+          path: *-bazel-lint-fixes.patch
         if: ${{ failure() }}
 
   robotpy_pregeneration:
     name: "Robotpy Pregeneration"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with: { fetch-depth: 0 }
 
       - id: Setup_build_buddy

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           ARTIFACTORY_PUBLISH_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PUBLISH_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: build/allOutputs
@@ -175,7 +175,7 @@ jobs:
         if: |
           matrix.artifact-name == 'macOS' && (github.repository == 'wpilibsuite/allwpilib' &&
           (github.ref == 'refs/heads/2027' || startsWith(github.ref, 'refs/tags/v2027')))
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.outputs }}
@@ -204,7 +204,7 @@ jobs:
         env:
           ARTIFACTORY_PUBLISH_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PUBLISH_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: Documentation
           path: docs/build/outputs
@@ -344,7 +344,7 @@ jobs:
           RUN_AZURE_ARTIFACTORY_RELEASE: "TRUE"
           ARTIFACTORY_PUBLISH_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PUBLISH_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         if: |
           github.repository == 'wpilibsuite/allwpilib' &&
           (github.ref == 'refs/heads/2027' || startsWith(github.ref, 'refs/tags/v2027'))

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -44,9 +44,9 @@ jobs:
       - name: Generate diff
         run: git diff HEAD > wpiformat-fixes.patch
         if: ${{ failure() }}
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
-          name: wpiformat fixes
+          archive: false
           path: wpiformat-fixes.patch
         if: ${{ failure() }}
       - name: Write to job summary
@@ -111,9 +111,9 @@ jobs:
       - name: Generate diff
         run: git diff HEAD > javaformat-fixes.patch
         if: ${{ failure() }}
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
-          name: javaformat fixes
+          archive: false
           path: javaformat-fixes.patch
         if: ${{ failure() }}
       - name: Write to job summary

--- a/.github/workflows/pregenerate.yml
+++ b/.github/workflows/pregenerate.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Generate diff
         run: git diff HEAD > pregenerated-files-fixes.patch
         if: ${{ failure() }}
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
-          name: pregenerated-files-fixes
+          archive: false
           path: pregenerated-files-fixes.patch
         if: ${{ failure() }}

--- a/.github/workflows/sentinel-build.yml
+++ b/.github/workflows/sentinel-build.yml
@@ -57,7 +57,7 @@ jobs:
           run: ./gradlew build -PbuildServer -PskipJavaFormat ${{ matrix.build-options }}
       - name: Check free disk space
         run: df .
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: build/allOutputs
@@ -159,7 +159,7 @@ jobs:
       - name: Check disk free space (macOS)
         run: df -h .
         if: matrix.os == 'macOS-15'
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.outputs }}


### PR DESCRIPTION
When downloading a patch to fix linting errors, it's annoying to have to unzip it, particularly when it's a single file. This PR updates the `upload-artifact` action to v7, which allows for uploading an artifact without zipping it. It also sets archive to false for all patches generated by linting.
