### PR TITLE
[ci] Use macos-26 runner and always use latest stable Xcode version

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -53,12 +53,6 @@ jobs:
       - name: Check disk free space post-cleanup
         run: df -h
 
-      - name: Setup Xcode 26.4 (macOS)
-        if: runner.os == 'macOS'
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: 26.4
-
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -21,7 +21,7 @@ jobs:
           - { name: "Linux x86-64 Static", classifier: "linuxx86-64static",               os: ubuntu-24.04, action: "test" }
           - { name: "Linux x86-64 Static Debug", classifier: "linuxx86-64staticdebug",        os: ubuntu-24.04, action: "test" }
 
-          - { name: "macOS", classifier: "osxuniversal,osxuniversaldebug,headers,sources,osxuniversalstatic,osxuniversalstaticdebug,linuxsystemcore,linuxsystemcoredebug,linuxsystemcorestatic,linuxsystemcorestaticdebug", os: macOS-15, action: "test" }
+          - { name: "macOS", classifier: "osxuniversal,osxuniversaldebug,headers,sources,osxuniversalstatic,osxuniversalstaticdebug,linuxsystemcore,linuxsystemcoredebug,linuxsystemcorestatic,linuxsystemcorestaticdebug", os: macOS-26, action: "test" }
 
           - { name: "Windows x86-64",      classifier: "windowsx86-64,windowsx86-64static,headers,sources",   os: windows-2022, action: "test" }
           - { name: "Windows x86-64 Debug", classifier: "windowsx86-64debug,windowsx86-64staticdebug",        os: windows-2022, action: "test" }
@@ -59,14 +59,14 @@ jobs:
           rm -rf /Users/runner/Library/Android
         if: startsWith(matrix.os, 'macOS')
 
+      - name: Check disk free space post-cleanup
+        run: df -h
+
       - name: Setup Xcode 26.4 (macOS)
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: 26.4
-
-      - name: Check disk free space post-cleanup
-        run: df -h
 
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -49,15 +49,6 @@ jobs:
           docker-images: false
           swap-storage: false
         if: startsWith(matrix.os, 'ubuntu')
-      - name: Free disk space (macOS)
-        # CodeQL: 5G
-        # go: 748M
-        # Android: 12G
-        run: |
-          rm -rf /Users/runner/hostedtoolcache/CodeQL
-          rm -rf /Users/runner/hostedtoolcache/go
-          rm -rf /Users/runner/Library/Android
-        if: startsWith(matrix.os, 'macOS')
 
       - name: Check disk free space post-cleanup
         run: df -h

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -53,11 +53,11 @@ jobs:
       - name: Check disk free space post-cleanup
         run: df -h
 
-      - name: Setup Xcode 26.4 (macOS)
+      - name: Setup Latest Xcode (macOS)
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 26.4
+          xcode-version: latest-stable
 
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -59,6 +59,12 @@ jobs:
           rm -rf /Users/runner/Library/Android
         if: startsWith(matrix.os, 'macOS')
 
+      - name: Setup Xcode 26.4 (macOS)
+        if: runner.os == 'macOS'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 26.4
+
       - name: Check disk free space post-cleanup
         run: df -h
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -53,6 +53,12 @@ jobs:
       - name: Check disk free space post-cleanup
         run: df -h
 
+      - name: Setup Xcode 26.4 (macOS)
+        if: runner.os == 'macOS'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 26.4
+
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,6 +47,12 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install opencv ninja
 
+      - name: Setup Xcode 26.4 (macOS)
+        if: runner.os == 'macOS'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 26.4
+
       - uses: ilammy/msvc-dev-cmd@v1.13.0
         if: runner.os == 'Windows'
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,12 +47,6 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install opencv ninja
 
-      - name: Setup Xcode 26.4 (macOS)
-        if: runner.os == 'macOS'
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: 26.4
-
       - uses: ilammy/msvc-dev-cmd@v1.13.0
         if: runner.os == 'Windows'
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,11 +47,11 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install opencv ninja
 
-      - name: Setup Xcode 26.4 (macOS)
+      - name: Setup Latest Xcode (macOS)
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 26.4
+          xcode-version: latest-stable
 
       - uses: ilammy/msvc-dev-cmd@v1.13.0
         if: runner.os == 'Windows'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,7 +20,7 @@ jobs:
             name: Linux
             container: wpilib/systemcore-cross-ubuntu:2027-24.04
             flags: "--preset with-java-and-sccache -DCMAKE_BUILD_TYPE=Release -DWITH_EXAMPLES=ON"
