### PR TITLE
Plumb local address through ConnectionInfo

### DIFF
--- a/ntcore/src/main/java/org/wpilib/networktables/ConnectionInfo.java
+++ b/ntcore/src/main/java/org/wpilib/networktables/ConnectionInfo.java
@@ -18,6 +18,9 @@ public final class ConnectionInfo {
   /** The port number of the remote node. */
   public final int remotePort;
 
+  public final String localIp;
+  public final int localPort;
+
   /**
    * The last time any update was received from the remote node (same scale as returned by {@link
    * NetworkTablesJNI#now()}).
@@ -40,10 +43,12 @@ public final class ConnectionInfo {
    * @param protocolVersion The protocol version used for the connection
    */
   public ConnectionInfo(
-      String remoteId, String remoteIp, int remotePort, long lastUpdate, int protocolVersion) {
+      String remoteId, String remoteIp, int remotePort, String localIp, int localPort, long lastUpdate, int protocolVersion) {
     this.remoteId = remoteId;
     this.remoteIp = remoteIp;
     this.remotePort = remotePort;
+    this.localIp = localIp;
+    this.localPort = localPort;
     this.lastUpdate = lastUpdate;
     this.protocolVersion = protocolVersion;
   }

--- a/ntcore/src/main/java/org/wpilib/networktables/ConnectionInfo.java
+++ b/ntcore/src/main/java/org/wpilib/networktables/ConnectionInfo.java
@@ -18,7 +18,16 @@ public final class ConnectionInfo {
   /** The port number of the remote node. */
   public final int remotePort;
 
+  /**
+   * The IP address we connected to the remote server using. Empty if this NetworkTable instance is
+   * a server.
+   */
   public final String localIp;
+
+  /**
+   * The port number we connected to the remote server using. Zero if this NetworkTable instance is
+   * a server.
+   */
   public final int localPort;
 
   /**
@@ -43,7 +52,13 @@ public final class ConnectionInfo {
    * @param protocolVersion The protocol version used for the connection
    */
   public ConnectionInfo(
-      String remoteId, String remoteIp, int remotePort, String localIp, int localPort, long lastUpdate, int protocolVersion) {
+      String remoteId,
+      String remoteIp,
+      int remotePort,
+      String localIp,
+      int localPort,
+      long lastUpdate,
+      int protocolVersion) {
     this.remoteId = remoteId;
     this.remoteIp = remoteIp;
     this.remotePort = remotePort;

--- a/ntcore/src/main/java/org/wpilib/networktables/ConnectionInfo.java
+++ b/ntcore/src/main/java/org/wpilib/networktables/ConnectionInfo.java
@@ -48,6 +48,8 @@ public final class ConnectionInfo {
    * @param remoteId Remote identifier
    * @param remoteIp Remote IP address
    * @param remotePort Remote port number
+   * @param localIp Local IP address, if a client
+   * @param localPort Local port number, if a client
    * @param lastUpdate Last time an update was received
    * @param protocolVersion The protocol version used for the connection
    */

--- a/ntcore/src/main/native/cpp/NetworkClient.cpp
+++ b/ntcore/src/main/native/cpp/NetworkClient.cpp
@@ -252,6 +252,7 @@ void NetworkClient::WsConnected(wpi::net::WebSocket& ws, uv::Tcp& tcp,
 
   ConnectionInfo connInfo;
   uv::AddrToName(tcp.GetPeer(), &connInfo.remote_ip, &connInfo.remote_port);
+  uv::AddrToName(tcp.GetSock(), &connInfo.local_ip, &connInfo.local_port);
   connInfo.protocol_version =
       protocol == "v4.1.networktables.first.wpi.edu" ? 0x0401 : 0x0400;
 

--- a/ntcore/src/main/native/cpp/NetworkClient.cpp
+++ b/ntcore/src/main/native/cpp/NetworkClient.cpp
@@ -256,7 +256,8 @@ void NetworkClient::WsConnected(wpi::net::WebSocket& ws, uv::Tcp& tcp,
   connInfo.protocol_version =
       protocol == "v4.1.networktables.first.wpi.edu" ? 0x0401 : 0x0400;
 
-  INFO("CONNECTED NT4 to {} port {}", connInfo.remote_ip, connInfo.remote_port);
+  INFO("CONNECTED NT4 from {} port {} to {} port {}", connInfo.local_ip,
+       connInfo.local_port, connInfo.remote_ip, connInfo.remote_port);
   m_connHandle = m_connList.AddConnection(connInfo);
 
   bool local = wpi::util::starts_with(connInfo.remote_ip, "127.");

--- a/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
+++ b/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
@@ -252,11 +252,13 @@ static jobject MakeJValue(JNIEnv* env, const wpi::nt::Value& value) {
 static jobject MakeJObject(JNIEnv* env, const wpi::nt::ConnectionInfo& info) {
   static jmethodID constructor =
       env->GetMethodID(connectionInfoCls, "<init>",
-                       "(Ljava/lang/String;Ljava/lang/String;IJI)V");
+                       "(Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;IIJ)V");
   JLocal<jstring> remote_id{env, MakeJString(env, info.remote_id)};
   JLocal<jstring> remote_ip{env, MakeJString(env, info.remote_ip)};
+  JLocal<jstring> local_ip{env, MakeJString(env, info.local_ip)};
   return env->NewObject(connectionInfoCls, constructor, remote_id.obj(),
                         remote_ip.obj(), static_cast<jint>(info.remote_port),
+                        local_ip.obj(), static_cast<jint>(info.local_port),
                         static_cast<jlong>(info.last_update),
                         static_cast<jint>(info.protocol_version));
 }

--- a/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
+++ b/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
@@ -250,9 +250,9 @@ static jobject MakeJValue(JNIEnv* env, const wpi::nt::Value& value) {
 }
 
 static jobject MakeJObject(JNIEnv* env, const wpi::nt::ConnectionInfo& info) {
-  static jmethodID constructor =
-      env->GetMethodID(connectionInfoCls, "<init>",
-                       "(Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;IIJ)V");
+  static jmethodID constructor = env->GetMethodID(
+      connectionInfoCls, "<init>",
+      "(Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;IJI)V");
   JLocal<jstring> remote_id{env, MakeJString(env, info.remote_id)};
   JLocal<jstring> remote_ip{env, MakeJString(env, info.remote_ip)};
   JLocal<jstring> local_ip{env, MakeJString(env, info.local_ip)};

--- a/ntcore/src/main/native/cpp/ntcore_c.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_c.cpp
@@ -35,7 +35,9 @@ static void ConvertToC(const TopicInfo& in, NT_TopicInfo* out) {
 static void ConvertToC(const ConnectionInfo& in, NT_ConnectionInfo* out) {
   ConvertToC(in.remote_id, &out->remote_id);
   ConvertToC(in.remote_ip, &out->remote_ip);
+  ConvertToC(in.local_ip, &out->local_ip);
   out->remote_port = in.remote_port;
+  out->local_port = in.local_port;
   out->last_update = in.last_update;
   out->protocol_version = in.protocol_version;
 }
@@ -89,6 +91,7 @@ static void ConvertToC(const Event& in, NT_Event* out) {
 static void DisposeConnectionInfo(NT_ConnectionInfo* info) {
   WPI_FreeString(&info->remote_id);
   WPI_FreeString(&info->remote_ip);
+  WPI_FreeString(&info->local_ip);
 }
 
 static void DisposeTopicInfo(NT_TopicInfo* info) {

--- a/ntcore/src/main/native/include/wpi/nt/ntcore_c.h
+++ b/ntcore/src/main/native/include/wpi/nt/ntcore_c.h
@@ -197,10 +197,12 @@ struct NT_ConnectionInfo {
   /** The port number of the remote node. */
   unsigned int remote_port;
 
-  /** The IP address we connected to the remote server using */
+  /** The IP address we connected to the remote server using. Empty if this
+   * NetworkTable instance is a server */
   struct WPI_String local_ip;
 
-  /** The port number we connected to the remote server using */
+  /** The port number we connected to the remote server using. Zero if this
+   * NetworkTable instance is a server */
   unsigned int local_port;
 
   /**

--- a/ntcore/src/main/native/include/wpi/nt/ntcore_c.h
+++ b/ntcore/src/main/native/include/wpi/nt/ntcore_c.h
@@ -197,6 +197,12 @@ struct NT_ConnectionInfo {
   /** The port number of the remote node. */
   unsigned int remote_port;
 
+  /** The IP address we connected to the remote server using */
+  struct WPI_String local_ip;
+
+  /** The port number we connected to the remote server using */
+  unsigned int local_port;
+
   /**
    * The last time any update was received from the remote node (same scale as
    * returned by wpi::nt::Now()).

--- a/ntcore/src/main/native/include/wpi/nt/ntcore_cpp.hpp
+++ b/ntcore/src/main/native/include/wpi/nt/ntcore_cpp.hpp
@@ -128,6 +128,12 @@ struct ConnectionInfo {
   /** The port number of the remote node. */
   unsigned int remote_port{0};
 
+  /** The IP address we connected to the remote server using */
+  struct WPI_String local_ip;
+
+  /** The port number we connected to the remote server using */
+  unsigned int local_port {0};
+
   /**
    * The last time any update was received from the remote node (same scale as
    * returned by wpi::nt::Now()).
@@ -145,6 +151,8 @@ struct ConnectionInfo {
     swap(first.remote_id, second.remote_id);
     swap(first.remote_ip, second.remote_ip);
     swap(first.remote_port, second.remote_port);
+    swap(first.local_ip, second.local_ip);
+    swap(first.local_port, second.local_port);
     swap(first.last_update, second.last_update);
     swap(first.protocol_version, second.protocol_version);
   }

--- a/ntcore/src/main/native/include/wpi/nt/ntcore_cpp.hpp
+++ b/ntcore/src/main/native/include/wpi/nt/ntcore_cpp.hpp
@@ -128,11 +128,13 @@ struct ConnectionInfo {
   /** The port number of the remote node. */
   unsigned int remote_port{0};
 
-  /** The IP address we connected to the remote server using */
-  struct WPI_String local_ip;
+  /** The IP address we connected to the remote server using. Empty if this
+   * NetworkTable instance is a server */
+  std::string local_ip;
 
-  /** The port number we connected to the remote server using */
-  unsigned int local_port {0};
+  /** The port number we connected to the remote server using. Zero if this
+   * NetworkTable instance is a server */
+  unsigned int local_port{0};
 
   /**
    * The last time any update was received from the remote node (same scale as

--- a/ntcore/src/test/native/cpp/ConnectionListenerTest.cpp
+++ b/ntcore/src/test/native/cpp/ConnectionListenerTest.cpp
@@ -12,6 +12,7 @@
 #include "wpi/nt/ntcore_cpp.hpp"
 #include "wpi/util/Synchronization.hpp"
 #include "wpi/util/mutex.hpp"
+#include "wpi/util/print.hpp"
 
 class ConnectionListenerTest : public ::testing::Test {
  public:
@@ -68,6 +69,16 @@ TEST_F(ConnectionListenerTest, Polled) {
   EXPECT_EQ(handle, result[0].listener);
   EXPECT_TRUE(result[0].GetConnectionInfo());
   EXPECT_EQ(result[0].flags, wpi::nt::EventFlags::CONNECTED);
+
+  // Check client sees a remote connection
+  {
+    size_t count;
+    auto arr = NT_GetConnections(client_inst, &count);
+    ASSERT_TRUE(count == 1);
+    EXPECT_TRUE(arr[0].local_ip.len > 0U);
+    EXPECT_TRUE(arr[0].local_port > 0U);
+    NT_DisposeConnectionInfoArray(arr, 1);
+  }
 
   // trigger a disconnect event
   wpi::nt::StopClient(client_inst);


### PR DESCRIPTION
Plumbs `tcp.GetSock()` through ConnectionInfo, in addition to `tcp.GetPeer`