### PR TITLE
[bazel] Update copybara scripts

### DIFF
--- a/copy.bara.sky
+++ b/copy.bara.sky
@@ -6,6 +6,12 @@ MOSTROBOTPY_PROJECTS = [
         has_tests = True,
     ),
     struct(
+        wpilib_name = "commandsv2",
+        robotpy_name = "robotpy-commands-v2",
+        native_robotpy_name = None,
+        has_tests = True,
+    ),
+    struct(
         wpilib_name = "datalog",
         robotpy_name = "robotpy-wpilog",
         native_robotpy_name = "robotpy-native-datalog",
@@ -59,13 +65,28 @@ MOSTROBOTPY_PROJECTS = [
         native_robotpy_name = "robotpy-native-xrp",
         has_tests = True,
     ),
+    struct(
+        wpilib_name = "simulation/halsim_ds_socket",
+        robotpy_name = "robotpy-halsim-ds-socket",
+        native_robotpy_name = None,
+        has_tests = True,
+    ),
+    struct(
+        wpilib_name = "simulation/halsim_gui",
+        robotpy_name = "robotpy-halsim-gui",
+        native_robotpy_name = None,
+        has_tests = True,
+    ),
+    struct(
+        wpilib_name = "simulation/halsim_ws_core",
+        robotpy_name = "robotpy-halsim-ws",
+        native_robotpy_name = None,
+        has_tests = True,
+    ),
 ]
 
 IGNORED_MOSTROBOTPY_PROJECTS = [
     "subprojects/robotpy-cscore",
-    "subprojects/robotpy-halsim-ds-socket",
-    "subprojects/robotpy-halsim-gui",
-    "subprojects/robotpy-halsim-ws",
 ]
 
 def define_mostrobotpy_to_allwpilib():
@@ -119,7 +140,7 @@ def define_mostrobotpy_to_allwpilib():
         destination_files += glob([
             project_info.wpilib_name + "/src/main/python/**",
             project_info.wpilib_name + "/src/test/python/**",
-        ], exclude = [])
+        ], exclude = [project_info.wpilib_name + "/src/main/python/examples/**"])
 
         if project_info.has_tests:
             transformations.append(core.move("subprojects/" + project_info.robotpy_name + "/tests", project_info.wpilib_name + "/src/test/python"))
@@ -149,6 +170,21 @@ def define_mostrobotpy_to_allwpilib():
 
         transformations = [core.transform(rename_transforms, noop_behavior = "IGNORE_NOOP", reversal = [])] + transformations
 
+    # Examples aren't as complicated
+    origin_files += glob([
+        "examples/robot/**",
+    ], exclude = EXCLUDES)
+    destination_files += glob(["robotpyExamples/**"], exclude = ["robotpyExamples/define_examples.bzl", "robotpyExamples/example_projects.bzl", "robotpyExamples/generate_bazel_files.py", "robotpyExamples/BUILD.bazel"])
+    transformations.append(core.move("examples/robot/", "robotpyExamples/"))
+
+    # Some tests seem to fail in mostrobotpy, but don't in allwpilib
+    # We will leave them turned on in allwpilib, and mark them as xfail in mostrobotpy.
+    transformations.append(core.replace(
+        before = '@pytest.mark.xfail(reason="wpilib bug")',
+        after = '# @pytest.mark.xfail(reason="wpilib bug")',
+        paths = glob(["**/src/test/python**/*.py"]),
+    ))
+
     core.workflow(
         name = "mostrobotpy_to_allwpilib",
         origin = git.origin(
@@ -167,21 +203,38 @@ def define_mostrobotpy_to_allwpilib():
     )
 
 def define_allwpilib_to_mostrobotpy():
-    ignored_project_exclude = [p + "/**" for p in IGNORED_MOSTROBOTPY_PROJECTS]
+    ignored_project_exclude = [p + "/**" for p in IGNORED_MOSTROBOTPY_PROJECTS] + [p + "/examples/**" for p in IGNORED_MOSTROBOTPY_PROJECTS]
     origin_files = []
-    destination_files = glob(["**"], exclude = ["*", ".github/**", "docs/**", "**/.gitignore", "**/meson.build", "**/requirements.txt", "devtools/**", "examples/**", "**/run_tests.py"] + ignored_project_exclude)
+    destination_files = glob(["**"], exclude = ["*", ".github/**", "docs/**", "**/.gitignore", "**/meson.build", "**/requirements.txt", "devtools/**", "examples/cscore/**", "examples/datalog/**", "examples/ntcore/**", "examples/wpinet/**", "examples/robot/.gitignore", "**/run_tests.py"] + ignored_project_exclude)
     transformations = []
 
     for project_info in MOSTROBOTPY_PROJECTS:
         origin_files += glob([
             project_info.wpilib_name + "/src/main/python/**",
             project_info.wpilib_name + "/src/test/python/**",
-        ], exclude = [])
+        ], exclude = [
+            project_info.wpilib_name + "/src/main/python/examples/**",
+        ])
 
         if project_info.has_tests:
             transformations.append(core.move(project_info.wpilib_name + "/src/test/python", "subprojects/" + project_info.robotpy_name + "/tests"))
         transformations.append(core.move(project_info.wpilib_name + "/src/main/python", "subprojects/" + project_info.robotpy_name))