-          - os: macOS-15
+          - os: macOS-26
             name: macOS
             container: ""
             flags: "--preset with-sccache -DCMAKE_BUILD_TYPE=Release -DWITH_EXAMPLES=ON"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -123,27 +123,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [validation]
     steps:
-      - name: Check disk free space pre-cleanup
+      - name: Check disk free space
         run: df -h
-
-      - name: Free disk space (macOS)
-        # CodeQL: 5G
-        # go: 748M
-        # Android: 12G
-        run: |
-          rm -rf /Users/runner/hostedtoolcache/CodeQL
-          rm -rf /Users/runner/hostedtoolcache/go
-          rm -rf /Users/runner/Library/Android
-        if: startsWith(matrix.os, 'macOS')
 
       - name: Setup Xcode 26.4 (macOS)
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: 26.4
-
-      - name: Check disk free space post-cleanup
-        run: df -h
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -126,12 +126,6 @@ jobs:
       - name: Check disk free space
         run: df -h
 
-      - name: Setup Xcode 26.4 (macOS)
-        if: runner.os == 'macOS'
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: 26.4
-
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -136,6 +136,12 @@ jobs:
           rm -rf /Users/runner/Library/Android
         if: startsWith(matrix.os, 'macOS')
 
+      - name: Setup Xcode 26.4 (macOS)
+        if: runner.os == 'macOS'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 26.4
+
       - name: Check disk free space post-cleanup
         run: df -h
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -108,7 +108,7 @@ jobs:
             build-options: "-PciReleaseOnly -Pbuildwinarm64 -Ponlywindowsarm64"
             task: "copyAllOutputs"
             outputs: "build/allOutputs"
-          - os: macOS-15
+          - os: macOS-26
             artifact-name: macOS
             architecture: aarch64
             task: "build"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -126,11 +126,11 @@ jobs:
       - name: Check disk free space
         run: df -h
 
-      - name: Setup Xcode 26.4 (macOS)
+      - name: Setup Latest Xcode (macOS)
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 26.4
+          xcode-version: latest-stable
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -126,6 +126,12 @@ jobs:
       - name: Check disk free space
         run: df -h
 
+      - name: Setup Xcode 26.4 (macOS)
+        if: runner.os == 'macOS'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 26.4
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/.github/workflows/sentinel-build.yml
+++ b/.github/workflows/sentinel-build.yml
@@ -117,13 +117,6 @@ jobs:
           distribution: 'temurin'
           java-version: 25
           architecture: ${{ matrix.architecture }}
-
-      - name: Setup Xcode 26.4 (macOS)
-        if: runner.os == 'macOS'
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: 26.4
-
       - name: Import Developer ID Certificate
         uses: wpilibsuite/import-signing-certificate@v3
         with:

--- a/.github/workflows/sentinel-build.yml
+++ b/.github/workflows/sentinel-build.yml
@@ -94,7 +94,7 @@ jobs:
             build-options: "-PciReleaseOnly -Pbuildwinarm64 -Ponlywindowsarm64"
             task: "copyAllOutputs"
             outputs: "build/allOutputs"
-          - os: macOS-15
+          - os: macOS-26
             artifact-name: macOS
             architecture: aarch64
             task: "build"
@@ -141,7 +141,7 @@ jobs:
         if: matrix.os == 'windows-2022'
       - name: Check disk free space pre-cleanup (macOS)
         run: df -h .
-        if: matrix.os == 'macOS-15'
+        if: matrix.os == 'macOS-26'
       - name: Cleanup disk space
         # CodeQL: 5G
         # go: 748M
@@ -150,10 +150,10 @@ jobs:
           rm -rf /Users/runner/hostedtoolcache/CodeQL
           rm -rf /Users/runner/hostedtoolcache/go
           rm -rf /Users/runner/Library/Android
-        if: matrix.os == 'macOS-15'
+        if: matrix.os == 'macOS-26'
       - name: Check disk free space post-cleanup (macOS)
         run: df -h .
