### PR TITLE
[ci] Don't check `matrix.os` when `runner.os` suffices

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -91,7 +91,7 @@ jobs:
           else
             TARGETS=...
           fi
-          if [ "${{ runner.os }}" = "Windows" ]
+          if [ "${{ runner.os }}" = "Windows" ]; then
             bazel --output_user_root=C:\\bazelroot ${ACTION} ${TARGETS} --config=ci -c opt --repo_env=WPI_PUBLISH_CLASSIFIER_FILTER='${{ matrix.classifier }}'
           else
             bazel ${ACTION} ${TARGETS} --config=ci -c opt --repo_env=WPI_PUBLISH_CLASSIFIER_FILTER='${{ matrix.classifier }}'

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -39,6 +39,7 @@ jobs:
         run: df -h
 
       - name: Free disk space (Linux)
+        if: runner.os == 'Linux'
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
@@ -48,8 +49,9 @@ jobs:
           large-packages: false
           docker-images: false
           swap-storage: false
-        if: startsWith(matrix.os, 'ubuntu')
+
       - name: Free disk space (macOS)
+        if: runner.os == 'macOS'
         # CodeQL: 5G
         # go: 748M
         # Android: 12G
@@ -57,7 +59,6 @@ jobs:
           rm -rf /Users/runner/hostedtoolcache/CodeQL
           rm -rf /Users/runner/hostedtoolcache/go
           rm -rf /Users/runner/Library/Android
-        if: startsWith(matrix.os, 'macOS')
 
       - name: Check disk free space post-cleanup
         run: df -h
@@ -72,10 +73,10 @@ jobs:
           password: ${{ secrets.BAZEL_CACHE_PASSWORD }}
 
       - name: Install apt dependencies
-        if: matrix.os == 'ubuntu-24.04'
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev libx11-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev avahi-daemon
 
-      - if: matrix.os == 'ubuntu-24.04'
+      - if: runner.os == 'Linux'
         uses: bazel-contrib/setup-bazel@0.15.0
         with:
           bazelisk-cache: true
@@ -85,12 +86,12 @@ jobs:
       - name: bazel ${{ matrix.action }}
         run: |
           ACTION='${{ matrix.action }}'
-          if [[ "${ACTION}" == "build" ]]; then
+          if [ "${ACTION}" = "build" ]; then
             TARGETS=:publish
           else
             TARGETS=...
           fi
-          if [[ "${{ matrix.os }}" == "windows-2022" ]]; then
+          if [ "${{ runner.os }}" = "Windows" ]
             bazel --output_user_root=C:\\bazelroot ${ACTION} ${TARGETS} --config=ci -c opt --repo_env=WPI_PUBLISH_CLASSIFIER_FILTER='${{ matrix.classifier }}'
           else
             bazel ${ACTION} ${TARGETS} --config=ci -c opt --repo_env=WPI_PUBLISH_CLASSIFIER_FILTER='${{ matrix.classifier }}'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -127,6 +127,7 @@ jobs:
         run: df -h
 
       - name: Free disk space (macOS)
+        if: runner.os == 'macOS'
         # CodeQL: 5G
         # go: 748M
         # Android: 12G
@@ -134,7 +135,6 @@ jobs:
           rm -rf /Users/runner/hostedtoolcache/CodeQL
           rm -rf /Users/runner/hostedtoolcache/go
           rm -rf /Users/runner/Library/Android
-        if: startsWith(matrix.os, 'macOS')
 
       - name: Check disk free space post-cleanup
         run: df -h

--- a/.github/workflows/sentinel-build.yml
+++ b/.github/workflows/sentinel-build.yml
@@ -131,10 +131,10 @@ jobs:
           matrix.artifact-name == 'macOS' && (github.repository_owner == 'wpilibsuite' && github.ref == 'refs/heads/main')
       - name: Check disk free space (Windows)
         run: wmic logicaldisk get caption, freespace
-        if: matrix.os == 'windows-2022'
+        if: runner.os == 'Windows'
       - name: Check disk free space pre-cleanup (macOS)
         run: df -h .
-        if: matrix.os == 'macOS-15'
+        if: runner.os == 'macOS'
       - name: Cleanup disk space
         # CodeQL: 5G
         # go: 748M
@@ -143,10 +143,10 @@ jobs:
           rm -rf /Users/runner/hostedtoolcache/CodeQL
           rm -rf /Users/runner/hostedtoolcache/go
           rm -rf /Users/runner/Library/Android
-        if: matrix.os == 'macOS-15'
+        if: runner.os == 'macOS'
       - name: Check disk free space post-cleanup (macOS)
         run: df -h .
-        if: matrix.os == 'macOS-15'
+        if: runner.os == 'macOS'
       - name: Build with Gradle
         run: ./gradlew ${{ matrix.task }} -PbuildServer -PskipJavaFormat ${{ matrix.build-options }}
       - name: Sign Libraries with Developer ID
@@ -155,10 +155,10 @@ jobs:
           matrix.artifact-name == 'macOS' && (github.repository_owner == 'wpilibsuite' && github.ref == 'refs/heads/main')
       - name: Check disk free space (Windows)
         run: wmic logicaldisk get caption, freespace
-        if: matrix.os == 'windows-2022'
+        if: runner.os == 'Windows'
       - name: Check disk free space (macOS)
         run: df -h .
-        if: matrix.os == 'macOS-15'
+        if: runner.os == 'macOS'
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}

--- a/.github/workflows/sentinel-build.yml
+++ b/.github/workflows/sentinel-build.yml
@@ -130,12 +130,13 @@ jobs:
         if: |
           matrix.artifact-name == 'macOS' && (github.repository_owner == 'wpilibsuite' && github.ref == 'refs/heads/main')
       - name: Check disk free space (Windows)
-        run: wmic logicaldisk get caption, freespace
         if: runner.os == 'Windows'
+        run: wmic logicaldisk get caption, freespace
       - name: Check disk free space pre-cleanup (macOS)
-        run: df -h .
         if: runner.os == 'macOS'
+        run: df -h .
       - name: Cleanup disk space
+        if: runner.os == 'macOS'
         # CodeQL: 5G
         # go: 748M
         # Android: 12G
@@ -143,10 +144,9 @@ jobs:
           rm -rf /Users/runner/hostedtoolcache/CodeQL
           rm -rf /Users/runner/hostedtoolcache/go
           rm -rf /Users/runner/Library/Android
-        if: runner.os == 'macOS'
       - name: Check disk free space post-cleanup (macOS)
-        run: df -h .
         if: runner.os == 'macOS'
+        run: df -h .
       - name: Build with Gradle
         run: ./gradlew ${{ matrix.task }} -PbuildServer -PskipJavaFormat ${{ matrix.build-options }}
       - name: Sign Libraries with Developer ID
@@ -154,11 +154,11 @@ jobs:
         if: |
           matrix.artifact-name == 'macOS' && (github.repository_owner == 'wpilibsuite' && github.ref == 'refs/heads/main')
       - name: Check disk free space (Windows)
-        run: wmic logicaldisk get caption, freespace
         if: runner.os == 'Windows'
+        run: wmic logicaldisk get caption, freespace
       - name: Check disk free space (macOS)
-        run: df -h .
         if: runner.os == 'macOS'
+        run: df -h .
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}


### PR DESCRIPTION
There's no real need to manually check the `runs-on`, as `runner.os`
provides a universally identifiable string for checking this anyways.

Signed-off-by: crueter <crueter@eden-emu.dev>
