### PR TITLE
[build] Fix CMake add_source_jar() OUTPUT_DIR warnings

### DIFF
--- a/wpiannotations/CMakeLists.txt
+++ b/wpiannotations/CMakeLists.txt
@@ -30,6 +30,7 @@ if(WITH_JAVA_SOURCE)
         wpiannotations_src_jar
         BASE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
         OUTPUT_NAME wpiannotations-sources
+        OUTPUT_DIR ${WPILIB_BINARY_DIR}/${java_lib_dest}
     )
     set_property(TARGET wpiannotations_src_jar PROPERTY FOLDER "java")
 

--- a/wpiunits/CMakeLists.txt
+++ b/wpiunits/CMakeLists.txt
@@ -28,6 +28,7 @@ if(WITH_JAVA_SOURCE)
             ${CMAKE_CURRENT_SOURCE_DIR}/src/main/java
             ${CMAKE_CURRENT_SOURCE_DIR}/src/generated/main/java
         OUTPUT_NAME wpiunits-sources
+        OUTPUT_DIR ${WPILIB_BINARY_DIR}/${java_lib_dest}
     )
     set_property(TARGET wpiunits_src_jar PROPERTY FOLDER "java")
 


### PR DESCRIPTION
```
CMake Warning (dev) at /usr/share/cmake/Modules/UseJava.cmake:716 (cmake_parse_arguments):
  The OUTPUT_DIR keyword was followed by an empty string or no value at all.
  Policy CMP0174 is not set, so cmake_parse_arguments() will unset the
  _add_jar_OUTPUT_DIR variable rather than setting it to an empty string.
Call Stack (most recent call first):
  cmake/modules/CreateSourceJar.cmake:29:EVAL:1 (add_jar)
  cmake/modules/CreateSourceJar.cmake:29 (cmake_language)
  wpiannotations/CMakeLists.txt:29 (add_source_jar)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /usr/share/cmake/Modules/UseJava.cmake:716 (cmake_parse_arguments):
  The OUTPUT_DIR keyword was followed by an empty string or no value at all.
  Policy CMP0174 is not set, so cmake_parse_arguments() will unset the
  _add_jar_OUTPUT_DIR variable rather than setting it to an empty string.
Call Stack (most recent call first):
  cmake/modules/CreateSourceJar.cmake:29:EVAL:1 (add_jar)
  cmake/modules/CreateSourceJar.cmake:29 (cmake_language)
  wpiunits/CMakeLists.txt:25 (add_source_jar)
This warning is for project developers.  Use -Wno-dev to suppress it.
```