-        if: matrix.os == 'macOS-15'
+        if: matrix.os == 'macOS-26'
       - name: Build with Gradle
         run: ./gradlew ${{ matrix.task }} -PbuildServer -PskipJavaFormat ${{ matrix.build-options }}
       - name: Sign Libraries with Developer ID
@@ -165,7 +165,7 @@ jobs:
         if: matrix.os == 'windows-2022'
       - name: Check disk free space (macOS)
         run: df -h .
-        if: matrix.os == 'macOS-15'
+        if: matrix.os == 'macOS-26'
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}

--- a/.github/workflows/sentinel-build.yml
+++ b/.github/workflows/sentinel-build.yml
@@ -117,6 +117,13 @@ jobs:
           distribution: 'temurin'
           java-version: 25
           architecture: ${{ matrix.architecture }}
+
+      - name: Setup Xcode 26.4 (macOS)
+        if: runner.os == 'macOS'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 26.4
+
       - name: Import Developer ID Certificate
         uses: wpilibsuite/import-signing-certificate@v3
         with:

--- a/.github/workflows/sentinel-build.yml
+++ b/.github/workflows/sentinel-build.yml
@@ -139,21 +139,6 @@ jobs:
       - name: Check disk free space (Windows)
         run: wmic logicaldisk get caption, freespace
         if: matrix.os == 'windows-2022'
-      - name: Check disk free space pre-cleanup (macOS)
-        run: df -h .
-        if: matrix.os == 'macOS-26'
-      - name: Cleanup disk space
-        # CodeQL: 5G
-        # go: 748M
-        # Android: 12G
-        run: |
-          rm -rf /Users/runner/hostedtoolcache/CodeQL
-          rm -rf /Users/runner/hostedtoolcache/go
-          rm -rf /Users/runner/Library/Android
-        if: matrix.os == 'macOS-26'
-      - name: Check disk free space post-cleanup (macOS)
-        run: df -h .
-        if: matrix.os == 'macOS-26'
       - name: Build with Gradle
         run: ./gradlew ${{ matrix.task }} -PbuildServer -PskipJavaFormat ${{ matrix.build-options }}
       - name: Sign Libraries with Developer ID

--- a/.github/workflows/sentinel-build.yml
+++ b/.github/workflows/sentinel-build.yml
@@ -118,11 +118,11 @@ jobs:
           java-version: 25
           architecture: ${{ matrix.architecture }}
 
-      - name: Setup Xcode 26.4 (macOS)
+      - name: Setup Latest Xcode (macOS)
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 26.4
+          xcode-version: latest-stable
 
       - name: Import Developer ID Certificate
         uses: wpilibsuite/import-signing-certificate@v3

--- a/upstream_utils/llvm_patches/0001-Remove-StringRef-ArrayRef-and-Optional.patch
+++ b/upstream_utils/llvm_patches/0001-Remove-StringRef-ArrayRef-and-Optional.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:09:18 -0400
-Subject: [PATCH 01/35] Remove StringRef, ArrayRef, and Optional
+Subject: [PATCH 01/36] Remove StringRef, ArrayRef, and Optional
 
 ---
  llvm/include/llvm/ADT/PointerUnion.h          |   1 -

--- a/upstream_utils/llvm_patches/0002-Wrap-std-min-max-calls-in-parens-for-Windows-warning.patch
+++ b/upstream_utils/llvm_patches/0002-Wrap-std-min-max-calls-in-parens-for-Windows-warning.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:12:41 -0400
-Subject: [PATCH 02/35] Wrap std::min/max calls in parens, for Windows warnings
+Subject: [PATCH 02/36] Wrap std::min/max calls in parens, for Windows warnings
 
 ---
  llvm/include/llvm/ADT/DenseMap.h       |  4 ++--

--- a/upstream_utils/llvm_patches/0003-Change-unique_function-storage-size.patch
+++ b/upstream_utils/llvm_patches/0003-Change-unique_function-storage-size.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:13:55 -0400
-Subject: [PATCH 03/35] Change unique_function storage size
+Subject: [PATCH 03/36] Change unique_function storage size
 
 ---
  llvm/include/llvm/ADT/FunctionExtras.h | 4 ++--

--- a/upstream_utils/llvm_patches/0004-Threading-updates.patch
+++ b/upstream_utils/llvm_patches/0004-Threading-updates.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:17:19 -0400
-Subject: [PATCH 04/35] Threading updates
+Subject: [PATCH 04/36] Threading updates
 
 - Remove guards for threads and exception
 - Prefer scope gaurd over lock gaurd

