### PR TITLE
Add nix files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,8 @@ bazel_auth.rc
 
 # Copybara user config
 shared/bazel/copybara/.copybara.json
+
+# Nix files
+shell.nix
+flake.nix
+flake.lock


### PR DESCRIPTION
Based on discord comments I assume we don't want to support a Nix shell or flake for use with building allwpilib so we should just ignore these files so users can have their own