### PR TITLE
[wpilib] Rename MotorController setThrottle() to setPower()

### DIFF
--- a/robotpyExamples/ArmSimulation/subsystems/arm.py
+++ b/robotpyExamples/ArmSimulation/subsystems/arm.py
@@ -76,7 +76,7 @@ class Arm:
         # In this method, we update our simulation of what our arm is doing
         # First, we set our "inputs" (voltages)
         self.armSim.setInput(
-            [self.motor.getThrottle() * wpilib.RobotController.getBatteryVoltage()]
+            [self.motor.getPower() * wpilib.RobotController.getBatteryVoltage()]
         )
 
         # Next, we update it. The standard loop time is 20ms.
@@ -111,4 +111,4 @@ class Arm:
         self.motor.setVoltage(pidOutput)
 
     def stop(self) -> None:
-        self.motor.setThrottle(0.0)
+        self.motor.setPower(0.0)

--- a/robotpyExamples/DifferentialDrivePoseEstimator/drivetrain.py
+++ b/robotpyExamples/DifferentialDrivePoseEstimator/drivetrain.py
@@ -244,8 +244,8 @@ class Drivetrain:
         # simulation, and write the simulated positions and velocities to our
         # simulated encoder and gyro.
         self.drivetrainSimulator.setInputs(
-            self.leftLeader.getThrottle() * wpilib.RobotController.getInputVoltage(),
-            self.rightLeader.getThrottle() * wpilib.RobotController.getInputVoltage(),
+            self.leftLeader.getPower() * wpilib.RobotController.getInputVoltage(),
+            self.rightLeader.getPower() * wpilib.RobotController.getInputVoltage(),
         )
         self.drivetrainSimulator.update(0.02)
 

--- a/robotpyExamples/ElevatorExponentialSimulation/subsystems/elevator.py
+++ b/robotpyExamples/ElevatorExponentialSimulation/subsystems/elevator.py
@@ -84,7 +84,7 @@ class Elevator:
         # In this method, we update our simulation of what our elevator is doing
         # First, we set our "inputs" (voltages)
         self.elevatorSim.setInputVoltage(
-            self.motorSim.getThrottle() * wpilib.RobotController.getBatteryVoltage()
+            self.motorSim.getPower() * wpilib.RobotController.getBatteryVoltage()
         )
 
         # Next, we update it. The standard loop time is 20ms.
@@ -120,7 +120,7 @@ class Elevator:
 
     def stop(self) -> None:
         """Stop the control loop and motor output."""
-        self.motor.setThrottle(0.0)
+        self.motor.setPower(0.0)
 
     def reset(self) -> None:
         """Reset Exponential profile to begin from current position on enable."""

--- a/robotpyExamples/ElevatorSimulation/subsystems/elevator.py
+++ b/robotpyExamples/ElevatorSimulation/subsystems/elevator.py
@@ -68,7 +68,7 @@ class Elevator:
         # In this method, we update our simulation of what our elevator is doing
         # First, we set our "inputs" (voltages)
         self.elevatorSim.setInputVoltage(
-            self.motorSim.getThrottle() * wpilib.RobotController.getBatteryVoltage()
+            self.motorSim.getPower() * wpilib.RobotController.getBatteryVoltage()
         )
 
         # Next, we update it. The standard loop time is 20ms.
@@ -99,7 +99,7 @@ class Elevator:
     def stop(self) -> None:
         """Stop the control loop and motor output."""
         self.controller.setGoal(0.0)
-        self.motor.setThrottle(0.0)
+        self.motor.setPower(0.0)
 
     def updateTelemetry(self) -> None:
         """Update telemetry, including the mechanism visualization."""

--- a/robotpyExamples/FlywheelBangBangController/robot.py
+++ b/robotpyExamples/FlywheelBangBangController/robot.py
@@ -102,7 +102,7 @@ class MyRobot(wpilib.TimedRobot):
         # To update our simulation, we set motor voltage inputs, update the
         # simulation, and write the simulated velocities to our simulated encoder
         self.flywheelSim.setInputVoltage(
-            self.flywheelMotor.getThrottle() * wpilib.RobotController.getInputVoltage()
+            self.flywheelMotor.getPower() * wpilib.RobotController.getInputVoltage()
         )
         self.flywheelSim.update(0.02)
         self.encoderSim.setRate(self.flywheelSim.getAngularVelocity())

--- a/robotpyExamples/Mechanism2d/robot.py
+++ b/robotpyExamples/Mechanism2d/robot.py
@@ -56,5 +56,5 @@ class MyRobot(wpilib.TimedRobot):
         self.wrist.setAngle(self.wristPot.get())
 
     def teleopPeriodic(self):
-        self.elevatorMotor.setThrottle(self.joystick.getRawAxis(0))
-        self.wristMotor.setThrottle(self.joystick.getRawAxis(1))
+        self.elevatorMotor.setPower(self.joystick.getRawAxis(0))
+        self.wristMotor.setPower(self.joystick.getRawAxis(1))

--- a/robotpyExamples/MotorControl/robot.py
+++ b/robotpyExamples/MotorControl/robot.py
@@ -43,4 +43,4 @@ class MyRobot(wpilib.TimedRobot):
         wpilib.SmartDashboard.putNumber("Encoder", self.encoder.getDistance())
 
     def teleopPeriodic(self):
-        self.motor.setThrottle(self.joystick.getY())
+        self.motor.setPower(self.joystick.getY())

--- a/robotpyExamples/SimpleDifferentialDriveSimulation/drivetrain.py
+++ b/robotpyExamples/SimpleDifferentialDriveSimulation/drivetrain.py
@@ -145,8 +145,8 @@ class Drivetrain:
         # simulated encoder and gyro. We negate the right side so that positive
         # voltages make the right side move forward.
         self.drivetrainSimulator.setInputs(
-            self.leftLeader.getThrottle() * wpilib.RobotController.getInputVoltage(),
-            self.rightLeader.getThrottle() * wpilib.RobotController.getInputVoltage(),
+            self.leftLeader.getPower() * wpilib.RobotController.getInputVoltage(),
+            self.rightLeader.getPower() * wpilib.RobotController.getInputVoltage(),
         )
         self.drivetrainSimulator.update(0.02)
 

--- a/robotpyExamples/SysId/subsystems/shooter.py
+++ b/robotpyExamples/SysId/subsystems/shooter.py
@@ -93,7 +93,7 @@ class Shooter(Subsystem):
                 )
                 + self.shooter_feedforward.calculate(target_velocity_radians)
             )
-            self.feeder_motor.setThrottle(ShooterConstants.kFeederVelocity)
+            self.feeder_motor.setPower(ShooterConstants.kFeederVelocity)
 
         def _stop_motors(interrupted: bool) -> None:
             self.shooter_motor.stopMotor()

--- a/robotpyExamples/UnitTest/subsystems/intake.py
+++ b/robotpyExamples/UnitTest/subsystems/intake.py
@@ -20,17 +20,17 @@ class Intake:
         )
 
     def deploy(self) -> None:
-        self.piston.setThrottle(wpilib.DoubleSolenoid.Value.FORWARD)
+        self.piston.setPower(wpilib.DoubleSolenoid.Value.FORWARD)
 
     def retract(self) -> None:
-        self.piston.setThrottle(wpilib.DoubleSolenoid.Value.REVERSE)
-        self.motor.setThrottle(0)  # turn off the motor
+        self.piston.setPower(wpilib.DoubleSolenoid.Value.REVERSE)
+        self.motor.setPower(0)  # turn off the motor
 
     def activate(self, velocity: float) -> None:
         if self.isDeployed():
-            self.motor.setThrottle(velocity)
+            self.motor.setPower(velocity)
         else:  # if piston isn't open, do nothing
-            self.motor.setThrottle(0)
+            self.motor.setPower(0)
 
     def isDeployed(self) -> bool:
         return self.piston.get() == wpilib.DoubleSolenoid.Value.FORWARD

--- a/robotpyExamples/XrpReference/subsystems/drivetrain.py
+++ b/robotpyExamples/XrpReference/subsystems/drivetrain.py
@@ -32,7 +32,7 @@ class Drivetrain(commands2.Subsystem):
 
         # Set up the differential drive controller
         self.drive = wpilib.DifferentialDrive(
-            self.leftMotor.setThrottle, self.rightMotor.setThrottle
+            self.leftMotor.setPower, self.rightMotor.setPower
         )
 
         # TODO: these don't work

