### PR TITLE
[bazel] Add mrclib dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -132,3 +132,15 @@ http_jar(
     integrity = "sha256-IHW6y6WXJFjX9RYD+IwVAMwAbEo36fLqonIKR+FaqpQ=",
     urls = ["https://github.com/google/copybara/releases/download/v20251027/copybara_deploy.jar"],
 )
+
+mrclib_extension = use_extension("//shared/bazel/thirdparty/mrclib:repos.bzl", "mrclib_extension")
+use_repo(
+    mrclib_extension,
+    "mrclib_headers",
+    "mrclib_linuxarm64",
+    "mrclib_linuxx86-64",
+    "mrclib_osx",
+    "mrclib_systemcore",
+    "mrclib_windowsarm64",
+    "mrclib_windowsx86-64",
+)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -204,6 +204,80 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "//shared/bazel/thirdparty/mrclib:repos.bzl%mrclib_extension": {
+      "general": {
+        "bzlTransitiveDigest": "qMp1oZVFsCCs9Y651XOpM7f0Fup9+N9TleK6j9ZlrbY=",
+        "usagesDigest": "k6P/p/2hgVVO/FJz9Cr9lpQpnrCn05LDx6SpICypN2Y=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "mrclib_headers": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://frcmaven.wpi.edu/artifactory/development-2027/org/wpilib/mrclib/mrclib-cpp/2027.1.0-alpha-1-42-g019903f/mrclib-cpp-2027.1.0-alpha-1-42-g019903f-headers.zip",
+              "integrity": "sha256-xxAR4sWTdJrKWF7sMI85TV5/NEUcGhTN2OB36jsTaLU=",
+              "build_file_content": "cc_library(\n    name = \"headers\",\n    hdrs = glob([\"**\"]),\n    includes = [\".\"],\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          },
+          "mrclib_linuxarm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://frcmaven.wpi.edu/artifactory/development-2027/org/wpilib/mrclib/mrclib-cpp/2027.1.0-alpha-1-42-g019903f/mrclib-cpp-2027.1.0-alpha-1-42-g019903f-linuxarm64.zip",
+              "integrity": "sha256-Zmt+0UV0SVtL8rwvnV4TClwXA45WIMM/+0pWtUR/g+g=",
+              "build_file_content": "\nfilegroup(\n    name = \"shared_interface\",\n    srcs = glob([\"**/*.lib\"], allow_empty=True),\n    visibility = [\"//visibility:public\"],\n)\n\nfilegroup(\n    name = \"shared_libs\",\n    srcs = glob([\n            \"**/*.dll\",\n            \"**/*.so*\",\n            \"**/*.dylib\",\n        ], \n        allow_empty = True,\n    ),\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          },
+          "mrclib_linuxx86-64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://frcmaven.wpi.edu/artifactory/development-2027/org/wpilib/mrclib/mrclib-cpp/2027.1.0-alpha-1-42-g019903f/mrclib-cpp-2027.1.0-alpha-1-42-g019903f-linuxx86-64.zip",
+              "integrity": "sha256-DkLWVl94dNv9AU6iAI7t2ynODh13aStBWPLcOi7feZc=",
+              "build_file_content": "\nfilegroup(\n    name = \"shared_interface\",\n    srcs = glob([\"**/*.lib\"], allow_empty=True),\n    visibility = [\"//visibility:public\"],\n)\n\nfilegroup(\n    name = \"shared_libs\",\n    srcs = glob([\n            \"**/*.dll\",\n            \"**/*.so*\",\n            \"**/*.dylib\",\n        ], \n        allow_empty = True,\n    ),\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          },
+          "mrclib_osx": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://frcmaven.wpi.edu/artifactory/development-2027/org/wpilib/mrclib/mrclib-cpp/2027.1.0-alpha-1-42-g019903f/mrclib-cpp-2027.1.0-alpha-1-42-g019903f-osxuniversal.zip",
+              "integrity": "sha256-kdYgf+roEUQ0Jmb192dmM7VMm9g6oiltBfkKRRsQi7I=",
+              "build_file_content": "\nfilegroup(\n    name = \"shared_interface\",\n    srcs = glob([\"**/*.lib\"], allow_empty=True),\n    visibility = [\"//visibility:public\"],\n)\n\nfilegroup(\n    name = \"shared_libs\",\n    srcs = glob([\n            \"**/*.dll\",\n            \"**/*.so*\",\n            \"**/*.dylib\",\n        ], \n        allow_empty = True,\n    ),\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          },
+          "mrclib_systemcore": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://frcmaven.wpi.edu/artifactory/development-2027/org/wpilib/mrclib/mrclib-cpp/2027.1.0-alpha-1-42-g019903f/mrclib-cpp-2027.1.0-alpha-1-42-g019903f-linuxsystemcore.zip",
+              "integrity": "sha256-wcrUn7lsqnP928hSWIxnohEEAlObOdukAlXCGXQRToQ=",
+              "build_file_content": "\nfilegroup(\n    name = \"shared_interface\",\n    srcs = glob([\"**/*.lib\"], allow_empty=True),\n    visibility = [\"//visibility:public\"],\n)\n\nfilegroup(\n    name = \"shared_libs\",\n    srcs = glob([\n            \"**/*.dll\",\n            \"**/*.so*\",\n            \"**/*.dylib\",\n        ], \n        allow_empty = True,\n    ),\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          },
+          "mrclib_windowsarm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://frcmaven.wpi.edu/artifactory/development-2027/org/wpilib/mrclib/mrclib-cpp/2027.1.0-alpha-1-42-g019903f/mrclib-cpp-2027.1.0-alpha-1-42-g019903f-windowsarm64.zip",
+              "integrity": "sha256-TQVFNxOppDqMCgHSPFKL4eT7U+OXtXPs3YwczLJ0kcs=",
+              "build_file_content": "\nfilegroup(\n    name = \"shared_interface\",\n    srcs = glob([\"**/*.lib\"], allow_empty=True),\n    visibility = [\"//visibility:public\"],\n)\n\nfilegroup(\n    name = \"shared_libs\",\n    srcs = glob([\n            \"**/*.dll\",\n            \"**/*.so*\",\n            \"**/*.dylib\",\n        ], \n        allow_empty = True,\n    ),\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          },
+          "mrclib_windowsx86-64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://frcmaven.wpi.edu/artifactory/development-2027/org/wpilib/mrclib/mrclib-cpp/2027.1.0-alpha-1-42-g019903f/mrclib-cpp-2027.1.0-alpha-1-42-g019903f-windowsx86-64.zip",
+              "integrity": "sha256-s26W4tUjgg55D1utgkrdYNycB9XdcKlokKG0dkQJDSA=",
+              "build_file_content": "\nfilegroup(\n    name = \"shared_interface\",\n    srcs = glob([\"**/*.lib\"], allow_empty=True),\n    visibility = [\"//visibility:public\"],\n)\n\nfilegroup(\n    name = \"shared_libs\",\n    srcs = glob([\n            \"**/*.dll\",\n            \"**/*.so*\",\n            \"**/*.dylib\",\n        ], \n        allow_empty = True,\n    ),\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_bzlmodrio_toolchains+//:extensions.bzl%sh_configure": {
       "general": {
         "bzlTransitiveDigest": "q+0LgnvjpZ9Y2r2JYzNeYCKGLphbczG73lZ3rBg+XhM=",

--- a/shared/bazel/thirdparty/mrclib/BUILD.bazel
+++ b/shared/bazel/thirdparty/mrclib/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_cc//cc:cc_import.bzl", "cc_import")
+
+filegroup(
+    name = "mrclib_shared_interface",
+    srcs = select({
+        "@rules_bzlmodrio_toolchains//conditions:windows_arm64": ["@mrclib_windowsarm64//:shared_interface"],
+        "@rules_bzlmodrio_toolchains//conditions:windows_x86_64": ["@mrclib_windowsx86-64//:shared_interface"],
+    }),
+    target_compatible_with = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)
+
+alias(
+    name = "MrcLib",
+    actual = select({
+        "@rules_bzlmodrio_toolchains//conditions:linux_x86_64": "@mrclib_linuxx86-64//:shared_libs",
+        "@rules_bzlmodrio_toolchains//conditions:osx": "@mrclib_osx//:shared_libs",
+        "@rules_bzlmodrio_toolchains//conditions:windows_arm64": "@mrclib_windowsarm64//:shared_libs",
+        "@rules_bzlmodrio_toolchains//conditions:windows_x86_64": "@mrclib_windowsx86-64//:shared_libs",
+        "@rules_bzlmodrio_toolchains//constraints/is_bookworm64:bookworm64": "@mrclib_linuxarm64//:shared_libs",
+        "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": "@mrclib_systemcore//:shared_libs",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_import(
+    name = "mrclib",
+    interface_library = select({
+        "@platforms//os:windows": ":mrclib_shared_interface",
+        "//conditions:default": None,
+    }),
+    shared_library = ":MrcLib",
+    visibility = ["//visibility:public"],
+    deps = ["@mrclib_headers//:headers"],
+)

--- a/shared/bazel/thirdparty/mrclib/repos.bzl
+++ b/shared/bazel/thirdparty/mrclib/repos.bzl
@@ -1,0 +1,100 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+cc_library_headers = """cc_library(
+    name = "headers",
+    hdrs = glob(["**"]),
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)
+"""
+
+cc_shared_library_build_contents = """
+filegroup(
+    name = "shared_interface",
+    srcs = glob(["**/*.lib"], allow_empty=True),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "shared_libs",
+    srcs = glob([
+            "**/*.dll",
+            "**/*.so*",
+            "**/*.dylib",
+        ], 
+        allow_empty = True,
+    ),
+    visibility = ["//visibility:public"],
+)
+"""
+
+def _mrclib_extension_impl(mctx):
+    mrclib_maven_base = "https://frcmaven.wpi.edu/artifactory/development-2027"
+    mrclib_version = "2027.1.0-alpha-1-42-g019903f"
+
+    mrclib_hdr_hash = "sha256-xxAR4sWTdJrKWF7sMI85TV5/NEUcGhTN2OB36jsTaLU="
+    mrclib_linuxarm64_hash = "sha256-Zmt+0UV0SVtL8rwvnV4TClwXA45WIMM/+0pWtUR/g+g="
+    mrclib_linuxx86_64_hash = "sha256-DkLWVl94dNv9AU6iAI7t2ynODh13aStBWPLcOi7feZc="
+    mrclib_osx_hash = "sha256-kdYgf+roEUQ0Jmb192dmM7VMm9g6oiltBfkKRRsQi7I="
+    mrclib_systemcore_hash = "sha256-wcrUn7lsqnP928hSWIxnohEEAlObOdukAlXCGXQRToQ="
+    mrclib_windowsarm64_hash = "sha256-TQVFNxOppDqMCgHSPFKL4eT7U+OXtXPs3YwczLJ0kcs="
+    mrclib_windowsx86_64_hash = "sha256-s26W4tUjgg55D1utgkrdYNycB9XdcKlokKG0dkQJDSA="
+
+    maybe(
+        http_archive,
+        "mrclib_headers",
+        url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-headers.zip".format(version = mrclib_version),
+        integrity = mrclib_hdr_hash,
+        build_file_content = cc_library_headers,
+    )
+
+    maybe(
+        http_archive,
+        "mrclib_linuxarm64",
+        url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-linuxarm64.zip".format(version = mrclib_version),
+        integrity = mrclib_linuxarm64_hash,
+        build_file_content = cc_shared_library_build_contents,
+    )
+
+    maybe(
+        http_archive,
+        "mrclib_linuxx86-64",
+        url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-linuxx86-64.zip".format(version = mrclib_version),
+        integrity = mrclib_linuxx86_64_hash,
+        build_file_content = cc_shared_library_build_contents,
+    )
+
+    maybe(
+        http_archive,
+        "mrclib_osx",
+        url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-osxuniversal.zip".format(version = mrclib_version),
+        integrity = mrclib_osx_hash,
+        build_file_content = cc_shared_library_build_contents,
+    )
+
+    maybe(
+        http_archive,
+        "mrclib_systemcore",
+        url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-linuxsystemcore.zip".format(version = mrclib_version),
+        integrity = mrclib_systemcore_hash,
+        build_file_content = cc_shared_library_build_contents,
+    )
+
+    maybe(
+        http_archive,
+        "mrclib_windowsarm64",
+        url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-windowsarm64.zip".format(version = mrclib_version),
+        integrity = mrclib_windowsarm64_hash,
+        build_file_content = cc_shared_library_build_contents,
+    )
+
+    maybe(
+        http_archive,
+        "mrclib_windowsx86-64",
+        url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-windowsx86-64.zip".format(version = mrclib_version),
+        integrity = mrclib_windowsx86_64_hash,
+        build_file_content = cc_shared_library_build_contents,
+    )
+
+mrclib_extension = module_extension(implementation = _mrclib_extension_impl)


### PR DESCRIPTION
This adds a bazel extension for pulling in the `mrclib` maven repository as a shared library. This is a prereq for #8858, but I wanted to separate out the bazel components to have an easier code review.

It is loosely tested against Thad's PR. Hard to tell if it 100% works because that PR has failing unit tests and failing builds, but this should handle the majority of the library import.