--- a/upstream_utils/llvm_patches/0005-ifdef-guard-safety.patch
+++ b/upstream_utils/llvm_patches/0005-ifdef-guard-safety.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:28:13 -0400
-Subject: [PATCH 05/35] \#ifdef guard safety
+Subject: [PATCH 05/36] \#ifdef guard safety
 
 Prevents redefinition if someone is pulling in real LLVM, since the macros are in global namespace
 ---

--- a/upstream_utils/llvm_patches/0006-Explicitly-use-std.patch
+++ b/upstream_utils/llvm_patches/0006-Explicitly-use-std.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:37:34 -0400
-Subject: [PATCH 06/35] Explicitly use std::
+Subject: [PATCH 06/36] Explicitly use std::
 
 ---
  llvm/include/llvm/ADT/SmallSet.h       |  2 +-

--- a/upstream_utils/llvm_patches/0007-Remove-format_provider.patch
+++ b/upstream_utils/llvm_patches/0007-Remove-format_provider.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:53:50 -0400
-Subject: [PATCH 07/35] Remove format_provider
+Subject: [PATCH 07/36] Remove format_provider
 
 ---
  llvm/include/llvm/Support/Chrono.h      | 114 ------------------------

--- a/upstream_utils/llvm_patches/0008-Add-compiler-warning-pragmas.patch
+++ b/upstream_utils/llvm_patches/0008-Add-compiler-warning-pragmas.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 13:34:07 -0400
-Subject: [PATCH 08/35] Add compiler warning pragmas
+Subject: [PATCH 08/36] Add compiler warning pragmas
 
 ---
  llvm/include/llvm/ADT/FunctionExtras.h    | 11 +++++++++++

--- a/upstream_utils/llvm_patches/0009-Remove-unused-functions.patch
+++ b/upstream_utils/llvm_patches/0009-Remove-unused-functions.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 13:43:50 -0400
-Subject: [PATCH 09/35] Remove unused functions
+Subject: [PATCH 09/36] Remove unused functions
 
 ---
  llvm/include/llvm/ADT/SmallString.h      |  77 ------

--- a/upstream_utils/llvm_patches/0010-Detemplatize-SmallVectorBase.patch
+++ b/upstream_utils/llvm_patches/0010-Detemplatize-SmallVectorBase.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Thu, 5 May 2022 23:18:34 -0400
-Subject: [PATCH 10/35] Detemplatize SmallVectorBase
+Subject: [PATCH 10/36] Detemplatize SmallVectorBase
 
 ---
  llvm/include/llvm/ADT/SmallVector.h | 35 ++++++++++-------------------

--- a/upstream_utils/llvm_patches/0011-Add-vectors-to-raw_ostream.patch
+++ b/upstream_utils/llvm_patches/0011-Add-vectors-to-raw_ostream.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 13:48:59 -0400
-Subject: [PATCH 11/35] Add vectors to raw_ostream
+Subject: [PATCH 11/36] Add vectors to raw_ostream
 
 ---
  llvm/include/llvm/Support/raw_ostream.h | 115 ++++++++++++++++++++++++

--- a/upstream_utils/llvm_patches/0012-Delete-numbers-from-MathExtras.patch
+++ b/upstream_utils/llvm_patches/0012-Delete-numbers-from-MathExtras.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Thu, 5 May 2022 18:09:45 -0400
-Subject: [PATCH 12/35] Delete numbers from MathExtras
+Subject: [PATCH 12/36] Delete numbers from MathExtras
 
 ---
  llvm/include/llvm/Support/MathExtras.h | 37 --------------------------

--- a/upstream_utils/llvm_patches/0013-Add-lerp-and-sgn.patch
+++ b/upstream_utils/llvm_patches/0013-Add-lerp-and-sgn.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 3 May 2022 22:50:24 -0400
-Subject: [PATCH 13/35] Add lerp and sgn
+Subject: [PATCH 13/36] Add lerp and sgn
 
 ---
  llvm/include/llvm/Support/MathExtras.h | 21 +++++++++++++++++++++