-        transformations.append(core.move("subprojects/" + project_info.robotpy_name + "/native-pyproject.toml", "subprojects/" + project_info.native_robotpy_name + "/pyproject.toml"))
+        if project_info.native_robotpy_name:
+            transformations.append(core.move("subprojects/" + project_info.robotpy_name + "/native-pyproject.toml", "subprojects/" + project_info.native_robotpy_name + "/pyproject.toml"))
+
+    origin_files += glob([
+        "robotpyExamples/**",
+    ], exclude = ["robotpyExamples/BUILD.bazel", "robotpyExamples/define_examples.bzl", "robotpyExamples/example_projects.bzl", "robotpyExamples/generate_bazel_files.py"])
+    destination_files += glob(["examples/robot/**"], exclude = ["examples/robot/.gitignore"])
+    transformations.append(core.move("robotpyExamples/", "examples/robot/"))
+
+    # Some tests seem to fail in mostrobotpy, but don't in allwpilib
+    # We will leave them turned on in allwpilib, and mark them as xfail in mostrobotpy.
+    transformations.append(core.replace(
+        before = '# @pytest.mark.xfail(reason="wpilib bug")',
+        after = '@pytest.mark.xfail(reason="wpilib bug")',
+        paths = glob(["**/tests**/*.py"]),
+    ))
 
     core.workflow(
         name = "allwpilib_to_mostrobotpy",
@@ -200,59 +253,5 @@ def define_allwpilib_to_mostrobotpy():
         transformations = transformations,
     )
 
-def define_robotpy_commandsv2_to_allwpilib():
-    origin_files = glob(["commands2/**", "tests/**"], exclude = ["tests/run_tests.py", "tests/requirements.txt"])
-    destination_files = glob(["commandsv2/src/main/python/**", "commandsv2/src/test/python/**"])
-    transformations = []
-
-    transformations.append(core.move("commands2/", "commandsv2/src/main/python/commands2/"))
-    transformations.append(core.move("tests/", "commandsv2/src/test/python/"))
-
-    core.workflow(
-        name = "commandsv2_to_allwpilib",
-        origin = git.origin(
-            url = "https://github.com/robotpy/robotpy-commands-v2.git",
-            ref = "2027",
-        ),
-        destination = git.destination(
-            url = "https://github.com/OVERRIDE_ME/OVERRIDE_ME",
-            fetch = "2027",
-            push = "copybara_commandsv2_to_allwpilib",
-        ),
-        destination_files = destination_files,
-        origin_files = origin_files,
-        authoring = authoring.pass_thru("Default email <default@default.com>"),
-        transformations = transformations,
-    )
-
-def define_allwpilib_to_robotpy_commandsv2():
-    ignored_project_exclude = [p + "/**" for p in IGNORED_MOSTROBOTPY_PROJECTS]
-    origin_files = glob(["commandsv2/src/main/python/**", "commandsv2/src/test/python/**"])
-    destination_files = glob(["**"], exclude = ["*", ".github/**", "**/run_tests.py", "docs/**", "tests/requirements.txt"])
-    transformations = []
-
-    transformations.append(core.move("commandsv2/src/main/python/", ""))
-    transformations.append(core.move("commandsv2/src/test/python", "tests"))
-
-    core.workflow(
-        name = "allwpilib_to_commandsv2",
-        origin = git.origin(
-            url = "https://github.com/wpilibsuite/allwpilib.git",
-            ref = "2027",
-        ),
-        destination = git.github_destination(
-            url = "https://github.com/OVERRIDE_ME/OVERRIDE_ME",
-            fetch = "2027",
-            push = "copybara_allwpilib_to_commandsv2",
-        ),
-        destination_files = destination_files,
-        origin_files = origin_files,
-        authoring = authoring.pass_thru("Default email <default@default.com>"),
-        transformations = transformations,
-    )
-
 define_mostrobotpy_to_allwpilib()
 define_allwpilib_to_mostrobotpy()
-
-define_robotpy_commandsv2_to_allwpilib()
-define_allwpilib_to_robotpy_commandsv2()

--- a/shared/bazel/copybara/run_copybara.py
+++ b/shared/bazel/copybara/run_copybara.py
@@ -26,7 +26,13 @@ class CopybaraConfig:
     allwpilib_truth_branch: str = "2027"
 
 
