### PR TITLE
[build] Always run Checkstyle after spotlessApply

### DIFF
--- a/shared/java/javastyle.gradle
+++ b/shared/java/javastyle.gradle
@@ -85,5 +85,9 @@ spotbugs {
 task javaFormat {
     dependsOn(tasks.withType(Checkstyle))
     dependsOn(tasks.withType(Pmd))
+    dependsOn 'spotlessApply'
 }
-javaFormat.dependsOn 'spotlessApply'
+
+tasks.withType(Checkstyle) {
+    it.mustRunAfter 'spotlessApply'
+}


### PR DESCRIPTION
This avoids issues where Checkstyle will error on line length by having Spotless run first and fix up line lengths before Checkstyle sees the files.