--- a/upstream_utils/llvm_patches/0014-Fixup-includes.patch
+++ b/upstream_utils/llvm_patches/0014-Fixup-includes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:38:11 -0400
-Subject: [PATCH 14/35] Fixup includes
+Subject: [PATCH 14/36] Fixup includes
 
 ---
  llvm/include/llvm/Support/PointerLikeTypeTraits.h | 1 +

--- a/upstream_utils/llvm_patches/0015-Use-std-is_trivially_copy_constructible.patch
+++ b/upstream_utils/llvm_patches/0015-Use-std-is_trivially_copy_constructible.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:42:09 -0400
-Subject: [PATCH 15/35] Use std::is_trivially_copy_constructible
+Subject: [PATCH 15/36] Use std::is_trivially_copy_constructible
 
 ---
  llvm/include/llvm/Support/type_traits.h | 16 ----------------

--- a/upstream_utils/llvm_patches/0016-Windows-support.patch
+++ b/upstream_utils/llvm_patches/0016-Windows-support.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 3 May 2022 20:22:38 -0400
-Subject: [PATCH 16/35] Windows support
+Subject: [PATCH 16/36] Windows support
 
 ---
  .../llvm/Support/Windows/WindowsSupport.h     | 45 +++++----

--- a/upstream_utils/llvm_patches/0017-Remove-call-to-RtlGetLastNtStatus.patch
+++ b/upstream_utils/llvm_patches/0017-Remove-call-to-RtlGetLastNtStatus.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Tue, 17 Sep 2024 21:19:52 -0700
-Subject: [PATCH 17/35] Remove call to RtlGetLastNtStatus()
+Subject: [PATCH 17/36] Remove call to RtlGetLastNtStatus()
 
 ---
  llvm/lib/Support/ErrorHandling.cpp | 23 -----------------------

--- a/upstream_utils/llvm_patches/0018-Prefer-fmtlib.patch
+++ b/upstream_utils/llvm_patches/0018-Prefer-fmtlib.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:46:20 -0400
-Subject: [PATCH 18/35] Prefer fmtlib
+Subject: [PATCH 18/36] Prefer fmtlib
 
 ---
  llvm/lib/Support/ErrorHandling.cpp | 20 ++++++--------------

--- a/upstream_utils/llvm_patches/0019-Prefer-wpi-s-fs.h.patch
+++ b/upstream_utils/llvm_patches/0019-Prefer-wpi-s-fs.h.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:49:36 -0400
-Subject: [PATCH 19/35] Prefer wpi's fs.h
+Subject: [PATCH 19/36] Prefer wpi's fs.h
 
 ---
  llvm/include/llvm/Support/raw_ostream.h | 7 ++-----

--- a/upstream_utils/llvm_patches/0020-Remove-unused-functions.patch
+++ b/upstream_utils/llvm_patches/0020-Remove-unused-functions.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 19:16:51 -0400
-Subject: [PATCH 20/35] Remove unused functions
+Subject: [PATCH 20/36] Remove unused functions
 
 ---
  llvm/include/llvm/Support/VersionTuple.h |  1 -

--- a/upstream_utils/llvm_patches/0021-OS-specific-changes.patch
+++ b/upstream_utils/llvm_patches/0021-OS-specific-changes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 19:30:43 -0400
-Subject: [PATCH 21/35] OS-specific changes
+Subject: [PATCH 21/36] OS-specific changes
 
 ---
  llvm/lib/Support/ErrorHandling.cpp | 16 +++++++---------

--- a/upstream_utils/llvm_patches/0022-Use-SmallVector-for-UTF-conversion.patch
+++ b/upstream_utils/llvm_patches/0022-Use-SmallVector-for-UTF-conversion.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Mon, 9 May 2022 00:04:30 -0400
-Subject: [PATCH 22/35] Use SmallVector for UTF conversion
+Subject: [PATCH 22/36] Use SmallVector for UTF conversion
 
 ---
  llvm/include/llvm/Support/ConvertUTF.h    |  6 +++---

--- a/upstream_utils/llvm_patches/0023-Prefer-to-use-static-pointers-in-raw_ostream.patch
+++ b/upstream_utils/llvm_patches/0023-Prefer-to-use-static-pointers-in-raw_ostream.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Thu, 19 May 2022 00:58:36 -0400
-Subject: [PATCH 23/35] Prefer to use static pointers in raw_ostream
+Subject: [PATCH 23/36] Prefer to use static pointers in raw_ostream
 
 See #1401
 ---

