### PR TITLE
[wpical] Fix linker errors

### DIFF
--- a/tools/wpical/build.gradle
+++ b/tools/wpical/build.gradle
@@ -157,6 +157,7 @@ model {
                     return
                 }
                 lib project: ':apriltag', library: 'apriltag', linkage: 'static'
+                lib project: ':fields', library: 'fields', linkage: 'static'
                 lib project: ':glass', library: 'glass', linkage: 'static'
                 lib project: ':wpimath', library: 'wpimath', linkage: 'static'
                 lib project: ':wpigui', library: 'wpigui', linkage: 'static'
@@ -211,6 +212,7 @@ model {
                     return
                 }
                 lib project: ':apriltag', library: 'apriltag', linkage: 'static'
+                lib project: ':fields', library: 'fields', linkage: 'static'
                 lib project: ':glass', library: 'glass', linkage: 'static'
                 lib project: ':wpimath', library: 'wpimath', linkage: 'static'
                 lib project: ':wpigui', library: 'wpigui', linkage: 'static'


### PR DESCRIPTION
```
mold: error: undefined symbol: wpi::fields::GetFields()
>>> referenced by Field2D.cpp
>>>               /home/tav/frc/wpilib/allwpilib/glass/build/libs/glass/static/linuxx86-64/debug/libglassd.a(Field2D.o):((anonymous namespace)::FieldInfo::DisplaySettings())
>>> referenced by Field2D.cpp
>>>               /home/tav/frc/wpilib/allwpilib/glass/build/libs/glass/static/linuxx86-64/debug/libglassd.a(Field2D.o):((anonymous namespace)::FieldInfo::LoadImage())
collect2: error: ld returned 1 exit status
```
The issue seems to stem from libglass linking to the shared version of fields, whereas wpical requires static linkage.