### PR TITLE
[build] Refactor zip base name generation for consistency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,10 @@ ext.addTaskToCopyAllOutputs = { task ->
     copyAllOutputs.from task.archiveFile
 }
 
+ext.makeZipBaseName = { group, artifactId ->
+    return "_GROUP_${group.replace(".", "_")}_ID_${artifactId}_CLS"
+}
+
 subprojects {
     apply plugin: 'eclipse'
     apply plugin: 'idea'

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -24,11 +24,11 @@ evaluationDependsOn(':datalog')
 
 def baseArtifactIdCpp = 'documentation'
 def artifactGroupIdCpp = 'org.wpilib.wpilibc'
-def zipBaseNameCpp = '_GROUP_org_wpilib_wpilibc_ID_documentation_CLS'
+def zipBaseNameCpp = makeZipBaseName(artifactGroupIdCpp, baseArtifactIdCpp)
 
 def baseArtifactIdJava = 'documentation'
 def artifactGroupIdJava = 'org.wpilib.wpilibj'
-def zipBaseNameJava = '_GROUP_org_wpilib_wpilibj_ID_documentation_CLS'
+def zipBaseNameJava = makeZipBaseName(artifactGroupIdJava, baseArtifactIdJava)
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/fields/publish.gradle
+++ b/fields/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 def baseArtifactId = project.nativeName
 def artifactGroupId = project.groupId
-def cppZipBaseName = "_GROUP_org_wpilib_fields_ID_${baseArtifactId}-cpp_CLS"
+def cppZipBaseName = makeZipBaseName(artifactGroupId, "${baseArtifactId}-cpp")
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/glass/publish.gradle
+++ b/glass/publish.gradle
@@ -2,15 +2,15 @@ apply plugin: 'maven-publish'
 
 def baseArtifactId = 'Glass'
 def artifactGroupId = 'org.wpilib.tools'
-def zipBaseName = '_GROUP_org_wpilib_tools_ID_Glass_CLS'
+def zipBaseName = makeZipBaseName(artifactGroupId, baseArtifactId)
 
 def libBaseArtifactId = 'libglass'
 def libArtifactGroupId = 'org.wpilib.glass'
-def libZipBaseName = '_GROUP_org_wpilib_glass_ID_libglass_CLS'
+def libZipBaseName = makeZipBaseName(libArtifactGroupId, libBaseArtifactId)
 
 def libntBaseArtifactId = 'libglassnt'
 def libntArtifactGroupId = 'org.wpilib.glass'
-def libntZipBaseName = '_GROUP_org_wpilib_glass_ID_libglassnt_CLS'
+def libntZipBaseName = makeZipBaseName(libntArtifactGroupId, libntBaseArtifactId)
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/msvcruntime/build.gradle
+++ b/msvcruntime/build.gradle
@@ -11,7 +11,7 @@ if (OperatingSystem.current().isWindows()) {
 
     def baseArtifactId = 'runtime'
     def artifactGroupId = "org.wpilib.msvc"
-    def zipBaseName = "_GROUP_org_wpilib_msvc_ID_runtime_CLS"
+    def zipBaseName = makeZipBaseName(artifactGroupId, baseArtifactId)
 
     def vsLocator = gradle.services.get(VisualStudioLocator)
 

--- a/ntcoreffi/build.gradle
+++ b/ntcoreffi/build.gradle
@@ -82,7 +82,7 @@ model {
 def nativeName = 'ntcoreffi'
 def baseArtifactId = nativeName
 def artifactGroupId = "org.wpilib.${nativeName}"
-def zipBaseName = "_GROUP_org_wpilib_${nativeName}_ID_${nativeName}-cpp_CLS"
+def zipBaseName = makeZipBaseName(artifactGroupId, "${baseArtifactId}-cpp")
 def outputsFolder = file("$project.buildDir/outputs")
 
 evaluationDependsOn(':ntcore')

--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -4,7 +4,7 @@ apply plugin: 'jacoco'
 
 def baseArtifactId = project.baseId
 def artifactGroupId = project.groupId
-def javaBaseName = "_GROUP_${project.groupId.replace('.', '_')}_ID_${project.baseId}-java_CLS"
+def javaBaseName = makeZipBaseName(artifactGroupId, "${baseArtifactId}-java")
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/shared/javacpp/publish.gradle
+++ b/shared/javacpp/publish.gradle
@@ -4,7 +4,7 @@ def outputsFolder = file("$buildDir/outputs")
 
 def baseArtifactId = nativeName
 def artifactGroupId = "org.wpilib.${nativeName}"
-def zipBaseName = "_GROUP_org_wpilib_${nativeName}_ID_${nativeName}-cpp_CLS"
+def zipBaseName = makeZipBaseName(artifactGroupId, "${baseArtifactId}-cpp")
 
 def licenseFile = file("$rootDir/license.md")
 

--- a/shared/jni/publish.gradle
+++ b/shared/jni/publish.gradle
@@ -5,9 +5,9 @@ def outputsFolder = file("$buildDir/outputs")
 
 def baseArtifactId = nativeName
 def artifactGroupId = "org.wpilib.${nativeName}"
-def zipBaseName = "_GROUP_org_wpilib_${nativeName}_ID_${nativeName}-cpp_CLS"
+def zipBaseName = makeZipBaseName(artifactGroupId, "${baseArtifactId}-cpp")
 ext.zipBaseName = zipBaseName
-def jniCvStaticBaseName = "_GROUP_org_wpilib_${nativeName}_ID_${nativeName}-jnicvstatic_CLS"
+def jniCvStaticBaseName = makeZipBaseName(artifactGroupId, "${nativeName}-jnicvstatic")
 
 def licenseFile = file("$rootDir/license.md")
 

--- a/shared/plugins/publish.gradle
+++ b/shared/plugins/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 def baseArtifactId = pluginName
 def artifactGroupId = 'org.wpilib.halsim'
-def zipBaseName = "_GROUP_org_wpilib_halsim_ID_${pluginName}_CLS"
+def zipBaseName = makeZipBaseName(artifactGroupId, baseArtifactId)
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/thirdparty/catch2/publish.gradle
+++ b/thirdparty/catch2/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 def baseArtifactId = 'catch2-cpp'
 def artifactGroupId = 'org.wpilib.thirdparty.catch2'
-def zipBaseName = '_GROUP_edu_wpi_first_thirdparty_catch2_ID_catch2-cpp_CLS'
+def zipBaseName = makeZipBaseName(artifactGroupId, baseArtifactId)
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/thirdparty/googletest/publish.gradle
+++ b/thirdparty/googletest/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 def baseArtifactId = 'googletest-cpp'
 def artifactGroupId = 'org.wpilib.thirdparty.googletest'
-def zipBaseName = '_GROUP_edu_wpi_first_thirdparty_googletest_ID_googletest-cpp_CLS'
+def zipBaseName = makeZipBaseName(artifactGroupId, baseArtifactId)
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/thirdparty/imgui_suite/publish.gradle
+++ b/thirdparty/imgui_suite/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 def baseArtifactId = 'imguiSuite-cpp'
 def artifactGroupId = 'org.wpilib.thirdparty.imguiSuite'
-def zipBaseName = '_GROUP_edu_wpi_first_thirdparty_imguiSuite_ID_imguiSuite-cpp_CLS'
+def zipBaseName = makeZipBaseName(artifactGroupId, baseArtifactId)
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/tools/datalogtool/publish.gradle
+++ b/tools/datalogtool/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 def baseArtifactId = 'DataLogTool'
 def artifactGroupId = 'org.wpilib.tools'
-def zipBaseName = '_GROUP_org_wpilib_tools_ID_DataLogTool_CLS'
+def zipBaseName = makeZipBaseName(artifactGroupId, baseArtifactId)
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/tools/outlineviewer/publish.gradle
+++ b/tools/outlineviewer/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 def baseArtifactId = 'OutlineViewer'
 def artifactGroupId = 'org.wpilib.tools'
-def zipBaseName = '_GROUP_org_wpilib_tools_ID_OutlineViewer_CLS'
+def zipBaseName = makeZipBaseName(artifactGroupId, baseArtifactId)
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/tools/processstarter/publish.gradle
+++ b/tools/processstarter/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 def baseArtifactId = 'processstarter'
 def artifactGroupId = 'org.wpilib.tools'
-def zipBaseName = '_GROUP_org_wpilib_tools_ID_processstarter_CLS'
+def zipBaseName = makeZipBaseName(artifactGroupId, baseArtifactId)
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/tools/sysid/publish.gradle
+++ b/tools/sysid/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 def baseArtifactId = 'SysId'
 def artifactGroupId = 'org.wpilib.tools'
-def zipBaseName = '_GROUP_org_wpilib_tools_ID_SysId_CLS'
+def zipBaseName = makeZipBaseName(artifactGroupId, baseArtifactId)
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/tools/wpical/publish.gradle
+++ b/tools/wpical/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 def baseArtifactId = 'wpical'
 def artifactGroupId = 'org.wpilib.tools'
-def zipBaseName = '_GROUP_org_wpilib_tools_ID_wpical_CLS'
+def zipBaseName = makeZipBaseName(artifactGroupId, baseArtifactId)
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/wpigui/publish.gradle
+++ b/wpigui/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 def baseArtifactId = 'wpigui-cpp'
 def artifactGroupId = 'org.wpilib.wpigui'
-def zipBaseName = '_GROUP_org_wpilib_wpigui_ID_wpigui-cpp_CLS'
+def zipBaseName = makeZipBaseName(artifactGroupId, baseArtifactId)
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/wpilibc/publish.gradle
+++ b/wpilibc/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 def baseArtifactId = 'wpilibc-cpp'
 def artifactGroupId = 'org.wpilib.wpilibc'
-def zipBaseName = '_GROUP_org_wpilib_wpilibc_ID_wpilibc-cpp_CLS'
+def zipBaseName = makeZipBaseName(artifactGroupId, baseArtifactId)
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/wpilibcExamples/publish.gradle
+++ b/wpilibcExamples/publish.gradle
@@ -5,9 +5,9 @@ def baseTemplatesArtifactId = 'templates'
 def baseCommandsArtifactId = 'commands'
 def artifactGroupId = 'org.wpilib.wpilibc'
 
-def examplesZipBaseName = '_GROUP_org_wpilib_wpilibc_ID_examples_CLS'
-def templatesZipBaseName = '_GROUP_org_wpilib_wpilibc_ID_templates_CLS'
-def commandsZipBaseName = '_GROUP_org_wpilib_wpilibc_ID_commands_CLS'
+def examplesZipBaseName = makeZipBaseName(artifactGroupId, baseExamplesArtifactId)
+def templatesZipBaseName = makeZipBaseName(artifactGroupId, baseTemplatesArtifactId)
+def commandsZipBaseName = makeZipBaseName(artifactGroupId, baseCommandsArtifactId)
 
 def outputsFolder = file("$project.buildDir/outputs")
 

--- a/wpilibjExamples/publish.gradle
+++ b/wpilibjExamples/publish.gradle
@@ -5,9 +5,9 @@ def baseTemplatesArtifactId = 'templates'
 def baseCommandsArtifactId = 'commands'
 def artifactGroupId = 'org.wpilib.wpilibj'
 
-def examplesZipBaseName = '_GROUP_org_wpilib_wpilibj_ID_examples_CLS'
-def templatesZipBaseName = '_GROUP_org_wpilib_wpilibj_ID_templates_CLS'
-def commandsZipBaseName = '_GROUP_org_wpilib_wpilibj_ID_commands_CLS'
+def examplesZipBaseName = makeZipBaseName(artifactGroupId, baseExamplesArtifactId)
+def templatesZipBaseName = makeZipBaseName(artifactGroupId, baseTemplatesArtifactId)
+def commandsZipBaseName = makeZipBaseName(artifactGroupId, baseCommandsArtifactId)
 
 def outputsFolder = file("$project.buildDir/outputs")
 


### PR DESCRIPTION
Right now, the `zipBaseName` variable in various publish.gradle files contains the group ID and artifact ID for use by the combiner, however, they are also duplicated in `artifactGroupId` and `baseArtifactId`, leading to potential mistakes if they aren't updated together. This fixes that by adding a new utility function `makeZipBaseName` to automatically create the right name given a group ID and artifact ID. This also fixes publishing for thirdparty subprojects, which didn't update `zipBaseName`.