--- a/upstream_utils/llvm_patches/0024-constexpr-endian-byte-swap.patch
+++ b/upstream_utils/llvm_patches/0024-constexpr-endian-byte-swap.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Fri, 1 Mar 2024 11:56:17 -0800
-Subject: [PATCH 24/35] constexpr endian byte swap
+Subject: [PATCH 24/36] constexpr endian byte swap
 
 ---
  llvm/include/llvm/Support/Endian.h | 4 +++-

--- a/upstream_utils/llvm_patches/0025-Copy-type-traits-from-STLExtras.h-into-PointerUnion..patch
+++ b/upstream_utils/llvm_patches/0025-Copy-type-traits-from-STLExtras.h-into-PointerUnion..patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Wed, 10 Aug 2022 17:07:52 -0700
-Subject: [PATCH 25/35] Copy type traits from STLExtras.h into PointerUnion.h
+Subject: [PATCH 25/36] Copy type traits from STLExtras.h into PointerUnion.h
 
 ---
  llvm/include/llvm/ADT/PointerUnion.h | 46 ++++++++++++++++++++++++++++

--- a/upstream_utils/llvm_patches/0026-Unused-variable-in-release-mode.patch
+++ b/upstream_utils/llvm_patches/0026-Unused-variable-in-release-mode.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Leander Schulten <Leander.Schulten@rwth-aachen.de>
 Date: Mon, 10 Jul 2023 00:53:43 +0200
-Subject: [PATCH 26/35] Unused variable in release mode
+Subject: [PATCH 26/36] Unused variable in release mode
 
 ---
  llvm/include/llvm/ADT/DenseMap.h | 2 +-

--- a/upstream_utils/llvm_patches/0027-Use-C-20-bit-header.patch
+++ b/upstream_utils/llvm_patches/0027-Use-C-20-bit-header.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Tue, 11 Jul 2023 22:56:09 -0700
-Subject: [PATCH 27/35] Use C++20 <bit> header
+Subject: [PATCH 27/36] Use C++20 <bit> header
 
 ---
  llvm/include/llvm/ADT/DenseMap.h       |   3 +-

--- a/upstream_utils/llvm_patches/0028-Remove-DenseMap-GTest-printer-test.patch
+++ b/upstream_utils/llvm_patches/0028-Remove-DenseMap-GTest-printer-test.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Sun, 30 Jul 2023 14:17:37 -0700
-Subject: [PATCH 28/35] Remove DenseMap GTest printer test
+Subject: [PATCH 28/36] Remove DenseMap GTest printer test
 
 LLVM modifies internal GTest headers to support it, which we can't do.
 ---

--- a/upstream_utils/llvm_patches/0029-raw_ostream-Add-SetNumBytesInBuffer.patch
+++ b/upstream_utils/llvm_patches/0029-raw_ostream-Add-SetNumBytesInBuffer.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sun, 29 Oct 2023 23:00:08 -0700
-Subject: [PATCH 29/35] raw_ostream: Add SetNumBytesInBuffer
+Subject: [PATCH 29/36] raw_ostream: Add SetNumBytesInBuffer
 
 ---
  llvm/include/llvm/Support/raw_ostream.h | 5 +++++

--- a/upstream_utils/llvm_patches/0030-raw_ostream-Replace-errnoAsErrorCode.patch
+++ b/upstream_utils/llvm_patches/0030-raw_ostream-Replace-errnoAsErrorCode.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Tue, 17 Sep 2024 15:30:31 -0700
-Subject: [PATCH 30/35] raw_ostream: Replace errnoAsErrorCode()
+Subject: [PATCH 30/36] raw_ostream: Replace errnoAsErrorCode()
 
 ---
  llvm/lib/Support/raw_ostream.cpp | 4 ++--

--- a/upstream_utils/llvm_patches/0031-type_traits.h-Add-is_constexpr.patch
+++ b/upstream_utils/llvm_patches/0031-type_traits.h-Add-is_constexpr.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Peter Johnson <johnson.peter@gmail.com>
 Date: Sat, 2 Dec 2023 15:21:32 -0800
