### PR TITLE
[wpimath] Prevent CoordinateSystem from accepting left-handed systems

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateAxis.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateAxis.java
@@ -84,4 +84,15 @@ public class CoordinateAxis {
   public static CoordinateAxis D() {
     return m_d;
   }
+
+   /**
+   * Returns whether or not a coordinate axis is negative.
+   * 
+   * @param coordinateAxis The coordinate axis
+   * @return 1 if the axis is positive, -1 if it is negative.
+   */
+  public static int getAxisPolarity(CoordinateAxis coordinateAxis) {
+    if (coordinateAxis == m_n || coordinateAxis == m_w || coordinateAxis == m_u) return 1;
+    return -1;
+  }
 }

--- a/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateAxis.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateAxis.java
@@ -84,15 +84,4 @@ public class CoordinateAxis {
   public static CoordinateAxis D() {
     return m_d;
   }
-
-   /**
-   * Returns whether or not a coordinate axis is negative.
-   * 
-   * @param coordinateAxis The coordinate axis
-   * @return 1 if the axis is positive, -1 if it is negative.
-   */
-  public static int getAxisPolarity(CoordinateAxis coordinateAxis) {
-    if (coordinateAxis == m_n || coordinateAxis == m_w || coordinateAxis == m_u) return 1;
-    return -1;
-  }
 }

