### PR TITLE
[wpiutil] Struct: fix is_constexpr check in constexpr functions

### DIFF
--- a/wpiutil/src/main/native/include/wpi/util/struct/Struct.hpp
+++ b/wpiutil/src/main/native/include/wpi/util/struct/Struct.hpp
@@ -314,7 +314,7 @@ template <typename T, typename... I>
 constexpr auto GetStructTypeString(const I&... info) {
   using S = Struct<T, typename std::remove_cvref_t<I>...>;
   if constexpr (sizeof...(I) == 0 &&
-                is_constexpr([&] { S::GetTypeName(info...); })) {
+                is_constexpr([&info...] { S::GetTypeName(info...); })) {
     constexpr auto typeName = S::GetTypeName(info...);
     using namespace literals;
     return Concat(
@@ -344,7 +344,7 @@ template <typename T, size_t N, typename... I>
 constexpr auto MakeStructArrayTypeName(const I&... info) {
   using S = Struct<T, typename std::remove_cvref_t<I>...>;
   if constexpr (sizeof...(I) == 0 &&
-                is_constexpr([&] { S::GetTypeName(info...); })) {
+                is_constexpr([&info...] { S::GetTypeName(info...); })) {
     constexpr auto typeName = S::GetTypeName(info...);
     using namespace literals;
     if constexpr (N == std::dynamic_extent) {
@@ -370,7 +370,7 @@ template <typename T, size_t N, typename... I>
 constexpr auto MakeStructArrayTypeString(const I&... info) {
   using S = Struct<T, typename std::remove_cvref_t<I>...>;
   if constexpr (sizeof...(I) == 0 &&
-                is_constexpr([&] { S::GetTypeName(info...); })) {
+                is_constexpr([&info...] { S::GetTypeName(info...); })) {
     using namespace literals;
     return Concat("struct:"_ct_string, MakeStructArrayTypeName<T, N>(info...));
   } else {
@@ -383,7 +383,7 @@ template <typename T, size_t N, typename... I>
 constexpr auto MakeStructArraySchema(const I&... info) {
   using S = Struct<T, typename std::remove_cvref_t<I>...>;
   if constexpr (sizeof...(I) == 0 &&
-                is_constexpr([&] { S::GetSchema(info...); })) {
+                is_constexpr([&info...] { S::GetSchema(info...); })) {
     constexpr auto schema = S::GetSchema(info...);
     using namespace literals;
     if constexpr (N == std::dynamic_extent) {

--- a/wpiutil/src/test/native/cpp/struct/StructTest.cpp
+++ b/wpiutil/src/test/native/cpp/struct/StructTest.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "wpi/util/struct/Struct.hpp"
+
+#include <stdint.h>
+
+#include <array>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace wpi::util;
+
+static_assert(StructSerializable<int>);
+static_assert(StructSerializable<std::array<int, 5>>);
+static_assert(!StructSerializable<std::vector<int>>);
+static_assert(!StructSerializable<std::string>);
+
+namespace {
+struct TestStruct {
+  int32_t a;
+  int32_t b;
+};
+}
+
+template <>
+struct wpi::util::Struct<TestStruct> {
+  static constexpr std::string_view GetTypeName() { return "TestStruct"; }
+  static constexpr size_t GetSize() { return 8; }
+  static constexpr std::string_view GetSchema() { return "int32 a;int32 b"; }
+  static TestStruct Unpack(std::span<const uint8_t> data) {
+    return {
+      wpi::util::UnpackStruct<int32_t, 0>(data),
+      wpi::util::UnpackStruct<int32_t, 4>(data)
+    };
+  }
+  static void Pack(std::span<uint8_t> data, TestStruct value) {
+    wpi::util::PackStruct<0>(data, value.a);
+    wpi::util::PackStruct<4>(data, value.b);
+  }
+};
+
+TEST(StructTest, Basic) {
+  constexpr auto typeName = GetStructTypeName<TestStruct>();
+  EXPECT_EQ(typeName, "TestStruct");
+
+  constexpr auto typeString = GetStructTypeString<TestStruct>();
+  EXPECT_EQ(typeString, "struct:TestStruct");
+
+  constexpr auto schema = GetStructSchema<TestStruct>();
+  EXPECT_EQ(schema, "int32 a;int32 b");
+
+  constexpr auto arrayTypeName = MakeStructArrayTypeName<TestStruct, 5>();
+  EXPECT_EQ(arrayTypeName, "TestStruct[5]");
+
+  constexpr auto arrayTypeString = MakeStructArrayTypeString<TestStruct, 5>();
+  EXPECT_EQ(arrayTypeString, "struct:TestStruct[5]");
+
+  TestStruct s{12345, 67890};
+  std::array<uint8_t, 8> data;
+  Struct<TestStruct>::Pack(data, s);
+  auto s2 = Struct<TestStruct>::Unpack(data);
+  EXPECT_EQ(s.a, s2.a);
+  EXPECT_EQ(s.b, s2.b);
+}

--- a/wpiutil/src/test/native/cpp/struct/StructTest.cpp
+++ b/wpiutil/src/test/native/cpp/struct/StructTest.cpp
@@ -24,7 +24,7 @@ struct TestStruct {
   int32_t a;
   int32_t b;
 };
-}
+}  // namespace
 
 template <>
 struct wpi::util::Struct<TestStruct> {
@@ -32,10 +32,8 @@ struct wpi::util::Struct<TestStruct> {
   static constexpr size_t GetSize() { return 8; }
   static constexpr std::string_view GetSchema() { return "int32 a;int32 b"; }
   static TestStruct Unpack(std::span<const uint8_t> data) {
-    return {
-      wpi::util::UnpackStruct<int32_t, 0>(data),
-      wpi::util::UnpackStruct<int32_t, 4>(data)
-    };
+    return {wpi::util::UnpackStruct<int32_t, 0>(data),
+            wpi::util::UnpackStruct<int32_t, 4>(data)};
   }
   static void Pack(std::span<uint8_t> data, TestStruct value) {
     wpi::util::PackStruct<0>(data, value.a);


### PR DESCRIPTION
Capturing the info parameter pack explicitly is required for the is_constexpr check to work.

Add some basic tests.

Fixes #8789.