### PR TITLE
[bazel][build] Add CI action to generate pregen patch

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -136,6 +136,35 @@ jobs:
           path: "*-bazel-lint-fixes.patch"
         if: ${{ failure() }}
 
+  non_robotpy_pregeneration:
+    name: "Non-RobotPy Pregen"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with: { fetch-depth: 0 }
+
+      - id: Setup_bazel_remote
+        uses: ./.github/actions/setup-bazel-remote
+        with:
+          username: ${{ secrets.BAZEL_CACHE_USERNAME }}
+          password: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+
+      - name: Run Non-RobotPy pregeneration
+        run: bazel run //:write_pregenerated_files
+
+      - name: Check Output
+        run: git --no-pager diff --exit-code HEAD
+
+      - name: Generate diff
+        run: git diff HEAD > non-robotpy-pregeneration.patch
+        if: ${{ failure() }}
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: non-robotpy-pregeneration-fixes
+          path: non-robotpy-pregeneration.patch
+        if: ${{ failure() }}
+
   robotpy_pregeneration:
     name: "Robotpy Pregeneration"
     runs-on: ubuntu-24.04

--- a/commandsv2/BUILD.bazel
+++ b/commandsv2/BUILD.bazel
@@ -43,6 +43,7 @@ generate_wpilib_new_commands(
 
 write_source_files(
     name = "write_wpilib_new_commands",
+    diff_args = ["-u"],
     files = {
         "src/generated": ":generate_wpilib_new_commands",
     },

--- a/commandsv3/BUILD.bazel
+++ b/commandsv3/BUILD.bazel
@@ -28,6 +28,7 @@ generate_commandsv3(
 
 write_source_files(
     name = "write_commandsv3",
+    diff_args = ["-u"],
     files = {
         "src/generated": ":generate_commandsv3",
     },

--- a/hal/BUILD.bazel
+++ b/hal/BUILD.bazel
@@ -45,6 +45,7 @@ generate_hal(
 
 write_source_files(
     name = "write_hal",
+    diff_args = ["-u"],
     files = {
         "src/generated": ":generate_hal_files",
     },

--- a/ntcore/BUILD.bazel
+++ b/ntcore/BUILD.bazel
@@ -48,6 +48,7 @@ py_binary(
 
 write_source_files(
     name = "write_ntcore",
+    diff_args = ["-u"],
     files = {
         "src/generated": ":generate_ntcore",
     },

--- a/robotpyExamples/BUILD.bazel
+++ b/robotpyExamples/BUILD.bazel
@@ -31,6 +31,7 @@ genrule(
 
 write_source_file(
     name = "write_example_project_list",
+    diff_args = ["-u"],
     in_file = ":generate_bazel_files_rule",
     out_file = "example_projects.bzl",
     suggested_update_target = "//:write_all",

--- a/shared/bazel/rules/robotpy/build_info_gen.bzl
+++ b/shared/bazel/rules/robotpy/build_info_gen.bzl
@@ -34,6 +34,7 @@ def generate_robotpy_native_wrapper_build_info(name, pyproject_toml, third_party
         suggested_update_target = "//:write_robotpy_generated_native_files",
         tags = ["robotpy"],
         target_compatible_with = robotpy_compatibility_select(),
+        diff_args = ["-u"],
     )
 
 def generate_robotpy_pybind_build_info(
@@ -91,4 +92,5 @@ def generate_robotpy_pybind_build_info(
         visibility = ["//visibility:public"],
         tags = ["robotpy"],
         target_compatible_with = robotpy_compatibility_select(),
+        diff_args = ["-u"],
     )

--- a/shared/bazel/rules/robotpy/semiwrap_tool_helpers.bzl
+++ b/shared/bazel/rules/robotpy/semiwrap_tool_helpers.bzl
@@ -61,6 +61,7 @@ def update_yaml_files(name, yaml_output_directory = "src/main/python/semiwrap", 
         suggested_update_target = "//:write_all",
         target_compatible_with = robotpy_compatibility_select(),
         visibility = ["//visibility:public"],
+        diff_args = ["-u"],
     )
 
 def scan_headers(name, pyproject_toml, package_root_file, extra_hdrs, pkgcfgs):

--- a/wpilibc/BUILD.bazel
+++ b/wpilibc/BUILD.bazel
@@ -76,6 +76,7 @@ generate_version_file(
 
 write_source_files(
     name = "write_wpilibc",
+    diff_args = ["-u"],
     files = {
         "src/generated": ":generate_wpilibc",
     },

--- a/wpilibcExamples/BUILD.bazel
+++ b/wpilibcExamples/BUILD.bazel
@@ -30,6 +30,7 @@ genrule(
 
 write_source_file(
     name = "write_example_project_list",
+    diff_args = ["-u"],
     in_file = ":generate_bazel_files_rule",
     out_file = "example_projects.bzl",
     suggested_update_target = "//:write_all",

--- a/wpilibj/BUILD.bazel
+++ b/wpilibj/BUILD.bazel
@@ -51,6 +51,7 @@ generate_wpilibj(
 
 write_source_files(
     name = "write_wpilibj",
+    diff_args = ["-u"],
     files = {
         "src/generated": ":generate_wpilibj",
     },

--- a/wpilibjExamples/BUILD.bazel
+++ b/wpilibjExamples/BUILD.bazel
@@ -28,6 +28,7 @@ genrule(
 
 write_source_file(
     name = "write_example_project_list",
+    diff_args = ["-u"],
     in_file = ":generate_bazel_files_rule",
     out_file = "example_projects.bzl",
     suggested_update_target = "//:write_all",

--- a/wpimath/BUILD.bazel
+++ b/wpimath/BUILD.bazel
@@ -91,6 +91,7 @@ generate_wpimath(
 
 write_source_files(
     name = "write_wpimath",
+    diff_args = ["-u"],
     files = {
         "src/generated": ":generate_wpimath",
     },

--- a/wpiunits/BUILD.bazel
+++ b/wpiunits/BUILD.bazel
@@ -22,6 +22,7 @@ generate_wpiunits(
 
 write_source_files(
     name = "write_wpiunits",
+    diff_args = ["-u"],
     files = {
         "src/generated": ":gen_units",
     },

--- a/wpiutil/BUILD.bazel
+++ b/wpiutil/BUILD.bazel
@@ -77,6 +77,7 @@ generate_wpiutil(
 
 write_source_files(
     name = "write_wpiutil",
+    diff_args = ["-u"],
     files = {
         "src/generated/test/native/cpp": ":generate_wpiutil",
     },


### PR DESCRIPTION
There were complaints about no patch files being created from CI when the examples pre-gen fails for people who don't build with bazel. This adds a new action step to run just the non-robotpy pregen. 

I also added an argument to the diff tests to make it a [unified diff](https://github.com/bzlmodRio/allwpilib/actions/runs/24936230590/job/73022151833#step:10:167), which might make it easier to hand fix.