### PR TITLE
[bazel] Add mrclib dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,8 @@ module(
 
 include("//docs:doxygen.MODULE.bazel")
 
+include("//shared/bazel/thirdparty/mrclib:mrclib.MODULE.bazel")
+
 bazel_dep(name = "apple_support", version = "2.0.0", repo_name = "build_bazel_apple_support")
 
 # TODO(austin): Upgrade when the patches land.

--- a/shared/bazel/thirdparty/mrclib/BUILD.bazel
+++ b/shared/bazel/thirdparty/mrclib/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_cc//cc:cc_import.bzl", "cc_import")
+
+filegroup(
+    name = "mrclib_shared_interface",
+    srcs = select({
+        "@rules_bzlmodrio_toolchains//conditions:windows_arm64": ["@mrclib_windowsarm64//:shared_interface"],
+        "@rules_bzlmodrio_toolchains//conditions:windows_x86_64": ["@mrclib_windowsx86-64//:shared_interface"],
+    }),
+    target_compatible_with = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)
+
+alias(
+    name = "MrcLib",
+    actual = select({
+        "@rules_bzlmodrio_toolchains//conditions:linux_x86_64": "@mrclib_linuxx86-64//:shared_libs",
+        "@rules_bzlmodrio_toolchains//conditions:osx": "@mrclib_osx//:shared_libs",
+        "@rules_bzlmodrio_toolchains//conditions:windows_arm64": "@mrclib_windowsarm64//:shared_libs",
+        "@rules_bzlmodrio_toolchains//conditions:windows_x86_64": "@mrclib_windowsx86-64//:shared_libs",
+        "@rules_bzlmodrio_toolchains//constraints/is_bookworm64:bookworm64": "@mrclib_linuxarm64//:shared_libs",
+        "@rules_bzlmodrio_toolchains//constraints/is_systemcore:systemcore": "@mrclib_systemcore//:shared_libs",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_import(
+    name = "mrclib",
+    interface_library = select({
+        "@platforms//os:windows": ":mrclib_shared_interface",
+        "//conditions:default": None,
+    }),
+    shared_library = ":MrcLib",
+    visibility = ["//visibility:public"],
+    deps = ["@mrclib_headers//:headers"],
+)

--- a/shared/bazel/thirdparty/mrclib/mrclib.MODULE.bazel
+++ b/shared/bazel/thirdparty/mrclib/mrclib.MODULE.bazel
@@ -27,7 +27,7 @@ mrclib_version = "2027.1.0-alpha-1-42-g019903f"
 http_archive(
     name = "mrclib_headers",
     url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-headers.zip".format(version = mrclib_version),
-    integrity = "sha256-xxAR4sWTdJrKWF7sMI85TV5/NEUcGhTN2OB36jsTaLU=",
+    sha256 = "c71011e2c593749aca585eec308f394d5e7f34451c1a14cdd8e077ea3b1368b5",
     build_file_content = """
 cc_library(
     name = "headers",
@@ -41,41 +41,41 @@ cc_library(
 http_archive(
     name = "mrclib_linuxarm64",
     url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-linuxarm64.zip".format(version = mrclib_version),
-    integrity = "sha256-Zmt+0UV0SVtL8rwvnV4TClwXA45WIMM/+0pWtUR/g+g=",
+    sha256 = "666b7ed14574495b4bf2bc2f9d5e130a5c17038e5620c33ffb4a56b5447f83e8",
     build_file_content = cc_shared_library_build_contents,
 )
 
 http_archive(
     name = "mrclib_linuxx86-64",
     url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-linuxx86-64.zip".format(version = mrclib_version),
-    integrity = "sha256-DkLWVl94dNv9AU6iAI7t2ynODh13aStBWPLcOi7feZc=",
+    sha256 = "0e42d6565f7874dbfd014ea2008eeddb29ce0e1d77692b4158f2dc3a2edf7997",
     build_file_content = cc_shared_library_build_contents,
 )
 
 http_archive(
     name = "mrclib_osx",
     url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-osxuniversal.zip".format(version = mrclib_version),
-    integrity = "sha256-kdYgf+roEUQ0Jmb192dmM7VMm9g6oiltBfkKRRsQi7I=",
+    sha256 = "91d6207feae81144342666f5f7676633b54c9bd83aa2296d05f90a451b108bb2",
     build_file_content = cc_shared_library_build_contents,
 )
 
 http_archive(
     name = "mrclib_systemcore",
     url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-linuxsystemcore.zip".format(version = mrclib_version),
-    integrity = "sha256-wcrUn7lsqnP928hSWIxnohEEAlObOdukAlXCGXQRToQ=",
+    sha256 = "c1cad49fb96caa73fddbc852588c67a2110402539b39dba40255c21974114e84",
     build_file_content = cc_shared_library_build_contents,
 )
 
 http_archive(
     name = "mrclib_windowsarm64",
     url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-windowsarm64.zip".format(version = mrclib_version),
-    integrity = "sha256-TQVFNxOppDqMCgHSPFKL4eT7U+OXtXPs3YwczLJ0kcs=",
+    sha256 = "4d05453713a9a43a8c0a01d23c528be1e4fb53e397b573ecdd8c1cccb27491cb",
     build_file_content = cc_shared_library_build_contents,
 )
 
 http_archive(
     name = "mrclib_windowsx86-64",
     url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-windowsx86-64.zip".format(version = mrclib_version),
-    integrity = "sha256-s26W4tUjgg55D1utgkrdYNycB9XdcKlokKG0dkQJDSA=",
+    sha256 = "b36e96e2d523820e790f5bad824add60dc9c07d5dd70a96890a1b47644090d20",
     build_file_content = cc_shared_library_build_contents,
 )

--- a/shared/bazel/thirdparty/mrclib/mrclib.MODULE.bazel
+++ b/shared/bazel/thirdparty/mrclib/mrclib.MODULE.bazel
@@ -1,0 +1,81 @@
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+cc_shared_library_build_contents = """
+filegroup(
+    name = "shared_interface",
+    srcs = glob(["**/*.lib"], allow_empty=True),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "shared_libs",
+    srcs = glob(
+        [
+            "**/*.dll",
+            "**/*.so*",
+            "**/*.dylib",
+        ],
+        allow_empty = True,
+    ),
+    visibility = ["//visibility:public"],
+)
+"""
+
+mrclib_maven_base = "https://frcmaven.wpi.edu/artifactory/development-2027"
+mrclib_version = "2027.1.0-alpha-1-42-g019903f"
+
+http_archive(
+    name = "mrclib_headers",
+    url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-headers.zip".format(version = mrclib_version),
+    integrity = "sha256-xxAR4sWTdJrKWF7sMI85TV5/NEUcGhTN2OB36jsTaLU=",
+    build_file_content = """
+cc_library(
+    name = "headers",
+    hdrs = glob(["**"]),
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)
+""",
+)
+
+http_archive(
+    name = "mrclib_linuxarm64",
+    url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-linuxarm64.zip".format(version = mrclib_version),
+    integrity = "sha256-Zmt+0UV0SVtL8rwvnV4TClwXA45WIMM/+0pWtUR/g+g=",
+    build_file_content = cc_shared_library_build_contents,
+)
+
+http_archive(
+    name = "mrclib_linuxx86-64",
+    url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-linuxx86-64.zip".format(version = mrclib_version),
+    integrity = "sha256-DkLWVl94dNv9AU6iAI7t2ynODh13aStBWPLcOi7feZc=",
+    build_file_content = cc_shared_library_build_contents,
+)
+
+http_archive(
+    name = "mrclib_osx",
+    url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-osxuniversal.zip".format(version = mrclib_version),
+    integrity = "sha256-kdYgf+roEUQ0Jmb192dmM7VMm9g6oiltBfkKRRsQi7I=",
+    build_file_content = cc_shared_library_build_contents,
+)
+
+http_archive(
+    name = "mrclib_systemcore",
+    url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-linuxsystemcore.zip".format(version = mrclib_version),
+    integrity = "sha256-wcrUn7lsqnP928hSWIxnohEEAlObOdukAlXCGXQRToQ=",
+    build_file_content = cc_shared_library_build_contents,
+)
+
+http_archive(
+    name = "mrclib_windowsarm64",
+    url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-windowsarm64.zip".format(version = mrclib_version),
+    integrity = "sha256-TQVFNxOppDqMCgHSPFKL4eT7U+OXtXPs3YwczLJ0kcs=",
+    build_file_content = cc_shared_library_build_contents,
+)
+
+http_archive(
+    name = "mrclib_windowsx86-64",
+    url = mrclib_maven_base + "/org/wpilib/mrclib/mrclib-cpp/{version}/mrclib-cpp-{version}-windowsx86-64.zip".format(version = mrclib_version),
+    integrity = "sha256-s26W4tUjgg55D1utgkrdYNycB9XdcKlokKG0dkQJDSA=",
+    build_file_content = cc_shared_library_build_contents,
+)


### PR DESCRIPTION
This pulls in the `mrclib` maven repository as shared libraries, as a prereq for #8858.

Alternative to #8869, which avoids the unnecessary lockfile entry. This should be a one-to-one replacement for that PR.

Closes #8869