--- a/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateSystem.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateSystem.java
@@ -29,6 +29,8 @@ public class CoordinateSystem {
    */
   public CoordinateSystem(
       CoordinateAxis positiveX, CoordinateAxis positiveY, CoordinateAxis positiveZ) {
+    if (CoordinateAxis.getAxisPolarity(positiveX) * CoordinateAxis.getAxisPolarity(positiveY) != CoordinateAxis.getAxisPolarity(positiveZ)) 
+      throw new IllegalArgumentException("CoordinateSystem only works for right-handed systems");
     // Construct a change of basis matrix from the source coordinate system to the
     // NWU coordinate system. Each column vector in the change of basis matrix is
     // one of the old basis vectors mapped to its representation in the new basis.

--- a/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateSystem.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateSystem.java
@@ -5,7 +5,6 @@
 package org.wpilib.math.geometry;
 
 import org.wpilib.math.linalg.Matrix;
-import org.wpilib.math.linalg.Vector;
 import org.wpilib.math.util.MathSharedStore;
 import org.wpilib.math.util.Nat;
 

--- a/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateSystem.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateSystem.java
@@ -39,7 +39,8 @@ public class CoordinateSystem {
     R.assignBlock(0, 2, positiveZ.m_axis);
 
     if (Math.abs(R.det() + 1.0) < 1e-9) {
-      var msg = "CoordinateSystem requires a right-handed system, but a left-handed one was provided";
+      var msg =
+          "CoordinateSystem requires a right-handed system, but a left-handed one was provided";
       MathSharedStore.reportError(msg, Thread.currentThread().getStackTrace());
       throw new IllegalArgumentException(msg);
     }

--- a/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateSystem.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateSystem.java
@@ -6,6 +6,7 @@ package org.wpilib.math.geometry;
 
 import org.wpilib.math.linalg.Matrix;
 import org.wpilib.math.linalg.Vector;
+import org.wpilib.math.util.MathSharedStore;
 import org.wpilib.math.util.Nat;
 
 /** A helper class that converts Pose3d objects between different standard coordinate frames. */
@@ -30,8 +31,6 @@ public class CoordinateSystem {
    */
   public CoordinateSystem(
       CoordinateAxis positiveX, CoordinateAxis positiveY, CoordinateAxis positiveZ) {
-    if (Vector.cross(positiveX.m_axis, positiveY.m_axis).dot(positiveZ.m_axis) == -1)
-      throw new IllegalArgumentException("CoordinateSystem requires a right-handed system, but a left-handed one was provided");
     // Construct a change of basis matrix from the source coordinate system to the
     // NWU coordinate system. Each column vector in the change of basis matrix is
     // one of the old basis vectors mapped to its representation in the new basis.
@@ -39,6 +38,12 @@ public class CoordinateSystem {
     R.assignBlock(0, 0, positiveX.m_axis);
     R.assignBlock(0, 1, positiveY.m_axis);
     R.assignBlock(0, 2, positiveZ.m_axis);
+
+    if (Math.abs(R.det() + 1.0) < 1e-9) {
+      var msg = "CoordinateSystem requires a right-handed system, but a left-handed one was provided";
+      MathSharedStore.reportError(msg, Thread.currentThread().getStackTrace());
+      throw new IllegalArgumentException(msg);
+    }
 
     // The change of basis matrix should be a pure rotation. The Rotation3d
     // constructor will verify this by checking for special orthogonality.

--- a/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateSystem.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateSystem.java
@@ -5,6 +5,7 @@
 package org.wpilib.math.geometry;
 
 import org.wpilib.math.linalg.Matrix;
+import org.wpilib.math.linalg.Vector;
 import org.wpilib.math.util.Nat;
 
 /** A helper class that converts Pose3d objects between different standard coordinate frames. */
@@ -29,8 +30,8 @@ public class CoordinateSystem {
    */
   public CoordinateSystem(
       CoordinateAxis positiveX, CoordinateAxis positiveY, CoordinateAxis positiveZ) {
-    if (CoordinateAxis.getAxisPolarity(positiveX) * CoordinateAxis.getAxisPolarity(positiveY) != CoordinateAxis.getAxisPolarity(positiveZ)) 
-      throw new IllegalArgumentException("CoordinateSystem only works for right-handed systems");
+    if (Vector.cross(positiveX.m_axis, positiveY.m_axis).dot(positiveZ.m_axis) == -1)
+      throw new IllegalArgumentException("CoordinateSystem requires a right-handed system, but a left-handed one was provided");
     // Construct a change of basis matrix from the source coordinate system to the
     // NWU coordinate system. Each column vector in the change of basis matrix is
     // one of the old basis vectors mapped to its representation in the new basis.

--- a/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateSystem.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/CoordinateSystem.java
@@ -38,6 +38,7 @@ public class CoordinateSystem {
     R.assignBlock(0, 1, positiveY.m_axis);
     R.assignBlock(0, 2, positiveZ.m_axis);
 
+    // If determinant is -1, coordinate system is left-handed
     if (Math.abs(R.det() + 1.0) < 1e-9) {
       var msg =
           "CoordinateSystem requires a right-handed system, but a left-handed one was provided";

--- a/wpimath/src/main/native/include/wpi/math/geometry/CoordinateSystem.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/CoordinateSystem.hpp
@@ -4,10 +4,13 @@
 
 #pragma once
 
+#include <gcem.hpp>
+
 #include "wpi/math/geometry/CoordinateAxis.hpp"
 #include "wpi/math/geometry/Pose3d.hpp"
 #include "wpi/math/geometry/Rotation3d.hpp"
 #include "wpi/math/geometry/Translation3d.hpp"
+#include "wpi/math/linalg/ct_matrix.hpp"
 #include "wpi/util/SymbolExports.hpp"
 
 namespace wpi::math {
@@ -38,6 +41,12 @@ class WPILIB_DLLEXPORT CoordinateSystem {
         {positiveX.m_axis(0), positiveY.m_axis(0), positiveZ.m_axis(0)},
         {positiveX.m_axis(1), positiveY.m_axis(1), positiveZ.m_axis(1)},
         {positiveX.m_axis(2), positiveY.m_axis(2), positiveZ.m_axis(2)}};
+
+    if (gcem::abs(ct_matrix{R}.determinant() + 1.0) > 1e-9) {
+      throw std::domain_error(
+          "CoordinateSystem requires a right-handed system, but a left-handed "
+          "one was provided");
+    }
 
     // The change of basis matrix should be a pure rotation. The Rotation3d
     // constructor will verify this by checking for special orthogonality.

--- a/wpimath/src/main/native/include/wpi/math/geometry/CoordinateSystem.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/CoordinateSystem.hpp
@@ -42,6 +42,7 @@ class WPILIB_DLLEXPORT CoordinateSystem {
         {positiveX.m_axis(1), positiveY.m_axis(1), positiveZ.m_axis(1)},
         {positiveX.m_axis(2), positiveY.m_axis(2), positiveZ.m_axis(2)}};
 
+    // If determinant is -1, coordinate system is left-handed
     if (gcem::abs(ct_matrix{R}.determinant() + 1.0) < 1e-9) {
       throw std::domain_error(
           "CoordinateSystem requires a right-handed system, but a left-handed "

--- a/wpimath/src/main/native/include/wpi/math/geometry/CoordinateSystem.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/CoordinateSystem.hpp
@@ -42,7 +42,7 @@ class WPILIB_DLLEXPORT CoordinateSystem {
         {positiveX.m_axis(1), positiveY.m_axis(1), positiveZ.m_axis(1)},
         {positiveX.m_axis(2), positiveY.m_axis(2), positiveZ.m_axis(2)}};
 
-    if (gcem::abs(ct_matrix{R}.determinant() + 1.0) > 1e-9) {
+    if (gcem::abs(ct_matrix{R}.determinant() + 1.0) < 1e-9) {
       throw std::domain_error(
           "CoordinateSystem requires a right-handed system, but a left-handed "
           "one was provided");

--- a/wpimath/src/test/java/org/wpilib/math/geometry/CoordinateSystemTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/geometry/CoordinateSystemTest.java
@@ -5,6 +5,7 @@
 package org.wpilib.math.geometry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.wpilib.math.util.Units;
@@ -231,5 +232,12 @@ class CoordinateSystemTest {
             new Rotation3d(Units.degreesToRadians(45.0), 0.0, 0.0)),
         CoordinateSystem.EDN(),
         CoordinateSystem.NED());
+  }
+
+  @Test
+  void testLeftHandedSystemThrowsException() {
+    assertThrows(IllegalArgumentException.class, () -> new CoordinateSystem(CoordinateAxis.N(), CoordinateAxis.E(), CoordinateAxis.U()));
+    assertThrows(IllegalArgumentException.class, () -> new CoordinateSystem(CoordinateAxis.E(), CoordinateAxis.U(), CoordinateAxis.N()));
+    assertThrows(IllegalArgumentException.class, () -> new CoordinateSystem(CoordinateAxis.N(), CoordinateAxis.W(), CoordinateAxis.D()));
   }
 }

--- a/wpimath/src/test/java/org/wpilib/math/geometry/CoordinateSystemTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/geometry/CoordinateSystemTest.java
@@ -236,8 +236,14 @@ class CoordinateSystemTest {
 
   @Test
   void testLeftHandedSystemThrowsException() {
-    assertThrows(IllegalArgumentException.class, () -> new CoordinateSystem(CoordinateAxis.N(), CoordinateAxis.E(), CoordinateAxis.U()));
-    assertThrows(IllegalArgumentException.class, () -> new CoordinateSystem(CoordinateAxis.E(), CoordinateAxis.U(), CoordinateAxis.N()));
-    assertThrows(IllegalArgumentException.class, () -> new CoordinateSystem(CoordinateAxis.N(), CoordinateAxis.W(), CoordinateAxis.D()));
+    assertThrows(
+        IllegalArgumentException.class, 
+        () -> new CoordinateSystem(CoordinateAxis.N(), CoordinateAxis.E(), CoordinateAxis.U()));
+    assertThrows(
+        IllegalArgumentException.class, 
+        () -> new CoordinateSystem(CoordinateAxis.E(), CoordinateAxis.U(), CoordinateAxis.N()));
+    assertThrows(
+        IllegalArgumentException.class, 
+        () -> new CoordinateSystem(CoordinateAxis.N(), CoordinateAxis.W(), CoordinateAxis.D()));
   }
 }

--- a/wpimath/src/test/java/org/wpilib/math/geometry/CoordinateSystemTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/geometry/CoordinateSystemTest.java
@@ -237,13 +237,13 @@ class CoordinateSystemTest {
   @Test
   void testLeftHandedSystemThrowsException() {
     assertThrows(
-        IllegalArgumentException.class, 
+        IllegalArgumentException.class,
         () -> new CoordinateSystem(CoordinateAxis.N(), CoordinateAxis.E(), CoordinateAxis.U()));
     assertThrows(
-        IllegalArgumentException.class, 
+        IllegalArgumentException.class,
         () -> new CoordinateSystem(CoordinateAxis.E(), CoordinateAxis.U(), CoordinateAxis.N()));
     assertThrows(
-        IllegalArgumentException.class, 
+        IllegalArgumentException.class,
         () -> new CoordinateSystem(CoordinateAxis.N(), CoordinateAxis.W(), CoordinateAxis.D()));
   }
 }

--- a/wpimath/src/test/native/cpp/geometry/CoordinateSystemTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/CoordinateSystemTest.cpp
@@ -162,8 +162,8 @@ TEST(CoordinateSystemTest, LeftHandedSystemThrowsException) {
                std::domain_error);
   EXPECT_THROW(CoordinateSystem(CoordinateAxis::E(), CoordinateAxis::U(),
                                 CoordinateAxis::N()),
-               std::domain_error)
+               std::domain_error);
   EXPECT_THROW(CoordinateSystem(CoordinateAxis::N(), CoordinateAxis::W(),
                                 CoordinateAxis::D()),
-               std::domain_error)
+               std::domain_error);
 }

--- a/wpimath/src/test/native/cpp/geometry/CoordinateSystemTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/CoordinateSystemTest.cpp
@@ -155,3 +155,15 @@ TEST(CoordinateSystemTest, Transform3dEDNtoNED) {
                                       Rotation3d{45_deg, 0_deg, 0_deg}},
                           CoordinateSystem::EDN(), CoordinateSystem::NED());
 }
+
+TEST(CoordinateSystemTest, LeftHandedSystemThrowsException) {
+  EXPECT_THROW(CoordinateSystem(CoordinateAxis::N(), CoordinateAxis::E(),
+                                CoordinateAxis::U()),
+               std::invalid_argument);
+  EXPECT_THROW(CoordinateSystem(CoordinateAxis::E(), CoordinateAxis::U(),
+                                CoordinateAxis::N()),
+               std::invalid_argument)
+  EXPECT_THROW(CoordinateSystem(CoordinateAxis::N(), CoordinateAxis::W(),
+                                CoordinateAxis::D()),
+               std::invalid_argument)
+}

--- a/wpimath/src/test/native/cpp/geometry/CoordinateSystemTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/CoordinateSystemTest.cpp
@@ -159,11 +159,11 @@ TEST(CoordinateSystemTest, Transform3dEDNtoNED) {
 TEST(CoordinateSystemTest, LeftHandedSystemThrowsException) {
   EXPECT_THROW(CoordinateSystem(CoordinateAxis::N(), CoordinateAxis::E(),
                                 CoordinateAxis::U()),
-               std::invalid_argument);
+               std::domain_error);
   EXPECT_THROW(CoordinateSystem(CoordinateAxis::E(), CoordinateAxis::U(),
                                 CoordinateAxis::N()),
-               std::invalid_argument)
+               std::domain_error)
   EXPECT_THROW(CoordinateSystem(CoordinateAxis::N(), CoordinateAxis::W(),
                                 CoordinateAxis::D()),
-               std::invalid_argument)
+               std::domain_error)
 }


### PR DESCRIPTION
Fix for #8746.

The math should be right for the exception in the constructor of CoordinateSystem. 
I'm unsure if including the getAxisPolarity() method in CoordinateAxis is the right way to go about this though, any insight on that would be greatly appreciated.