### PR TITLE
bump sccache-action to v0.0.10

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -55,7 +55,7 @@ jobs:
         uses: lukka/get-cmake@v3.29.3
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - uses: actions/checkout@v6
 

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -36,7 +36,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libopencv-dev libopencv-java clang-18 ninja-build avahi-daemon
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
GitHub will force actions to run on node 24 on September 16th, 2026: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

sccache-action v0.0.9 which is present does not support node 24

 sccache-action v0.0.10 adds support: https://github.com/Mozilla-Actions/sccache-action/releases/tag/v0.0.10