--- a/romiVendordep/src/main/java/org/wpilib/romi/RomiMotor.java
+++ b/romiVendordep/src/main/java/org/wpilib/romi/RomiMotor.java
@@ -15,7 +15,7 @@ public class RomiMotor extends PWMMotorController {
   /** Common initialization code called by all constructors. */
   protected final void initRomiMotor() {
     m_pwm.setOutputPeriod(5);
-    setThrottle(0.0);
+    setPower(0.0);
   }
 
   /**

--- a/romiVendordep/src/main/native/cpp/romi/RomiMotor.cpp
+++ b/romiVendordep/src/main/native/cpp/romi/RomiMotor.cpp
@@ -8,5 +8,5 @@ using namespace wpi::romi;
 
 RomiMotor::RomiMotor(int channel) : PWMMotorController("Romi Motor", channel) {
   m_pwm.SetOutputPeriod(5_ms);
-  SetThrottle(0.0);
+  SetPower(0.0);
 }

--- a/simulation/halsim_xrp/src/main/native/cpp/XRP.cpp
+++ b/simulation/halsim_xrp/src/main/native/cpp/XRP.cpp
@@ -144,9 +144,9 @@ void XRP::HandleMotorSimValueChanged(const wpi::util::json& data) {
     deviceId = 3;
   }
 
-  auto dutyCycle = motorData->lookup("<duty_cycle");
-  if (deviceId != -1 && dutyCycle && dutyCycle->is_number()) {
-    m_motor_outputs[deviceId] = dutyCycle->get_number();
+  auto power = motorData->lookup("<power");
+  if (deviceId != -1 && power && power->is_number()) {
+    m_motor_outputs[deviceId] = power->get_number();
   }
 }
 

--- a/wpilibc/src/generate/main/native/cpp/hardware/motor/pwm_motor_controller.cpp.jinja
+++ b/wpilibc/src/generate/main/native/cpp/hardware/motor/pwm_motor_controller.cpp.jinja
@@ -13,7 +13,7 @@ using namespace wpi;
 {{ name }}::{{ name }}(int channel) : PWMMotorController("{{ name }}", channel) {
   SetBounds({{ pulse_width_ms.max }}_ms, {{ pulse_width_ms.deadbandMax }}_ms, {{ pulse_width_ms.center }}_ms, {{ pulse_width_ms.deadbandMin }}_ms, {{ pulse_width_ms.min }}_ms);
   m_pwm.SetOutputPeriod({{ OutputPeriod | default("5", true)}}_ms);
-  SetThrottle(0.0);
+  SetPower(0.0);
 
   HAL_ReportUsage("IO", GetChannel(), "{{ ResourceName }}");
 }

--- a/wpilibc/src/generated/main/native/cpp/hardware/motor/Koors40.cpp
+++ b/wpilibc/src/generated/main/native/cpp/hardware/motor/Koors40.cpp
@@ -13,7 +13,7 @@ using namespace wpi;
 Koors40::Koors40(int channel) : PWMMotorController("Koors40", channel) {
   SetBounds(2.004_ms, 1.52_ms, 1.5_ms, 1.48_ms, 0.997_ms);
   m_pwm.SetOutputPeriod(20_ms);
-  SetThrottle(0.0);
+  SetPower(0.0);
 
   HAL_ReportUsage("IO", GetChannel(), "Koors40");
 }

--- a/wpilibc/src/generated/main/native/cpp/hardware/motor/PWMSparkFlex.cpp
+++ b/wpilibc/src/generated/main/native/cpp/hardware/motor/PWMSparkFlex.cpp
@@ -13,7 +13,7 @@ using namespace wpi;
 PWMSparkFlex::PWMSparkFlex(int channel) : PWMMotorController("PWMSparkFlex", channel) {
   SetBounds(2.003_ms, 1.55_ms, 1.5_ms, 1.46_ms, 0.999_ms);
   m_pwm.SetOutputPeriod(5_ms);
-  SetThrottle(0.0);
+  SetPower(0.0);
 
   HAL_ReportUsage("IO", GetChannel(), "RevSparkFlexPWM");
 }

--- a/wpilibc/src/generated/main/native/cpp/hardware/motor/PWMSparkMax.cpp
+++ b/wpilibc/src/generated/main/native/cpp/hardware/motor/PWMSparkMax.cpp
@@ -13,7 +13,7 @@ using namespace wpi;
 PWMSparkMax::PWMSparkMax(int channel) : PWMMotorController("PWMSparkMax", channel) {
   SetBounds(2.003_ms, 1.55_ms, 1.5_ms, 1.46_ms, 0.999_ms);
   m_pwm.SetOutputPeriod(5_ms);
-  SetThrottle(0.0);
+  SetPower(0.0);
 
   HAL_ReportUsage("IO", GetChannel(), "RevSparkMaxPWM");
 }

--- a/wpilibc/src/generated/main/native/cpp/hardware/motor/PWMTalonFX.cpp
+++ b/wpilibc/src/generated/main/native/cpp/hardware/motor/PWMTalonFX.cpp
@@ -13,7 +13,7 @@ using namespace wpi;
 PWMTalonFX::PWMTalonFX(int channel) : PWMMotorController("PWMTalonFX", channel) {
   SetBounds(2.004_ms, 1.52_ms, 1.5_ms, 1.48_ms, 0.997_ms);
   m_pwm.SetOutputPeriod(5_ms);
-  SetThrottle(0.0);
+  SetPower(0.0);
 
   HAL_ReportUsage("IO", GetChannel(), "TalonFX");
 }

--- a/wpilibc/src/generated/main/native/cpp/hardware/motor/PWMTalonSRX.cpp
+++ b/wpilibc/src/generated/main/native/cpp/hardware/motor/PWMTalonSRX.cpp
@@ -13,7 +13,7 @@ using namespace wpi;
 PWMTalonSRX::PWMTalonSRX(int channel) : PWMMotorController("PWMTalonSRX", channel) {
   SetBounds(2.004_ms, 1.52_ms, 1.5_ms, 1.48_ms, 0.997_ms);
   m_pwm.SetOutputPeriod(5_ms);
-  SetThrottle(0.0);
+  SetPower(0.0);
 
   HAL_ReportUsage("IO", GetChannel(), "PWMTalonSRX");
 }

--- a/wpilibc/src/generated/main/native/cpp/hardware/motor/PWMVenom.cpp
+++ b/wpilibc/src/generated/main/native/cpp/hardware/motor/PWMVenom.cpp
@@ -13,7 +13,7 @@ using namespace wpi;
 PWMVenom::PWMVenom(int channel) : PWMMotorController("PWMVenom", channel) {
   SetBounds(2.004_ms, 1.52_ms, 1.5_ms, 1.48_ms, 0.997_ms);
   m_pwm.SetOutputPeriod(5_ms);
-  SetThrottle(0.0);
+  SetPower(0.0);
 
   HAL_ReportUsage("IO", GetChannel(), "FusionVenom");
 }

--- a/wpilibc/src/generated/main/native/cpp/hardware/motor/PWMVictorSPX.cpp
+++ b/wpilibc/src/generated/main/native/cpp/hardware/motor/PWMVictorSPX.cpp
@@ -13,7 +13,7 @@ using namespace wpi;
 PWMVictorSPX::PWMVictorSPX(int channel) : PWMMotorController("PWMVictorSPX", channel) {
   SetBounds(2.004_ms, 1.52_ms, 1.5_ms, 1.48_ms, 0.997_ms);
   m_pwm.SetOutputPeriod(5_ms);
-  SetThrottle(0.0);
+  SetPower(0.0);
 
   HAL_ReportUsage("IO", GetChannel(), "PWMVictorSPX");
 }

--- a/wpilibc/src/generated/main/native/cpp/hardware/motor/Spark.cpp
+++ b/wpilibc/src/generated/main/native/cpp/hardware/motor/Spark.cpp
@@ -13,7 +13,7 @@ using namespace wpi;
 Spark::Spark(int channel) : PWMMotorController("Spark", channel) {
   SetBounds(2.003_ms, 1.55_ms, 1.5_ms, 1.46_ms, 0.999_ms);
   m_pwm.SetOutputPeriod(5_ms);
-  SetThrottle(0.0);
+  SetPower(0.0);
 
   HAL_ReportUsage("IO", GetChannel(), "RevSPARK");
 }

--- a/wpilibc/src/generated/main/native/cpp/hardware/motor/SparkMini.cpp
+++ b/wpilibc/src/generated/main/native/cpp/hardware/motor/SparkMini.cpp
@@ -13,7 +13,7 @@ using namespace wpi;
 SparkMini::SparkMini(int channel) : PWMMotorController("SparkMini", channel) {
   SetBounds(2.5_ms, 1.51_ms, 1.5_ms, 1.49_ms, 0.5_ms);
   m_pwm.SetOutputPeriod(5_ms);
-  SetThrottle(0.0);
+  SetPower(0.0);
 
   HAL_ReportUsage("IO", GetChannel(), "RevSPARK");
 }

--- a/wpilibc/src/generated/main/native/cpp/hardware/motor/Talon.cpp
+++ b/wpilibc/src/generated/main/native/cpp/hardware/motor/Talon.cpp
@@ -13,7 +13,7 @@ using namespace wpi;
 Talon::Talon(int channel) : PWMMotorController("Talon", channel) {
   SetBounds(2.037_ms, 1.539_ms, 1.513_ms, 1.487_ms, 0.989_ms);
   m_pwm.SetOutputPeriod(5_ms);
-  SetThrottle(0.0);
+  SetPower(0.0);
 
   HAL_ReportUsage("IO", GetChannel(), "Talon");
 }

--- a/wpilibc/src/generated/main/native/cpp/hardware/motor/VictorSP.cpp
+++ b/wpilibc/src/generated/main/native/cpp/hardware/motor/VictorSP.cpp
@@ -13,7 +13,7 @@ using namespace wpi;
 VictorSP::VictorSP(int channel) : PWMMotorController("VictorSP", channel) {
   SetBounds(2.004_ms, 1.52_ms, 1.5_ms, 1.48_ms, 0.997_ms);
   m_pwm.SetOutputPeriod(5_ms);
-  SetThrottle(0.0);
+  SetPower(0.0);
 
   HAL_ReportUsage("IO", GetChannel(), "VictorSP");
 }

--- a/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp
+++ b/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp
@@ -19,9 +19,8 @@ using namespace wpi;
 
 DifferentialDrive::DifferentialDrive(MotorController& leftMotor,
                                      MotorController& rightMotor)
-    : DifferentialDrive{
-          [&](double output) { leftMotor.SetThrottle(output); },
-          [&](double output) { rightMotor.SetThrottle(output); }} {
+    : DifferentialDrive{[&](double output) { leftMotor.SetPower(output); },
+                        [&](double output) { rightMotor.SetPower(output); }} {
   wpi::util::SendableRegistry::AddChild(this, &leftMotor);
   wpi::util::SendableRegistry::AddChild(this, &rightMotor);
 }

--- a/wpilibc/src/main/native/cpp/drive/MecanumDrive.cpp
+++ b/wpilibc/src/main/native/cpp/drive/MecanumDrive.cpp
@@ -21,10 +21,10 @@ MecanumDrive::MecanumDrive(MotorController& frontLeftMotor,
                            MotorController& rearLeftMotor,
                            MotorController& frontRightMotor,
                            MotorController& rearRightMotor)
-    : MecanumDrive{[&](double output) { frontLeftMotor.SetThrottle(output); },
-                   [&](double output) { rearLeftMotor.SetThrottle(output); },
-                   [&](double output) { frontRightMotor.SetThrottle(output); },
-                   [&](double output) { rearRightMotor.SetThrottle(output); }} {
+    : MecanumDrive{[&](double output) { frontLeftMotor.SetPower(output); },
+                   [&](double output) { rearLeftMotor.SetPower(output); },
+                   [&](double output) { frontRightMotor.SetPower(output); },
+                   [&](double output) { rearRightMotor.SetPower(output); }} {
   wpi::util::SendableRegistry::AddChild(this, &frontLeftMotor);
   wpi::util::SendableRegistry::AddChild(this, &rearLeftMotor);
   wpi::util::SendableRegistry::AddChild(this, &frontRightMotor);

--- a/wpilibc/src/main/native/cpp/hardware/expansionhub/ExpansionHubMotor.cpp
+++ b/wpilibc/src/main/native/cpp/hardware/expansionhub/ExpansionHubMotor.cpp
@@ -92,10 +92,10 @@ ExpansionHubMotor::~ExpansionHubMotor() noexcept {
   m_hub.UnreserveMotor(m_channel);
 }
 
-void ExpansionHubMotor::SetThrottle(double throttle) {
+void ExpansionHubMotor::SetPower(double power) {
   SetEnabled(true);
   m_modePublisher.Set(kPercentageMode);
-  m_setpointPublisher.Set(throttle);
+  m_setpointPublisher.Set(power);
 }
 
 void ExpansionHubMotor::SetVoltage(wpi::units::volt_t voltage) {

--- a/wpilibc/src/main/native/cpp/hardware/motor/MotorController.cpp
+++ b/wpilibc/src/main/native/cpp/hardware/motor/MotorController.cpp
@@ -10,5 +10,5 @@ using namespace wpi;
 
 void MotorController::SetVoltage(wpi::units::volt_t voltage) {
   // NOLINTNEXTLINE(bugprone-integer-division)
-  SetThrottle(voltage / RobotController::GetBatteryVoltage());
+  SetPower(voltage / RobotController::GetBatteryVoltage());
 }

--- a/wpilibc/src/main/native/cpp/hardware/motor/PWMMotorController.cpp
+++ b/wpilibc/src/main/native/cpp/hardware/motor/PWMMotorController.cpp
@@ -14,28 +14,28 @@
 
 using namespace wpi;
 
-void PWMMotorController::SetThrottle(double throttle) {
+void PWMMotorController::SetPower(double power) {
   if (m_isInverted) {
-    throttle = -throttle;
+    power = -power;
   }
-  SetDutyCycleInternal(throttle);
+  SetDutyCycleInternal(power);
 
   for (auto& follower : m_nonowningFollowers) {
-    follower->SetThrottle(throttle);
+    follower->SetPower(power);
   }
   for (auto& follower : m_owningFollowers) {
-    follower->SetThrottle(throttle);
+    follower->SetPower(power);
   }
 
   Feed();
 }
 
-double PWMMotorController::GetThrottle() const {
+double PWMMotorController::GetPower() const {
   return GetDutyCycleInternal() * (m_isInverted ? -1.0 : 1.0);
 }
 
 wpi::units::volt_t PWMMotorController::GetVoltage() const {
-  return GetThrottle() * RobotController::GetBatteryVoltage();
+  return GetPower() * RobotController::GetBatteryVoltage();
 }
 
 void PWMMotorController::SetInverted(bool isInverted) {
@@ -49,8 +49,8 @@ bool PWMMotorController::GetInverted() const {
 void PWMMotorController::Disable() {
   m_pwm.SetDisabled();
 
-  if (m_simThrottle) {
-    m_simThrottle.Set(0.0);
+  if (m_simPower) {
+    m_simPower.Set(0.0);
   }
 
   for (auto& follower : m_nonowningFollowers) {
@@ -87,8 +87,8 @@ PWMMotorController::PWMMotorController(std::string_view name, int channel)
 
   m_simDevice = wpi::hal::SimDevice{"PWMMotorController", channel};
   if (m_simDevice) {
-    m_simThrottle = m_simDevice.CreateDouble(
-        "Throttle", wpi::hal::SimDevice::Direction::OUTPUT, 0.0);
+    m_simPower = m_simDevice.CreateDouble(
+        "Power", wpi::hal::SimDevice::Direction::OUTPUT, 0.0);
     m_pwm.SetSimDevice(m_simDevice);
   }
 }
@@ -97,8 +97,8 @@ void PWMMotorController::InitSendable(wpi::util::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Motor Controller");
   builder.SetActuator(true);
   builder.AddDoubleProperty(
-      "Value", [=, this] { return GetThrottle(); },
-      [=, this](double value) { SetThrottle(value); });
+      "Power", [=, this] { return GetPower(); },
+      [=, this](double value) { SetPower(value); });
 }
 
 wpi::units::microsecond_t PWMMotorController::GetMinPositivePwm() const {
@@ -132,8 +132,8 @@ void PWMMotorController::SetDutyCycleInternal(double dutyCycle) {
     dutyCycle = 0.0;
   }
 
-  if (m_simThrottle) {
-    m_simThrottle.Set(dutyCycle);
+  if (m_simPower) {
+    m_simPower.Set(dutyCycle);
   }
 
   wpi::units::microsecond_t rawValue;

--- a/wpilibc/src/main/native/cpp/simulation/PWMMotorControllerSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/PWMMotorControllerSim.cpp
@@ -16,9 +16,9 @@ PWMMotorControllerSim::PWMMotorControllerSim(
 
 PWMMotorControllerSim::PWMMotorControllerSim(int channel) {
   wpi::sim::SimDeviceSim deviceSim{"PWMMotorController", channel};
-  m_simThrottle = deviceSim.GetDouble("Throttle");
+  m_simPower = deviceSim.GetDouble("Power");
 }
 
-double PWMMotorControllerSim::GetThrottle() const {
-  return m_simThrottle.Get();
+double PWMMotorControllerSim::GetPower() const {
+  return m_simPower.Get();
 }

--- a/wpilibc/src/main/native/include/wpi/hardware/expansionhub/ExpansionHubMotor.hpp
+++ b/wpilibc/src/main/native/include/wpi/hardware/expansionhub/ExpansionHubMotor.hpp
@@ -29,12 +29,26 @@ class ExpansionHubMotor {
   ~ExpansionHubMotor() noexcept;
 
   /**
-   * Sets the throttle.
+   * Sets the output power level of the motor, expressed as a fraction of the
+   * maximum possible.
    *
-   * @param throttle The throttle where -1 indicates full reverse and 1
+   * <p>This is generally perceived as "speed" of the output for a fixed load,
+   * but the actual speed will depend on the applied load.  For example, a value
+   * of 1.0 will result in the motor outputting full power in the forward
+   * direction, so it will move as fast as it can for the amount of load it is
+   * under, which will be slower for heavier loads and faster for lighter loads.
+   *
+   * <p>The maximum possible output is determined by the battery voltage, so a
+   * value of e.g. 0.5 will result in a different amount of motor power being
+   * applied for a fully charged battery vs. a nearly depleted battery. For
+   * consistent output that is independent of battery voltage, use SetVoltage(),
+   * potentially combined with closed-loop control that uses a sensor to control
+   * the amount of applied output.
+   *
+   * @param power The power level, where -1.0 indicates full reverse and 1.0
    *     indicates full forward.
    */
-  void SetThrottle(double throttle);
+  void SetPower(double power);
 
   /**
    * Sets the voltage to run the motor at. This value will be continuously

--- a/wpilibc/src/main/native/include/wpi/hardware/motor/MotorController.hpp
+++ b/wpilibc/src/main/native/include/wpi/hardware/motor/MotorController.hpp
@@ -16,12 +16,26 @@ class MotorController {
   virtual ~MotorController() = default;
 
   /**
-   * Sets the throttle of the motor controller.
+   * Sets the output power level of the motor controller, expressed as a
+   * fraction of the maximum possible.
    *
-   * @param throttle The throttle where -1 indicates full reverse and 1
+   * This is generally perceived as "speed" of the output for a fixed load, but
+   * the actual speed will depend on the applied load.  For example, a value
+   * of 1.0 will result in the motor outputting full power in the forward
+   * direction, so it will move as fast as it can for the amount of load it is
+   * under, which will be slower for heavier loads and faster for lighter loads.
+   *
+   * The maximum possible output is determined by the battery voltage, so a
+   * value of e.g. 0.5 will result in a different amount of motor power being
+   * applied for a fully charged battery vs. a nearly depleted battery. For
+   * consistent output that is independent of battery voltage, use SetVoltage(),
+   * potentially combined with closed-loop control that uses a sensor to control
+   * the amount of applied output.
+   *
+   * @param power The power level, where -1.0 indicates full reverse and 1.0
    *     indicates full forward.
    */
-  virtual void SetThrottle(double throttle) = 0;
+  virtual void SetPower(double power) = 0;
 
   /**
    * Sets the voltage output of the motor controller.
@@ -40,12 +54,12 @@ class MotorController {
   virtual void SetVoltage(wpi::units::volt_t voltage);
 
   /**
-   * Gets the throttle of the motor controller.
+   * Gets the power level of the motor controller.
    *
-   * @return The throttle where -1 represents full reverse and 1 represents full
-   *     forward.
+   * @return The power level, where -1.0 represents full reverse and 1.0
+   *     represents full forward.
    */
-  virtual double GetThrottle() const = 0;
+  virtual double GetPower() const = 0;
 
   /**
    * Sets the inversion state of the motor controller.

--- a/wpilibc/src/main/native/include/wpi/hardware/motor/PWMMotorController.hpp
+++ b/wpilibc/src/main/native/include/wpi/hardware/motor/PWMMotorController.hpp
@@ -34,9 +34,9 @@ class PWMMotorController
   PWMMotorController(PWMMotorController&&) = default;
   PWMMotorController& operator=(PWMMotorController&&) = default;
 
-  void SetThrottle(double throttle) override;
+  void SetPower(double power) override;
 
-  double GetThrottle() const override;
+  double GetPower() const override;
 
   /**
    * Gets the voltage output of the motor controller, nominally between -12 V
@@ -116,7 +116,7 @@ class PWMMotorController
   std::vector<std::unique_ptr<PWMMotorController>> m_owningFollowers;
 
   wpi::hal::SimDevice m_simDevice;
-  wpi::hal::SimDouble m_simThrottle;
+  wpi::hal::SimDouble m_simPower;
 
   bool m_eliminateDeadband{0};
   wpi::units::microsecond_t m_minPwm{0};

--- a/wpilibc/src/main/native/include/wpi/simulation/PWMMotorControllerSim.hpp
+++ b/wpilibc/src/main/native/include/wpi/simulation/PWMMotorControllerSim.hpp
@@ -19,10 +19,10 @@ class PWMMotorControllerSim {
 
   explicit PWMMotorControllerSim(int channel);
 
-  double GetThrottle() const;
+  double GetPower() const;
 
  private:
-  wpi::hal::SimDouble m_simThrottle;
+  wpi::hal::SimDouble m_simPower;
 };
 }  // namespace sim
 }  // namespace wpi

--- a/wpilibc/src/main/python/semiwrap/ExpansionHubMotor.yml
+++ b/wpilibc/src/main/python/semiwrap/ExpansionHubMotor.yml
@@ -2,7 +2,7 @@ classes:
   wpi::ExpansionHubMotor:
     methods:
       ExpansionHubMotor:
-      SetThrottle:
+      SetPower:
       SetVoltage:
       SetPositionSetpoint:
       SetVelocitySetpoint:

--- a/wpilibc/src/main/python/semiwrap/MotorController.yml
+++ b/wpilibc/src/main/python/semiwrap/MotorController.yml
@@ -1,9 +1,9 @@
 classes:
   wpi::MotorController:
     methods:
-      SetThrottle:
+      SetPower:
       SetVoltage:
-      GetThrottle:
+      GetPower:
       SetInverted:
       GetInverted:
       Disable:

--- a/wpilibc/src/main/python/semiwrap/MotorControllerGroup.yml
+++ b/wpilibc/src/main/python/semiwrap/MotorControllerGroup.yml
@@ -33,9 +33,9 @@ classes:
         param_override:
           args:
             ignore: true
-      SetThrottle:
+      SetPower:
       SetVoltage:
-      GetThrottle:
+      GetPower:
       SetInverted:
       GetInverted:
       Disable:

--- a/wpilibc/src/main/python/semiwrap/PWMMotorController.yml
+++ b/wpilibc/src/main/python/semiwrap/PWMMotorController.yml
@@ -8,8 +8,8 @@ classes:
     attributes:
       m_pwm:
     methods:
-      SetThrottle:
-      GetThrottle:
+      SetPower:
+      GetPower:
       GetVoltage:
       SetInverted:
       GetInverted:

--- a/wpilibc/src/main/python/semiwrap/simulation/PWMMotorControllerSim.yml
+++ b/wpilibc/src/main/python/semiwrap/simulation/PWMMotorControllerSim.yml
@@ -5,4 +5,4 @@ classes:
         overloads:
           const PWMMotorController&:
           int:
-      GetThrottle:
+      GetPower:

--- a/wpilibc/src/main/python/wpilib/src/rpy/MotorControllerGroup.cpp
+++ b/wpilibc/src/main/python/wpilib/src/rpy/MotorControllerGroup.cpp
@@ -17,9 +17,9 @@ void PyMotorControllerGroup::Initialize() {
   wpi::util::SendableRegistry::Add(this, "MotorControllerGroup", instances);
 }
 
-void PyMotorControllerGroup::SetThrottle(double throttle) {
+void PyMotorControllerGroup::SetPower(double power) {
   for (auto motorController : m_motorControllers) {
-    motorController->SetThrottle(m_isInverted ? -throttle : throttle);
+    motorController->SetPower(m_isInverted ? -power : power);
   }
 }
 
@@ -29,9 +29,9 @@ void PyMotorControllerGroup::SetVoltage(wpi::units::volt_t voltage) {
   }
 }
 
-double PyMotorControllerGroup::GetThrottle() const {
+double PyMotorControllerGroup::GetPower() const {
   if (!m_motorControllers.empty()) {
-    return m_motorControllers.front()->GetThrottle() * (m_isInverted ? -1 : 1);
+    return m_motorControllers.front()->GetPower() * (m_isInverted ? -1 : 1);
   }
   return 0.0;
 }
@@ -51,6 +51,6 @@ void PyMotorControllerGroup::Disable() {
 void PyMotorControllerGroup::InitSendable(wpi::util::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Motor Controller");
   builder.SetActuator(true);
-  builder.AddDoubleProperty("Value", [=, this]() { return GetThrottle(); },
-                            [=, this](double value) { SetThrottle(value); });
+  builder.AddDoubleProperty("Power", [=, this]() { return GetPower(); },
+                            [=, this](double value) { SetPower(value); });
 }

--- a/wpilibc/src/main/python/wpilib/src/rpy/MotorControllerGroup.h
+++ b/wpilibc/src/main/python/wpilib/src/rpy/MotorControllerGroup.h
@@ -26,9 +26,9 @@ class PyMotorControllerGroup : public wpi::util::Sendable,
   PyMotorControllerGroup(PyMotorControllerGroup&&) = default;
   PyMotorControllerGroup& operator=(PyMotorControllerGroup&&) = default;
 
-  void SetThrottle(double throttle) override;
+  void SetPower(double power) override;
   void SetVoltage(wpi::units::volt_t voltage) override;
-  double GetThrottle() const override;
+  double GetPower() const override;
   void SetInverted(bool isInverted) override;
   bool GetInverted() const override;
   void Disable() override;

--- a/wpilibc/src/test/native/cpp/drive/DifferentialDriveTest.cpp
+++ b/wpilibc/src/test/native/cpp/drive/DifferentialDriveTest.cpp
@@ -243,233 +243,227 @@ TEST(DifferentialDriveTest, TankDriveIKSquared) {
 TEST(DifferentialDriveTest, ArcadeDrive) {
   wpi::MockPWMMotorController left;
   wpi::MockPWMMotorController right;
-  wpi::DifferentialDrive drive{
-      [&](double output) { left.SetThrottle(output); },
-      [&](double output) { right.SetThrottle(output); }};
+  wpi::DifferentialDrive drive{[&](double output) { left.SetPower(output); },
+                               [&](double output) { right.SetPower(output); }};
   drive.SetDeadband(0.0);
 
   // Forward
   drive.ArcadeDrive(1.0, 0.0, false);
-  EXPECT_DOUBLE_EQ(1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, right.GetPower());
 
   // Forward left turn
   drive.ArcadeDrive(0.5, 0.5, false);
-  EXPECT_DOUBLE_EQ(0.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(0.5, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(0.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(0.5, right.GetPower());
 
   // Forward right turn
   drive.ArcadeDrive(0.5, -0.5, false);
-  EXPECT_DOUBLE_EQ(0.5, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(0.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(0.5, left.GetPower());
+  EXPECT_DOUBLE_EQ(0.0, right.GetPower());
 
   // Backward
   drive.ArcadeDrive(-1.0, 0.0, false);
-  EXPECT_DOUBLE_EQ(-1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, right.GetPower());
 
   // Backward left turn
   drive.ArcadeDrive(-0.5, 0.5, false);
-  EXPECT_DOUBLE_EQ(-0.5, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(0.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-0.5, left.GetPower());
+  EXPECT_DOUBLE_EQ(0.0, right.GetPower());
 
   // Backward right turn
   drive.ArcadeDrive(-0.5, -0.5, false);
-  EXPECT_DOUBLE_EQ(0.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(-0.5, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(0.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(-0.5, right.GetPower());
 }
 
 TEST(DifferentialDriveTest, ArcadeDriveSquared) {
   wpi::MockPWMMotorController left;
   wpi::MockPWMMotorController right;
-  wpi::DifferentialDrive drive{
-      [&](double output) { left.SetThrottle(output); },
-      [&](double output) { right.SetThrottle(output); }};
+  wpi::DifferentialDrive drive{[&](double output) { left.SetPower(output); },
+                               [&](double output) { right.SetPower(output); }};
   drive.SetDeadband(0.0);
 
   // Forward
   drive.ArcadeDrive(1.0, 0.0, true);
-  EXPECT_DOUBLE_EQ(1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, right.GetPower());
 
   // Forward left turn
   drive.ArcadeDrive(0.5, 0.5, true);
-  EXPECT_DOUBLE_EQ(0.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(0.25, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(0.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(0.25, right.GetPower());
 
   // Forward right turn
   drive.ArcadeDrive(0.5, -0.5, true);
-  EXPECT_DOUBLE_EQ(0.25, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(0.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(0.25, left.GetPower());
+  EXPECT_DOUBLE_EQ(0.0, right.GetPower());
 
   // Backward
   drive.ArcadeDrive(-1.0, 0.0, true);
-  EXPECT_DOUBLE_EQ(-1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, right.GetPower());
 
   // Backward left turn
   drive.ArcadeDrive(-0.5, 0.5, true);
-  EXPECT_DOUBLE_EQ(-0.25, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(0.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-0.25, left.GetPower());
+  EXPECT_DOUBLE_EQ(0.0, right.GetPower());
 
   // Backward right turn
   drive.ArcadeDrive(-0.5, -0.5, true);
-  EXPECT_DOUBLE_EQ(0.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(-0.25, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(0.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(-0.25, right.GetPower());
 }
 
 TEST(DifferentialDriveTest, CurvatureDrive) {
   wpi::MockPWMMotorController left;
   wpi::MockPWMMotorController right;
-  wpi::DifferentialDrive drive{
-      [&](double output) { left.SetThrottle(output); },
-      [&](double output) { right.SetThrottle(output); }};
+  wpi::DifferentialDrive drive{[&](double output) { left.SetPower(output); },
+                               [&](double output) { right.SetPower(output); }};
   drive.SetDeadband(0.0);
 
   // Forward
   drive.CurvatureDrive(1.0, 0.0, false);
-  EXPECT_DOUBLE_EQ(1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, right.GetPower());
 
   // Forward left turn
   drive.CurvatureDrive(0.5, 0.5, false);
-  EXPECT_DOUBLE_EQ(0.25, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(0.75, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(0.25, left.GetPower());
+  EXPECT_DOUBLE_EQ(0.75, right.GetPower());
 
   // Forward right turn
   drive.CurvatureDrive(0.5, -0.5, false);
-  EXPECT_DOUBLE_EQ(0.75, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(0.25, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(0.75, left.GetPower());
+  EXPECT_DOUBLE_EQ(0.25, right.GetPower());
 
   // Backward
   drive.CurvatureDrive(-1.0, 0.0, false);
-  EXPECT_DOUBLE_EQ(-1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, right.GetPower());
 
   // Backward left turn
   drive.CurvatureDrive(-0.5, 0.5, false);
-  EXPECT_DOUBLE_EQ(-0.75, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(-0.25, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-0.75, left.GetPower());
+  EXPECT_DOUBLE_EQ(-0.25, right.GetPower());
 
   // Backward right turn
   drive.CurvatureDrive(-0.5, -0.5, false);
-  EXPECT_DOUBLE_EQ(-0.25, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(-0.75, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-0.25, left.GetPower());
+  EXPECT_DOUBLE_EQ(-0.75, right.GetPower());
 }
 
 TEST(DifferentialDriveTest, CurvatureDriveTurnInPlace) {
   wpi::MockPWMMotorController left;
   wpi::MockPWMMotorController right;
-  wpi::DifferentialDrive drive{
-      [&](double output) { left.SetThrottle(output); },
-      [&](double output) { right.SetThrottle(output); }};
+  wpi::DifferentialDrive drive{[&](double output) { left.SetPower(output); },
+                               [&](double output) { right.SetPower(output); }};
   drive.SetDeadband(0.0);
 
   // Forward
   drive.CurvatureDrive(1.0, 0.0, true);
-  EXPECT_DOUBLE_EQ(1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, right.GetPower());
 
   // Forward left turn
   drive.CurvatureDrive(0.5, 0.5, true);
-  EXPECT_DOUBLE_EQ(0.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(0.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, right.GetPower());
 
   // Forward right turn
   drive.CurvatureDrive(0.5, -0.5, true);
-  EXPECT_DOUBLE_EQ(1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(0.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(0.0, right.GetPower());
 
   // Backward
   drive.CurvatureDrive(-1.0, 0.0, true);
-  EXPECT_DOUBLE_EQ(-1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, right.GetPower());
 
   // Backward left turn
   drive.CurvatureDrive(-0.5, 0.5, true);
-  EXPECT_DOUBLE_EQ(-1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(0.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(0.0, right.GetPower());
 
   // Backward right turn
   drive.CurvatureDrive(-0.5, -0.5, true);
-  EXPECT_DOUBLE_EQ(0.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(0.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, right.GetPower());
 }
 
 TEST(DifferentialDriveTest, TankDrive) {
   wpi::MockPWMMotorController left;
   wpi::MockPWMMotorController right;
-  wpi::DifferentialDrive drive{
-      [&](double output) { left.SetThrottle(output); },
-      [&](double output) { right.SetThrottle(output); }};
+  wpi::DifferentialDrive drive{[&](double output) { left.SetPower(output); },
+                               [&](double output) { right.SetPower(output); }};
   drive.SetDeadband(0.0);
 
   // Forward
   drive.TankDrive(1.0, 1.0, false);
-  EXPECT_DOUBLE_EQ(1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, right.GetPower());
 
   // Forward left turn
   drive.TankDrive(0.5, 1.0, false);
-  EXPECT_DOUBLE_EQ(0.5, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(0.5, left.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, right.GetPower());
 
   // Forward right turn
   drive.TankDrive(1.0, 0.5, false);
-  EXPECT_DOUBLE_EQ(1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(0.5, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(0.5, right.GetPower());
 
   // Backward
   drive.TankDrive(-1.0, -1.0, false);
-  EXPECT_DOUBLE_EQ(-1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, right.GetPower());
 
   // Backward left turn
   drive.TankDrive(-0.5, -1.0, false);
-  EXPECT_DOUBLE_EQ(-0.5, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-0.5, left.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, right.GetPower());
 
   // Backward right turn
   drive.TankDrive(-0.5, 1.0, false);
-  EXPECT_DOUBLE_EQ(-0.5, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-0.5, left.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, right.GetPower());
 }
 
 TEST(DifferentialDriveTest, TankDriveSquared) {
   wpi::MockPWMMotorController left;
   wpi::MockPWMMotorController right;
-  wpi::DifferentialDrive drive{
-      [&](double output) { left.SetThrottle(output); },
-      [&](double output) { right.SetThrottle(output); }};
+  wpi::DifferentialDrive drive{[&](double output) { left.SetPower(output); },
+                               [&](double output) { right.SetPower(output); }};
   drive.SetDeadband(0.0);
 
   // Forward
   drive.TankDrive(1.0, 1.0, true);
-  EXPECT_DOUBLE_EQ(1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, right.GetPower());
 
   // Forward left turn
   drive.TankDrive(0.5, 1.0, true);
-  EXPECT_DOUBLE_EQ(0.25, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(0.25, left.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, right.GetPower());
 
   // Forward right turn
   drive.TankDrive(1.0, 0.5, true);
-  EXPECT_DOUBLE_EQ(1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(0.25, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(0.25, right.GetPower());
 
   // Backward
   drive.TankDrive(-1.0, -1.0, true);
-  EXPECT_DOUBLE_EQ(-1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, right.GetPower());
 
   // Backward left turn
   drive.TankDrive(-0.5, -1.0, true);
-  EXPECT_DOUBLE_EQ(-0.25, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-0.25, left.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, right.GetPower());
 
   // Backward right turn
   drive.TankDrive(-1.0, -0.5, true);
-  EXPECT_DOUBLE_EQ(-1.0, left.GetThrottle());
-  EXPECT_DOUBLE_EQ(-0.25, right.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, left.GetPower());
+  EXPECT_DOUBLE_EQ(-0.25, right.GetPower());
 }

--- a/wpilibc/src/test/native/cpp/drive/MecanumDriveTest.cpp
+++ b/wpilibc/src/test/native/cpp/drive/MecanumDriveTest.cpp
@@ -87,46 +87,46 @@ TEST(MecanumDriveTest, Cartesian) {
   wpi::MockPWMMotorController rl;
   wpi::MockPWMMotorController fr;
   wpi::MockPWMMotorController rr;
-  wpi::MecanumDrive drive{[&](double output) { fl.SetThrottle(output); },
-                          [&](double output) { rl.SetThrottle(output); },
-                          [&](double output) { fr.SetThrottle(output); },
-                          [&](double output) { rr.SetThrottle(output); }};
+  wpi::MecanumDrive drive{[&](double output) { fl.SetPower(output); },
+                          [&](double output) { rl.SetPower(output); },
+                          [&](double output) { fr.SetPower(output); },
+                          [&](double output) { rr.SetPower(output); }};
   drive.SetDeadband(0.0);
 
   // Forward
   drive.DriveCartesian(1.0, 0.0, 0.0);
-  EXPECT_DOUBLE_EQ(1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rr.GetPower());
 
   // Left
   drive.DriveCartesian(0.0, -1.0, 0.0);
-  EXPECT_DOUBLE_EQ(-1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, rr.GetPower());
 
   // Right
   drive.DriveCartesian(0.0, 1.0, 0.0);
-  EXPECT_DOUBLE_EQ(1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rr.GetPower());
 
   // Rotate CCW
   drive.DriveCartesian(0.0, 0.0, -1.0);
-  EXPECT_DOUBLE_EQ(-1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rr.GetPower());
 
   // Rotate CW
   drive.DriveCartesian(0.0, 0.0, 1.0);
-  EXPECT_DOUBLE_EQ(1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, rr.GetPower());
 }
 
 TEST(MecanumDriveTest, CartesianGyro90CW) {
@@ -134,46 +134,46 @@ TEST(MecanumDriveTest, CartesianGyro90CW) {
   wpi::MockPWMMotorController rl;
   wpi::MockPWMMotorController fr;
   wpi::MockPWMMotorController rr;
-  wpi::MecanumDrive drive{[&](double output) { fl.SetThrottle(output); },
-                          [&](double output) { rl.SetThrottle(output); },
-                          [&](double output) { fr.SetThrottle(output); },
-                          [&](double output) { rr.SetThrottle(output); }};
+  wpi::MecanumDrive drive{[&](double output) { fl.SetPower(output); },
+                          [&](double output) { rl.SetPower(output); },
+                          [&](double output) { fr.SetPower(output); },
+                          [&](double output) { rr.SetPower(output); }};
   drive.SetDeadband(0.0);
 
   // Forward in global frame; left in robot frame
   drive.DriveCartesian(1.0, 0.0, 0.0, 90_deg);
-  EXPECT_DOUBLE_EQ(-1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, rr.GetPower());
 
   // Left in global frame; backward in robot frame
   drive.DriveCartesian(0.0, -1.0, 0.0, 90_deg);
-  EXPECT_DOUBLE_EQ(-1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, rr.GetPower());
 
   // Right in global frame; forward in robot frame
   drive.DriveCartesian(0.0, 1.0, 0.0, 90_deg);
-  EXPECT_DOUBLE_EQ(1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rr.GetPower());
 
   // Rotate CCW
   drive.DriveCartesian(0.0, 0.0, -1.0, 90_deg);
-  EXPECT_DOUBLE_EQ(-1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rr.GetPower());
 
   // Rotate CW
   drive.DriveCartesian(0.0, 0.0, 1.0, 90_deg);
-  EXPECT_DOUBLE_EQ(1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, rr.GetPower());
 }
 
 TEST(MecanumDriveTest, Polar) {
@@ -181,44 +181,44 @@ TEST(MecanumDriveTest, Polar) {
   wpi::MockPWMMotorController rl;
   wpi::MockPWMMotorController fr;
   wpi::MockPWMMotorController rr;
-  wpi::MecanumDrive drive{[&](double output) { fl.SetThrottle(output); },
-                          [&](double output) { rl.SetThrottle(output); },
-                          [&](double output) { fr.SetThrottle(output); },
-                          [&](double output) { rr.SetThrottle(output); }};
+  wpi::MecanumDrive drive{[&](double output) { fl.SetPower(output); },
+                          [&](double output) { rl.SetPower(output); },
+                          [&](double output) { fr.SetPower(output); },
+                          [&](double output) { rr.SetPower(output); }};
   drive.SetDeadband(0.0);
 
   // Forward
   drive.DrivePolar(1.0, 0_deg, 0.0);
-  EXPECT_DOUBLE_EQ(1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rr.GetPower());
 
   // Left
   drive.DrivePolar(1.0, -90_deg, 0.0);
-  EXPECT_DOUBLE_EQ(-1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, rr.GetPower());
 
   // Right
   drive.DrivePolar(1.0, 90_deg, 0.0);
-  EXPECT_DOUBLE_EQ(1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rr.GetPower());
 
   // Rotate CCW
   drive.DrivePolar(0.0, 0_deg, -1.0);
-  EXPECT_DOUBLE_EQ(-1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(-1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rr.GetPower());
 
   // Rotate CW
   drive.DrivePolar(0.0, 0_deg, 1.0);
-  EXPECT_DOUBLE_EQ(1.0, fl.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, fr.GetThrottle());
-  EXPECT_DOUBLE_EQ(1.0, rl.GetThrottle());
-  EXPECT_DOUBLE_EQ(-1.0, rr.GetThrottle());
+  EXPECT_DOUBLE_EQ(1.0, fl.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, fr.GetPower());
+  EXPECT_DOUBLE_EQ(1.0, rl.GetPower());
+  EXPECT_DOUBLE_EQ(-1.0, rr.GetPower());
 }

--- a/wpilibc/src/test/native/cpp/motorcontrol/MockMotorController.cpp
+++ b/wpilibc/src/test/native/cpp/motorcontrol/MockMotorController.cpp
@@ -6,12 +6,12 @@
 
 using namespace wpi;
 
-void MockMotorController::SetThrottle(double throttle) {
-  m_throttle = m_isInverted ? -throttle : throttle;
+void MockMotorController::SetPower(double power) {
+  m_power = m_isInverted ? -power : power;
 }
 
-double MockMotorController::GetThrottle() const {
-  return m_throttle;
+double MockMotorController::GetPower() const {
+  return m_power;
 }
 
 void MockMotorController::SetInverted(bool isInverted) {
@@ -23,5 +23,5 @@ bool MockMotorController::GetInverted() const {
 }
 
 void MockMotorController::Disable() {
-  m_throttle = 0;
+  m_power = 0;
 }

--- a/wpilibc/src/test/native/cpp/motorcontrol/MockPWMMotorController.cpp
+++ b/wpilibc/src/test/native/cpp/motorcontrol/MockPWMMotorController.cpp
@@ -6,12 +6,12 @@
 
 using namespace wpi;
 
-void MockPWMMotorController::SetThrottle(double throttle) {
-  m_throttle = m_isInverted ? -throttle : throttle;
+void MockPWMMotorController::SetPower(double power) {
+  m_power = m_isInverted ? -power : power;
 }
 
-double MockPWMMotorController::GetThrottle() const {
-  return m_throttle;
+double MockPWMMotorController::GetPower() const {
+  return m_power;
 }
 
 void MockPWMMotorController::SetInverted(bool isInverted) {
@@ -23,7 +23,7 @@ bool MockPWMMotorController::GetInverted() const {
 }
 
 void MockPWMMotorController::Disable() {
-  m_throttle = 0;
+  m_power = 0;
 }
 
 void MockPWMMotorController::StopMotor() {

--- a/wpilibc/src/test/native/cpp/simulation/DCMotorSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/DCMotorSimTest.cpp
@@ -37,7 +37,7 @@ TEST(DCMotorSimTest, VoltageSteadyState) {
     // Then, SimulationPeriodic runs
     wpi::sim::RoboRioSim::SetVInVoltage(
         wpi::sim::BatterySim::Calculate({sim.GetCurrentDraw()}));
-    sim.SetInputVoltage(motor.GetThrottle() *
+    sim.SetInputVoltage(motor.GetPower() *
                         wpi::RobotController::GetBatteryVoltage());
     sim.Update(20_ms);
     encoderSim.SetRate(sim.GetAngularVelocity().value());
@@ -53,7 +53,7 @@ TEST(DCMotorSimTest, VoltageSteadyState) {
     // Then, SimulationPeriodic runs
     wpi::sim::RoboRioSim::SetVInVoltage(
         wpi::sim::BatterySim::Calculate({sim.GetCurrentDraw()}));
-    sim.SetInputVoltage(motor.GetThrottle() *
+    sim.SetInputVoltage(motor.GetPower() *
                         wpi::RobotController::GetBatteryVoltage());
     sim.Update(20_ms);
     encoderSim.SetRate(sim.GetAngularVelocity().value());
@@ -80,12 +80,12 @@ TEST(DCMotorSimTest, PositionFeedbackControl) {
 
   for (int i = 0; i < 140; i++) {
     // RobotPeriodic runs first
-    motor.SetThrottle(controller.Calculate(encoder.GetDistance(), 750));
+    motor.SetPower(controller.Calculate(encoder.GetDistance(), 750));
 
     // Then, SimulationPeriodic runs
     wpi::sim::RoboRioSim::SetVInVoltage(
         wpi::sim::BatterySim::Calculate({sim.GetCurrentDraw()}));
-    sim.SetInputVoltage(motor.GetThrottle() *
+    sim.SetInputVoltage(motor.GetPower() *
                         wpi::RobotController::GetBatteryVoltage());
     sim.Update(20_ms);
     encoderSim.SetDistance(sim.GetAngularPosition().value());

--- a/wpilibc/src/test/native/cpp/simulation/ElevatorSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/ElevatorSimTest.cpp
@@ -30,9 +30,9 @@ TEST(ElevatorSimTest, StateSpaceSim) {
   for (size_t i = 0; i < 100; ++i) {
     controller.SetSetpoint(2.0);
     auto nextVoltage = controller.Calculate(encoderSim.GetDistance());
-    motor.SetThrottle(nextVoltage / wpi::RobotController::GetInputVoltage());
+    motor.SetPower(nextVoltage / wpi::RobotController::GetInputVoltage());
 
-    wpi::math::Vectord<1> u{motor.GetThrottle() *
+    wpi::math::Vectord<1> u{motor.GetPower() *
                             wpi::RobotController::GetInputVoltage()};
     sim.SetInput(u);
     sim.Update(20_ms);

--- a/wpilibc/src/test/native/cpp/simulation/PWMMotorControlllerSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/PWMMotorControlllerSimTest.cpp
@@ -15,13 +15,13 @@ TEST(PWMMotorControllerSimTest, TestMotor) {
   wpi::Spark spark{0};
   wpi::sim::PWMMotorControllerSim sim{spark};
 
-  spark.SetThrottle(0);
-  EXPECT_EQ(0, sim.GetThrottle());
+  spark.SetPower(0);
+  EXPECT_EQ(0, sim.GetPower());
 
-  spark.SetThrottle(0.354);
-  EXPECT_EQ(0.354, sim.GetThrottle());
+  spark.SetPower(0.354);
+  EXPECT_EQ(0.354, sim.GetPower());
 
-  spark.SetThrottle(-0.785);
-  EXPECT_EQ(-0.785, sim.GetThrottle());
+  spark.SetPower(-0.785);
+  EXPECT_EQ(-0.785, sim.GetPower());
 }
 }  // namespace wpi::sim

--- a/wpilibc/src/test/native/cpp/simulation/StateSpaceSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/StateSpaceSimTest.cpp
@@ -42,7 +42,7 @@ TEST(StateSpaceSimTest, FlywheelSim) {
     wpi::sim::RoboRioSim::SetVInVoltage(
         wpi::sim::BatterySim::Calculate({sim.GetCurrentDraw()}));
     sim.SetInput(wpi::math::Vectord<1>{
-        motor.GetThrottle() * wpi::RobotController::GetInputVoltage()});
+        motor.GetPower() * wpi::RobotController::GetInputVoltage()});
     sim.Update(20_ms);
     encoderSim.SetRate(sim.GetAngularVelocity().value());
   }

--- a/wpilibc/src/test/native/include/motorcontrol/MockMotorController.hpp
+++ b/wpilibc/src/test/native/include/motorcontrol/MockMotorController.hpp
@@ -10,14 +10,14 @@ namespace wpi {
 
 class MockMotorController : public MotorController {
  public:
-  void SetThrottle(double throttle) override;
-  double GetThrottle() const override;
+  void SetPower(double power) override;
+  double GetPower() const override;
   void SetInverted(bool isInverted) override;
   bool GetInverted() const override;
   void Disable() override;
 
  private:
-  double m_throttle = 0.0;
+  double m_power = 0.0;
   bool m_isInverted = false;
 };
 

--- a/wpilibc/src/test/native/include/motorcontrol/MockPWMMotorController.hpp
+++ b/wpilibc/src/test/native/include/motorcontrol/MockPWMMotorController.hpp
@@ -8,15 +8,15 @@ namespace wpi {
 
 class MockPWMMotorController {
  public:
-  void SetThrottle(double throttle);
-  double GetThrottle() const;
+  void SetPower(double power);
+  double GetPower() const;
   void SetInverted(bool isInverted);
   bool GetInverted() const;
   void Disable();
   void StopMotor();
 
  private:
-  double m_throttle = 0.0;
+  double m_power = 0.0;
   bool m_isInverted = false;
 };
 

--- a/wpilibc/src/test/python/test_wpilib.py
+++ b/wpilibc/src/test/python/test_wpilib.py
@@ -27,13 +27,13 @@ def test_motorcontrollergroup():
     t2 = wpilib.Talon(8)
     g = wpilib.MotorControllerGroup(t1, t2)
 
-    g.setThrottle(1)
-    assert t1.getThrottle() == pytest.approx(1)
-    assert t2.getThrottle() == pytest.approx(1)
+    g.setPower(1)
+    assert t1.getPower() == pytest.approx(1)
+    assert t2.getPower() == pytest.approx(1)
 
-    g.setThrottle(-1)
-    assert t1.getThrottle() == pytest.approx(-1)
-    assert t2.getThrottle() == pytest.approx(-1)
+    g.setPower(-1)
+    assert t1.getPower() == pytest.approx(-1)
+    assert t2.getPower() == pytest.approx(-1)
 
 
 def test_motorcontrollergroup_error():

--- a/wpilibcExamples/src/main/cpp/examples/ArcadeDriveGamepad/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArcadeDriveGamepad/cpp/Robot.cpp
@@ -15,8 +15,8 @@ class Robot : public wpi::TimedRobot {
   wpi::PWMSparkMax m_leftMotor{0};
   wpi::PWMSparkMax m_rightMotor{1};
   wpi::DifferentialDrive m_robotDrive{
-      [&](double output) { m_leftMotor.SetThrottle(output); },
-      [&](double output) { m_rightMotor.SetThrottle(output); }};
+      [&](double output) { m_leftMotor.SetPower(output); },
+      [&](double output) { m_rightMotor.SetPower(output); }};
   wpi::Gamepad m_driverController{0};
 
  public:

--- a/wpilibcExamples/src/main/cpp/examples/ArmSimulation/cpp/subsystems/Arm.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArmSimulation/cpp/subsystems/Arm.cpp
@@ -24,7 +24,7 @@ void Arm::SimulationPeriodic() {
   // In this method, we update our simulation of what our arm is doing
   // First, we set our "inputs" (voltages)
   m_armSim.SetInput(wpi::math::Vectord<1>{
-      m_motor.GetThrottle() * wpi::RobotController::GetInputVoltage()});
+      m_motor.GetPower() * wpi::RobotController::GetInputVoltage()});
 
   // Next, we update it. The standard loop time is 20ms.
   m_armSim.Update(20_ms);
@@ -59,5 +59,5 @@ void Arm::ReachSetpoint() {
 }
 
 void Arm::Stop() {
-  m_motor.SetThrottle(0.0);
+  m_motor.SetPower(0.0);
 }

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/cpp/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/cpp/Drivetrain.cpp
@@ -122,11 +122,10 @@ void Drivetrain::SimulationPeriodic() {
   // To update our simulation, we set motor voltage inputs, update the
   // simulation, and write the simulated positions and velocities to our
   // simulated encoder and gyro.
-  m_drivetrainSimulator.SetInputs(
-      wpi::units::volt_t{m_leftLeader.GetThrottle()} *
-          wpi::RobotController::GetInputVoltage(),
-      wpi::units::volt_t{m_rightLeader.GetThrottle()} *
-          wpi::RobotController::GetInputVoltage());
+  m_drivetrainSimulator.SetInputs(wpi::units::volt_t{m_leftLeader.GetPower()} *
+                                      wpi::RobotController::GetInputVoltage(),
+                                  wpi::units::volt_t{m_rightLeader.GetPower()} *
+                                      wpi::RobotController::GetInputVoltage());
   m_drivetrainSimulator.Update(20_ms);
 
   m_leftEncoderSim.SetDistance(m_drivetrainSimulator.GetLeftPosition().value());

--- a/wpilibcExamples/src/main/cpp/examples/ElevatorExponentialSimulation/cpp/subsystems/Elevator.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ElevatorExponentialSimulation/cpp/subsystems/Elevator.cpp
@@ -20,7 +20,7 @@ void Elevator::SimulationPeriodic() {
   // In this method, we update our simulation of what our elevator is doing
   // First, we set our "inputs" (voltages)
   m_elevatorSim.SetInput(wpi::math::Vectord<1>{
-      m_motorSim.GetThrottle() * wpi::RobotController::GetInputVoltage()});
+      m_motorSim.GetPower() * wpi::RobotController::GetInputVoltage()});
 
   // Next, we update it. The standard loop time is 20ms.
   m_elevatorSim.Update(20_ms);
@@ -59,5 +59,5 @@ void Elevator::Reset() {
 }
 
 void Elevator::Stop() {
-  m_motor.SetThrottle(0.0);
+  m_motor.SetPower(0.0);
 }

--- a/wpilibcExamples/src/main/cpp/examples/ElevatorSimulation/cpp/subsystems/Elevator.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ElevatorSimulation/cpp/subsystems/Elevator.cpp
@@ -20,7 +20,7 @@ void Elevator::SimulationPeriodic() {
   // In this method, we update our simulation of what our elevator is doing
   // First, we set our "inputs" (voltages)
   m_elevatorSim.SetInput(wpi::math::Vectord<1>{
-      m_motorSim.GetThrottle() * wpi::RobotController::GetInputVoltage()});
+      m_motorSim.GetPower() * wpi::RobotController::GetInputVoltage()});
 
   // Next, we update it. The standard loop time is 20ms.
   m_elevatorSim.Update(20_ms);
@@ -50,5 +50,5 @@ void Elevator::ReachGoal(wpi::units::meter_t goal) {
 
 void Elevator::Stop() {
   m_controller.SetGoal(0.0_m);
-  m_motor.SetThrottle(0.0);
+  m_motor.SetPower(0.0);
 }

--- a/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
@@ -52,8 +52,8 @@ class Robot : public wpi::TimedRobot {
   wpi::PWMSparkMax m_left{0};
   wpi::PWMSparkMax m_right{1};
   wpi::DifferentialDrive m_robotDrive{
-      [&](double output) { m_left.SetThrottle(output); },
-      [&](double output) { m_right.SetThrottle(output); }};
+      [&](double output) { m_left.SetPower(output); },
+      [&](double output) { m_right.SetPower(output); }};
 
   wpi::Gamepad m_controller{0};
   wpi::Timer m_timer;

--- a/wpilibcExamples/src/main/cpp/examples/Gyro/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Gyro/cpp/Robot.cpp
@@ -51,8 +51,8 @@ class Robot : public wpi::TimedRobot {
   wpi::PWMSparkMax m_left{kLeftMotorPort};
   wpi::PWMSparkMax m_right{kRightMotorPort};
   wpi::DifferentialDrive m_drive{
-      [&](double output) { m_left.SetThrottle(output); },
-      [&](double output) { m_right.SetThrottle(output); }};
+      [&](double output) { m_left.SetPower(output); },
+      [&](double output) { m_right.SetPower(output); }};
 
   wpi::OnboardIMU m_imu{kIMUMountOrientation};
   wpi::Joystick m_joystick{kJoystickPort};

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/subsystems/DriveSubsystem.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/subsystems/DriveSubsystem.hpp
@@ -63,8 +63,8 @@ class DriveSubsystem : public wpi::cmd::SubsystemBase {
 
   // The robot's drive
   wpi::DifferentialDrive m_drive{
-      [&](double output) { m_left1.SetThrottle(output); },
-      [&](double output) { m_right1.SetThrottle(output); }};
+      [&](double output) { m_left1.SetPower(output); },
+      [&](double output) { m_right1.SetPower(output); }};
 
   // The left-side drive encoder
   wpi::Encoder m_leftEncoder;

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/include/subsystems/DriveSubsystem.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/include/subsystems/DriveSubsystem.hpp
@@ -63,8 +63,8 @@ class DriveSubsystem : public wpi::cmd::SubsystemBase {
 
   // The robot's drive
   wpi::DifferentialDrive m_drive{
-      [&](double output) { m_left1.SetThrottle(output); },
-      [&](double output) { m_right1.SetThrottle(output); }};
+      [&](double output) { m_left1.SetPower(output); },
+      [&](double output) { m_right1.SetPower(output); }};
 
   // The left-side drive encoder
   wpi::Encoder m_leftEncoder;

--- a/wpilibcExamples/src/main/cpp/examples/MecanumDrive/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumDrive/cpp/Robot.cpp
@@ -52,10 +52,10 @@ class Robot : public wpi::TimedRobot {
   wpi::PWMSparkMax m_frontRight{kFrontRightMotorPort};
   wpi::PWMSparkMax m_rearRight{kRearRightMotorPort};
   wpi::MecanumDrive m_robotDrive{
-      [&](double output) { m_frontLeft.SetThrottle(output); },
-      [&](double output) { m_rearLeft.SetThrottle(output); },
-      [&](double output) { m_frontRight.SetThrottle(output); },
-      [&](double output) { m_rearRight.SetThrottle(output); }};
+      [&](double output) { m_frontLeft.SetPower(output); },
+      [&](double output) { m_rearLeft.SetPower(output); },
+      [&](double output) { m_frontRight.SetPower(output); },
+      [&](double output) { m_rearRight.SetPower(output); }};
 
   wpi::OnboardIMU m_imu{kIMUMountOrientation};
   wpi::Joystick m_joystick{kJoystickPort};

--- a/wpilibcExamples/src/main/cpp/examples/Mechanism2d/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Mechanism2d/cpp/Robot.cpp
@@ -44,8 +44,8 @@ class Robot : public wpi::TimedRobot {
   }
 
   void TeleopPeriodic() override {
-    m_elevatorMotor.SetThrottle(m_joystick.GetRawAxis(0));
-    m_wristMotor.SetThrottle(m_joystick.GetRawAxis(1));
+    m_elevatorMotor.SetPower(m_joystick.GetRawAxis(0));
+    m_wristMotor.SetPower(m_joystick.GetRawAxis(1));
   }
 
  private:

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Intake.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Intake.cpp
@@ -6,7 +6,7 @@
 
 wpi::cmd::CommandPtr Intake::IntakeCommand() {
   return RunOnce([this] { m_piston.Set(wpi::DoubleSolenoid::FORWARD); })
-      .AndThen(Run([this] { m_motor.SetThrottle(1.0); }))
+      .AndThen(Run([this] { m_motor.SetPower(1.0); }))
       .WithName("Intake");
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Shooter.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Shooter.cpp
@@ -34,6 +34,6 @@ wpi::cmd::CommandPtr Shooter::ShootCommand(
              // run the feeder
              wpi::cmd::WaitUntil([this] {
                return m_shooterFeedback.AtSetpoint();
-             }).AndThen([this] { m_feederMotor.SetThrottle(1.0); }))
+             }).AndThen([this] { m_feederMotor.SetPower(1.0); }))
       .WithName("Shoot");
 }

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Storage.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Storage.cpp
@@ -10,5 +10,5 @@ Storage::Storage() {
 }
 
 wpi::cmd::CommandPtr Storage::RunCommand() {
-  return Run([this] { m_motor.SetThrottle(1.0); }).WithName("Run");
+  return Run([this] { m_motor.SetPower(1.0); }).WithName("Run");
 }

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Drive.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/subsystems/Drive.hpp
@@ -55,8 +55,8 @@ class Drive : public wpi::cmd::SubsystemBase {
   wpi::PWMSparkMax m_rightFollower{DriveConstants::kRightMotor2Port};
 
   wpi::DifferentialDrive m_drive{
-      [&](double output) { m_leftLeader.SetThrottle(output); },
-      [&](double output) { m_rightLeader.SetThrottle(output); }};
+      [&](double output) { m_leftLeader.SetPower(output); },
+      [&](double output) { m_rightLeader.SetPower(output); }};
 
   wpi::Encoder m_leftEncoder{DriveConstants::kLeftEncoderPorts[0],
                              DriveConstants::kLeftEncoderPorts[1],

--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/include/subsystems/Drivetrain.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/include/subsystems/Drivetrain.hpp
@@ -106,8 +106,8 @@ class Drivetrain : public wpi::cmd::SubsystemBase {
   wpi::Encoder m_rightEncoder{6, 7};
 
   wpi::DifferentialDrive m_drive{
-      [&](double output) { m_leftMotor.SetThrottle(output); },
-      [&](double output) { m_rightMotor.SetThrottle(output); }};
+      [&](double output) { m_leftMotor.SetPower(output); },
+      [&](double output) { m_rightMotor.SetPower(output); }};
 
   wpi::romi::RomiGyro m_gyro;
 };

--- a/wpilibcExamples/src/main/cpp/examples/SimpleDifferentialDriveSimulation/cpp/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SimpleDifferentialDriveSimulation/cpp/Drivetrain.cpp
@@ -42,11 +42,10 @@ void Drivetrain::SimulationPeriodic() {
   // simulation, and write the simulated positions and velocities to our
   // simulated encoder and gyro. We negate the right side so that positive
   // voltages make the right side move forward.
-  m_drivetrainSimulator.SetInputs(
-      wpi::units::volt_t{m_leftLeader.GetThrottle()} *
-          wpi::RobotController::GetInputVoltage(),
-      wpi::units::volt_t{m_rightLeader.GetThrottle()} *
-          wpi::RobotController::GetInputVoltage());
+  m_drivetrainSimulator.SetInputs(wpi::units::volt_t{m_leftLeader.GetPower()} *
+                                      wpi::RobotController::GetInputVoltage(),
+                                  wpi::units::volt_t{m_rightLeader.GetPower()} *
+                                      wpi::RobotController::GetInputVoltage());
   m_drivetrainSimulator.Update(20_ms);
 
   m_leftEncoderSim.SetDistance(m_drivetrainSimulator.GetLeftPosition().value());

--- a/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/cpp/subsystems/Shooter.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/cpp/subsystems/Shooter.cpp
@@ -22,7 +22,7 @@ wpi::cmd::CommandPtr Shooter::RunShooterCommand(
                        m_shooterEncoder.GetRate(), shooterVelocity())} +
                    m_shooterFeedforward.Calculate(
                        wpi::units::turns_per_second_t{shooterVelocity()}));
-               m_feederMotor.SetThrottle(constants::shooter::kFeederVelocity);
+               m_feederMotor.SetPower(constants::shooter::kFeederVelocity);
              },
              {this})
       .WithName("Set Shooter Velocity");

--- a/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/include/subsystems/Drive.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/include/subsystems/Drive.hpp
@@ -27,8 +27,8 @@ class Drive : public wpi::cmd::SubsystemBase {
   wpi::PWMSparkMax m_leftMotor{constants::drive::kLeftMotor1Port};
   wpi::PWMSparkMax m_rightMotor{constants::drive::kRightMotor1Port};
   wpi::DifferentialDrive m_drive{
-      [this](auto val) { m_leftMotor.SetThrottle(val); },
-      [this](auto val) { m_rightMotor.SetThrottle(val); }};
+      [this](auto val) { m_leftMotor.SetPower(val); },
+      [this](auto val) { m_rightMotor.SetPower(val); }};
 
   wpi::Encoder m_leftEncoder{constants::drive::kLeftEncoderPorts[0],
                              constants::drive::kLeftEncoderPorts[1],
@@ -48,13 +48,13 @@ class Drive : public wpi::cmd::SubsystemBase {
           },
           [this](wpi::sysid::SysIdRoutineLog* log) {
             log->Motor("drive-left")
-                .voltage(m_leftMotor.GetThrottle() *
+                .voltage(m_leftMotor.GetPower() *
                          wpi::RobotController::GetBatteryVoltage())
                 .position(wpi::units::meter_t{m_leftEncoder.GetDistance()})
                 .velocity(
                     wpi::units::meters_per_second_t{m_leftEncoder.GetRate()});
             log->Motor("drive-right")
-                .voltage(m_rightMotor.GetThrottle() *
+                .voltage(m_rightMotor.GetPower() *
                          wpi::RobotController::GetBatteryVoltage())
                 .position(wpi::units::meter_t{m_rightEncoder.GetDistance()})
                 .velocity(

--- a/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/include/subsystems/Shooter.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/include/subsystems/Shooter.hpp
@@ -41,7 +41,7 @@ class Shooter : public wpi::cmd::SubsystemBase {
           },
           [this](wpi::sysid::SysIdRoutineLog* log) {
             log->Motor("shooter-wheel")
-                .voltage(m_shooterMotor.GetThrottle() *
+                .voltage(m_shooterMotor.GetPower() *
                          wpi::RobotController::GetBatteryVoltage())
                 .position(wpi::units::turn_t{m_shooterEncoder.GetDistance()})
                 .velocity(

--- a/wpilibcExamples/src/main/cpp/examples/TankDriveGamepad/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/TankDriveGamepad/cpp/Robot.cpp
@@ -15,8 +15,8 @@ class Robot : public wpi::TimedRobot {
   wpi::PWMSparkMax m_leftMotor{0};
   wpi::PWMSparkMax m_rightMotor{1};
   wpi::DifferentialDrive m_robotDrive{
-      [&](double output) { m_leftMotor.SetThrottle(output); },
-      [&](double output) { m_rightMotor.SetThrottle(output); }};
+      [&](double output) { m_leftMotor.SetPower(output); },
+      [&](double output) { m_rightMotor.SetPower(output); }};
   wpi::Gamepad m_driverController{0};
 
  public:

--- a/wpilibcExamples/src/main/cpp/examples/UnitTest/cpp/subsystems/Intake.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/UnitTest/cpp/subsystems/Intake.cpp
@@ -10,14 +10,14 @@ void Intake::Deploy() {
 
 void Intake::Retract() {
   m_piston.Set(wpi::DoubleSolenoid::Value::REVERSE);
-  m_motor.SetThrottle(0);  // turn off the motor
+  m_motor.SetPower(0);  // turn off the motor
 }
 
 void Intake::Activate(double velocity) {
   if (IsDeployed()) {
-    m_motor.SetThrottle(velocity);
+    m_motor.SetPower(velocity);
   } else {  // if piston isn't open, do nothing
-    m_motor.SetThrottle(0);
+    m_motor.SetPower(0);
   }
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/XRPReference/include/subsystems/Drivetrain.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/XRPReference/include/subsystems/Drivetrain.hpp
@@ -111,8 +111,8 @@ class Drivetrain : public wpi::cmd::SubsystemBase {
   wpi::Encoder m_rightEncoder{6, 7};
 
   wpi::DifferentialDrive m_drive{
-      [&](double output) { m_leftMotor.SetThrottle(output); },
-      [&](double output) { m_rightMotor.SetThrottle(output); }};
+      [&](double output) { m_leftMotor.SetPower(output); },
+      [&](double output) { m_rightMotor.SetPower(output); }};
 
   wpi::xrp::XRPGyro m_gyro;
 };

--- a/wpilibcExamples/src/main/cpp/examples/Xrptimed/include/Robot.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/Xrptimed/include/Robot.hpp
@@ -27,6 +27,6 @@ class Robot : public wpi::TimedRobot {
   wpi::Timer m_timer;
 
   wpi::DifferentialDrive m_drive{
-      [&](double output) { m_leftMotor.SetThrottle(output); },
-      [&](double output) { m_rightMotor.SetThrottle(output); }};
+      [&](double output) { m_leftMotor.SetPower(output); },
+      [&](double output) { m_rightMotor.SetPower(output); }};
 };

--- a/wpilibcExamples/src/main/cpp/snippets/EncoderDrive/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/snippets/EncoderDrive/cpp/Robot.cpp
@@ -44,8 +44,8 @@ class Robot : public wpi::TimedRobot {
   wpi::Spark rightLeader{2};
   wpi::Spark rightFollower{3};
   wpi::DifferentialDrive drive{
-      [&](double output) { leftLeader.SetThrottle(output); },
-      [&](double output) { rightLeader.SetThrottle(output); }};
+      [&](double output) { leftLeader.SetPower(output); },
+      [&](double output) { rightLeader.SetPower(output); }};
 };
 
 #ifndef RUNNING_WPILIB_TESTS

--- a/wpilibcExamples/src/main/cpp/snippets/EncoderHoming/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/snippets/EncoderHoming/cpp/Robot.cpp
@@ -17,9 +17,9 @@ class Robot : public wpi::TimedRobot {
     // Runs the motor backwards at half velocity until the limit switch is
     // pressed then turn off the motor and reset the encoder
     if (!m_limit.Get()) {
-      m_spark.SetThrottle(-0.5);
+      m_spark.SetPower(-0.5);
     } else {
-      m_spark.SetThrottle(0);
+      m_spark.SetPower(0);
       m_encoder.Reset();
     }
   }

--- a/wpilibcExamples/src/main/cpp/snippets/EventLoop/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/snippets/EventLoop/cpp/Robot.cpp
@@ -36,14 +36,14 @@ class Robot : public wpi::TimedRobot {
      // and there is not a ball at the kicker
      && !isBallAtKicker)
         // activate the intake
-        .IfHigh([&intake = m_intake] { intake.SetThrottle(0.5); });
+        .IfHigh([&intake = m_intake] { intake.SetPower(0.5); });
 
     // if the thumb button is not held
     (!intakeButton
      // or there is a ball in the kicker
      || isBallAtKicker)
         // stop the intake
-        .IfHigh([&intake = m_intake] { intake.SetThrottle(0.0); });
+        .IfHigh([&intake = m_intake] { intake.SetPower(0.0); });
 
     wpi::BooleanEvent shootTrigger{
         &m_loop, [&joystick = m_joystick] { return joystick.GetTrigger(); }};
@@ -59,9 +59,7 @@ class Robot : public wpi::TimedRobot {
               ff.Calculate(wpi::units::radians_per_second_t{SHOT_VELOCITY}));
         });
     // if not, stop
-    (!shootTrigger).IfHigh([&shooter = m_shooter] {
-      shooter.SetThrottle(0.0);
-    });
+    (!shootTrigger).IfHigh([&shooter = m_shooter] { shooter.SetPower(0.0); });
 
     wpi::BooleanEvent atTargetVelocity =
         wpi::BooleanEvent(
@@ -71,13 +69,13 @@ class Robot : public wpi::TimedRobot {
             .Debounce(0.2_s);
 
     // if we're at the target velocity, kick the ball into the shooter wheel
-    atTargetVelocity.IfHigh([&kicker = m_kicker] { kicker.SetThrottle(0.7); });
+    atTargetVelocity.IfHigh([&kicker = m_kicker] { kicker.SetPower(0.7); });
 
     // when we stop being at the target velocity, it means the ball was shot
     atTargetVelocity
         .Falling()
         // so stop the kicker
-        .IfHigh([&kicker = m_kicker] { kicker.SetThrottle(0.0); });
+        .IfHigh([&kicker = m_kicker] { kicker.SetPower(0.0); });
   }
 
   void RobotPeriodic() override { m_loop.Poll(); }

--- a/wpilibcExamples/src/main/cpp/snippets/FlywheelBangBangController/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/snippets/FlywheelBangBangController/cpp/Robot.cpp
@@ -53,7 +53,7 @@ class Robot : public wpi::TimedRobot {
     // To update our simulation, we set motor voltage inputs, update the
     // simulation, and write the simulated velocities to our simulated encoder
     m_flywheelSim.SetInputVoltage(
-        m_flywheelMotor.GetThrottle() *
+        m_flywheelMotor.GetPower() *
         wpi::units::volt_t{wpi::RobotController::GetInputVoltage()});
     m_flywheelSim.Update(20_ms);
     m_encoderSim.SetRate(m_flywheelSim.GetAngularVelocity().value());

--- a/wpilibcExamples/src/main/cpp/snippets/LimitSwitch/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/snippets/LimitSwitch/cpp/Robot.cpp
@@ -18,20 +18,20 @@ class Robot : public wpi::TimedRobot {
     if (velocity > 0) {
       if (m_toplimitSwitch.Get()) {
         // We are going up and top limit is tripped so stop
-        m_motor.SetThrottle(0);
+        m_motor.SetPower(0);
       } else {
         // We are going up but top limit is not tripped so go at commanded
         // velocity
-        m_motor.SetThrottle(velocity);
+        m_motor.SetPower(velocity);
       }
     } else {
       if (m_bottomlimitSwitch.Get()) {
         // We are going down and bottom limit is tripped so stop
-        m_motor.SetThrottle(0);
+        m_motor.SetPower(0);
       } else {
         // We are going down but bottom limit is not tripped so go at commanded
         // velocity
-        m_motor.SetThrottle(velocity);
+        m_motor.SetPower(velocity);
       }
     }
   }

--- a/wpilibcExamples/src/main/cpp/snippets/MotorControl/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/snippets/MotorControl/cpp/Robot.cpp
@@ -23,7 +23,7 @@
  */
 class Robot : public wpi::TimedRobot {
  public:
-  void TeleopPeriodic() override { m_motor.SetThrottle(m_stick.GetY()); }
+  void TeleopPeriodic() override { m_motor.SetPower(m_stick.GetY()); }
 
   /*
    * The RobotPeriodic function is called every control packet no matter the

--- a/wpilibcExamples/src/test/cpp/examples/ArmSimulation/cpp/ArmSimulationTest.cpp
+++ b/wpilibcExamples/src/test/cpp/examples/ArmSimulation/cpp/ArmSimulationTest.cpp
@@ -134,7 +134,7 @@ TEST_P(ArmSimulationTest, Teleop) {
 
     wpi::sim::StepTiming(3_s);
 
-    ASSERT_NEAR(0.0, m_motorSim.GetThrottle(), 0.05);
+    ASSERT_NEAR(0.0, m_motorSim.GetPower(), 0.05);
     EXPECT_NEAR(kMinAngle.value(), m_encoderSim.GetDistance(), 2.0);
   }
 }

--- a/wpilibcExamples/src/test/cpp/examples/ElevatorSimulation/cpp/ElevatorSimulationTest.cpp
+++ b/wpilibcExamples/src/test/cpp/examples/ElevatorSimulation/cpp/ElevatorSimulationTest.cpp
@@ -118,7 +118,7 @@ TEST_F(ElevatorSimulationTest, Teleop) {
     // advance 75 timesteps
     wpi::sim::StepTiming(1.5_s);
 
-    ASSERT_NEAR(0.0, m_motorSim.GetThrottle(), 0.05);
+    ASSERT_NEAR(0.0, m_motorSim.GetPower(), 0.05);
     ASSERT_NEAR(0.0, m_encoderSim.GetDistance(), 0.05);
   }
 }

--- a/wpilibcExamples/src/test/cpp/examples/UnitTest/cpp/subsystems/IntakeTest.cpp
+++ b/wpilibcExamples/src/test/cpp/examples/UnitTest/cpp/subsystems/IntakeTest.cpp
@@ -26,14 +26,13 @@ TEST_F(IntakeTest, DoesntWorkWhenClosed) {
   intake.Activate(0.5);  // try to activate the motor
   EXPECT_DOUBLE_EQ(
       0.0,
-      simMotor
-          .GetThrottle());  // make sure that the value set to the motor is 0
+      simMotor.GetPower());  // make sure that the value set to the motor is 0
 }
 
 TEST_F(IntakeTest, WorksWhenOpen) {
   intake.Deploy();
   intake.Activate(0.5);
-  EXPECT_DOUBLE_EQ(0.5, simMotor.GetThrottle());
+  EXPECT_DOUBLE_EQ(0.5, simMotor.GetPower());
 }
 
 TEST_F(IntakeTest, Retract) {

--- a/wpilibj/src/generate/main/java/pwm_motor_controller.java.jinja
+++ b/wpilibj/src/generate/main/java/pwm_motor_controller.java.jinja
@@ -37,7 +37,7 @@ public class {{ name }} extends PWMMotorController {
 
     setBoundsMicroseconds({{ (pulse_width_ms.max * 1000) | int }}, {{ (pulse_width_ms.deadbandMax * 1000) | int }}, {{ (pulse_width_ms.center * 1000) | int }}, {{ (pulse_width_ms.deadbandMin * 1000) | int }}, {{ (pulse_width_ms.min * 1000) | int }});
     m_pwm.setOutputPeriod({{ OutputPeriod | default("5", true)}});
-    setThrottle(0.0);
+    setPower(0.0);
 
     HAL.reportUsage("IO", getChannel(), "{{ ResourceName }}");
   }

--- a/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/Koors40.java
+++ b/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/Koors40.java
@@ -37,7 +37,7 @@ public class Koors40 extends PWMMotorController {
 
     setBoundsMicroseconds(2004, 1520, 1500, 1480, 997);
     m_pwm.setOutputPeriod(20);
-    setThrottle(0.0);
+    setPower(0.0);
 
     HAL.reportUsage("IO", getChannel(), "Koors40");
   }

--- a/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/PWMSparkFlex.java
+++ b/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/PWMSparkFlex.java
@@ -37,7 +37,7 @@ public class PWMSparkFlex extends PWMMotorController {
 
     setBoundsMicroseconds(2003, 1550, 1500, 1460, 999);
     m_pwm.setOutputPeriod(5);
-    setThrottle(0.0);
+    setPower(0.0);
 
     HAL.reportUsage("IO", getChannel(), "RevSparkFlexPWM");
   }

--- a/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/PWMSparkMax.java
+++ b/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/PWMSparkMax.java
@@ -37,7 +37,7 @@ public class PWMSparkMax extends PWMMotorController {
 
     setBoundsMicroseconds(2003, 1550, 1500, 1460, 999);
     m_pwm.setOutputPeriod(5);
-    setThrottle(0.0);
+    setPower(0.0);
 
     HAL.reportUsage("IO", getChannel(), "RevSparkMaxPWM");
   }

--- a/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/PWMTalonFX.java
+++ b/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/PWMTalonFX.java
@@ -37,7 +37,7 @@ public class PWMTalonFX extends PWMMotorController {
 
     setBoundsMicroseconds(2004, 1520, 1500, 1480, 997);
     m_pwm.setOutputPeriod(5);
-    setThrottle(0.0);
+    setPower(0.0);
 
     HAL.reportUsage("IO", getChannel(), "TalonFX");
   }

--- a/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/PWMTalonSRX.java
+++ b/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/PWMTalonSRX.java
@@ -37,7 +37,7 @@ public class PWMTalonSRX extends PWMMotorController {
 
     setBoundsMicroseconds(2004, 1520, 1500, 1480, 997);
     m_pwm.setOutputPeriod(5);
-    setThrottle(0.0);
+    setPower(0.0);
 
     HAL.reportUsage("IO", getChannel(), "PWMTalonSRX");
   }

--- a/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/PWMVenom.java
+++ b/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/PWMVenom.java
@@ -37,7 +37,7 @@ public class PWMVenom extends PWMMotorController {
 
     setBoundsMicroseconds(2004, 1520, 1500, 1480, 997);
     m_pwm.setOutputPeriod(5);
-    setThrottle(0.0);
+    setPower(0.0);
 
     HAL.reportUsage("IO", getChannel(), "FusionVenom");
   }

--- a/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/PWMVictorSPX.java
+++ b/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/PWMVictorSPX.java
@@ -37,7 +37,7 @@ public class PWMVictorSPX extends PWMMotorController {
 
     setBoundsMicroseconds(2004, 1520, 1500, 1480, 997);
     m_pwm.setOutputPeriod(5);
-    setThrottle(0.0);
+    setPower(0.0);
 
     HAL.reportUsage("IO", getChannel(), "PWMVictorSPX");
   }

--- a/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/Spark.java
+++ b/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/Spark.java
@@ -37,7 +37,7 @@ public class Spark extends PWMMotorController {
 
     setBoundsMicroseconds(2003, 1550, 1500, 1460, 999);
     m_pwm.setOutputPeriod(5);
-    setThrottle(0.0);
+    setPower(0.0);
 
     HAL.reportUsage("IO", getChannel(), "RevSPARK");
   }

--- a/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/SparkMini.java
+++ b/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/SparkMini.java
@@ -37,7 +37,7 @@ public class SparkMini extends PWMMotorController {
 
     setBoundsMicroseconds(2500, 1510, 1500, 1490, 500);
     m_pwm.setOutputPeriod(5);
-    setThrottle(0.0);
+    setPower(0.0);
 
     HAL.reportUsage("IO", getChannel(), "RevSPARK");
   }

--- a/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/Talon.java
+++ b/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/Talon.java
@@ -37,7 +37,7 @@ public class Talon extends PWMMotorController {
 
     setBoundsMicroseconds(2037, 1539, 1513, 1487, 989);
     m_pwm.setOutputPeriod(5);
-    setThrottle(0.0);
+    setPower(0.0);
 
     HAL.reportUsage("IO", getChannel(), "Talon");
   }

--- a/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/VictorSP.java
+++ b/wpilibj/src/generated/main/java/org/wpilib/hardware/motor/VictorSP.java
@@ -37,7 +37,7 @@ public class VictorSP extends PWMMotorController {
 
     setBoundsMicroseconds(2004, 1520, 1500, 1480, 997);
     m_pwm.setOutputPeriod(5);
-    setThrottle(0.0);
+    setPower(0.0);
 
     HAL.reportUsage("IO", getChannel(), "VictorSP");
   }

--- a/wpilibj/src/main/java/org/wpilib/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/org/wpilib/drive/DifferentialDrive.java
@@ -104,8 +104,8 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
   @SuppressWarnings({"removal", "this-escape"})
   public DifferentialDrive(MotorController leftMotor, MotorController rightMotor) {
     this(
-        (double output) -> leftMotor.setThrottle(output),
-        (double output) -> rightMotor.setThrottle(output));
+        (double output) -> leftMotor.setPower(output),
+        (double output) -> rightMotor.setPower(output));
     SendableRegistry.addChild(this, leftMotor);
     SendableRegistry.addChild(this, rightMotor);
   }

--- a/wpilibj/src/main/java/org/wpilib/drive/MecanumDrive.java
+++ b/wpilibj/src/main/java/org/wpilib/drive/MecanumDrive.java
@@ -120,10 +120,10 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
       MotorController frontRightMotor,
       MotorController rearRightMotor) {
     this(
-        (double output) -> frontLeftMotor.setThrottle(output),
-        (double output) -> rearLeftMotor.setThrottle(output),
-        (double output) -> frontRightMotor.setThrottle(output),
-        (double output) -> rearRightMotor.setThrottle(output));
+        (double output) -> frontLeftMotor.setPower(output),
+        (double output) -> rearLeftMotor.setPower(output),
+        (double output) -> frontRightMotor.setPower(output),
+        (double output) -> rearRightMotor.setPower(output));
     SendableRegistry.addChild(this, frontLeftMotor);
     SendableRegistry.addChild(this, rearLeftMotor);
     SendableRegistry.addChild(this, frontRightMotor);

--- a/wpilibj/src/main/java/org/wpilib/hardware/expansionhub/ExpansionHubMotor.java
+++ b/wpilibj/src/main/java/org/wpilib/hardware/expansionhub/ExpansionHubMotor.java
@@ -151,14 +151,26 @@ public class ExpansionHubMotor implements AutoCloseable {
   }
 
   /**
-   * Sets the throttle.
+   * Sets the output power level of the motor, expressed as a fraction of the maximum possible.
    *
-   * @param throttle The throttle where -1 represents full reverse and 1 represents full forward.
+   * <p>This is generally perceived as "speed" of the output for a fixed load, but the actual speed
+   * will depend on the applied load. For example, a value of 1.0 will result in the motor
+   * outputting full power in the forward direction, so it will move as fast as it can for the
+   * amount of load it is under, which will be slower for heavier loads and faster for lighter
+   * loads.
+   *
+   * <p>The maximum possible output is determined by the battery voltage, so a value of e.g. 0.5
+   * will result in a different amount of motor power being applied for a fully charged battery vs.
+   * a nearly depleted battery. For consistent output that is independent of battery voltage, use
+   * {@link #setVoltage(Voltage)}, potentially combined with closed-loop control that uses a sensor
+   * to control the amount of applied output.
+   *
+   * @param power The power level, where -1.0 indicates full reverse and 1.0 indicates full forward.
    */
-  public void setThrottle(double throttle) {
+  public void setPower(double power) {
     setEnabled(true);
     m_modePublisher.set(kPercentageMode);
-    m_setpointPublisher.set(throttle);
+    m_setpointPublisher.set(power);
   }
 
   /**

--- a/wpilibj/src/main/java/org/wpilib/hardware/motor/MotorController.java
+++ b/wpilibj/src/main/java/org/wpilib/hardware/motor/MotorController.java
@@ -12,11 +12,24 @@ import org.wpilib.units.measure.Voltage;
 /** Interface for motor controlling devices. */
 public interface MotorController {
   /**
-   * Sets the throttle of the motor controller.
+   * Sets the output power level of the motor controller, expressed as a fraction of the maximum
+   * possible.
    *
-   * @param throttle The throttle where -1 indicates full reverse and 1 indicates full forward.
+   * <p>This is generally perceived as "speed" of the output for a fixed load, but the actual speed
+   * will depend on the applied load. For example, a value of 1.0 will result in the motor
+   * outputting full power in the forward direction, so it will move as fast as it can for the
+   * amount of load it is under, which will be slower for heavier loads and faster for lighter
+   * loads.
+   *
+   * <p>The maximum possible output is determined by the battery voltage, so a value of e.g. 0.5
+   * will result in a different amount of motor power being applied for a fully charged battery vs.
+   * a nearly depleted battery. For consistent output that is independent of battery voltage, use
+   * {@link #setVoltage(double)}, potentially combined with closed-loop control that uses a sensor
+   * to control the amount of applied output.
+   *
+   * @param power The power level, where -1.0 indicates full reverse and 1.0 indicates full forward.
    */
-  void setThrottle(double throttle);
+  void setPower(double power);
 
   /**
    * Sets the voltage output of the motor controller.
@@ -31,7 +44,7 @@ public interface MotorController {
    * @param voltage The voltage.
    */
   default void setVoltage(double voltage) {
-    setThrottle(voltage / RobotController.getBatteryVoltage());
+    setPower(voltage / RobotController.getBatteryVoltage());
   }
 
   /**
@@ -51,11 +64,11 @@ public interface MotorController {
   }
 
   /**
-   * Gets the throttle of the motor controller.
+   * Gets the power level of the motor controller.
    *
-   * @return The throttle where -1 represents full reverse and 1 represents full forward.
+   * @return The power level, where -1.0 represents full reverse and 1.0 represents full forward.
    */
-  double getThrottle();
+  double getPower();
 
   /**
    * Sets the inversion state of the motor controller.

--- a/wpilibj/src/main/java/org/wpilib/hardware/motor/PWMMotorController.java
+++ b/wpilibj/src/main/java/org/wpilib/hardware/motor/PWMMotorController.java
@@ -25,7 +25,7 @@ public abstract class PWMMotorController extends MotorSafety
   protected PWM m_pwm;
 
   private SimDevice m_simDevice;
-  private SimDouble m_simThrottle;
+  private SimDouble m_simPower;
 
   private boolean m_eliminateDeadband;
   private int m_minPwm;
@@ -47,7 +47,7 @@ public abstract class PWMMotorController extends MotorSafety
 
     m_simDevice = SimDevice.create("PWMMotorController", channel);
     if (m_simDevice != null) {
-      m_simThrottle = m_simDevice.createDouble("Throttle", Direction.OUTPUT, 0.0);
+      m_simPower = m_simDevice.createDouble("Power", Direction.OUTPUT, 0.0);
       m_pwm.setSimDevice(m_simDevice);
     }
   }
@@ -61,7 +61,7 @@ public abstract class PWMMotorController extends MotorSafety
     if (m_simDevice != null) {
       m_simDevice.close();
       m_simDevice = null;
-      m_simThrottle = null;
+      m_simPower = null;
     }
   }
 
@@ -102,8 +102,8 @@ public abstract class PWMMotorController extends MotorSafety
       dutyCycle = 0.0;
     }
 
-    if (m_simThrottle != null) {
-      m_simThrottle.set(dutyCycle);
+    if (m_simPower != null) {
+      m_simPower.set(dutyCycle);
     }
 
     int rawValue;
@@ -161,21 +161,21 @@ public abstract class PWMMotorController extends MotorSafety
   }
 
   @Override
-  public void setThrottle(double throttle) {
+  public void setPower(double power) {
     if (m_isInverted) {
-      throttle = -throttle;
+      power = -power;
     }
-    setDutyCycleInternal(throttle);
+    setDutyCycleInternal(power);
 
     for (var follower : m_followers) {
-      follower.setThrottle(throttle);
+      follower.setPower(power);
     }
 
     feed();
   }
 
   @Override
-  public double getThrottle() {
+  public double getPower() {
     return getDutyCycleInternal() * (m_isInverted ? -1.0 : 1.0);
   }
 
@@ -185,7 +185,7 @@ public abstract class PWMMotorController extends MotorSafety
    * @return The voltage of the motor controller, nominally between -12 V and 12 V.
    */
   public double getVoltage() {
-    return getThrottle() * RobotController.getBatteryVoltage();
+    return getPower() * RobotController.getBatteryVoltage();
   }
 
   @Override
@@ -202,8 +202,8 @@ public abstract class PWMMotorController extends MotorSafety
   public void disable() {
     m_pwm.setDisabled();
 
-    if (m_simThrottle != null) {
-      m_simThrottle.set(0.0);
+    if (m_simPower != null) {
+      m_simPower.set(0.0);
     }
 
     for (var follower : m_followers) {
@@ -263,6 +263,6 @@ public abstract class PWMMotorController extends MotorSafety
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("Motor Controller");
     builder.setActuator(true);
-    builder.addDoubleProperty("Value", this::getThrottle, this::setThrottle);
+    builder.addDoubleProperty("Power", this::getPower, this::setPower);
   }
 }

--- a/wpilibj/src/main/java/org/wpilib/simulation/PWMMotorControllerSim.java
+++ b/wpilibj/src/main/java/org/wpilib/simulation/PWMMotorControllerSim.java
@@ -9,7 +9,7 @@ import org.wpilib.hardware.motor.PWMMotorController;
 
 /** Class to control a simulated PWM motor controller. */
 public class PWMMotorControllerSim {
-  private final SimDouble m_simThrottle;
+  private final SimDouble m_simPower;
 
   /**
    * Constructor.
@@ -27,15 +27,15 @@ public class PWMMotorControllerSim {
    */
   public PWMMotorControllerSim(int channel) {
     SimDeviceSim simDevice = new SimDeviceSim("PWMMotorController", channel);
-    m_simThrottle = simDevice.getDouble("Throttle");
+    m_simPower = simDevice.getDouble("Power");
   }
 
   /**
-   * Gets the motor throttle.
+   * Gets the motor power.
    *
-   * @return Throttle
+   * @return Power
    */
-  public double getThrottle() {
-    return m_simThrottle.get();
+  public double getPower() {
+    return m_simPower.get();
   }
 }

--- a/wpilibj/src/test/java/org/wpilib/drive/DifferentialDriveTest.java
+++ b/wpilibj/src/test/java/org/wpilib/drive/DifferentialDriveTest.java
@@ -253,227 +253,227 @@ class DifferentialDriveTest {
   void testArcadeDrive() {
     var left = new MockPWMMotorController();
     var right = new MockPWMMotorController();
-    var drive = new DifferentialDrive(left::setThrottle, right::setThrottle);
+    var drive = new DifferentialDrive(left::setPower, right::setPower);
     drive.setDeadband(0.0);
 
     // Forward
     drive.arcadeDrive(1.0, 0.0, false);
-    assertEquals(1.0, left.getThrottle(), 1e-9);
-    assertEquals(1.0, right.getThrottle(), 1e-9);
+    assertEquals(1.0, left.getPower(), 1e-9);
+    assertEquals(1.0, right.getPower(), 1e-9);
 
     // Forward left turn
     drive.arcadeDrive(0.5, 0.5, false);
-    assertEquals(0.0, left.getThrottle(), 1e-9);
-    assertEquals(0.5, right.getThrottle(), 1e-9);
+    assertEquals(0.0, left.getPower(), 1e-9);
+    assertEquals(0.5, right.getPower(), 1e-9);
 
     // Forward right turn
     drive.arcadeDrive(0.5, -0.5, false);
-    assertEquals(0.5, left.getThrottle(), 1e-9);
-    assertEquals(0.0, right.getThrottle(), 1e-9);
+    assertEquals(0.5, left.getPower(), 1e-9);
+    assertEquals(0.0, right.getPower(), 1e-9);
 
     // Backward
     drive.arcadeDrive(-1.0, 0.0, false);
-    assertEquals(-1.0, left.getThrottle(), 1e-9);
-    assertEquals(-1.0, right.getThrottle(), 1e-9);
+    assertEquals(-1.0, left.getPower(), 1e-9);
+    assertEquals(-1.0, right.getPower(), 1e-9);
 
     // Backward left turn
     drive.arcadeDrive(-0.5, 0.5, false);
-    assertEquals(-0.5, left.getThrottle(), 1e-9);
-    assertEquals(0.0, right.getThrottle(), 1e-9);
+    assertEquals(-0.5, left.getPower(), 1e-9);
+    assertEquals(0.0, right.getPower(), 1e-9);
 
     // Backward right turn
     drive.arcadeDrive(-0.5, -0.5, false);
-    assertEquals(0.0, left.getThrottle(), 1e-9);
-    assertEquals(-0.5, right.getThrottle(), 1e-9);
+    assertEquals(0.0, left.getPower(), 1e-9);
+    assertEquals(-0.5, right.getPower(), 1e-9);
   }
 
   @Test
   void testArcadeDriveSquared() {
     var left = new MockPWMMotorController();
     var right = new MockPWMMotorController();
-    var drive = new DifferentialDrive(left::setThrottle, right::setThrottle);
+    var drive = new DifferentialDrive(left::setPower, right::setPower);
     drive.setDeadband(0.0);
 
     // Forward
     drive.arcadeDrive(1.0, 0.0, true);
-    assertEquals(1.0, left.getThrottle(), 1e-9);
-    assertEquals(1.0, right.getThrottle(), 1e-9);
+    assertEquals(1.0, left.getPower(), 1e-9);
+    assertEquals(1.0, right.getPower(), 1e-9);
 
     // Forward left turn
     drive.arcadeDrive(0.5, 0.5, true);
-    assertEquals(0.0, left.getThrottle(), 1e-9);
-    assertEquals(0.25, right.getThrottle(), 1e-9);
+    assertEquals(0.0, left.getPower(), 1e-9);
+    assertEquals(0.25, right.getPower(), 1e-9);
 
     // Forward right turn
     drive.arcadeDrive(0.5, -0.5, true);
-    assertEquals(0.25, left.getThrottle(), 1e-9);
-    assertEquals(0.0, right.getThrottle(), 1e-9);
+    assertEquals(0.25, left.getPower(), 1e-9);
+    assertEquals(0.0, right.getPower(), 1e-9);
 
     // Backward
     drive.arcadeDrive(-1.0, 0.0, true);
-    assertEquals(-1.0, left.getThrottle(), 1e-9);
-    assertEquals(-1.0, right.getThrottle(), 1e-9);
+    assertEquals(-1.0, left.getPower(), 1e-9);
+    assertEquals(-1.0, right.getPower(), 1e-9);
 
     // Backward left turn
     drive.arcadeDrive(-0.5, 0.5, true);
-    assertEquals(-0.25, left.getThrottle(), 1e-9);
-    assertEquals(0.0, right.getThrottle(), 1e-9);
+    assertEquals(-0.25, left.getPower(), 1e-9);
+    assertEquals(0.0, right.getPower(), 1e-9);
 
     // Backward right turn
     drive.arcadeDrive(-0.5, -0.5, true);
-    assertEquals(0.0, left.getThrottle(), 1e-9);
-    assertEquals(-0.25, right.getThrottle(), 1e-9);
+    assertEquals(0.0, left.getPower(), 1e-9);
+    assertEquals(-0.25, right.getPower(), 1e-9);
   }
 
   @Test
   void testCurvatureDrive() {
     var left = new MockPWMMotorController();
     var right = new MockPWMMotorController();
-    var drive = new DifferentialDrive(left::setThrottle, right::setThrottle);
+    var drive = new DifferentialDrive(left::setPower, right::setPower);
     drive.setDeadband(0.0);
 
     // Forward
     drive.curvatureDrive(1.0, 0.0, false);
-    assertEquals(1.0, left.getThrottle(), 1e-9);
-    assertEquals(1.0, right.getThrottle(), 1e-9);
+    assertEquals(1.0, left.getPower(), 1e-9);
+    assertEquals(1.0, right.getPower(), 1e-9);
 
     // Forward left turn
     drive.curvatureDrive(0.5, 0.5, false);
-    assertEquals(0.25, left.getThrottle(), 1e-9);
-    assertEquals(0.75, right.getThrottle(), 1e-9);
+    assertEquals(0.25, left.getPower(), 1e-9);
+    assertEquals(0.75, right.getPower(), 1e-9);
 
     // Forward right turn
     drive.curvatureDrive(0.5, -0.5, false);
-    assertEquals(0.75, left.getThrottle(), 1e-9);
-    assertEquals(0.25, right.getThrottle(), 1e-9);
+    assertEquals(0.75, left.getPower(), 1e-9);
+    assertEquals(0.25, right.getPower(), 1e-9);
 
     // Backward
     drive.curvatureDrive(-1.0, 0.0, false);
-    assertEquals(-1.0, left.getThrottle(), 1e-9);
-    assertEquals(-1.0, right.getThrottle(), 1e-9);
+    assertEquals(-1.0, left.getPower(), 1e-9);
+    assertEquals(-1.0, right.getPower(), 1e-9);
 
     // Backward left turn
     drive.curvatureDrive(-0.5, 0.5, false);
-    assertEquals(-0.75, left.getThrottle(), 1e-9);
-    assertEquals(-0.25, right.getThrottle(), 1e-9);
+    assertEquals(-0.75, left.getPower(), 1e-9);
+    assertEquals(-0.25, right.getPower(), 1e-9);
 
     // Backward right turn
     drive.curvatureDrive(-0.5, -0.5, false);
-    assertEquals(-0.25, left.getThrottle(), 1e-9);
-    assertEquals(-0.75, right.getThrottle(), 1e-9);
+    assertEquals(-0.25, left.getPower(), 1e-9);
+    assertEquals(-0.75, right.getPower(), 1e-9);
   }
 
   @Test
   void testCurvatureDriveTurnInPlace() {
     var left = new MockPWMMotorController();
     var right = new MockPWMMotorController();
-    var drive = new DifferentialDrive(left::setThrottle, right::setThrottle);
+    var drive = new DifferentialDrive(left::setPower, right::setPower);
     drive.setDeadband(0.0);
 
     // Forward
     drive.curvatureDrive(1.0, 0.0, true);
-    assertEquals(1.0, left.getThrottle(), 1e-9);
-    assertEquals(1.0, right.getThrottle(), 1e-9);
+    assertEquals(1.0, left.getPower(), 1e-9);
+    assertEquals(1.0, right.getPower(), 1e-9);
 
     // Forward left turn
     drive.curvatureDrive(0.5, 0.5, true);
-    assertEquals(0.0, left.getThrottle(), 1e-9);
-    assertEquals(1.0, right.getThrottle(), 1e-9);
+    assertEquals(0.0, left.getPower(), 1e-9);
+    assertEquals(1.0, right.getPower(), 1e-9);
 
     // Forward right turn
     drive.curvatureDrive(0.5, -0.5, true);
-    assertEquals(1.0, left.getThrottle(), 1e-9);
-    assertEquals(0.0, right.getThrottle(), 1e-9);
+    assertEquals(1.0, left.getPower(), 1e-9);
+    assertEquals(0.0, right.getPower(), 1e-9);
 
     // Backward
     drive.curvatureDrive(-1.0, 0.0, true);
-    assertEquals(-1.0, left.getThrottle(), 1e-9);
-    assertEquals(-1.0, right.getThrottle(), 1e-9);
+    assertEquals(-1.0, left.getPower(), 1e-9);
+    assertEquals(-1.0, right.getPower(), 1e-9);
 
     // Backward left turn
     drive.curvatureDrive(-0.5, 0.5, true);
-    assertEquals(-1.0, left.getThrottle(), 1e-9);
-    assertEquals(0.0, right.getThrottle(), 1e-9);
+    assertEquals(-1.0, left.getPower(), 1e-9);
+    assertEquals(0.0, right.getPower(), 1e-9);
 
     // Backward right turn
     drive.curvatureDrive(-0.5, -0.5, true);
-    assertEquals(0.0, left.getThrottle(), 1e-9);
-    assertEquals(-1.0, right.getThrottle(), 1e-9);
+    assertEquals(0.0, left.getPower(), 1e-9);
+    assertEquals(-1.0, right.getPower(), 1e-9);
   }
 
   @Test
   void testTankDrive() {
     var left = new MockPWMMotorController();
     var right = new MockPWMMotorController();
-    var drive = new DifferentialDrive(left::setThrottle, right::setThrottle);
+    var drive = new DifferentialDrive(left::setPower, right::setPower);
     drive.setDeadband(0.0);
 
     // Forward
     drive.tankDrive(1.0, 1.0, false);
-    assertEquals(1.0, left.getThrottle(), 1e-9);
-    assertEquals(1.0, right.getThrottle(), 1e-9);
+    assertEquals(1.0, left.getPower(), 1e-9);
+    assertEquals(1.0, right.getPower(), 1e-9);
 
     // Forward left turn
     drive.tankDrive(0.5, 1.0, false);
-    assertEquals(0.5, left.getThrottle(), 1e-9);
-    assertEquals(1.0, right.getThrottle(), 1e-9);
+    assertEquals(0.5, left.getPower(), 1e-9);
+    assertEquals(1.0, right.getPower(), 1e-9);
 
     // Forward right turn
     drive.tankDrive(1.0, 0.5, false);
-    assertEquals(1.0, left.getThrottle(), 1e-9);
-    assertEquals(0.5, right.getThrottle(), 1e-9);
+    assertEquals(1.0, left.getPower(), 1e-9);
+    assertEquals(0.5, right.getPower(), 1e-9);
 
     // Backward
     drive.tankDrive(-1.0, -1.0, false);
-    assertEquals(-1.0, left.getThrottle(), 1e-9);
-    assertEquals(-1.0, right.getThrottle(), 1e-9);
+    assertEquals(-1.0, left.getPower(), 1e-9);
+    assertEquals(-1.0, right.getPower(), 1e-9);
 
     // Backward left turn
     drive.tankDrive(-0.5, -1.0, false);
-    assertEquals(-0.5, left.getThrottle(), 1e-9);
-    assertEquals(-1.0, right.getThrottle(), 1e-9);
+    assertEquals(-0.5, left.getPower(), 1e-9);
+    assertEquals(-1.0, right.getPower(), 1e-9);
 
     // Backward right turn
     drive.tankDrive(-0.5, 1.0, false);
-    assertEquals(-0.5, left.getThrottle(), 1e-9);
-    assertEquals(1.0, right.getThrottle(), 1e-9);
+    assertEquals(-0.5, left.getPower(), 1e-9);
+    assertEquals(1.0, right.getPower(), 1e-9);
   }
 
   @Test
   void testTankDriveSquared() {
     var left = new MockPWMMotorController();
     var right = new MockPWMMotorController();
-    var drive = new DifferentialDrive(left::setThrottle, right::setThrottle);
+    var drive = new DifferentialDrive(left::setPower, right::setPower);
     drive.setDeadband(0.0);
 
     // Forward
     drive.tankDrive(1.0, 1.0, true);
-    assertEquals(1.0, left.getThrottle(), 1e-9);
-    assertEquals(1.0, right.getThrottle(), 1e-9);
+    assertEquals(1.0, left.getPower(), 1e-9);
+    assertEquals(1.0, right.getPower(), 1e-9);
 
     // Forward left turn
     drive.tankDrive(0.5, 1.0, true);
-    assertEquals(0.25, left.getThrottle(), 1e-9);
-    assertEquals(1.0, right.getThrottle(), 1e-9);
+    assertEquals(0.25, left.getPower(), 1e-9);
+    assertEquals(1.0, right.getPower(), 1e-9);
 
     // Forward right turn
     drive.tankDrive(1.0, 0.5, true);
-    assertEquals(1.0, left.getThrottle(), 1e-9);
-    assertEquals(0.25, right.getThrottle(), 1e-9);
+    assertEquals(1.0, left.getPower(), 1e-9);
+    assertEquals(0.25, right.getPower(), 1e-9);
 
     // Backward
     drive.tankDrive(-1.0, -1.0, true);
-    assertEquals(-1.0, left.getThrottle(), 1e-9);
-    assertEquals(-1.0, right.getThrottle(), 1e-9);
+    assertEquals(-1.0, left.getPower(), 1e-9);
+    assertEquals(-1.0, right.getPower(), 1e-9);
 
     // Backward left turn
     drive.tankDrive(-0.5, -1.0, true);
-    assertEquals(-0.25, left.getThrottle(), 1e-9);
-    assertEquals(-1.0, right.getThrottle(), 1e-9);
+    assertEquals(-0.25, left.getPower(), 1e-9);
+    assertEquals(-1.0, right.getPower(), 1e-9);
 
     // Backward right turn
     drive.tankDrive(-1.0, -0.5, true);
-    assertEquals(-1.0, left.getThrottle(), 1e-9);
-    assertEquals(-0.25, right.getThrottle(), 1e-9);
+    assertEquals(-1.0, left.getPower(), 1e-9);
+    assertEquals(-0.25, right.getPower(), 1e-9);
   }
 }

--- a/wpilibj/src/test/java/org/wpilib/drive/MecanumDriveTest.java
+++ b/wpilibj/src/test/java/org/wpilib/drive/MecanumDriveTest.java
@@ -94,44 +94,43 @@ class MecanumDriveTest {
     var rl = new MockPWMMotorController();
     var fr = new MockPWMMotorController();
     var rr = new MockPWMMotorController();
-    var drive =
-        new MecanumDrive(fl::setThrottle, rl::setThrottle, fr::setThrottle, rr::setThrottle);
+    var drive = new MecanumDrive(fl::setPower, rl::setPower, fr::setPower, rr::setPower);
     drive.setDeadband(0.0);
 
     // Forward
     drive.driveCartesian(1.0, 0.0, 0.0);
-    assertEquals(1.0, fl.getThrottle(), 1e-9);
-    assertEquals(1.0, fr.getThrottle(), 1e-9);
-    assertEquals(1.0, rl.getThrottle(), 1e-9);
-    assertEquals(1.0, rr.getThrottle(), 1e-9);
+    assertEquals(1.0, fl.getPower(), 1e-9);
+    assertEquals(1.0, fr.getPower(), 1e-9);
+    assertEquals(1.0, rl.getPower(), 1e-9);
+    assertEquals(1.0, rr.getPower(), 1e-9);
 
     // Left
     drive.driveCartesian(0.0, -1.0, 0.0);
-    assertEquals(-1.0, fl.getThrottle(), 1e-9);
-    assertEquals(1.0, fr.getThrottle(), 1e-9);
-    assertEquals(1.0, rl.getThrottle(), 1e-9);
-    assertEquals(-1.0, rr.getThrottle(), 1e-9);
+    assertEquals(-1.0, fl.getPower(), 1e-9);
+    assertEquals(1.0, fr.getPower(), 1e-9);
+    assertEquals(1.0, rl.getPower(), 1e-9);
+    assertEquals(-1.0, rr.getPower(), 1e-9);
 
     // Right
     drive.driveCartesian(0.0, 1.0, 0.0);
-    assertEquals(1.0, fl.getThrottle(), 1e-9);
-    assertEquals(-1.0, fr.getThrottle(), 1e-9);
-    assertEquals(-1.0, rl.getThrottle(), 1e-9);
-    assertEquals(1.0, rr.getThrottle(), 1e-9);
+    assertEquals(1.0, fl.getPower(), 1e-9);
+    assertEquals(-1.0, fr.getPower(), 1e-9);
+    assertEquals(-1.0, rl.getPower(), 1e-9);
+    assertEquals(1.0, rr.getPower(), 1e-9);
 
     // Rotate CCW
     drive.driveCartesian(0.0, 0.0, -1.0);
-    assertEquals(-1.0, fl.getThrottle(), 1e-9);
-    assertEquals(1.0, fr.getThrottle(), 1e-9);
-    assertEquals(-1.0, rl.getThrottle(), 1e-9);
-    assertEquals(1.0, rr.getThrottle(), 1e-9);
+    assertEquals(-1.0, fl.getPower(), 1e-9);
+    assertEquals(1.0, fr.getPower(), 1e-9);
+    assertEquals(-1.0, rl.getPower(), 1e-9);
+    assertEquals(1.0, rr.getPower(), 1e-9);
 
     // Rotate CW
     drive.driveCartesian(0.0, 0.0, 1.0);
-    assertEquals(1.0, fl.getThrottle(), 1e-9);
-    assertEquals(-1.0, fr.getThrottle(), 1e-9);
-    assertEquals(1.0, rl.getThrottle(), 1e-9);
-    assertEquals(-1.0, rr.getThrottle(), 1e-9);
+    assertEquals(1.0, fl.getPower(), 1e-9);
+    assertEquals(-1.0, fr.getPower(), 1e-9);
+    assertEquals(1.0, rl.getPower(), 1e-9);
+    assertEquals(-1.0, rr.getPower(), 1e-9);
   }
 
   @Test
@@ -140,44 +139,43 @@ class MecanumDriveTest {
     var rl = new MockPWMMotorController();
     var fr = new MockPWMMotorController();
     var rr = new MockPWMMotorController();
-    var drive =
-        new MecanumDrive(fl::setThrottle, rl::setThrottle, fr::setThrottle, rr::setThrottle);
+    var drive = new MecanumDrive(fl::setPower, rl::setPower, fr::setPower, rr::setPower);
     drive.setDeadband(0.0);
 
     // Forward in global frame; left in robot frame
     drive.driveCartesian(1.0, 0.0, 0.0, Rotation2d.kCCW_Pi_2);
-    assertEquals(-1.0, fl.getThrottle(), 1e-9);
-    assertEquals(1.0, fr.getThrottle(), 1e-9);
-    assertEquals(1.0, rl.getThrottle(), 1e-9);
-    assertEquals(-1.0, rr.getThrottle(), 1e-9);
+    assertEquals(-1.0, fl.getPower(), 1e-9);
+    assertEquals(1.0, fr.getPower(), 1e-9);
+    assertEquals(1.0, rl.getPower(), 1e-9);
+    assertEquals(-1.0, rr.getPower(), 1e-9);
 
     // Left in global frame; backward in robot frame
     drive.driveCartesian(0.0, -1.0, 0.0, Rotation2d.kCCW_Pi_2);
-    assertEquals(-1.0, fl.getThrottle(), 1e-9);
-    assertEquals(-1.0, fr.getThrottle(), 1e-9);
-    assertEquals(-1.0, rl.getThrottle(), 1e-9);
-    assertEquals(-1.0, rr.getThrottle(), 1e-9);
+    assertEquals(-1.0, fl.getPower(), 1e-9);
+    assertEquals(-1.0, fr.getPower(), 1e-9);
+    assertEquals(-1.0, rl.getPower(), 1e-9);
+    assertEquals(-1.0, rr.getPower(), 1e-9);
 
     // Right in global frame; forward in robot frame
     drive.driveCartesian(0.0, 1.0, 0.0, Rotation2d.kCCW_Pi_2);
-    assertEquals(1.0, fl.getThrottle(), 1e-9);
-    assertEquals(1.0, fr.getThrottle(), 1e-9);
-    assertEquals(1.0, rl.getThrottle(), 1e-9);
-    assertEquals(1.0, rr.getThrottle(), 1e-9);
+    assertEquals(1.0, fl.getPower(), 1e-9);
+    assertEquals(1.0, fr.getPower(), 1e-9);
+    assertEquals(1.0, rl.getPower(), 1e-9);
+    assertEquals(1.0, rr.getPower(), 1e-9);
 
     // Rotate CCW
     drive.driveCartesian(0.0, 0.0, -1.0, Rotation2d.kCCW_Pi_2);
-    assertEquals(-1.0, fl.getThrottle(), 1e-9);
-    assertEquals(1.0, fr.getThrottle(), 1e-9);
-    assertEquals(-1.0, rl.getThrottle(), 1e-9);
-    assertEquals(1.0, rr.getThrottle(), 1e-9);
+    assertEquals(-1.0, fl.getPower(), 1e-9);
+    assertEquals(1.0, fr.getPower(), 1e-9);
+    assertEquals(-1.0, rl.getPower(), 1e-9);
+    assertEquals(1.0, rr.getPower(), 1e-9);
 
     // Rotate CW
     drive.driveCartesian(0.0, 0.0, 1.0, Rotation2d.kCCW_Pi_2);
-    assertEquals(1.0, fl.getThrottle(), 1e-9);
-    assertEquals(-1.0, fr.getThrottle(), 1e-9);
-    assertEquals(1.0, rl.getThrottle(), 1e-9);
-    assertEquals(-1.0, rr.getThrottle(), 1e-9);
+    assertEquals(1.0, fl.getPower(), 1e-9);
+    assertEquals(-1.0, fr.getPower(), 1e-9);
+    assertEquals(1.0, rl.getPower(), 1e-9);
+    assertEquals(-1.0, rr.getPower(), 1e-9);
   }
 
   @Test
@@ -186,43 +184,42 @@ class MecanumDriveTest {
     var rl = new MockPWMMotorController();
     var fr = new MockPWMMotorController();
     var rr = new MockPWMMotorController();
-    var drive =
-        new MecanumDrive(fl::setThrottle, rl::setThrottle, fr::setThrottle, rr::setThrottle);
+    var drive = new MecanumDrive(fl::setPower, rl::setPower, fr::setPower, rr::setPower);
     drive.setDeadband(0.0);
 
     // Forward
     drive.drivePolar(1.0, Rotation2d.kZero, 0.0);
-    assertEquals(1.0, fl.getThrottle(), 1e-9);
-    assertEquals(1.0, fr.getThrottle(), 1e-9);
-    assertEquals(1.0, rl.getThrottle(), 1e-9);
-    assertEquals(1.0, rr.getThrottle(), 1e-9);
+    assertEquals(1.0, fl.getPower(), 1e-9);
+    assertEquals(1.0, fr.getPower(), 1e-9);
+    assertEquals(1.0, rl.getPower(), 1e-9);
+    assertEquals(1.0, rr.getPower(), 1e-9);
 
     // Left
     drive.drivePolar(1.0, Rotation2d.kCW_Pi_2, 0.0);
-    assertEquals(-1.0, fl.getThrottle(), 1e-9);
-    assertEquals(1.0, fr.getThrottle(), 1e-9);
-    assertEquals(1.0, rl.getThrottle(), 1e-9);
-    assertEquals(-1.0, rr.getThrottle(), 1e-9);
+    assertEquals(-1.0, fl.getPower(), 1e-9);
+    assertEquals(1.0, fr.getPower(), 1e-9);
+    assertEquals(1.0, rl.getPower(), 1e-9);
+    assertEquals(-1.0, rr.getPower(), 1e-9);
 
     // Right
     drive.drivePolar(1.0, Rotation2d.kCCW_Pi_2, 0.0);
-    assertEquals(1.0, fl.getThrottle(), 1e-9);
-    assertEquals(-1.0, fr.getThrottle(), 1e-9);
-    assertEquals(-1.0, rl.getThrottle(), 1e-9);
-    assertEquals(1.0, rr.getThrottle(), 1e-9);
+    assertEquals(1.0, fl.getPower(), 1e-9);
+    assertEquals(-1.0, fr.getPower(), 1e-9);
+    assertEquals(-1.0, rl.getPower(), 1e-9);
+    assertEquals(1.0, rr.getPower(), 1e-9);
 
     // Rotate CCW
     drive.drivePolar(0.0, Rotation2d.kZero, -1.0);
-    assertEquals(-1.0, fl.getThrottle(), 1e-9);
-    assertEquals(1.0, fr.getThrottle(), 1e-9);
-    assertEquals(-1.0, rl.getThrottle(), 1e-9);
-    assertEquals(1.0, rr.getThrottle(), 1e-9);
+    assertEquals(-1.0, fl.getPower(), 1e-9);
+    assertEquals(1.0, fr.getPower(), 1e-9);
+    assertEquals(-1.0, rl.getPower(), 1e-9);
+    assertEquals(1.0, rr.getPower(), 1e-9);
 
     // Rotate CW
     drive.drivePolar(0.0, Rotation2d.kZero, 1.0);
-    assertEquals(1.0, fl.getThrottle(), 1e-9);
-    assertEquals(-1.0, fr.getThrottle(), 1e-9);
-    assertEquals(1.0, rl.getThrottle(), 1e-9);
-    assertEquals(-1.0, rr.getThrottle(), 1e-9);
+    assertEquals(1.0, fl.getPower(), 1e-9);
+    assertEquals(-1.0, fr.getPower(), 1e-9);
+    assertEquals(1.0, rl.getPower(), 1e-9);
+    assertEquals(-1.0, rr.getPower(), 1e-9);
   }
 }

--- a/wpilibj/src/test/java/org/wpilib/hardware/motor/MockMotorController.java
+++ b/wpilibj/src/test/java/org/wpilib/hardware/motor/MockMotorController.java
@@ -6,17 +6,17 @@ package org.wpilib.hardware.motor;
 
 @SuppressWarnings("removal")
 public class MockMotorController implements MotorController {
-  private double m_throttle;
+  private double m_power;
   private boolean m_isInverted;
 
   @Override
-  public void setThrottle(double throttle) {
-    m_throttle = m_isInverted ? -throttle : throttle;
+  public void setPower(double power) {
+    m_power = m_isInverted ? -power : power;
   }
 
   @Override
-  public double getThrottle() {
-    return m_throttle;
+  public double getPower() {
+    return m_power;
   }
 
   @Override
@@ -31,6 +31,6 @@ public class MockMotorController implements MotorController {
 
   @Override
   public void disable() {
-    m_throttle = 0;
+    m_power = 0;
   }
 }

--- a/wpilibj/src/test/java/org/wpilib/hardware/motor/MockPWMMotorController.java
+++ b/wpilibj/src/test/java/org/wpilib/hardware/motor/MockPWMMotorController.java
@@ -5,15 +5,15 @@
 package org.wpilib.hardware.motor;
 
 public class MockPWMMotorController {
-  private double m_throttle;
+  private double m_power;
   private boolean m_isInverted;
 
-  public void setThrottle(double throttle) {
-    m_throttle = m_isInverted ? -throttle : throttle;
+  public void setPower(double power) {
+    m_power = m_isInverted ? -power : power;
   }
 
-  public double getThrottle() {
-    return m_throttle;
+  public double getPower() {
+    return m_power;
   }
 
   public void setInverted(boolean isInverted) {
@@ -25,7 +25,7 @@ public class MockPWMMotorController {
   }
 
   public void disable() {
-    m_throttle = 0;
+    m_power = 0;
   }
 
   public void stopMotor() {

--- a/wpilibj/src/test/java/org/wpilib/simulation/DCMotorSimTest.java
+++ b/wpilibj/src/test/java/org/wpilib/simulation/DCMotorSimTest.java
@@ -38,7 +38,7 @@ class DCMotorSimTest {
         // ------ SimulationPeriodic() happens after user code -------
         RoboRioSim.setVInVoltage(
             BatterySim.calculateDefaultBatteryLoadedVoltage(sim.getCurrentDraw()));
-        sim.setInputVoltage(motor.getThrottle() * RobotController.getBatteryVoltage());
+        sim.setInputVoltage(motor.getPower() * RobotController.getBatteryVoltage());
         sim.update(0.020);
         encoderSim.setRate(sim.getAngularVelocity());
       }
@@ -51,7 +51,7 @@ class DCMotorSimTest {
         // ------ SimulationPeriodic() happens after user code -------
         RoboRioSim.setVInVoltage(
             BatterySim.calculateDefaultBatteryLoadedVoltage(sim.getCurrentDraw()));
-        sim.setInputVoltage(motor.getThrottle() * RobotController.getBatteryVoltage());
+        sim.setInputVoltage(motor.getPower() * RobotController.getBatteryVoltage());
         sim.update(0.020);
         encoderSim.setRate(sim.getAngularVelocity());
       }
@@ -76,12 +76,12 @@ class DCMotorSimTest {
       encoderSim.resetData();
 
       for (int i = 0; i < 140; i++) {
-        motor.setThrottle(controller.calculate(encoder.getDistance(), 750));
+        motor.setPower(controller.calculate(encoder.getDistance(), 750));
 
         // ------ SimulationPeriodic() happens after user code -------
         RoboRioSim.setVInVoltage(
             BatterySim.calculateDefaultBatteryLoadedVoltage(sim.getCurrentDraw()));
-        sim.setInputVoltage(motor.getThrottle() * RobotController.getBatteryVoltage());
+        sim.setInputVoltage(motor.getPower() * RobotController.getBatteryVoltage());
         sim.update(0.020);
         encoderSim.setDistance(sim.getAngularPosition());
         encoderSim.setRate(sim.getAngularVelocity());

--- a/wpilibj/src/test/java/org/wpilib/simulation/ElevatorSimTest.java
+++ b/wpilibj/src/test/java/org/wpilib/simulation/ElevatorSimTest.java
@@ -48,11 +48,11 @@ class ElevatorSimTest {
         double nextVoltage = controller.calculate(encoderSim.getDistance());
 
         double currentBatteryVoltage = RobotController.getBatteryVoltage();
-        motor.setThrottle(nextVoltage / currentBatteryVoltage);
+        motor.setPower(nextVoltage / currentBatteryVoltage);
 
         // ------ SimulationPeriodic() happens after user code -------
 
-        var u = VecBuilder.fill(motor.getThrottle() * currentBatteryVoltage);
+        var u = VecBuilder.fill(motor.getPower() * currentBatteryVoltage);
         sim.setInput(u);
         sim.update(0.020);
         var y = sim.getOutput();

--- a/wpilibj/src/test/java/org/wpilib/simulation/PWMMotorControllerSimTest.java
+++ b/wpilibj/src/test/java/org/wpilib/simulation/PWMMotorControllerSimTest.java
@@ -18,14 +18,14 @@ class PWMMotorControllerSimTest {
     try (Spark spark = new Spark(0)) {
       PWMMotorControllerSim sim = new PWMMotorControllerSim(spark);
 
-      spark.setThrottle(0);
-      assertEquals(0, sim.getThrottle());
+      spark.setPower(0);
+      assertEquals(0, sim.getPower());
 
-      spark.setThrottle(0.354);
-      assertEquals(0.354, sim.getThrottle());
+      spark.setPower(0.354);
+      assertEquals(0.354, sim.getPower());
 
-      spark.setThrottle(-0.785);
-      assertEquals(-0.785, sim.getThrottle());
+      spark.setPower(-0.785);
+      assertEquals(-0.785, sim.getPower());
     }
   }
 }

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/arcadedrivegamepad/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/arcadedrivegamepad/Robot.java
@@ -18,7 +18,7 @@ public class Robot extends TimedRobot {
   private final PWMSparkMax m_leftMotor = new PWMSparkMax(0);
   private final PWMSparkMax m_rightMotor = new PWMSparkMax(1);
   private final DifferentialDrive m_robotDrive =
-      new DifferentialDrive(m_leftMotor::setThrottle, m_rightMotor::setThrottle);
+      new DifferentialDrive(m_leftMotor::setPower, m_rightMotor::setPower);
   private final Gamepad m_driverController = new Gamepad(0);
 
   /** Called once at the beginning of the robot program. */

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/armsimulation/subsystems/Arm.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/armsimulation/subsystems/Arm.java
@@ -86,7 +86,7 @@ public class Arm implements AutoCloseable {
   public void simulationPeriodic() {
     // In this method, we update our simulation of what our arm is doing
     // First, we set our "inputs" (voltages)
-    m_armSim.setInput(m_motor.getThrottle() * RobotController.getBatteryVoltage());
+    m_armSim.setInput(m_motor.getPower() * RobotController.getBatteryVoltage());
 
     // Next, we update it. The standard loop time is 20ms.
     m_armSim.update(0.020);
@@ -120,7 +120,7 @@ public class Arm implements AutoCloseable {
   }
 
   public void stop() {
-    m_motor.setThrottle(0.0);
+    m_motor.setPower(0.0);
   }
 
   @Override

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/differentialdriveposeestimator/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/differentialdriveposeestimator/Drivetrain.java
@@ -248,8 +248,8 @@ public class Drivetrain {
     // simulation, and write the simulated positions and velocities to our
     // simulated encoder and gyro.
     m_drivetrainSimulator.setInputs(
-        m_leftLeader.getThrottle() * RobotController.getInputVoltage(),
-        m_rightLeader.getThrottle() * RobotController.getInputVoltage());
+        m_leftLeader.getPower() * RobotController.getInputVoltage(),
+        m_rightLeader.getPower() * RobotController.getInputVoltage());
     m_drivetrainSimulator.update(0.02);
 
     m_leftEncoderSim.setDistance(m_drivetrainSimulator.getLeftPosition());

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/drivedistanceoffboard/ExampleSmartMotorController.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/drivedistanceoffboard/ExampleSmartMotorController.java
@@ -71,11 +71,11 @@ public class ExampleSmartMotorController {
   /** Resets the encoder to zero distance. */
   public void resetEncoder() {}
 
-  public void setThrottle(double throttle) {
-    m_value = throttle;
+  public void setPower(double power) {
+    m_value = power;
   }
 
-  public double getThrottle() {
+  public double getPower() {
     return m_value;
   }
 

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/drivedistanceoffboard/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/drivedistanceoffboard/subsystems/DriveSubsystem.java
@@ -37,7 +37,7 @@ public class DriveSubsystem extends SubsystemBase {
 
   // The robot's drive
   private final DifferentialDrive m_drive =
-      new DifferentialDrive(m_leftLeader::setThrottle, m_rightLeader::setThrottle);
+      new DifferentialDrive(m_leftLeader::setPower, m_rightLeader::setPower);
 
   // The trapezoid profile
   private final TrapezoidProfile m_profile =

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/elevatorexponentialprofile/ExampleSmartMotorController.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/elevatorexponentialprofile/ExampleSmartMotorController.java
@@ -69,9 +69,9 @@ public class ExampleSmartMotorController {
   /** Resets the encoder to zero distance. */
   public void resetEncoder() {}
 
-  public void setThrottle(double throttle) {}
+  public void setPower(double power) {}
 
-  public double getThrottle() {
+  public double getPower() {
     return 0;
   }
 

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/elevatorexponentialsimulation/subsystems/Elevator.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/elevatorexponentialsimulation/subsystems/Elevator.java
@@ -85,7 +85,7 @@ public class Elevator implements AutoCloseable {
   public void simulationPeriodic() {
     // In this method, we update our simulation of what our elevator is doing
     // First, we set our "inputs" (voltages)
-    m_elevatorSim.setInput(m_motorSim.getThrottle() * RobotController.getBatteryVoltage());
+    m_elevatorSim.setInput(m_motorSim.getPower() * RobotController.getBatteryVoltage());
 
     // Next, we update it. The standard loop time is 20ms.
     m_elevatorSim.update(0.020);
@@ -118,7 +118,7 @@ public class Elevator implements AutoCloseable {
 
   /** Stop the control loop and motor output. */
   public void stop() {
-    m_motor.setThrottle(0.0);
+    m_motor.setPower(0.0);
   }
 
   /** Reset Exponential profile to begin from current position on enable. */

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/elevatorsimulation/subsystems/Elevator.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/elevatorsimulation/subsystems/Elevator.java
@@ -78,7 +78,7 @@ public class Elevator implements AutoCloseable {
   public void simulationPeriodic() {
     // In this method, we update our simulation of what our elevator is doing
     // First, we set our "inputs" (voltages)
-    m_elevatorSim.setInput(m_motorSim.getThrottle() * RobotController.getBatteryVoltage());
+    m_elevatorSim.setInput(m_motorSim.getPower() * RobotController.getBatteryVoltage());
 
     // Next, we update it. The standard loop time is 20ms.
     m_elevatorSim.update(0.020);
@@ -107,7 +107,7 @@ public class Elevator implements AutoCloseable {
   /** Stop the control loop and motor output. */
   public void stop() {
     m_controller.setGoal(0.0);
-    m_motor.setThrottle(0.0);
+    m_motor.setPower(0.0);
   }
 
   /** Update telemetry, including the mechanism visualization. */

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/elevatortrapezoidprofile/ExampleSmartMotorController.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/elevatortrapezoidprofile/ExampleSmartMotorController.java
@@ -69,9 +69,9 @@ public class ExampleSmartMotorController {
   /** Resets the encoder to zero distance. */
   public void resetEncoder() {}
 
-  public void setThrottle(double throttle) {}
+  public void setPower(double power) {}
 
-  public double getThrottle() {
+  public double getPower() {
     return 0;
   }
 

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/gettingstarted/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/gettingstarted/Robot.java
@@ -20,7 +20,7 @@ public class Robot extends TimedRobot {
   private final PWMSparkMax m_leftDrive = new PWMSparkMax(0);
   private final PWMSparkMax m_rightDrive = new PWMSparkMax(1);
   private final DifferentialDrive m_robotDrive =
-      new DifferentialDrive(m_leftDrive::setThrottle, m_rightDrive::setThrottle);
+      new DifferentialDrive(m_leftDrive::setPower, m_rightDrive::setPower);
   private final Gamepad m_controller = new Gamepad(0);
   private final Timer m_timer = new Timer();
 

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/gyro/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/gyro/Robot.java
@@ -29,7 +29,7 @@ public class Robot extends TimedRobot {
   private final PWMSparkMax m_leftDrive = new PWMSparkMax(kLeftMotorPort);
   private final PWMSparkMax m_rightDrive = new PWMSparkMax(kRightMotorPort);
   private final DifferentialDrive m_robotDrive =
-      new DifferentialDrive(m_leftDrive::setThrottle, m_rightDrive::setThrottle);
+      new DifferentialDrive(m_leftDrive::setPower, m_rightDrive::setPower);
   private final OnboardIMU m_imu = new OnboardIMU(kIMUMountOrientation);
   private final Joystick m_joystick = new Joystick(kJoystickPort);
 

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotinlined/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotinlined/subsystems/DriveSubsystem.java
@@ -23,7 +23,7 @@ public class DriveSubsystem extends SubsystemBase {
 
   // The robot's drive
   private final DifferentialDrive m_drive =
-      new DifferentialDrive(m_leftLeader::setThrottle, m_rightLeader::setThrottle);
+      new DifferentialDrive(m_leftLeader::setPower, m_rightLeader::setPower);
 
   // The left-side drive encoder
   private final Encoder m_leftEncoder =

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbottraditional/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbottraditional/subsystems/DriveSubsystem.java
@@ -23,7 +23,7 @@ public class DriveSubsystem extends SubsystemBase {
 
   // The robot's drive
   private final DifferentialDrive m_drive =
-      new DifferentialDrive(m_leftLeader::setThrottle, m_rightLeader::setThrottle);
+      new DifferentialDrive(m_leftLeader::setPower, m_rightLeader::setPower);
 
   // The left-side drive encoder
   private final Encoder m_leftEncoder =

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/mecanumdrive/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/mecanumdrive/Robot.java
@@ -42,10 +42,7 @@ public class Robot extends TimedRobot {
 
     m_robotDrive =
         new MecanumDrive(
-            frontLeft::setThrottle,
-            rearLeft::setThrottle,
-            frontRight::setThrottle,
-            rearRight::setThrottle);
+            frontLeft::setPower, rearLeft::setPower, frontRight::setPower, rearRight::setPower);
 
     SendableRegistry.addChild(m_robotDrive, frontLeft);
     SendableRegistry.addChild(m_robotDrive, rearLeft);

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/mechanism2d/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/mechanism2d/Robot.java
@@ -65,7 +65,7 @@ public class Robot extends TimedRobot {
 
   @Override
   public void teleopPeriodic() {
-    m_elevatorMotor.setThrottle(m_joystick.getRawAxis(0));
-    m_wristMotor.setThrottle(m_joystick.getRawAxis(1));
+    m_elevatorMotor.setPower(m_joystick.getRawAxis(0));
+    m_wristMotor.setPower(m_joystick.getRawAxis(1));
   }
 }

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Drive.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Drive.java
@@ -33,7 +33,7 @@ public class Drive extends SubsystemBase {
   // The robot's drive
   @NotLogged // Would duplicate motor data, there's no point sending it twice
   private final DifferentialDrive m_drive =
-      new DifferentialDrive(m_leftLeader::setThrottle, m_rightLeader::setThrottle);
+      new DifferentialDrive(m_leftLeader::setPower, m_rightLeader::setPower);
 
   // The left-side drive encoder
   private final Encoder m_leftEncoder =

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Intake.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Intake.java
@@ -29,7 +29,7 @@ public class Intake extends SubsystemBase {
   /** Returns a command that deploys the intake, and then runs the intake motor indefinitely. */
   public Command intakeCommand() {
     return runOnce(() -> m_pistons.set(DoubleSolenoid.Value.FORWARD))
-        .andThen(run(() -> m_motor.setThrottle(1.0)))
+        .andThen(run(() -> m_motor.setPower(1.0)))
         .withName("Intake");
   }
 

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Shooter.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Shooter.java
@@ -56,14 +56,14 @@ public class Shooter extends SubsystemBase {
             // Run the shooter flywheel at the desired setpoint using feedforward and feedback
             run(
                 () -> {
-                  m_shooterMotor.setThrottle(
+                  m_shooterMotor.setPower(
                       m_shooterFeedforward.calculate(setpointRotationsPerSecond)
                           + m_shooterFeedback.calculate(
                               m_shooterEncoder.getRate(), setpointRotationsPerSecond));
                 }),
 
             // Wait until the shooter has reached the setpoint, and then run the feeder
-            waitUntil(m_shooterFeedback::atSetpoint).andThen(() -> m_feederMotor.setThrottle(1)))
+            waitUntil(m_shooterFeedback::atSetpoint).andThen(() -> m_feederMotor.setPower(1)))
         .withName("Shoot");
   }
 }

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Storage.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Storage.java
@@ -34,6 +34,6 @@ public class Storage extends SubsystemBase {
 
   /** Returns a command that runs the storage motor indefinitely. */
   public Command runCommand() {
-    return run(() -> m_motor.setThrottle(1)).withName("run");
+    return run(() -> m_motor.setPower(1)).withName("run");
   }
 }

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/romireference/subsystems/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/romireference/subsystems/Drivetrain.java
@@ -27,7 +27,7 @@ public class Drivetrain extends SubsystemBase {
 
   // Set up the differential drive controller
   private final DifferentialDrive m_diffDrive =
-      new DifferentialDrive(m_leftMotor::setThrottle, m_rightMotor::setThrottle);
+      new DifferentialDrive(m_leftMotor::setPower, m_rightMotor::setPower);
 
   // Set up the RomiGyro
   private final RomiGyro m_gyro = new RomiGyro();

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/simpledifferentialdrivesimulation/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/simpledifferentialdrivesimulation/Drivetrain.java
@@ -136,8 +136,8 @@ public class Drivetrain {
     // simulated encoder and gyro. We negate the right side so that positive
     // voltages make the right side move forward.
     m_drivetrainSimulator.setInputs(
-        m_leftLeader.getThrottle() * RobotController.getInputVoltage(),
-        m_rightLeader.getThrottle() * RobotController.getInputVoltage());
+        m_leftLeader.getPower() * RobotController.getInputVoltage(),
+        m_rightLeader.getPower() * RobotController.getInputVoltage());
     m_drivetrainSimulator.update(0.02);
 
     m_leftEncoderSim.setDistance(m_drivetrainSimulator.getLeftPosition());

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/subsystems/Drive.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/subsystems/Drive.java
@@ -27,7 +27,7 @@ public class Drive extends SubsystemBase {
 
   // The robot's drive
   private final DifferentialDrive m_drive =
-      new DifferentialDrive(m_leftMotor::setThrottle, m_rightMotor::setThrottle);
+      new DifferentialDrive(m_leftMotor::setPower, m_rightMotor::setPower);
 
   // The left-side drive encoder
   private final Encoder m_leftEncoder =
@@ -60,15 +60,14 @@ public class Drive extends SubsystemBase {
                 // Record a frame for the left motors.  Since these share an encoder, we consider
                 // the entire group to be one motor.
                 log.motor("drive-left")
-                    .voltage(
-                        Volts.of(m_leftMotor.getThrottle() * RobotController.getBatteryVoltage()))
+                    .voltage(Volts.of(m_leftMotor.getPower() * RobotController.getBatteryVoltage()))
                     .linearPosition(Meters.of(m_leftEncoder.getDistance()))
                     .linearVelocity(MetersPerSecond.of(m_leftEncoder.getRate()));
                 // Record a frame for the right motors.  Since these share an encoder, we consider
                 // the entire group to be one motor.
                 log.motor("drive-right")
                     .voltage(
-                        Volts.of(m_rightMotor.getThrottle() * RobotController.getBatteryVoltage()))
+                        Volts.of(m_rightMotor.getPower() * RobotController.getBatteryVoltage()))
                     .linearPosition(Meters.of(m_rightEncoder.getDistance()))
                     .linearVelocity(MetersPerSecond.of(m_rightEncoder.getRate()));
               },

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/subsystems/Shooter.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/subsystems/Shooter.java
@@ -47,8 +47,7 @@ public class Shooter extends SubsystemBase {
                 // Record a frame for the shooter motor.
                 log.motor("shooter-wheel")
                     .voltage(
-                        Volts.of(
-                            m_shooterMotor.getThrottle() * RobotController.getBatteryVoltage()))
+                        Volts.of(m_shooterMotor.getPower() * RobotController.getBatteryVoltage()))
                     .angularPosition(Rotations.of(m_shooterEncoder.getDistance()))
                     .angularVelocity(RotationsPerSecond.of(m_shooterEncoder.getRate()));
               },
@@ -80,7 +79,7 @@ public class Shooter extends SubsystemBase {
           m_shooterMotor.setVoltage(
               m_shooterFeedback.calculate(m_shooterEncoder.getRate(), shooterVelocity.getAsDouble())
                   + m_shooterFeedforward.calculate(shooterVelocity.getAsDouble()));
-          m_feederMotor.setThrottle(ShooterConstants.kFeederVelocity);
+          m_feederMotor.setPower(ShooterConstants.kFeederVelocity);
         })
         .finallyDo(
             () -> {

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/tankdrivegamepad/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/tankdrivegamepad/Robot.java
@@ -18,7 +18,7 @@ public class Robot extends TimedRobot {
   private final PWMSparkMax m_leftMotor = new PWMSparkMax(0);
   private final PWMSparkMax m_rightMotor = new PWMSparkMax(1);
   private final DifferentialDrive m_robotDrive =
-      new DifferentialDrive(m_leftMotor::setThrottle, m_rightMotor::setThrottle);
+      new DifferentialDrive(m_leftMotor::setPower, m_rightMotor::setPower);
   private final Gamepad m_driverController = new Gamepad(0);
 
   /** Called once at the beginning of the robot program. */

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/unittest/subsystems/Intake.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/unittest/subsystems/Intake.java
@@ -29,14 +29,14 @@ public class Intake implements AutoCloseable {
 
   public void retract() {
     m_piston.set(DoubleSolenoid.Value.REVERSE);
-    m_motor.setThrottle(0); // turn off the motor
+    m_motor.setPower(0); // turn off the motor
   }
 
   public void activate(double velocity) {
     if (isDeployed()) {
-      m_motor.setThrottle(velocity);
+      m_motor.setPower(velocity);
     } else { // if piston isn't open, do nothing
-      m_motor.setThrottle(0);
+      m_motor.setPower(0);
     }
   }
 

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/xrpreference/subsystems/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/xrpreference/subsystems/Drivetrain.java
@@ -30,7 +30,7 @@ public class Drivetrain extends SubsystemBase {
 
   // Set up the differential drive controller
   private final DifferentialDrive m_diffDrive =
-      new DifferentialDrive(m_leftMotor::setThrottle, m_rightMotor::setThrottle);
+      new DifferentialDrive(m_leftMotor::setPower, m_rightMotor::setPower);
 
   // Set up the XRPGyro
   private final XRPGyro m_gyro = new XRPGyro();

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/xrptimed/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/xrptimed/Robot.java
@@ -20,7 +20,7 @@ public class Robot extends TimedRobot {
   private final XRPMotor m_leftDrive = new XRPMotor(0);
   private final XRPMotor m_rightDrive = new XRPMotor(1);
   private final DifferentialDrive m_robotDrive =
-      new DifferentialDrive(m_leftDrive::setThrottle, m_rightDrive::setThrottle);
+      new DifferentialDrive(m_leftDrive::setPower, m_rightDrive::setPower);
   // Assumes a gamepad plugged into channel 0
   private final Joystick m_controller = new Joystick(0);
   private final Timer m_timer = new Timer();

--- a/wpilibjExamples/src/main/java/org/wpilib/snippets/encoderdrive/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/snippets/encoderdrive/Robot.java
@@ -22,7 +22,7 @@ public class Robot extends TimedRobot {
   Spark m_rightLeader = new Spark(2);
   Spark m_rightFollower = new Spark(3);
   DifferentialDrive m_drive =
-      new DifferentialDrive(m_leftLeader::setThrottle, m_rightLeader::setThrottle);
+      new DifferentialDrive(m_leftLeader::setPower, m_rightLeader::setPower);
 
   /** Called once at the beginning of the robot program. */
   public Robot() {

--- a/wpilibjExamples/src/main/java/org/wpilib/snippets/encoderhoming/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/snippets/encoderhoming/Robot.java
@@ -26,9 +26,9 @@ public class Robot extends TimedRobot {
   @Override
   public void autonomousPeriodic() {
     if (!m_limit.get()) {
-      m_spark.setThrottle(-0.5);
+      m_spark.setPower(-0.5);
     } else {
-      m_spark.setThrottle(0.0);
+      m_spark.setPower(0.0);
       m_encoder.reset();
     }
   }

--- a/wpilibjExamples/src/main/java/org/wpilib/snippets/eventloop/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/snippets/eventloop/Robot.java
@@ -42,7 +42,7 @@ public class Robot extends TimedRobot {
         // and there is not a ball at the kicker
         .and(isBallAtKicker.negate())
         // activate the intake
-        .ifHigh(() -> m_intake.setThrottle(0.5));
+        .ifHigh(() -> m_intake.setPower(0.5));
 
     // if the thumb button is not held
     intakeButton
@@ -73,7 +73,7 @@ public class Robot extends TimedRobot {
             .debounce(0.2);
 
     // if we're at the target velocity, kick the ball into the shooter wheel
-    atTargetVelocity.ifHigh(() -> m_kicker.setThrottle(0.7));
+    atTargetVelocity.ifHigh(() -> m_kicker.setPower(0.7));
 
     // when we stop being at the target velocity, it means the ball was shot
     atTargetVelocity

--- a/wpilibjExamples/src/main/java/org/wpilib/snippets/flywheelbangbangcontroller/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/snippets/flywheelbangbangcontroller/Robot.java
@@ -94,8 +94,7 @@ public class Robot extends TimedRobot {
   public void simulationPeriodic() {
     // To update our simulation, we set motor voltage inputs, update the
     // simulation, and write the simulated velocities to our simulated encoder
-    m_flywheelSim.setInputVoltage(
-        m_flywheelMotor.getThrottle() * RobotController.getInputVoltage());
+    m_flywheelSim.setInputVoltage(m_flywheelMotor.getPower() * RobotController.getInputVoltage());
     m_flywheelSim.update(0.02);
     m_encoderSim.setRate(m_flywheelSim.getAngularVelocity());
   }

--- a/wpilibjExamples/src/main/java/org/wpilib/snippets/limitswitch/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/snippets/limitswitch/Robot.java
@@ -33,18 +33,18 @@ public class Robot extends TimedRobot {
     if (velocity > 0) {
       if (m_toplimitSwitch.get()) {
         // We are going up and top limit is tripped so stop
-        m_motor.setThrottle(0);
+        m_motor.setPower(0);
       } else {
         // We are going up but top limit is not tripped so go at commanded velocity
-        m_motor.setThrottle(velocity);
+        m_motor.setPower(velocity);
       }
     } else {
       if (m_bottomlimitSwitch.get()) {
         // We are going down and bottom limit is tripped so stop
-        m_motor.setThrottle(0);
+        m_motor.setPower(0);
       } else {
         // We are going down but bottom limit is not tripped so go at commanded velocity
-        m_motor.setThrottle(velocity);
+        m_motor.setPower(velocity);
       }
     }
   }

--- a/wpilibjExamples/src/main/java/org/wpilib/snippets/motorcontrol/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/snippets/motorcontrol/Robot.java
@@ -52,6 +52,6 @@ public class Robot extends TimedRobot {
   /** The teleop periodic function is called every control packet in teleop. */
   @Override
   public void teleopPeriodic() {
-    m_motor.setThrottle(m_joystick.getY());
+    m_motor.setPower(m_joystick.getY());
   }
 }

--- a/wpilibjExamples/src/main/java/org/wpilib/templates/romicommandv2/subsystems/RomiDrivetrain.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/templates/romicommandv2/subsystems/RomiDrivetrain.java
@@ -25,7 +25,7 @@ public class RomiDrivetrain extends SubsystemBase {
 
   // Set up the differential drive controller
   private final DifferentialDrive m_diffDrive =
-      new DifferentialDrive(m_leftMotor::setThrottle, m_rightMotor::setThrottle);
+      new DifferentialDrive(m_leftMotor::setPower, m_rightMotor::setPower);
 
   /** Creates a new RomiDrivetrain. */
   public RomiDrivetrain() {

--- a/wpilibjExamples/src/main/java/org/wpilib/templates/romieducational/RomiDrivetrain.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/templates/romieducational/RomiDrivetrain.java
@@ -24,7 +24,7 @@ public class RomiDrivetrain {
 
   // Set up the differential drive controller
   private final DifferentialDrive m_diffDrive =
-      new DifferentialDrive(m_leftMotor::setThrottle, m_rightMotor::setThrottle);
+      new DifferentialDrive(m_leftMotor::setPower, m_rightMotor::setPower);
 
   /** Creates a new RomiDrivetrain. */
   public RomiDrivetrain() {

--- a/wpilibjExamples/src/main/java/org/wpilib/templates/romitimed/RomiDrivetrain.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/templates/romitimed/RomiDrivetrain.java
@@ -24,7 +24,7 @@ public class RomiDrivetrain {
 
   // Set up the differential drive controller
   private final DifferentialDrive m_diffDrive =
-      new DifferentialDrive(m_leftMotor::setThrottle, m_rightMotor::setThrottle);
+      new DifferentialDrive(m_leftMotor::setPower, m_rightMotor::setPower);
 
   /** Creates a new RomiDrivetrain. */
   public RomiDrivetrain() {

--- a/wpilibjExamples/src/main/java/org/wpilib/templates/xrpcommandv2/subsystems/XRPDrivetrain.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/templates/xrpcommandv2/subsystems/XRPDrivetrain.java
@@ -28,7 +28,7 @@ public class XRPDrivetrain extends SubsystemBase {
 
   // Set up the differential drive controller
   private final DifferentialDrive m_diffDrive =
-      new DifferentialDrive(m_leftMotor::setThrottle, m_rightMotor::setThrottle);
+      new DifferentialDrive(m_leftMotor::setPower, m_rightMotor::setPower);
 
   /** Creates a new XRPDrivetrain. */
   public XRPDrivetrain() {

--- a/wpilibjExamples/src/main/java/org/wpilib/templates/xrpeducational/XRPDrivetrain.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/templates/xrpeducational/XRPDrivetrain.java
@@ -27,7 +27,7 @@ public class XRPDrivetrain {
 
   // Set up the differential drive controller
   private final DifferentialDrive m_diffDrive =
-      new DifferentialDrive(m_leftMotor::setThrottle, m_rightMotor::setThrottle);
+      new DifferentialDrive(m_leftMotor::setPower, m_rightMotor::setPower);
 
   /** Creates a new XRPDrivetrain. */
   public XRPDrivetrain() {

--- a/wpilibjExamples/src/main/java/org/wpilib/templates/xrptimed/XRPDrivetrain.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/templates/xrptimed/XRPDrivetrain.java
@@ -27,7 +27,7 @@ public class XRPDrivetrain {
 
   // Set up the differential drive controller
   private final DifferentialDrive m_diffDrive =
-      new DifferentialDrive(m_leftMotor::setThrottle, m_rightMotor::setThrottle);
+      new DifferentialDrive(m_leftMotor::setPower, m_rightMotor::setPower);
 
   /** Creates a new XRPDrivetrain. */
   public XRPDrivetrain() {

--- a/wpilibjExamples/src/test/java/org/wpilib/examples/armsimulation/ArmSimulationTest.java
+++ b/wpilibjExamples/src/test/java/org/wpilib/examples/armsimulation/ArmSimulationTest.java
@@ -142,7 +142,7 @@ class ArmSimulationTest {
       // advance 75 timesteps
       SimHooks.stepTiming(3.5);
 
-      assertEquals(0.0, m_motorSim.getThrottle(), 0.01);
+      assertEquals(0.0, m_motorSim.getPower(), 0.01);
       assertEquals(Constants.kMinAngleRads, m_encoderSim.getDistance(), 2.0);
     }
   }

--- a/wpilibjExamples/src/test/java/org/wpilib/examples/elevatorsimulation/ElevatorSimulationTest.java
+++ b/wpilibjExamples/src/test/java/org/wpilib/examples/elevatorsimulation/ElevatorSimulationTest.java
@@ -131,7 +131,7 @@ class ElevatorSimulationTest {
       // advance 75 timesteps
       SimHooks.stepTiming(1.5);
 
-      assertEquals(0.0, m_motorSim.getThrottle(), 0.05);
+      assertEquals(0.0, m_motorSim.getPower(), 0.05);
       assertEquals(0.0, m_encoderSim.getDistance(), 0.05);
     }
   }

--- a/wpilibjExamples/src/test/java/org/wpilib/examples/unittest/subsystems/IntakeTest.java
+++ b/wpilibjExamples/src/test/java/org/wpilib/examples/unittest/subsystems/IntakeTest.java
@@ -47,14 +47,14 @@ class IntakeTest {
     m_intake.retract(); // close the intake
     m_intake.activate(0.5); // try to activate the motor
     assertEquals(
-        0.0, m_simMotor.getThrottle(), DELTA); // make sure that the value set to the motor is 0
+        0.0, m_simMotor.getPower(), DELTA); // make sure that the value set to the motor is 0
   }
 
   @Test
   void worksWhenOpen() {
     m_intake.deploy();
     m_intake.activate(0.5);
-    assertEquals(0.5, m_simMotor.getThrottle(), DELTA);
+    assertEquals(0.5, m_simMotor.getPower(), DELTA);
   }
 
   @Test

--- a/xrpVendordep/src/main/java/org/wpilib/xrp/XRPMotor.java
+++ b/xrpVendordep/src/main/java/org/wpilib/xrp/XRPMotor.java
@@ -41,7 +41,7 @@ public class XRPMotor implements MotorController {
     s_simDeviceNameMap.put(3, "motor4");
   }
 
-  private final SimDouble m_simThrottle;
+  private final SimDouble m_simPower;
   private final SimBoolean m_simInverted;
 
   /**
@@ -59,29 +59,29 @@ public class XRPMotor implements MotorController {
     if (xrpMotorSimDevice != null) {
       xrpMotorSimDevice.createBoolean("init", Direction.OUTPUT, true);
       m_simInverted = xrpMotorSimDevice.createBoolean("inverted", Direction.INPUT, false);
-      m_simThrottle = xrpMotorSimDevice.createDouble("throttle", Direction.OUTPUT, 0.0);
+      m_simPower = xrpMotorSimDevice.createDouble("power", Direction.OUTPUT, 0.0);
     } else {
       m_simInverted = null;
-      m_simThrottle = null;
+      m_simPower = null;
     }
   }
 
   @Override
-  public void setThrottle(double throttle) {
-    if (m_simThrottle != null) {
+  public void setPower(double power) {
+    if (m_simPower != null) {
       boolean invert = false;
       if (m_simInverted != null) {
         invert = m_simInverted.get();
       }
 
-      m_simThrottle.set(invert ? -throttle : throttle);
+      m_simPower.set(invert ? -power : power);
     }
   }
 
   @Override
-  public double getThrottle() {
-    if (m_simThrottle != null) {
-      return m_simThrottle.get();
+  public double getPower() {
+    if (m_simPower != null) {
+      return m_simPower.get();
     }
 
     return 0.0;
@@ -101,6 +101,6 @@ public class XRPMotor implements MotorController {
 
   @Override
   public void disable() {
-    setThrottle(0.0);
+    setPower(0.0);
   }
 }

--- a/xrpVendordep/src/main/native/cpp/xrp/XRPMotor.cpp
+++ b/xrpVendordep/src/main/native/cpp/xrp/XRPMotor.cpp
@@ -41,25 +41,25 @@ XRPMotor::XRPMotor(int deviceNum) {
     m_simDevice.CreateBoolean("init", hal::SimDevice::Direction::OUTPUT, true);
     m_simInverted = m_simDevice.CreateBoolean(
         "inverted", hal::SimDevice::Direction::INPUT, false);
-    m_simThrottle = m_simDevice.CreateDouble(
-        "throttle", hal::SimDevice::Direction::OUTPUT, 0.0);
+    m_simPower = m_simDevice.CreateDouble(
+        "power", hal::SimDevice::Direction::OUTPUT, 0.0);
   }
 }
 
-void XRPMotor::SetThrottle(double throttle) {
-  if (m_simThrottle) {
+void XRPMotor::SetPower(double power) {
+  if (m_simPower) {
     bool invert = false;
     if (m_simInverted) {
       invert = m_simInverted.Get();
     }
 
-    m_simThrottle.Set(invert ? -throttle : throttle);
+    m_simPower.Set(invert ? -power : power);
   }
 }
 
-double XRPMotor::GetThrottle() const {
-  if (m_simThrottle) {
-    return m_simThrottle.Get();
+double XRPMotor::GetPower() const {
+  if (m_simPower) {
+    return m_simPower.Get();
   }
 
   return 0.0;
@@ -80,11 +80,11 @@ bool XRPMotor::GetInverted() const {
 }
 
 void XRPMotor::Disable() {
-  SetThrottle(0.0);
+  SetPower(0.0);
 }
 
 void XRPMotor::StopMotor() {
-  SetThrottle(0.0);
+  SetPower(0.0);
 }
 
 std::string XRPMotor::GetDescription() const {

--- a/xrpVendordep/src/main/native/include/wpi/xrp/XRPMotor.hpp
+++ b/xrpVendordep/src/main/native/include/wpi/xrp/XRPMotor.hpp
@@ -33,8 +33,8 @@ class XRPMotor : public wpi::MotorController, public wpi::MotorSafety {
    */
   explicit XRPMotor(int deviceNum);
 
-  void SetThrottle(double throttle) override;
-  double GetThrottle() const override;
+  void SetPower(double power) override;
+  double GetPower() const override;
 
   void SetInverted(bool isInverted) override;
   bool GetInverted() const override;
@@ -46,7 +46,7 @@ class XRPMotor : public wpi::MotorController, public wpi::MotorSafety {
 
  private:
   hal::SimDevice m_simDevice;
-  hal::SimDouble m_simThrottle;
+  hal::SimDouble m_simPower;
   hal::SimBoolean m_simInverted;
 
   std::string m_deviceName;

--- a/xrpVendordep/src/main/python/semiwrap/XRPMotor.yml
+++ b/xrpVendordep/src/main/python/semiwrap/XRPMotor.yml
@@ -2,8 +2,8 @@ classes:
   wpi::xrp::XRPMotor:
     methods:
       XRPMotor:
-      SetThrottle:
-      GetThrottle:
+      SetPower:
+      GetPower:
       SetInverted:
       GetInverted:
       Disable:


### PR DESCRIPTION
Also rename in other motor controllers (XRPMotor, ExpansionHubMotor).

The throttle naming was merged with the idea that it would be interim until we got FTC team feedback.  It was never a final decision.  Essentially the decision to go with power boiled down to:
- Throttle is a less common word and deemed not discoverable by middle school students
- Throttle has overloaded meanings (eg limiting)
- Plain set() is ambiguous, and isn’t actually that commonly used in FRC given wide use of vendor libraries and other control methods
- Percent doesn’t work due to 100 vs 1 issue.
- VEX uses spin(), but nobody was a huge fan of it
- Power is the term used in LEGO (eg blocks LEGO)
- Power is the term used in FTC

When there’s no obvious best answer, the tie-break we’ve been using is to minimize change from one program or the other—in this case, the decision was to minimize change from FTC.  I will note that there have been a number of other cases where a similar decision went to minimizing change to FRC (in fact since we’re using WPILib, that’s effectively been the *default* decision).

More discussion background in #8716.