### PR TITLE
[epilogue] Use full class names in static logger fields

### DIFF
--- a/epilogue-processor/src/main/java/org/wpilib/epilogue/processor/ConfiguredLoggerHandler.java
+++ b/epilogue-processor/src/main/java/org/wpilib/epilogue/processor/ConfiguredLoggerHandler.java
@@ -41,7 +41,7 @@ public class ConfiguredLoggerHandler extends ElementHandler {
             .getValue();
 
     return "Epilogue."
-        + StringUtils.lowerCamelCase(loggerType.asElement().getSimpleName())
+        + loggerType.toString().replace('.', '_')
         + ".tryUpdate(backend.getNested(\""
         + loggedName(element)
         + "\"), "

--- a/epilogue-processor/src/main/java/org/wpilib/epilogue/processor/EpilogueGenerator.java
+++ b/epilogue-processor/src/main/java/org/wpilib/epilogue/processor/EpilogueGenerator.java
@@ -97,31 +97,20 @@ public class EpilogueGenerator {
         out.println();
 
         loggerClassNames.forEach(
-            name -> {
-              String simple = StringUtils.simpleName(name);
-
-              // public static final FooLogger fooLogger = new FooLogger();
-              out.print("  public static final ");
-              out.print(simple);
-              out.print(" ");
-              out.print(StringUtils.lowerCamelCase(simple));
-              out.print(" = new ");
-              out.print(simple);
-              out.println("();");
+            clazz -> {
+              // public static final com.example.FooLogger com_example_fooLogger =
+              //   new com.example.FooLogger();
+              String field = clazz.replace('.', '_');
+              out.printf("  public static final %s %s = new %s();%n", clazz, field, clazz);
             });
         m_customLoggers.values().stream()
             .distinct()
             .forEach(
                 loggerType -> {
-                  var loggerTypeName = loggerType.asElement().getSimpleName();
-                  out.println(
-                      "  public static final "
-                          + loggerTypeName
-                          + " "
-                          + StringUtils.lowerCamelCase(loggerTypeName)
-                          + " = new "
-                          + loggerTypeName
-                          + "();");
+                  var loggerTypeName = loggerType.toString();
+                  out.printf(
+                      "  public static final %s %s = new %s();%n",
+                      loggerTypeName, loggerTypeName.replace('.', '_'), loggerTypeName);
                 });
         out.println();
 

--- a/epilogue-processor/src/main/java/org/wpilib/epilogue/processor/StringUtils.java
+++ b/epilogue-processor/src/main/java/org/wpilib/epilogue/processor/StringUtils.java
@@ -100,7 +100,7 @@ public final class StringUtils {
    * @return the logger field name
    */
   public static String loggerFieldName(TypeElement clazz) {
-    return lowerCamelCase(simpleName(loggerClassName(clazz)));
+    return loggerClassName(clazz).replace('.', '_');
   }
 
   /**

--- a/epilogue-processor/src/test/java/org/wpilib/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/org/wpilib/epilogue/processor/AnnotationProcessorTest.java
@@ -1500,8 +1500,8 @@ class AnnotationProcessorTest {
         @Override
         public void update(EpilogueBackend backend, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            Epilogue.childLogger.tryUpdate(backend.getNested("child"), object.child, Epilogue.getConfig().errorHandler);
-            Epilogue.ioLogger.tryUpdate(backend.getNested("io"), object.io, Epilogue.getConfig().errorHandler);
+            Epilogue.org_wpilib_epilogue_ChildLogger.tryUpdate(backend.getNested("child"), object.child, Epilogue.getConfig().errorHandler);
+            Epilogue.org_wpilib_epilogue_IOLogger.tryUpdate(backend.getNested("io"), object.io, Epilogue.getConfig().errorHandler);
           }
         }
       }
@@ -1589,27 +1589,27 @@ class AnnotationProcessorTest {
             if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
               var $$asInterface = object.asInterface;
               if ($$asInterface instanceof org.wpilib.epilogue.Impl1 org_wpilib_epilogue_Impl1) {
-                Epilogue.impl1Logger.tryUpdate(backend.getNested("asInterface"), org_wpilib_epilogue_Impl1, Epilogue.getConfig().errorHandler);
+                Epilogue.org_wpilib_epilogue_Impl1Logger.tryUpdate(backend.getNested("asInterface"), org_wpilib_epilogue_Impl1, Epilogue.getConfig().errorHandler);
               } else if ($$asInterface instanceof org.wpilib.epilogue.Impl2 org_wpilib_epilogue_Impl2) {
-                Epilogue.impl2Logger.tryUpdate(backend.getNested("asInterface"), org_wpilib_epilogue_Impl2, Epilogue.getConfig().errorHandler);
+                Epilogue.org_wpilib_epilogue_Impl2Logger.tryUpdate(backend.getNested("asInterface"), org_wpilib_epilogue_Impl2, Epilogue.getConfig().errorHandler);
               } else {
                 // Base type org.wpilib.epilogue.IFace
-                Epilogue.iFaceLogger.tryUpdate(backend.getNested("asInterface"), $$asInterface, Epilogue.getConfig().errorHandler);
+                Epilogue.org_wpilib_epilogue_IFaceLogger.tryUpdate(backend.getNested("asInterface"), $$asInterface, Epilogue.getConfig().errorHandler);
               };
-              Epilogue.impl1Logger.tryUpdate(backend.getNested("firstImpl"), object.firstImpl, Epilogue.getConfig().errorHandler);
-              Epilogue.impl2Logger.tryUpdate(backend.getNested("secondImpl"), object.secondImpl, Epilogue.getConfig().errorHandler);
+              Epilogue.org_wpilib_epilogue_Impl1Logger.tryUpdate(backend.getNested("firstImpl"), object.firstImpl, Epilogue.getConfig().errorHandler);
+              Epilogue.org_wpilib_epilogue_Impl2Logger.tryUpdate(backend.getNested("secondImpl"), object.secondImpl, Epilogue.getConfig().errorHandler);
               var $$complex = object.complex;
               if ($$complex instanceof org.wpilib.epilogue.ConcreteLogged org_wpilib_epilogue_ConcreteLogged) {
-                Epilogue.concreteLoggedLogger.tryUpdate(backend.getNested("complex"), org_wpilib_epilogue_ConcreteLogged, Epilogue.getConfig().errorHandler);
+                Epilogue.org_wpilib_epilogue_ConcreteLoggedLogger.tryUpdate(backend.getNested("complex"), org_wpilib_epilogue_ConcreteLogged, Epilogue.getConfig().errorHandler);
               } else if ($$complex instanceof org.wpilib.epilogue.I4 org_wpilib_epilogue_I4) {
-                Epilogue.i4Logger.tryUpdate(backend.getNested("complex"), org_wpilib_epilogue_I4, Epilogue.getConfig().errorHandler);
+                Epilogue.org_wpilib_epilogue_I4Logger.tryUpdate(backend.getNested("complex"), org_wpilib_epilogue_I4, Epilogue.getConfig().errorHandler);
               } else if ($$complex instanceof org.wpilib.epilogue.I2 org_wpilib_epilogue_I2) {
-                Epilogue.i2Logger.tryUpdate(backend.getNested("complex"), org_wpilib_epilogue_I2, Epilogue.getConfig().errorHandler);
+                Epilogue.org_wpilib_epilogue_I2Logger.tryUpdate(backend.getNested("complex"), org_wpilib_epilogue_I2, Epilogue.getConfig().errorHandler);
               } else if ($$complex instanceof org.wpilib.epilogue.I3 org_wpilib_epilogue_I3) {
-                Epilogue.i3Logger.tryUpdate(backend.getNested("complex"), org_wpilib_epilogue_I3, Epilogue.getConfig().errorHandler);
+                Epilogue.org_wpilib_epilogue_I3Logger.tryUpdate(backend.getNested("complex"), org_wpilib_epilogue_I3, Epilogue.getConfig().errorHandler);
               } else {
                 // Base type org.wpilib.epilogue.I
-                Epilogue.iLogger.tryUpdate(backend.getNested("complex"), $$complex, Epilogue.getConfig().errorHandler);
+                Epilogue.org_wpilib_epilogue_ILogger.tryUpdate(backend.getNested("complex"), $$complex, Epilogue.getConfig().errorHandler);
               };
             }
           }
@@ -1791,12 +1791,12 @@ class AnnotationProcessorTest {
             if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
               var $$theField = object.theField;
               if ($$theField instanceof org.wpilib.epilogue.Base org_wpilib_epilogue_Base) {
-                Epilogue.baseLogger.tryUpdate(backend.getNested("theField"), org_wpilib_epilogue_Base, Epilogue.getConfig().errorHandler);
+                Epilogue.org_wpilib_epilogue_BaseLogger.tryUpdate(backend.getNested("theField"), org_wpilib_epilogue_Base, Epilogue.getConfig().errorHandler);
               } else if ($$theField instanceof org.wpilib.epilogue.ExtendingInterface org_wpilib_epilogue_ExtendingInterface) {
-                Epilogue.extendingInterfaceLogger.tryUpdate(backend.getNested("theField"), org_wpilib_epilogue_ExtendingInterface, Epilogue.getConfig().errorHandler);
+                Epilogue.org_wpilib_epilogue_ExtendingInterfaceLogger.tryUpdate(backend.getNested("theField"), org_wpilib_epilogue_ExtendingInterface, Epilogue.getConfig().errorHandler);
               } else {
                 // Base type org.wpilib.epilogue.I
-                Epilogue.iLogger.tryUpdate(backend.getNested("theField"), $$theField, Epilogue.getConfig().errorHandler);
+                Epilogue.org_wpilib_epilogue_ILogger.tryUpdate(backend.getNested("theField"), $$theField, Epilogue.getConfig().errorHandler);
               };
             }
           }
@@ -1858,10 +1858,10 @@ class AnnotationProcessorTest {
             if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
               var $$theField = ((org.wpilib.epilogue.I) $org_wpilib_epilogue_Example_theField.get(object));
               if ($$theField instanceof org.wpilib.epilogue.Base org_wpilib_epilogue_Base) {
-                Epilogue.baseLogger.tryUpdate(backend.getNested("theField"), org_wpilib_epilogue_Base, Epilogue.getConfig().errorHandler);
+                Epilogue.org_wpilib_epilogue_BaseLogger.tryUpdate(backend.getNested("theField"), org_wpilib_epilogue_Base, Epilogue.getConfig().errorHandler);
               } else {
                 // Base type org.wpilib.epilogue.I
-                Epilogue.iLogger.tryUpdate(backend.getNested("theField"), $$theField, Epilogue.getConfig().errorHandler);
+                Epilogue.org_wpilib_epilogue_ILogger.tryUpdate(backend.getNested("theField"), $$theField, Epilogue.getConfig().errorHandler);
               };
             }
           }
@@ -1903,7 +1903,7 @@ class AnnotationProcessorTest {
           @Override
           public void update(EpilogueBackend backend, Example object) {
             if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-              Epilogue.implicitLogger.tryUpdate(backend.getNested("i"), object.i, Epilogue.getConfig().errorHandler);
+              Epilogue.org_wpilib_epilogue_ImplicitLogger.tryUpdate(backend.getNested("i"), object.i, Epilogue.getConfig().errorHandler);
             }
           }
         }
@@ -1957,7 +1957,7 @@ class AnnotationProcessorTest {
         @Override
         public void update(EpilogueBackend backend, Example object) {
           if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-            Epilogue.customPointLogger.tryUpdate(backend.getNested("point"), object.point, Epilogue.getConfig().errorHandler);
+            Epilogue.org_wpilib_epilogue_CustomPointLogger.tryUpdate(backend.getNested("point"), object.point, Epilogue.getConfig().errorHandler);
           }
         }
       }
@@ -2012,7 +2012,7 @@ class AnnotationProcessorTest {
           @Override
           public void update(EpilogueBackend backend, Example object) {
             if (Epilogue.shouldLog(Logged.Importance.DEBUG)) {
-              Epilogue.vectorLogger.tryUpdate(backend.getNested("vec"), object.vec, Epilogue.getConfig().errorHandler);
+              Epilogue.org_wpilib_epilogue_VectorLogger.tryUpdate(backend.getNested("vec"), object.vec, Epilogue.getConfig().errorHandler);
             }
           }
         }

--- a/epilogue-processor/src/test/java/org/wpilib/epilogue/processor/EpilogueGeneratorTest.java
+++ b/epilogue-processor/src/test/java/org/wpilib/epilogue/processor/EpilogueGeneratorTest.java
@@ -44,7 +44,7 @@ class EpilogueGeneratorTest {
 
           private static final EpilogueConfiguration config = new EpilogueConfiguration();
 
-          public static final ExampleLogger exampleLogger = new ExampleLogger();
+          public static final org.wpilib.epilogue.ExampleLogger org_wpilib_epilogue_ExampleLogger = new org.wpilib.epilogue.ExampleLogger();
 
           public static void configure(java.util.function.Consumer<EpilogueConfiguration> configurator) {
             configurator.accept(config);
@@ -99,7 +99,7 @@ class EpilogueGeneratorTest {
 
           private static final EpilogueConfiguration config = new EpilogueConfiguration();
 
-          public static final ExampleLogger exampleLogger = new ExampleLogger();
+          public static final org.wpilib.epilogue.ExampleLogger org_wpilib_epilogue_ExampleLogger = new org.wpilib.epilogue.ExampleLogger();
 
           public static void configure(java.util.function.Consumer<EpilogueConfiguration> configurator) {
             configurator.accept(config);
@@ -149,7 +149,7 @@ class EpilogueGeneratorTest {
 
           private static final EpilogueConfiguration config = new EpilogueConfiguration();
 
-          public static final ExampleLogger exampleLogger = new ExampleLogger();
+          public static final org.wpilib.epilogue.ExampleLogger org_wpilib_epilogue_ExampleLogger = new org.wpilib.epilogue.ExampleLogger();
 
           public static void configure(java.util.function.Consumer<EpilogueConfiguration> configurator) {
             configurator.accept(config);
@@ -173,8 +173,8 @@ class EpilogueGeneratorTest {
            */
           public static void update(org.wpilib.epilogue.Example robot) {
             long start = System.nanoTime();
-            exampleLogger.tryUpdate(config.backend.getNested(config.root), robot, config.errorHandler);
-            config.backend.log(\"Epilogue/Stats/Last Run\", (System.nanoTime() - start) / 1e6);
+            org_wpilib_epilogue_ExampleLogger.tryUpdate(config.backend.getNested(config.root), robot, config.errorHandler);
+            config.backend.log("Epilogue/Stats/Last Run", (System.nanoTime() - start) / 1e6);
           }
 
           /**
@@ -234,8 +234,8 @@ class EpilogueGeneratorTest {
 
           private static final EpilogueConfiguration config = new EpilogueConfiguration();
 
-          public static final AlphaBotLogger alphaBotLogger = new AlphaBotLogger();
-          public static final BetaBotLogger betaBotLogger = new BetaBotLogger();
+          public static final org.wpilib.epilogue.AlphaBotLogger org_wpilib_epilogue_AlphaBotLogger = new org.wpilib.epilogue.AlphaBotLogger();
+          public static final org.wpilib.epilogue.BetaBotLogger org_wpilib_epilogue_BetaBotLogger = new org.wpilib.epilogue.BetaBotLogger();
 
           public static void configure(java.util.function.Consumer<EpilogueConfiguration> configurator) {
             configurator.accept(config);
@@ -259,8 +259,8 @@ class EpilogueGeneratorTest {
            */
           public static void update(org.wpilib.epilogue.AlphaBot robot) {
             long start = System.nanoTime();
-            alphaBotLogger.tryUpdate(config.backend.getNested(config.root), robot, config.errorHandler);
-            config.backend.log(\"Epilogue/Stats/Last Run\", (System.nanoTime() - start) / 1e6);
+            org_wpilib_epilogue_AlphaBotLogger.tryUpdate(config.backend.getNested(config.root), robot, config.errorHandler);
+            config.backend.log("Epilogue/Stats/Last Run", (System.nanoTime() - start) / 1e6);
           }
 
           /**
@@ -291,8 +291,8 @@ class EpilogueGeneratorTest {
            */
           public static void update(org.wpilib.epilogue.BetaBot robot) {
             long start = System.nanoTime();
-            betaBotLogger.tryUpdate(config.backend.getNested(config.root), robot, config.errorHandler);
-            config.backend.log(\"Epilogue/Stats/Last Run\", (System.nanoTime() - start) / 1e6);
+            org_wpilib_epilogue_BetaBotLogger.tryUpdate(config.backend.getNested(config.root), robot, config.errorHandler);
+            config.backend.log("Epilogue/Stats/Last Run", (System.nanoTime() - start) / 1e6);
           }
 
           /**
@@ -367,8 +367,8 @@ class EpilogueGeneratorTest {
 
           private static final EpilogueConfiguration config = new EpilogueConfiguration();
 
-          public static final ExampleLogger exampleLogger = new ExampleLogger();
-          public static final CustomLogger customLogger = new CustomLogger();
+          public static final org.wpilib.epilogue.ExampleLogger org_wpilib_epilogue_ExampleLogger = new org.wpilib.epilogue.ExampleLogger();
+          public static final org.wpilib.epilogue.CustomLogger org_wpilib_epilogue_CustomLogger = new org.wpilib.epilogue.CustomLogger();
 
           public static void configure(java.util.function.Consumer<EpilogueConfiguration> configurator) {
             configurator.accept(config);


### PR DESCRIPTION
This prevents conflicts when multiple classes with the same simple name exist in separate packages