### PR TITLE
Fix imgui assertion on scalar inputs

### DIFF
--- a/glass/src/lib/native/cpp/other/DeviceTree.cpp
+++ b/glass/src/lib/native/cpp/other/DeviceTree.cpp
@@ -93,8 +93,8 @@ static bool DeviceDoubleImpl(const char* name, bool readonly, double* value) {
     ImGui::LabelText(name, "%.6f", *value);
     return false;
   } else {
-    return ImGui::InputDouble(name, value, 0, 0, "%.6f",
-                              ImGuiInputTextFlags_EnterReturnsTrue);
+    return ImGui::InputDouble(name, value, 0, 0, "%.6f") &&
+           ImGui::IsItemDeactivatedAfterEdit();
   }
 }
 
@@ -118,7 +118,8 @@ static bool DeviceIntImpl(const char* name, bool readonly, int32_t* value) {
     return false;
   } else {
     return ImGui::InputScalar(name, ImGuiDataType_S32, value, nullptr, nullptr,
-                              nullptr, ImGuiInputTextFlags_EnterReturnsTrue);
+                              nullptr) &&
+           ImGui::IsItemDeactivatedAfterEdit();
   }
 }
 
@@ -128,7 +129,8 @@ static bool DeviceLongImpl(const char* name, bool readonly, int64_t* value) {
     return false;
   } else {
     return ImGui::InputScalar(name, ImGuiDataType_S64, value, nullptr, nullptr,
-                              nullptr, ImGuiInputTextFlags_EnterReturnsTrue);
+                              nullptr) &&
+           ImGui::IsItemDeactivatedAfterEdit();
   }
 }
 

--- a/tools/sysid/src/main/native/cpp/view/Analyzer.cpp
+++ b/tools/sysid/src/main/native/cpp/view/Analyzer.cpp
@@ -438,8 +438,8 @@ void Analyzer::DisplayFeedforwardParameters(float beginX, float beginY) {
     // prematurely refresh with "1". That can cause display stuttering.
     ImGui::SetNextItemWidth(ImGui::GetFontSize() * 4);
     int window = m_settings.medianWindow;
-    if (ImGui::InputInt("Window Size", &window, 0, 0,
-                        ImGuiInputTextFlags_EnterReturnsTrue)) {
+    if (ImGui::InputInt("Window Size", &window, 0, 0) &&
+        ImGui::IsItemDeactivatedAfterEdit()) {
       m_settings.medianWindow = std::clamp(window, 1, 15);
       PrepareData();
     }
@@ -455,8 +455,9 @@ void Analyzer::DisplayFeedforwardParameters(float beginX, float beginY) {
     SetPosition(beginX, beginY, kHorizontalOffset, 1);
     ImGui::SetNextItemWidth(ImGui::GetFontSize() * 4);
     double threshold = m_settings.velocityThreshold;
-    if (ImGui::InputDouble("Velocity Threshold", &threshold, 0.0, 0.0, "%.3f",
-                           ImGuiInputTextFlags_EnterReturnsTrue)) {
+    if (ImGui::InputDouble("Velocity Threshold", &threshold, 0.0, 0.0,
+                           "%.3f") &&
+        ImGui::IsItemDeactivatedAfterEdit()) {
       m_settings.velocityThreshold = std::max(0.0, threshold);
       PrepareData();
     }


### PR DESCRIPTION
The imgui upgrade made it so that `ImGuiInputTextFlags_EnterReturnsTrue` is no longer a valid flag for scalar inputs. Instead, you're meant to use `IsItemDeactivatedAfterEdit`, which appears to have the same desired behavior (not updating values as they're being typed, only when the input is unfocused or Enter is pressed).