### PR TITLE
[wpilibc] Return empty string instead of null for GetOpMode

### DIFF
--- a/wpilibc/src/main/native/cpp/driverstation/DriverStation.cpp
+++ b/wpilibc/src/main/native/cpp/driverstation/DriverStation.cpp
@@ -695,7 +695,7 @@ int64_t DriverStation::GetOpModeId() {
 
 std::string DriverStation::GetOpMode() {
   if (!::GetInstance().userProgramStarted) {
-    return 0;
+    return "";
   }
 
   return GetInstance().OpModeToString(GetOpModeId());


### PR DESCRIPTION
Clang 21 catches returning `0` from `GetOpMode` as returning `null`. Since this state is very momentary and all comparisons inside WPILib are done against `GetOpModeId` instead, I changed it to return an empty string.