### PR TITLE
[ci] Add Arch Linux test build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -41,7 +41,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           if command -v pacman >/dev/null 2>&1; then
-            pacman -Syu --noconfirm opencv ninja avahi
+            pacman -Syu --noconfirm opencv ninja avahi cmake sccache jdk25-openjdk
           else
             apt-get update
             apt-get install -y libopencv-dev libopencv-java ninja-build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -41,7 +41,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           if command -v pacman >/dev/null 2>&1; then
-            pacman -Syu --noconfirm opencv ninja avahi cmake sccache jdk25-openjdk gcc
+            pacman -Syu --noconfirm opencv ninja avahi cmake sccache jdk25-openjdk gcc xorg-xrandr
           else
             apt-get update
             apt-get install -y libopencv-dev libopencv-java ninja-build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -41,7 +41,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           if command -v pacman >/dev/null 2>&1; then
-            pacman -Syu --noconfirm opencv ninja avahi cmake sccache jdk25-openjdk gcc xorg-xrandr
+            pacman -Syu --noconfirm opencv ninja avahi cmake sccache jdk25-openjdk gcc xorg-xrandr libxinerama
           else
             apt-get update
             apt-get install -y libopencv-dev libopencv-java ninja-build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -41,7 +41,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           if command -v pacman >/dev/null 2>&1; then
-            pacman -Syu --noconfirm opencv ninja
+            pacman -Syu --noconfirm opencv ninja avahi
           else
             apt-get update
             apt-get install -y libopencv-dev libopencv-java ninja-build
@@ -50,8 +50,10 @@ jobs:
       - name: Setup avahi-daemon
         if: runner.os == 'Linux'
         run: |
-          systemctl start dbus
-          systemctl start avahi-daemon
+          mkdir -p /var/run/dbus
+          dbus-uuidgen --ensure
+          dbus-daemon --system --address=unix:path=/var/run/dbus/system_bus_socket
+          avahi-daemon -D
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,6 +20,10 @@ jobs:
             name: Linux
             container: wpilib/systemcore-cross-ubuntu:2027-24.04
             flags: "--preset with-java-and-sccache -DCMAKE_BUILD_TYPE=Release -DWITH_EXAMPLES=ON"
+          - os: ubuntu-24.04
+            name: Arch Linux
+            container: ghcr.io/pkgforge-dev/archlinux:latest
+            flags: "--preset with-java-and-sccache -DCMAKE_BUILD_TYPE=Release -DWITH_EXAMPLES=ON"
           - os: macOS-15
             name: macOS
             container: ""
@@ -35,13 +39,19 @@ jobs:
     steps:
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libopencv-dev libopencv-java ninja-build
+        run: |
+          if command -v pacman >/dev/null 2>&1; then
+            pacman -Syu --noconfirm opencv ninja
+          else
+            apt-get update
+            apt-get install -y libopencv-dev libopencv-java ninja-build
+          fi
 
       - name: Setup avahi-daemon
         if: runner.os == 'Linux'
         run: |
-          sudo service dbus start
-          sudo avahi-daemon -D
+          systemctl start dbus
+          systemctl start avahi-daemon
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -41,7 +41,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           if command -v pacman >/dev/null 2>&1; then
-            pacman -Syu --noconfirm opencv ninja avahi cmake sccache jdk25-openjdk
+            pacman -Syu --noconfirm opencv ninja avahi cmake sccache jdk25-openjdk gcc
           else
             apt-get update
             apt-get install -y libopencv-dev libopencv-java ninja-build


### PR DESCRIPTION
amd64-only for now, ARM will get tested when #7705 or similar is added.

WIP because GCC 16 still fails to build

Other stuff
- manual invocations for dbus/avahi (sysvinit death)
- no need for sudo in docker land
- uses pkgforge-dev's container since it will also work with ARM

Signed-off-by: crueter <crueter@eden-emu.dev>