-def run_copybara(copybara_file: pathlib.Path, migration: str, destination_url: str):
+def run_copybara(
+    copybara_file: pathlib.Path,
+    migration: str,
+    destination_url: str,
+    force: bool,
+    verbose: bool,
+):
     args = [
         "bazel",
         "run",
@@ -35,11 +41,15 @@ def run_copybara(copybara_file: pathlib.Path, migration: str, destination_url: s
         "migrate",
         str(copybara_file),
         migration,
-        "--force",
         "--git-destination-url",
         destination_url,
         "--git-destination-non-fast-forward",
     ]
+
+    if force:
+        args.append("--force")
+    if verbose:
+        args.append("--verbose")
 
     subprocess.check_call(args)
 
@@ -99,25 +109,31 @@ def allwpilib_to_mostrobotpy(
     wpilib_bin_version: str,
     is_development_build: bool,
     auto_delete_branch: bool,
+    force: bool,
+    verbose: bool,
 ):
-    run_copybara(copybara_file, "allwpilib_to_mostrobotpy", mostrobotpy_fork_repo)
+    run_copybara(
+        copybara_file, "allwpilib_to_mostrobotpy", mostrobotpy_fork_repo, force, verbose
+    )
 
     os.chdir(mostrobotpy_local_repository)
     checkout_branch(auto_delete_branch, "copybara_allwpilib_to_mostrobotpy")
     update_mostrobotpy_rdev(wpilib_bin_version, is_development_build)
+
+    # Run black
+    subprocess.check_call(["black", "."])
+    subprocess.check_call(["git", "add", "-A"])
+    subprocess.call(["git", "commit", "-m", "Run black"])
+
     subprocess.check_call(["git", "push", "-f"])
 
 
-def mostrobotpy_to_allwpilib(copybara_file: pathlib.Path, allwpilib_fork):
-    run_copybara(copybara_file, "mostrobotpy_to_allwpilib", allwpilib_fork)
-
-
-def commandsv2_to_allwpilib(copybara_file: pathlib.Path, allwpilib_fork):
-    run_copybara(copybara_file, "commandsv2_to_allwpilib", allwpilib_fork)
-
-
-def allwpilib_to_commandsv2(copybara_file: pathlib.Path, allwpilib_fork):
-    run_copybara(copybara_file, "allwpilib_to_commandsv2", allwpilib_fork)
+def mostrobotpy_to_allwpilib(
+    copybara_file: pathlib.Path, allwpilib_fork, force: bool, verbose: bool
+):
+    run_copybara(
+        copybara_file, "mostrobotpy_to_allwpilib", allwpilib_fork, force, verbose
+    )
 
 
 def load_user_config() -> CopybaraConfig:
@@ -143,6 +159,9 @@ def main():
     subparsers = parser.add_subparsers(
         dest="migration", required=True, help="Available commands"
     )
+
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
 
     def add_allwpilib_fork_arg(subparser):
         subparser.add_argument(
@@ -191,24 +210,6 @@ def main():
     )
     add_allwpilib_fork_arg(mostrobotpy_to_allwpilib_parser)
 
-    # allwpilib -> commands-v2
-    allwpilib_to_commandsv2_parser = subparsers.add_parser(
-        "allwpilib_to_commandsv2",
-        help="Pushes changes from the allwpilib mirror to the robotpy commands-v2 repo",
-    )
-    allwpilib_to_commandsv2_parser.add_argument(
-        "--robotpy_commandsv2_fork_repo",
-        default=user_config.robotpy_commandsv2_fork_repo,
-        help="URL to your github fork of mostrobotpy that you have write permissions for",
-    )
-
-    # commands-v2 -> allwpilib
-    commandsv2_to_allwpilib_parser = subparsers.add_parser(
-        "commandsv2_to_allwpilib",
-        help="Pulls changes from the robotpy commands-v2 source of truth into this mirror",
-    )
-    add_allwpilib_fork_arg(commandsv2_to_allwpilib_parser)
-
     script_dir = pathlib.Path(__file__).parent
     copybara_file = script_dir / "../../../copy.bara.sky"
 
@@ -230,25 +231,17 @@ def main():
             args.wpilib_bin_version,
             args.development_build,
             args.auto_delete_branch,
+            args.force,
+            args.verbose,
         )
     elif args.migration == "mostrobotpy_to_allwpilib":
         if args.allwpilib_fork_repo is None:
             raise Exception(
                 "You mist specify allwpilib_fork_repo, either on the command line or in your user config"
             )
-        mostrobotpy_to_allwpilib(copybara_file, args.allwpilib_fork_repo)
-    elif args.migration == "allwpilib_to_commandsv2":
-        if args.robotpy_commandsv2_fork_repo is None:
-            raise Exception(
-                "You mist specify robotpy_commandsv2_fork_repo, either on the command line or in your user config"
-            )
-        allwpilib_to_commandsv2(copybara_file, args.robotpy_commandsv2_fork_repo)
-    elif args.migration == "commandsv2_to_allwpilib":
-        if args.allwpilib_fork_repo is None:
-            raise Exception(
-                "You mist specify allwpilib_fork_repo, either on the command line or in your user config"
-            )
-        commandsv2_to_allwpilib(copybara_file, args.allwpilib_fork_repo)
+        mostrobotpy_to_allwpilib(
+            copybara_file, args.allwpilib_fork_repo, args.force, args.verbose
+        )
     else:
         raise Exception(f"Unexpected migration {args.migration}")
 


### PR DESCRIPTION
I've been running my copybara syncs from this branch for a long time. Finally deciding to PR it.

The biggest update was due to `mostrobotpy` absorbing the commands, examples, and pyfrc libraries, but I also added in hooks to "enable" the flakey `xfail` tests on the allwpilib side, and the ability to run verbose or force push updates.