### PR TITLE
[build] Remove Javadoc fonts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,11 +145,13 @@ subprojects {
         options.encoding = 'UTF-8'
     }
 
-    // Enables UTF-8 support in Javadoc
+    // Enables UTF-8 support in Javadoc, disables 4 MB of fonts being added to every Javadoc JAR, add our styles
     tasks.withType(Javadoc) {
         options.addStringOption("charset", "utf-8")
         options.addStringOption("docencoding", "utf-8")
         options.addStringOption("encoding", "utf-8")
+        options.addBooleanOption("-no-fonts", true)
+        options.addStringOption("-add-stylesheet", "${rootDir}/docs/javadoc.css")
     }
 
     // Sign outputs with Developer ID

--- a/docs/javadoc.css
+++ b/docs/javadoc.css
@@ -1,0 +1,6 @@
+:root {
+    --body-font-size: calc(14.2px * 1.1);
+    --block-font-size: calc(14.4px * 1.1);
+    --code-font-size: calc(14px * 1.1);
+    --nav-font-size: calc(13.4px * 1.1);
+}


### PR DESCRIPTION
Javadoc now includes 4 MB of fonts for every Javadoc JAR, which we have 18 of, which causes unnecessary bloat to the installer size. This disables the inclusion of those fonts, using the built-in fallback included in the Javadoc stylesheet. This also increases the default font size by 10% after polling the FTC Discord resulted in people asking for a bigger font.