### PR TITLE
[wpimath, wpiunits] Add PoundSquareInches MOI unit, and improve KilogramMetersSquaredPerSecond definition

### DIFF
--- a/wpimath/src/main/native/include/wpi/units/moment_of_inertia.hpp
+++ b/wpimath/src/main/native/include/wpi/units/moment_of_inertia.hpp
@@ -10,9 +10,9 @@
 
 namespace wpi::units {
 UNIT_ADD(moment_of_inertia, kilogram_square_meter, kilogram_square_meters,
-         kg_sq_m, compound_unit<mass::pounds, area::square_inches>)
+         kg_sq_m, compound_unit<mass::kilograms, area::square_meters>)
 UNIT_ADD(moment_of_inertia, pound_square_inch, pound_square_inches,
-         lb_sq_in, compound_unit<mass::kilograms, area::square_meters>)
+         lb_sq_in, compound_unit<mass::pounds, area::square_inches>)
 
 using namespace moment_of_inertia;
 }  // namespace wpi::units

--- a/wpimath/src/main/native/include/wpi/units/moment_of_inertia.hpp
+++ b/wpimath/src/main/native/include/wpi/units/moment_of_inertia.hpp
@@ -11,8 +11,8 @@
 namespace wpi::units {
 UNIT_ADD(moment_of_inertia, kilogram_square_meter, kilogram_square_meters,
          kg_sq_m, compound_unit<mass::kilograms, area::square_meters>)
-UNIT_ADD(moment_of_inertia, pound_square_inch, pound_square_inches,
-         lb_sq_in, compound_unit<mass::pounds, area::square_inches>)
+UNIT_ADD(moment_of_inertia, pound_square_inch, pound_square_inches, lb_sq_in,
+         compound_unit<mass::pounds, area::square_inches>)
 
 using namespace moment_of_inertia;
 }  // namespace wpi::units

--- a/wpimath/src/main/native/include/wpi/units/moment_of_inertia.hpp
+++ b/wpimath/src/main/native/include/wpi/units/moment_of_inertia.hpp
@@ -10,7 +10,9 @@
 
 namespace wpi::units {
 UNIT_ADD(moment_of_inertia, kilogram_square_meter, kilogram_square_meters,
-         kg_sq_m, compound_unit<mass::kilograms, area::square_meters>)
+         kg_sq_m, compound_unit<mass::pounds, area::square_inches>)
+UNIT_ADD(moment_of_inertia, pound_square_inch, pound_square_inches,
+         lb_sq_in, compound_unit<mass::kilograms, area::square_meters>)
 
 using namespace moment_of_inertia;
 }  // namespace wpi::units

