### PR TITLE
[build] Compress shared object debug info

### DIFF
--- a/cmake/modules/CompileWarnings.cmake
+++ b/cmake/modules/CompileWarnings.cmake
@@ -63,5 +63,6 @@ macro(wpilib_target_warnings target)
         AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU"
     )
         target_compile_options(${target} PRIVATE -gz=zlib)
+        target_link_options(${target} PRIVATE -gz=zlib)
     endif()
 endmacro()

--- a/shared/bazel/compiler_flags/linux_flags.rc
+++ b/shared/bazel/compiler_flags/linux_flags.rc
@@ -13,7 +13,7 @@ common:linux --repo_env=BAZEL_CXXOPTS="-std=c++23:-Wformat=2:-pedantic:-Wno-psab
 common:linux --repo_env=BAZEL_CONLYOPTS="-Wformat=2:-pedantic:-Wno-psabi:-Wno-unused-parameter:-fPIC:-pthread"
 
 # Linker
-common:linux --repo_env=BAZEL_LINKOPTS="-rdynamic:-pthread:-ldl:-latomic:-Wl,-rpath,'$ORIGIN'"
+common:linux --repo_env=BAZEL_LINKOPTS="-rdynamic:-pthread:-ldl:-latomic:-Wl,-rpath,'$ORIGIN':-gz=zlib"
 
 # Cleanup build output for tools
 build:linux --host_cxxopt=-Wno-missing-field-initializers

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -46,6 +46,7 @@ nativeUtils.platformConfigs.each {
   if (it.name.contains('linux')) {
     // Compress debug info on Linux
     it.cppCompiler.debugArgs.add("-gz=zlib")
+    it.linker.args.add("-gz=zlib")
     // Make warning in OpenCV 4.10 from GCC 15 not an error
     it.cppCompiler.args.add("-Wno-error=overloaded-virtual")
     // Make warning from Google Benchmark not an error


### PR DESCRIPTION
This saves a huge amount of space when they're unzipped for robot projects, while not increasing artifact size.