### PR TITLE
[wpilib] Change PWMMotorController::AddFollower to Follow

### DIFF
--- a/robotpyExamples/DifferentialDriveBot/drivetrain.py
+++ b/robotpyExamples/DifferentialDriveBot/drivetrain.py
@@ -26,8 +26,8 @@ class Drivetrain:
         self.rightFollower = wpilib.PWMSparkMax(4)
 
         # Make sure both motors for each side are in the same group
-        self.leftLeader.addFollower(self.leftFollower)
-        self.rightLeader.addFollower(self.rightFollower)
+        self.leftFollower.follow(self.leftLeader)
+        self.rightFollower.follow(self.rightLeader)
 
         # We need to invert one side of the drivetrain so that positive voltages
         # result in both sides moving forward. Depending on how your robot's

--- a/robotpyExamples/DifferentialDrivePoseEstimator/drivetrain.py
+++ b/robotpyExamples/DifferentialDrivePoseEstimator/drivetrain.py
@@ -87,8 +87,8 @@ class Drivetrain:
 
         self.imu.resetYaw()
 
-        self.leftLeader.addFollower(self.leftFollower)
-        self.rightLeader.addFollower(self.rightFollower)
+        self.leftFollower.follow(self.leftLeader)
+        self.rightFollower.follow(self.rightLeader)
 
         # We need to invert one side of the drivetrain so that positive voltages
         # result in both sides moving forward. Depending on how your robot's

--- a/robotpyExamples/HatchbotInlined/subsystems/drivesubsystem.py
+++ b/robotpyExamples/HatchbotInlined/subsystems/drivesubsystem.py
@@ -17,8 +17,8 @@ class DriveSubsystem(commands2.Subsystem):
         self.right1 = wpilib.PWMVictorSPX(constants.kRightMotor1Port)
         self.right2 = wpilib.PWMVictorSPX(constants.kRightMotor2Port)
 
-        self.left1.addFollower(self.left2)
-        self.right1.addFollower(self.right2)
+        self.left2.follow(self.left1)
+        self.right2.follow(self.right1)
 
         # We need to invert one side of the drivetrain so that positive velocities
         # result in both sides moving forward. Depending on how your robot's

--- a/robotpyExamples/RapidReactCommandBot/subsystems/drive.py
+++ b/robotpyExamples/RapidReactCommandBot/subsystems/drive.py
@@ -57,8 +57,8 @@ class Drive(Subsystem):
             DriveConstants.kS, DriveConstants.kV, DriveConstants.kA
         )
 
-        self.leftLeader.addFollower(self.leftFollower)
-        self.rightLeader.addFollower(self.rightFollower)
+        self.leftFollower.follow(self.leftLeader)
+        self.rightLeader.follow(self.rightFollower)
 
         # We need to invert one side of the drivetrain so that positive voltages
         # result in both sides moving forward. Depending on how your robot's

--- a/robotpyExamples/SimpleDifferentialDriveSimulation/drivetrain.py
+++ b/robotpyExamples/SimpleDifferentialDriveSimulation/drivetrain.py
@@ -64,8 +64,8 @@ class Drivetrain:
         )
 
         # Subsystem constructor.
-        self.leftLeader.addFollower(self.leftFollower)
-        self.rightLeader.addFollower(self.rightFollower)
+        self.leftFollower.follow(self.leftLeader)
+        self.rightLeader.follow(self.rightFollower)
 
         # We need to invert one side of the drivetrain so that positive voltages
         # result in both sides moving forward. Depending on how your robot's

--- a/robotpyExamples/SysId/subsystems/drive.py
+++ b/robotpyExamples/SysId/subsystems/drive.py
@@ -61,8 +61,8 @@ class Drive(Subsystem):
         )
 
         # Add the second motors on each side of the drivetrain
-        self.left_motor.addFollower(PWMSparkMax(DriveConstants.kLeftMotor2Port))
-        self.right_motor.addFollower(PWMSparkMax(DriveConstants.kRightMotor2Port))
+        PWMSparkMax(DriveConstants.kLeftMotor2Port).follow(self.left_motor)
+        PWMSparkMax(DriveConstants.kRightMotor2Port).follow(self.right_motor)
 
         # We need to invert one side of the drivetrain so that positive voltages
         # result in both sides moving forward. Depending on how your robot's