--- a/wpiunits/src/main/java/org/wpilib/units/Units.java
+++ b/wpiunits/src/main/java/org/wpilib/units/Units.java
@@ -386,6 +386,8 @@ public final class Units {
   public static final MomentOfInertiaUnit KilogramSquareMeters =
       KilogramMetersSquaredPerSecond.per(RadiansPerSecond);
 
+  public static final MomentOfInertiaUnit PoundSquareInches = PoundInches.mult(Inches);
+
   // VoltageUnit
   /** The base unit of electric potential. */
   public static final VoltageUnit Volts = BaseUnits.VoltageUnit;

--- a/wpiunits/src/main/java/org/wpilib/units/Units.java
+++ b/wpiunits/src/main/java/org/wpilib/units/Units.java
@@ -374,7 +374,7 @@ public final class Units {
    */
   public static final LinearMomentumUnit KilogramMetersPerSecond = Kilograms.mult(MetersPerSecond);
 
-  /** The equivalent of a one {@link #Pound} mass moving at one {@link #InchPerSecond} */
+  /** The equivalent of a one {@link #Pound} mass moving at one {@link #InchesPerSecond}. */
   public static LinearMomentumUnit PoundInchesPerSecond = Pounds.mult(InchesPerSecond);
 
   // Angular momentum

--- a/wpiunits/src/main/java/org/wpilib/units/Units.java
+++ b/wpiunits/src/main/java/org/wpilib/units/Units.java
@@ -376,7 +376,7 @@ public final class Units {
 
   /** The equivalent of a one {@link #Pound} mass moving at one {@link #InchPerSecond} */
   public static LinearMomentumUnit PoundInchesPerSecond = Pounds.mult(InchesPerSecond);
-  
+
   // Angular momentum
 
   /**

--- a/wpiunits/src/main/java/org/wpilib/units/Units.java
+++ b/wpiunits/src/main/java/org/wpilib/units/Units.java
@@ -374,11 +374,23 @@ public final class Units {
    */
   public static final LinearMomentumUnit KilogramMetersPerSecond = Kilograms.mult(MetersPerSecond);
 
+  /** The equivalent of a one {@link #Pound} mass moving at one {@link #InchPerSecond} */
+  public static LinearMomentumUnit PoundInchesPerSecond = Pounds.mult(InchesPerSecond);
+  
   // Angular momentum
 
-  /** The standard SI unit for angular momentum. */
+  /**
+   * The angular momentum of an object with a linear momentum of one {@link
+   * #KilogramMetersPerSecond} one {@link #Meter} away from its center of mass.
+   */
   public static final AngularMomentumUnit KilogramMetersSquaredPerSecond =
       KilogramMetersPerSecond.mult(Meters);
+
+  /**
+   * The angular momentum of an object with a linear momentum of one {@link PoundInchesPerSecond}
+   * one {@link Inch} away from its center of mass.
+   */
+  public static AngularMomentumUnit PoundInchesSquaredPerSecond = PoundInchesPerSecond.mult(Inches);
 
   // Moment of Inertia
 
@@ -386,7 +398,9 @@ public final class Units {
   public static final MomentOfInertiaUnit KilogramSquareMeters =
       KilogramMetersSquaredPerSecond.per(RadiansPerSecond);
 
-  public static final MomentOfInertiaUnit PoundSquareInches = PoundInches.mult(Inches);
+  /** A common imperial unit for moment of inertia. */
+  public static final MomentOfInertiaUnit PoundSquareInches =
+      PoundInchesSquaredPerSecond.per(RadiansPerSecond);
 
   // VoltageUnit
   /** The base unit of electric potential. */

--- a/wpiunits/src/main/java/org/wpilib/units/Units.java
+++ b/wpiunits/src/main/java/org/wpilib/units/Units.java
@@ -375,7 +375,7 @@ public final class Units {
   public static final LinearMomentumUnit KilogramMetersPerSecond = Kilograms.mult(MetersPerSecond);
 
   /** The equivalent of a one {@link #Pound} mass moving at one {@link #InchesPerSecond}. */
-  public static LinearMomentumUnit PoundInchesPerSecond = Pounds.mult(InchesPerSecond);
+  public static final LinearMomentumUnit PoundInchesPerSecond = Pounds.mult(InchesPerSecond);
 
   // Angular momentum
 
@@ -390,7 +390,8 @@ public final class Units {
    * The angular momentum of an object with a linear momentum of one {@link PoundInchesPerSecond}
    * one {@link Inch} away from its center of mass.
    */
-  public static AngularMomentumUnit PoundInchesSquaredPerSecond = PoundInchesPerSecond.mult(Inches);
+  public static final AngularMomentumUnit PoundInchesSquaredPerSecond =
+      PoundInchesPerSecond.mult(Inches);
 
   // Moment of Inertia
 

--- a/wpiunits/src/main/java/org/wpilib/units/Units.java
+++ b/wpiunits/src/main/java/org/wpilib/units/Units.java
@@ -380,8 +380,9 @@ public final class Units {
   // Angular momentum
 
   /**
-   * The angular momentum of an object with a linear momentum of one {@link
-   * #KilogramMetersPerSecond} one {@link #Meter} away from its center of mass.
+   * The standard SI unit for angular momentum, equivalent to a rotating object with a linear
+   * momentum of one {@link #KilogramMetersPerSecond} one {@link #Meter} away from its center of
+   * mass.
    */
   public static final AngularMomentumUnit KilogramMetersSquaredPerSecond =
       KilogramMetersPerSecond.mult(Meters);


### PR DESCRIPTION
As discussed in the discord. lb-in^2 is the common imperial MOI unit, e.g. Onshape uses it.

Also, improved the Java docstring for `KilogramMetersSquaredPerSecond` to explain what it represents.