### PR TITLE
[ci] Build Javadoc with JDK 26 for dark theme support

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -195,7 +195,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 25
+          java-version: 26
       - name: Set release environment variable
         run: echo "EXTRA_GRADLE_ARGS=-PreleaseMode" >> $GITHUB_ENV
         if: startsWith(github.ref, 'refs/tags/v2027')


### PR DESCRIPTION
<img width="342" height="152" alt="image" src="https://github.com/user-attachments/assets/4faa8dfa-d4fd-472e-87f0-e757717b3cfd" />

This is done to include https://github.com/openjdk/jdk/commit/0755477c9a06cc773f307c7119efb97df797d23a (relevant PR https://github.com/openjdk/jdk/pull/26185).