-Subject: [PATCH 31/35] type_traits.h: Add is_constexpr()
+Subject: [PATCH 31/36] type_traits.h: Add is_constexpr()
 
 ---
  llvm/include/llvm/Support/type_traits.h | 5 +++++

--- a/upstream_utils/llvm_patches/0032-Remove-auto-conversion-from-raw_ostream.patch
+++ b/upstream_utils/llvm_patches/0032-Remove-auto-conversion-from-raw_ostream.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Sun, 17 Mar 2024 14:51:11 -0700
-Subject: [PATCH 32/35] Remove auto-conversion from raw_ostream
+Subject: [PATCH 32/36] Remove auto-conversion from raw_ostream
 
 ---
  llvm/lib/Support/raw_ostream.cpp | 11 +----------

--- a/upstream_utils/llvm_patches/0033-Add-SmallVector-erase_if.patch
+++ b/upstream_utils/llvm_patches/0033-Add-SmallVector-erase_if.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Tue, 18 Jun 2024 09:07:33 -0700
-Subject: [PATCH 33/35] Add SmallVector erase_if()
+Subject: [PATCH 33/36] Add SmallVector erase_if()
 
 ---
  llvm/include/llvm/ADT/SmallVector.h | 8 ++++++++

--- a/upstream_utils/llvm_patches/0034-Fix-AlignedCharArrayUnion-for-C-23.patch
+++ b/upstream_utils/llvm_patches/0034-Fix-AlignedCharArrayUnion-for-C-23.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Sat, 13 Jul 2024 15:24:30 -0700
-Subject: [PATCH 34/35] Fix AlignedCharArrayUnion for C++23
+Subject: [PATCH 34/36] Fix AlignedCharArrayUnion for C++23
 
 ---
  llvm/include/llvm/Support/AlignOf.h | 14 +++++---------

--- a/upstream_utils/llvm_patches/0035-Fix-minIntN-and-maxIntN-assertions.patch
+++ b/upstream_utils/llvm_patches/0035-Fix-minIntN-and-maxIntN-assertions.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Mon, 23 Dec 2024 22:56:29 -0800
-Subject: [PATCH 35/35] Fix minIntN() and maxIntN() assertions
+Subject: [PATCH 35/36] Fix minIntN() and maxIntN() assertions
 
 ---
  llvm/include/llvm/Support/MathExtras.h | 4 ++--

--- a/upstream_utils/llvm_patches/0036-Add-postincrement-operator-to-SmallSetIterator.patch
+++ b/upstream_utils/llvm_patches/0036-Add-postincrement-operator-to-SmallSetIterator.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: crueter <crueter@eden-emu.dev>
+Date: Wed, 6 May 2026 12:42:53 -0400
+Subject: [PATCH 36/36] Add postincrement operator to SmallSetIterator
+
+Required for Xcode 26.4
+---
+ llvm/include/llvm/ADT/SmallSet.h | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/llvm/include/llvm/ADT/SmallSet.h b/llvm/include/llvm/ADT/SmallSet.h
+index c62a3a55d9bda188670e7d6042867943dcd44c68..ffe5ae6e227368dc5582258b402c6521d68bc724 100644
+--- a/llvm/include/llvm/ADT/SmallSet.h
++++ b/llvm/include/llvm/ADT/SmallSet.h
+@@ -121,6 +121,12 @@ public:
+     return *this;
+   }
+ 
++  SmallSetIterator operator++(int) { // Postincrement
++    SmallSetIterator Copy = *this;
++    ++(*this);
++    return Copy;
++  }
++
+   const T &operator*() const { return IsSmall ? *VecIter : *SetIter; }
+ };
+ 

--- a/wpiutil/src/main/native/thirdparty/llvm/include/wpi/util/SmallSet.hpp
+++ b/wpiutil/src/main/native/thirdparty/llvm/include/wpi/util/SmallSet.hpp
@@ -121,6 +121,12 @@ public:
     return *this;
   }
 
+  SmallSetIterator operator++(int) { // Postincrement
+    SmallSetIterator Copy = *this;
+    ++(*this);
+    return Copy;
+  }
+
   const T &operator*() const { return IsSmall ? *VecIter : *SetIter; }
 };
 


### PR DESCRIPTION
Freeing disk space should no longer be required, as the macos-26 image has considerably more disk space.

Signed-off-by: crueter <crueter@eden-emu.dev>