--- a/wpilibc/src/main/native/cpp/hardware/motor/PWMMotorController.cpp
+++ b/wpilibc/src/main/native/cpp/hardware/motor/PWMMotorController.cpp
@@ -77,10 +77,6 @@ void PWMMotorController::EnableDeadbandElimination(bool eliminateDeadband) {
   m_eliminateDeadband = eliminateDeadband;
 }
 
-void PWMMotorController::AddFollower(PWMMotorController& follower) {
-  m_nonowningFollowers.emplace_back(&follower);
-}
-
 PWMMotorController::PWMMotorController(std::string_view name, int channel)
     : m_pwm(channel, false) {
   wpi::util::SendableRegistry::Add(this, name, channel);

--- a/wpilibc/src/main/native/include/wpi/drive/DifferentialDrive.hpp
+++ b/wpilibc/src/main/native/include/wpi/drive/DifferentialDrive.hpp
@@ -22,7 +22,7 @@ class MotorController;
  * These drive bases typically have drop-center / skid-steer with two or more
  * wheels per side (e.g., 6WD or 8WD). This class takes a setter per side. For
  * four and six motor drivetrains, use CAN motor controller followers or
- * PWMMotorController::AddFollower().
+ * PWMMotorController::Follow().
  *
  * A differential drive robot has left and right wheels separated by an
  * arbitrary width.
@@ -73,7 +73,7 @@ class DifferentialDrive : public RobotDriveBase,
    * Construct a DifferentialDrive.
    *
    * To pass multiple motors per side, use CAN motor controller followers or
-   * PWMMotorController::AddFollower(). If a motor needs to be inverted, do so
+   * PWMMotorController::Follow(). If a motor needs to be inverted, do so
    * before passing it in.
    *
    * @param leftMotor Left motor.
@@ -85,7 +85,7 @@ class DifferentialDrive : public RobotDriveBase,
    * Construct a DifferentialDrive.
    *
    * To pass multiple motors per side, use CAN motor controller followers or
-   * PWMMotorController::AddFollower(). If a motor needs to be inverted, do so
+   * PWMMotorController::Follow(). If a motor needs to be inverted, do so
    * before passing it in.
    *
    * @param leftMotor Left motor setter.

--- a/wpilibc/src/main/native/include/wpi/hardware/motor/PWMMotorController.hpp
+++ b/wpilibc/src/main/native/include/wpi/hardware/motor/PWMMotorController.hpp
@@ -71,7 +71,7 @@ class PWMMotorController
    *
    * @param leader The motor controller to follow.
    */
-  void Follow(PWMMotorController& leader) {
+  void Follow(PWMMotorController& leader) & {
     leader.m_nonowningFollowers.push_back(this);
   }
 

--- a/wpilibc/src/main/native/include/wpi/hardware/motor/PWMMotorController.hpp
+++ b/wpilibc/src/main/native/include/wpi/hardware/motor/PWMMotorController.hpp
@@ -4,12 +4,9 @@
 
 #pragma once
 
-#include <concepts>
 #include <memory>
 #include <string>
 #include <string_view>
-#include <type_traits>
-#include <utility>
 #include <vector>
 
 #include "wpi/hal/SimDevice.hpp"
@@ -70,21 +67,12 @@ class PWMMotorController
   void EnableDeadbandElimination(bool eliminateDeadband);
 
   /**
-   * Make the given PWM motor controller follow the output of this one.
+   * Make the this PWM motor controller follow the output of the given one.
    *
-   * @param follower The motor controller follower.
+   * @param leader The motor controller to follow.
    */
-  void AddFollower(PWMMotorController& follower);
-
-  /**
-   * Make the given PWM motor controller follow the output of this one.
-   *
-   * @param follower The motor controller follower.
-   */
-  template <std::derived_from<PWMMotorController> T>
-  void AddFollower(T&& follower) {
-    m_owningFollowers.emplace_back(
-        std::make_unique<std::decay_t<T>>(std::forward<T>(follower)));
+  void Follow(PWMMotorController& leader) {
+    leader.m_nonowningFollowers.push_back(this);
   }
 
  protected:

--- a/wpilibc/src/main/python/semiwrap/PWMMotorController.yml
+++ b/wpilibc/src/main/python/semiwrap/PWMMotorController.yml
@@ -18,7 +18,7 @@ classes:
       GetDescription:
       GetChannel:
       EnableDeadbandElimination:
-      AddFollower:
+      Follow:
         overloads:
           PWMMotorController&:
             keepalive:

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDriveBot/include/Drivetrain.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDriveBot/include/Drivetrain.hpp
@@ -24,8 +24,8 @@
 class Drivetrain {
  public:
   Drivetrain() {
-    leftLeader.AddFollower(leftFollower);
-    rightLeader.AddFollower(rightFollower);
+    leftFollower.Follow(leftLeader);
+    rightFollower.Follow(rightLeader);
 
     // We need to invert one side of the drivetrain so that positive voltages
     // result in both sides moving forward. Depending on how your robot's

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/cpp/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/cpp/Drivetrain.cpp
@@ -12,8 +12,8 @@
 #include "wpi/system/RobotController.hpp"
 
 Drivetrain::Drivetrain() {
-  leftLeader.AddFollower(leftFollower);
-  rightLeader.AddFollower(rightFollower);
+  leftFollower.Follow(leftLeader);
+  rightFollower.Follow(rightLeader);
 
   // We need to invert one side of the drivetrain so that positive voltages
   // result in both sides moving forward. Depending on how your robot's

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/subsystems/DriveSubsystem.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/subsystems/DriveSubsystem.cpp
@@ -18,8 +18,8 @@ DriveSubsystem::DriveSubsystem()
   wpi::util::SendableRegistry::AddChild(&drive, &left1);
   wpi::util::SendableRegistry::AddChild(&drive, &right1);
 
-  left1.AddFollower(left2);
-  right1.AddFollower(right2);
+  left2.Follow(left1);
+  right2.Follow(right1);
 
   // We need to invert one side of the drivetrain so that positive voltages
   // result in both sides moving forward. Depending on how your robot's

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/subsystems/DriveSubsystem.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/subsystems/DriveSubsystem.cpp
@@ -18,8 +18,8 @@ DriveSubsystem::DriveSubsystem()
   wpi::util::SendableRegistry::AddChild(&drive, &left1);
   wpi::util::SendableRegistry::AddChild(&drive, &right1);
 
-  left1.AddFollower(left2);
-  right1.AddFollower(right2);
+  left2.Follow(left1);
+  right2.Follow(right1);
 
   // We need to invert one side of the drivetrain so that positive voltages
   // result in both sides moving forward. Depending on how your robot's

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Drive.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Drive.cpp
@@ -13,8 +13,8 @@ Drive::Drive() {
   wpi::util::SendableRegistry::AddChild(&drive, &leftLeader);
   wpi::util::SendableRegistry::AddChild(&drive, &rightLeader);
 
-  leftLeader.AddFollower(leftFollower);
-  rightLeader.AddFollower(rightFollower);
+  leftFollower.Follow(leftLeader);
+  rightFollower.Follow(rightLeader);
 
   // We need to invert one side of the drivetrain so that positive voltages
   // result in both sides moving forward. Depending on how your robot's

--- a/wpilibcExamples/src/main/cpp/examples/SimpleDifferentialDriveSimulation/include/Drivetrain.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/SimpleDifferentialDriveSimulation/include/Drivetrain.hpp
@@ -30,8 +30,8 @@ class Drivetrain {
   Drivetrain() {
     imu.ResetYaw();
 
-    leftLeader.AddFollower(leftFollower);
-    rightLeader.AddFollower(rightFollower);
+    leftFollower.Follow(leftLeader);
+    rightFollower.Follow(rightLeader);
 
     // We need to invert one side of the drivetrain so that positive voltages
     // result in both sides moving forward. Depending on how your robot's

--- a/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/cpp/subsystems/Drive.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/cpp/subsystems/Drive.cpp
@@ -7,10 +7,10 @@
 #include "wpi/commands2/Commands.hpp"
 
 Drive::Drive() {
-  leftMotor.AddFollower(wpi::PWMSparkMax{constants::drive::kLeftMotor2Port});
-  rightMotor.AddFollower(wpi::PWMSparkMax{constants::drive::kRightMotor2Port});
+  leftFollower.Follow(leftLeader);
+  rightFollower.Follow(rightLeader);
 
-  rightMotor.SetInverted(true);
+  rightLeader.SetInverted(true);
 
   leftEncoder.SetDistancePerPulse(
       constants::drive::kEncoderDistancePerPulse.value());

--- a/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/include/subsystems/Drive.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/include/subsystems/Drive.hpp
@@ -44,18 +44,18 @@ class Drive : public wpi::cmd::SubsystemBase {
                               nullptr},
       wpi::cmd::sysid::Mechanism{
           [this](wpi::units::volt_t driveVoltage) {
-            leftMotor.SetVoltage(driveVoltage);
-            rightMotor.SetVoltage(driveVoltage);
+            leftLeader.SetVoltage(driveVoltage);
+            rightLeader.SetVoltage(driveVoltage);
           },
           [this](wpi::sysid::SysIdRoutineLog* log) {
             log->Motor("drive-left")
-                .voltage(leftMotor.GetThrottle() *
+                .voltage(leftLeader.GetThrottle() *
                          wpi::RobotController::GetBatteryVoltage())
                 .position(wpi::units::meter_t{leftEncoder.GetDistance()})
                 .velocity(
                     wpi::units::meters_per_second_t{leftEncoder.GetRate()});
             log->Motor("drive-right")
-                .voltage(rightMotor.GetThrottle() *
+                .voltage(rightLeader.GetThrottle() *
                          wpi::RobotController::GetBatteryVoltage())
                 .position(wpi::units::meter_t{rightEncoder.GetDistance()})
                 .velocity(

--- a/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/include/subsystems/Drive.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/include/subsystems/Drive.hpp
@@ -24,12 +24,13 @@ class Drive : public wpi::cmd::SubsystemBase {
   wpi::cmd::CommandPtr SysIdDynamic(wpi::cmd::sysid::Direction direction);
 
  private:
-  wpi::PWMSparkMax leftMotor{constants::drive::kLeftMotor1Port};
-  wpi::PWMSparkMax rightMotor{constants::drive::kRightMotor1Port};
+  wpi::PWMSparkMax leftLeader{constants::drive::kLeftMotor1Port};
+  wpi::PWMSparkMax rightLeader{constants::drive::kRightMotor1Port};
+  wpi::PWMSparkMax leftFollower{constants::drive::kLeftMotor2Port};
+  wpi::PWMSparkMax rightFollower{constants::drive::kRightMotor2Port};
   wpi::DifferentialDrive drive{
-      [this](auto val) { leftMotor.SetThrottle(val); },
-      [this](auto val) { rightMotor.SetThrottle(val); }};
-
+      [this](auto val) { leftLeader.SetThrottle(val); },
+      [this](auto val) { rightLeader.SetThrottle(val); }};
   wpi::Encoder leftEncoder{constants::drive::kLeftEncoderPorts[0],
                            constants::drive::kLeftEncoderPorts[1],
                            constants::drive::kLeftEncoderReversed};

--- a/wpilibcExamples/src/main/cpp/snippets/EncoderDrive/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/snippets/EncoderDrive/cpp/Robot.cpp
@@ -22,8 +22,8 @@ class Robot : public wpi::TimedRobot {
     // other side
     rightLeader.SetInverted(true);
     // Configure the followers to follow the leaders
-    leftLeader.AddFollower(leftFollower);
-    rightLeader.AddFollower(rightFollower);
+    leftFollower.Follow(leftLeader);
+    rightFollower.Follow(rightLeader);
   }
   void AutonomousPeriodic() override {
     // Drives forward at half velocity until the robot has moved 5 feet, then

--- a/wpilibj/src/main/java/org/wpilib/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/org/wpilib/drive/DifferentialDrive.java
@@ -94,8 +94,8 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * Construct a DifferentialDrive.
    *
    * <p>To pass multiple motors per side, use CAN motor controller followers or {@link
-   * org.wpilib.hardware.motor.PWMMotorController#follow(PWMMotorController)}. If a motor needs
-   * to be inverted, do so before passing it in.
+   * org.wpilib.hardware.motor.PWMMotorController#follow(PWMMotorController)}. If a motor needs to
+   * be inverted, do so before passing it in.
    *
    * @param leftMotor Left motor.
    * @param rightMotor Right motor.
@@ -113,8 +113,8 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * Construct a DifferentialDrive.
    *
    * <p>To pass multiple motors per side, use CAN motor controller followers or {@link
-   * org.wpilib.hardware.motor.PWMMotorController#follow(PWMMotorController)}. If a motor needs
-   * to be inverted, do so before passing it in.
+   * org.wpilib.hardware.motor.PWMMotorController#follow(PWMMotorController)}. If a motor needs to
+   * be inverted, do so before passing it in.
    *
    * @param leftMotor Left motor setter.
    * @param rightMotor Right motor setter.

--- a/wpilibj/src/main/java/org/wpilib/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/org/wpilib/drive/DifferentialDrive.java
@@ -21,7 +21,7 @@ import org.wpilib.util.sendable.SendableRegistry;
  * <p>These drive bases typically have drop-center / skid-steer with two or more wheels per side
  * (e.g., 6WD or 8WD). This class takes a setter per side. For four and six motor drivetrains, use
  * CAN motor controller followers or {@link
- * org.wpilib.hardware.motor.PWMMotorController#addFollower(PWMMotorController)}.
+ * org.wpilib.hardware.motor.PWMMotorController#follow(PWMMotorController)}.
  *
  * <p>A differential drive robot has left and right wheels separated by an arbitrary width.
  *
@@ -94,7 +94,7 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * Construct a DifferentialDrive.
    *
    * <p>To pass multiple motors per side, use CAN motor controller followers or {@link
-   * org.wpilib.hardware.motor.PWMMotorController#addFollower(PWMMotorController)}. If a motor needs
+   * org.wpilib.hardware.motor.PWMMotorController#follow(PWMMotorController)}. If a motor needs
    * to be inverted, do so before passing it in.
    *
    * @param leftMotor Left motor.
@@ -113,7 +113,7 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * Construct a DifferentialDrive.
    *
    * <p>To pass multiple motors per side, use CAN motor controller followers or {@link
-   * org.wpilib.hardware.motor.PWMMotorController#addFollower(PWMMotorController)}. If a motor needs
+   * org.wpilib.hardware.motor.PWMMotorController#follow(PWMMotorController)}. If a motor needs
    * to be inverted, do so before passing it in.
    *
    * @param leftMotor Left motor setter.

--- a/wpilibj/src/main/java/org/wpilib/hardware/motor/PWMMotorController.java
+++ b/wpilibj/src/main/java/org/wpilib/hardware/motor/PWMMotorController.java
@@ -251,12 +251,11 @@ public abstract class PWMMotorController extends MotorSafety
   }
 
   /**
-   * Make the given PWM motor controller follow the output of this one.
-   *
-   * @param follower The motor controller follower.
+   * Makes this motor controller follow another.
+   * @param leader The motor controller to follow.
    */
-  public void addFollower(PWMMotorController follower) {
-    m_followers.add(follower);
+  public void follow(PWMMotorController leader) {
+    leader.m_followers.add(this);
   }
 
   @Override

--- a/wpilibj/src/main/java/org/wpilib/hardware/motor/PWMMotorController.java
+++ b/wpilibj/src/main/java/org/wpilib/hardware/motor/PWMMotorController.java
@@ -252,6 +252,7 @@ public abstract class PWMMotorController extends MotorSafety
 
   /**
    * Makes this motor controller follow another.
+   *
    * @param leader The motor controller to follow.
    */
   public void follow(PWMMotorController leader) {

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/differentialdrivebot/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/differentialdrivebot/Drivetrain.java
@@ -51,8 +51,8 @@ public class Drivetrain {
   public Drivetrain() {
     imu.resetYaw();
 
-    leftLeader.addFollower(leftFollower);
-    rightLeader.addFollower(rightFollower);
+    leftFollower.follow(leftLeader);
+    rightFollower.follow(rightLeader);
 
     // We need to invert one side of the drivetrain so that positive voltages
     // result in both sides moving forward. Depending on how your robot's

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/differentialdriveposeestimator/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/differentialdriveposeestimator/Drivetrain.java
@@ -105,8 +105,8 @@ public class Drivetrain {
   public Drivetrain(DoubleArrayTopic cameraToObjectTopic) {
     imu.resetYaw();
 
-    leftLeader.addFollower(leftFollower);
-    rightLeader.addFollower(rightFollower);
+    leftFollower.follow(leftLeader);
+    rightFollower.follow(rightLeader);
 
     // We need to invert one side of the drivetrain so that positive voltages
     // result in both sides moving forward. Depending on how your robot's

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotcmdv3/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotcmdv3/subsystems/DriveSubsystem.java
@@ -43,8 +43,8 @@ public class DriveSubsystem extends Mechanism {
     SendableRegistry.addChild(drive, leftLeader);
     SendableRegistry.addChild(drive, rightLeader);
 
-    leftLeader.addFollower(leftFollower);
-    rightLeader.addFollower(rightFollower);
+    leftFollower.follow(leftLeader);
+    rightFollower.follow(rightLeader);
 
     // We need to invert one side of the drivetrain so that positive voltages
     // result in both sides moving forward. Depending on how your robot's

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotinlined/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotinlined/subsystems/DriveSubsystem.java
@@ -44,8 +44,8 @@ public class DriveSubsystem extends SubsystemBase {
     SendableRegistry.addChild(drive, leftLeader);
     SendableRegistry.addChild(drive, rightLeader);
 
-    leftLeader.addFollower(leftFollower);
-    rightLeader.addFollower(rightFollower);
+    leftFollower.follow(leftLeader);
+    rightFollower.follow(rightLeader);
 
     // We need to invert one side of the drivetrain so that positive voltages
     // result in both sides moving forward. Depending on how your robot's

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbottraditional/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbottraditional/subsystems/DriveSubsystem.java
@@ -44,8 +44,8 @@ public class DriveSubsystem extends SubsystemBase {
     SendableRegistry.addChild(drive, leftLeader);
     SendableRegistry.addChild(drive, rightLeader);
 
-    leftLeader.addFollower(leftFollower);
-    rightLeader.addFollower(rightFollower);
+    leftFollower.follow(leftLeader);
+    rightFollower.follow(rightLeader);
 
     // We need to invert one side of the drivetrain so that positive voltages
     // result in both sides moving forward. Depending on how your robot's

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Drive.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Drive.java
@@ -66,8 +66,8 @@ public class Drive extends SubsystemBase {
     SendableRegistry.addChild(drive, leftLeader);
     SendableRegistry.addChild(drive, rightLeader);
 
-    leftLeader.addFollower(leftFollower);
-    rightLeader.addFollower(rightFollower);
+    leftFollower.follow(leftLeader);
+    rightFollower.follow(rightLeader);
 
     // We need to invert one side of the drivetrain so that positive voltages
     // result in both sides moving forward. Depending on how your robot's

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/simpledifferentialdrivesimulation/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/simpledifferentialdrivesimulation/Drivetrain.java
@@ -69,8 +69,8 @@ public class Drivetrain {
 
   /** Subsystem constructor. */
   public Drivetrain() {
-    leftLeader.addFollower(leftFollower);
-    rightLeader.addFollower(rightFollower);
+    leftFollower.follow(leftLeader);
+    rightFollower.follow(rightLeader);
 
     // We need to invert one side of the drivetrain so that positive voltages
     // result in both sides moving forward. Depending on how your robot's

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/subsystems/Drive.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/subsystems/Drive.java
@@ -20,15 +20,14 @@ import org.wpilib.system.RobotController;
 
 public class Drive extends SubsystemBase {
   // The motors on the left side of the drive.
-  private final PWMSparkMax leftMotor = new PWMSparkMax(DriveConstants.kLeftMotor1Port);
+  private final PWMSparkMax leftLeader = new PWMSparkMax(DriveConstants.kLeftMotor1Port);
 
   // The motors on the right side of the drive.
-  private final PWMSparkMax rightMotor = new PWMSparkMax(DriveConstants.kRightMotor1Port);
+  private final PWMSparkMax rightLeader = new PWMSparkMax(DriveConstants.kRightMotor1Port);
 
   // The robot's drive
   private final DifferentialDrive drive =
-      new DifferentialDrive(leftMotor::setThrottle, rightMotor::setThrottle);
-
+      new DifferentialDrive(leftLeader::setThrottle, rightLeader::setThrottle);
   // The left-side drive encoder
   private final Encoder leftEncoder =
       new Encoder(
@@ -51,8 +50,8 @@ public class Drive extends SubsystemBase {
           new SysIdRoutine.Mechanism(
               // Tell SysId how to plumb the driving voltage to the motors.
               voltage -> {
-                leftMotor.setVoltage(voltage);
-                rightMotor.setVoltage(voltage);
+                leftLeader.setVoltage(voltage);
+                rightLeader.setVoltage(voltage);
               },
               // Tell SysId how to record a frame of data for each motor on the mechanism being
               // characterized.
@@ -61,14 +60,14 @@ public class Drive extends SubsystemBase {
                 // the entire group to be one motor.
                 log.motor("drive-left")
                     .voltage(
-                        Volts.of(leftMotor.getThrottle() * RobotController.getBatteryVoltage()))
+                        Volts.of(leftLeader.getThrottle() * RobotController.getBatteryVoltage()))
                     .linearPosition(Meters.of(leftEncoder.getDistance()))
                     .linearVelocity(MetersPerSecond.of(leftEncoder.getRate()));
                 // Record a frame for the right motors.  Since these share an encoder, we consider
                 // the entire group to be one motor.
                 log.motor("drive-right")
                     .voltage(
-                        Volts.of(rightMotor.getThrottle() * RobotController.getBatteryVoltage()))
+                        Volts.of(rightLeader.getThrottle() * RobotController.getBatteryVoltage()))
                     .linearPosition(Meters.of(rightEncoder.getDistance()))
                     .linearVelocity(MetersPerSecond.of(rightEncoder.getRate()));
               },
@@ -79,13 +78,13 @@ public class Drive extends SubsystemBase {
   /** Creates a new Drive subsystem. */
   public Drive() {
     // Add the second motors on each side of the drivetrain
-    leftMotor.addFollower(new PWMSparkMax(DriveConstants.kLeftMotor2Port));
-    rightMotor.addFollower(new PWMSparkMax(DriveConstants.kRightMotor2Port));
+    new PWMSparkMax(DriveConstants.kLeftMotor2Port).follow(leftLeader);
+    new PWMSparkMax(DriveConstants.kRightMotor2Port).follow(rightLeader);
 
     // We need to invert one side of the drivetrain so that positive voltages
     // result in both sides moving forward. Depending on how your robot's
     // gearbox is constructed, you might have to invert the left side instead.
-    rightMotor.setInverted(true);
+    rightLeader.setInverted(true);
 
     // Sets the distance per pulse for the encoders
     leftEncoder.setDistancePerPulse(DriveConstants.kEncoderDistancePerPulse);

--- a/wpilibjExamples/src/main/java/org/wpilib/snippets/encoderdrive/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/snippets/encoderdrive/Robot.java
@@ -33,8 +33,8 @@ public class Robot extends TimedRobot {
     // Invert the right side of the drivetrain. You might have to invert the other side
     rightLeader.setInverted(true);
     // Configure the followers to follow the leaders
-    leftLeader.addFollower(leftFollower);
-    rightLeader.addFollower(rightFollower);
+    leftFollower.follow(leftLeader);
+    rightFollower.follow(rightLeader);
   }
 
   /** Drives forward at half velocity until the robot has moved 5 feet, then stops. */


### PR DESCRIPTION
The new `ExpansionHubMotor` class uses `follower.follow(leader)` syntax, as do all vendor libraries. In the interest of consistency, so should the WPILib PWM controller classes. (Double lookover of the C++ requested, that was very much by the seat of my pants...)