### PR TITLE
[wpilib,cmd] Rename gamepad face-button trigger APIs to directional names (faceUp/Down/Left/Right) 

### DIFF
--- a/commandsv2/src/main/java/org/wpilib/command2/button/CommandGamepad.java
+++ b/commandsv2/src/main/java/org/wpilib/command2/button/CommandGamepad.java
@@ -61,90 +61,90 @@ public class CommandGamepad extends CommandGenericHID {
   }
 
   /**
-   * Constructs a Trigger instance around the South Face button's digital signal.
+   * Constructs a Trigger instance around the Face Down button's digital signal.
    *
-   * @return a Trigger instance representing the South Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Down button's digital signal attached to the
    *     {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
-   * @see #southFace(EventLoop)
+   * @see #faceDown(EventLoop)
    */
-  public Trigger southFace() {
-    return southFace(CommandScheduler.getInstance().getDefaultButtonLoop());
+  public Trigger faceDown() {
+    return faceDown(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
   /**
-   * Constructs a Trigger instance around the South Face button's digital signal.
+   * Constructs a Trigger instance around the Face Down button's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return a Trigger instance representing the South Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Down button's digital signal attached to the
    *     given loop.
    */
-  public Trigger southFace(EventLoop loop) {
+  public Trigger faceDown(EventLoop loop) {
     return button(Gamepad.Button.SOUTH_FACE, loop);
   }
 
   /**
-   * Constructs a Trigger instance around the East Face button's digital signal.
+   * Constructs a Trigger instance around the Face Right button's digital signal.
    *
-   * @return a Trigger instance representing the East Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Right button's digital signal attached to the
    *     {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
-   * @see #eastFace(EventLoop)
+   * @see #faceRight(EventLoop)
    */
-  public Trigger eastFace() {
-    return eastFace(CommandScheduler.getInstance().getDefaultButtonLoop());
+  public Trigger faceRight() {
+    return faceRight(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
   /**
-   * Constructs a Trigger instance around the East Face button's digital signal.
+   * Constructs a Trigger instance around the Face Right button's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return a Trigger instance representing the East Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Right button's digital signal attached to the
    *     given loop.
    */
-  public Trigger eastFace(EventLoop loop) {
+  public Trigger faceRight(EventLoop loop) {
     return button(Gamepad.Button.EAST_FACE, loop);
   }
 
   /**
-   * Constructs a Trigger instance around the West Face button's digital signal.
+   * Constructs a Trigger instance around the Face Left button's digital signal.
    *
-   * @return a Trigger instance representing the West Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Left button's digital signal attached to the
    *     {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
-   * @see #westFace(EventLoop)
+   * @see #faceLeft(EventLoop)
    */
-  public Trigger westFace() {
-    return westFace(CommandScheduler.getInstance().getDefaultButtonLoop());
+  public Trigger faceLeft() {
+    return faceLeft(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
   /**
-   * Constructs a Trigger instance around the West Face button's digital signal.
+   * Constructs a Trigger instance around the Face Left button's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return a Trigger instance representing the West Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Left button's digital signal attached to the
    *     given loop.
    */
-  public Trigger westFace(EventLoop loop) {
+  public Trigger faceLeft(EventLoop loop) {
     return button(Gamepad.Button.WEST_FACE, loop);
   }
 
   /**
-   * Constructs a Trigger instance around the North Face button's digital signal.
+   * Constructs a Trigger instance around the Face Up button's digital signal.
    *
-   * @return a Trigger instance representing the North Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Up button's digital signal attached to the
    *     {@link CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
-   * @see #northFace(EventLoop)
+   * @see #faceUp(EventLoop)
    */
-  public Trigger northFace() {
-    return northFace(CommandScheduler.getInstance().getDefaultButtonLoop());
+  public Trigger faceUp() {
+    return faceUp(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
   /**
-   * Constructs a Trigger instance around the North Face button's digital signal.
+   * Constructs a Trigger instance around the Face Up button's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return a Trigger instance representing the North Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Up button's digital signal attached to the
    *     given loop.
    */
-  public Trigger northFace(EventLoop loop) {
+  public Trigger faceUp(EventLoop loop) {
     return button(Gamepad.Button.NORTH_FACE, loop);
   }
 

--- a/commandsv2/src/main/native/cpp/frc2/command/button/CommandGamepad.cpp
+++ b/commandsv2/src/main/native/cpp/frc2/command/button/CommandGamepad.cpp
@@ -20,19 +20,19 @@ Trigger CommandGamepad::Button(enum wpi::Gamepad::Button button,
   return CommandGenericHID::Button(static_cast<int>(button), loop);
 }
 
-Trigger CommandGamepad::SouthFace(wpi::EventLoop* loop) const {
+Trigger CommandGamepad::FaceDown(wpi::EventLoop* loop) const {
   return Button(wpi::Gamepad::Button::SOUTH_FACE, loop);
 }
 
-Trigger CommandGamepad::EastFace(wpi::EventLoop* loop) const {
+Trigger CommandGamepad::FaceRight(wpi::EventLoop* loop) const {
   return Button(wpi::Gamepad::Button::EAST_FACE, loop);
 }
 
-Trigger CommandGamepad::WestFace(wpi::EventLoop* loop) const {
+Trigger CommandGamepad::FaceLeft(wpi::EventLoop* loop) const {
   return Button(wpi::Gamepad::Button::WEST_FACE, loop);
 }
 
-Trigger CommandGamepad::NorthFace(wpi::EventLoop* loop) const {
+Trigger CommandGamepad::FaceUp(wpi::EventLoop* loop) const {
   return Button(wpi::Gamepad::Button::NORTH_FACE, loop);
 }
 

--- a/commandsv2/src/main/native/include/wpi/commands2/button/CommandGamepad.hpp
+++ b/commandsv2/src/main/native/include/wpi/commands2/button/CommandGamepad.hpp
@@ -46,52 +46,52 @@ class CommandGamepad : public CommandGenericHID {
                                             .GetDefaultButtonLoop()) const;
 
   /**
-   * Constructs a Trigger instance around the South Face button's
+   * Constructs a Trigger instance around the Face Down button's
    * digital signal.
    *
    * @param loop the event loop instance to attach the event to. Defaults to the
    * CommandScheduler's default loop.
-   * @return a Trigger instance representing the South Face button's
+   * @return a Trigger instance representing the Face Down button's
    * digital signal attached to the given loop.
    */
-  Trigger SouthFace(wpi::EventLoop* loop = CommandScheduler::GetInstance()
-                                               .GetDefaultButtonLoop()) const;
-
-  /**
-   * Constructs a Trigger instance around the East Face button's
-   * digital signal.
-   *
-   * @param loop the event loop instance to attach the event to. Defaults to the
-   * CommandScheduler's default loop.
-   * @return a Trigger instance representing the East Face button's
-   * digital signal attached to the given loop.
-   */
-  Trigger EastFace(wpi::EventLoop* loop = CommandScheduler::GetInstance()
+  Trigger FaceDown(wpi::EventLoop* loop = CommandScheduler::GetInstance()
                                               .GetDefaultButtonLoop()) const;
 
   /**
-   * Constructs a Trigger instance around the West Face button's
+   * Constructs a Trigger instance around the Face Right button's
    * digital signal.
    *
    * @param loop the event loop instance to attach the event to. Defaults to the
    * CommandScheduler's default loop.
-   * @return a Trigger instance representing the West Face button's
+   * @return a Trigger instance representing the Face Right button's
    * digital signal attached to the given loop.
    */
-  Trigger WestFace(wpi::EventLoop* loop = CommandScheduler::GetInstance()
+  Trigger FaceRight(wpi::EventLoop* loop = CommandScheduler::GetInstance()
+                                               .GetDefaultButtonLoop()) const;
+
+  /**
+   * Constructs a Trigger instance around the Face Left button's
+   * digital signal.
+   *
+   * @param loop the event loop instance to attach the event to. Defaults to the
+   * CommandScheduler's default loop.
+   * @return a Trigger instance representing the Face Left button's
+   * digital signal attached to the given loop.
+   */
+  Trigger FaceLeft(wpi::EventLoop* loop = CommandScheduler::GetInstance()
                                               .GetDefaultButtonLoop()) const;
 
   /**
-   * Constructs a Trigger instance around the North Face button's
+   * Constructs a Trigger instance around the Face Up button's
    * digital signal.
    *
    * @param loop the event loop instance to attach the event to. Defaults to the
    * CommandScheduler's default loop.
-   * @return a Trigger instance representing the North Face button's
+   * @return a Trigger instance representing the Face Up button's
    * digital signal attached to the given loop.
    */
-  Trigger NorthFace(wpi::EventLoop* loop = CommandScheduler::GetInstance()
-                                               .GetDefaultButtonLoop()) const;
+  Trigger FaceUp(wpi::EventLoop* loop = CommandScheduler::GetInstance()
+                                            .GetDefaultButtonLoop()) const;
 
   /**
    * Constructs a Trigger instance around the Back button's

--- a/commandsv3/src/main/java/org/wpilib/command3/Trigger.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Trigger.java
@@ -19,7 +19,7 @@ import org.wpilib.units.measure.Time;
 /**
  * Triggers allow users to specify conditions for when commands should run. Triggers can be set up
  * to read from joystick and controller buttons (eg {@link
- * org.wpilib.command3.button.CommandGamepad#southFace()}) or be customized to read sensor values or
+ * org.wpilib.command3.button.CommandGamepad#faceDown()}) or be customized to read sensor values or
  * any other arbitrary true/false condition.
  *
  * <p>It is very easy to link a button to a command. For instance, you could link the trigger button

--- a/commandsv3/src/main/java/org/wpilib/command3/button/CommandGamepad.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/button/CommandGamepad.java
@@ -50,98 +50,98 @@ public class CommandGamepad extends CommandGenericHID {
   }
 
   /**
-   * Constructs a Trigger instance around the South Face button's digital signal.
+   * Constructs a Trigger instance around the Face Down button's digital signal.
    *
-   * @return a Trigger instance representing the South Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Down button's digital signal attached to the
    *     {@link Scheduler#getDefaultEventLoop() default scheduler event loop} on the scheduler
    *     passed to the controller's constructor, or the {@link Scheduler#getDefault default
    *     scheduler} if a scheduler was not explicitly provided.
-   * @see #southFace(EventLoop)
+   * @see #faceDown(EventLoop)
    */
-  public Trigger southFace() {
-    return southFace(getScheduler().getDefaultEventLoop());
+  public Trigger faceDown() {
+    return faceDown(getScheduler().getDefaultEventLoop());
   }
 
   /**
-   * Constructs a Trigger instance around the South Face button's digital signal.
+   * Constructs a Trigger instance around the Face Down button's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return a Trigger instance representing the South Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Down button's digital signal attached to the
    *     given loop.
    */
-  public Trigger southFace(EventLoop loop) {
+  public Trigger faceDown(EventLoop loop) {
     return button(Gamepad.Button.SOUTH_FACE.value, loop);
   }
 
   /**
-   * Constructs a Trigger instance around the East Face button's digital signal.
+   * Constructs a Trigger instance around the Face Right button's digital signal.
    *
-   * @return a Trigger instance representing the East Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Right button's digital signal attached to the
    *     {@link Scheduler#getDefaultEventLoop() default scheduler event loop} on the scheduler
    *     passed to the controller's constructor, or the {@link Scheduler#getDefault default
    *     scheduler} if a scheduler was not explicitly provided.
-   * @see #eastFace(EventLoop)
+   * @see #faceRight(EventLoop)
    */
-  public Trigger eastFace() {
-    return eastFace(getScheduler().getDefaultEventLoop());
+  public Trigger faceRight() {
+    return faceRight(getScheduler().getDefaultEventLoop());
   }
 
   /**
-   * Constructs a Trigger instance around the East Face button's digital signal.
+   * Constructs a Trigger instance around the Face Right button's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return a Trigger instance representing the East Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Right button's digital signal attached to the
    *     given loop.
    */
-  public Trigger eastFace(EventLoop loop) {
+  public Trigger faceRight(EventLoop loop) {
     return button(Gamepad.Button.EAST_FACE.value, loop);
   }
 
   /**
-   * Constructs a Trigger instance around the West Face button's digital signal.
+   * Constructs a Trigger instance around the Face Left button's digital signal.
    *
-   * @return a Trigger instance representing the West Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Left button's digital signal attached to the
    *     {@link Scheduler#getDefaultEventLoop() default scheduler event loop} on the scheduler
    *     passed to the controller's constructor, or the {@link Scheduler#getDefault default
    *     scheduler} if a scheduler was not explicitly provided.
-   * @see #westFace(EventLoop)
+   * @see #faceLeft(EventLoop)
    */
-  public Trigger westFace() {
-    return westFace(getScheduler().getDefaultEventLoop());
+  public Trigger faceLeft() {
+    return faceLeft(getScheduler().getDefaultEventLoop());
   }
 
   /**
-   * Constructs a Trigger instance around the West Face button's digital signal.
+   * Constructs a Trigger instance around the Face Left button's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return a Trigger instance representing the West Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Left button's digital signal attached to the
    *     given loop.
    */
-  public Trigger westFace(EventLoop loop) {
+  public Trigger faceLeft(EventLoop loop) {
     return button(Gamepad.Button.WEST_FACE.value, loop);
   }
 
   /**
-   * Constructs a Trigger instance around the North Face button's digital signal.
+   * Constructs a Trigger instance around the Face Up button's digital signal.
    *
-   * @return a Trigger instance representing the North Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Up button's digital signal attached to the
    *     {@link Scheduler#getDefaultEventLoop() default scheduler event loop} on the scheduler
    *     passed to the controller's constructor, or the {@link Scheduler#getDefault default
    *     scheduler} if a scheduler was not explicitly provided.
-   * @see #northFace(EventLoop)
+   * @see #faceUp(EventLoop)
    */
-  public Trigger northFace() {
-    return northFace(getScheduler().getDefaultEventLoop());
+  public Trigger faceUp() {
+    return faceUp(getScheduler().getDefaultEventLoop());
   }
 
   /**
-   * Constructs a Trigger instance around the North Face button's digital signal.
+   * Constructs a Trigger instance around the Face Up button's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return a Trigger instance representing the North Face button's digital signal attached to the
+   * @return a Trigger instance representing the Face Up button's digital signal attached to the
    *     given loop.
    */
-  public Trigger northFace(EventLoop loop) {
+  public Trigger faceUp(EventLoop loop) {
     return button(Gamepad.Button.NORTH_FACE.value, loop);
   }
 

--- a/wpilibc/src/main/native/cpp/driverstation/Gamepad.cpp
+++ b/wpilibc/src/main/native/cpp/driverstation/Gamepad.cpp
@@ -70,7 +70,7 @@ bool Gamepad::GetSouthFaceButtonReleased() {
   return GetButtonReleased(Button::SOUTH_FACE);
 }
 
-BooleanEvent Gamepad::SouthFace(EventLoop* loop) const {
+BooleanEvent Gamepad::FaceDown(EventLoop* loop) const {
   return BooleanEvent(loop, [this]() { return this->GetSouthFaceButton(); });
 }
 
@@ -86,7 +86,7 @@ bool Gamepad::GetEastFaceButtonReleased() {
   return GetButtonReleased(Button::EAST_FACE);
 }
 
-BooleanEvent Gamepad::EastFace(EventLoop* loop) const {
+BooleanEvent Gamepad::FaceRight(EventLoop* loop) const {
   return BooleanEvent(loop, [this]() { return this->GetEastFaceButton(); });
 }
 
@@ -102,7 +102,7 @@ bool Gamepad::GetWestFaceButtonReleased() {
   return GetButtonReleased(Button::WEST_FACE);
 }
 
-BooleanEvent Gamepad::WestFace(EventLoop* loop) const {
+BooleanEvent Gamepad::FaceLeft(EventLoop* loop) const {
   return BooleanEvent(loop, [this]() { return this->GetWestFaceButton(); });
 }
 
@@ -118,7 +118,7 @@ bool Gamepad::GetNorthFaceButtonReleased() {
   return GetButtonReleased(Button::NORTH_FACE);
 }
 
-BooleanEvent Gamepad::NorthFace(EventLoop* loop) const {
+BooleanEvent Gamepad::FaceUp(EventLoop* loop) const {
   return BooleanEvent(loop, [this]() { return this->GetNorthFaceButton(); });
 }
 

--- a/wpilibc/src/main/native/include/wpi/driverstation/Gamepad.hpp
+++ b/wpilibc/src/main/native/include/wpi/driverstation/Gamepad.hpp
@@ -223,14 +223,14 @@ class Gamepad : public GenericHID,
   bool GetSouthFaceButtonReleased();
 
   /**
-   * Constructs an event instance around the South Face button's
+   * Constructs an event instance around the Face Down button's
    * digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return an event instance representing the South Face button's
+   * @return an event instance representing the Face Down button's
    * digital signal attached to the given loop.
    */
-  BooleanEvent SouthFace(EventLoop* loop) const;
+  BooleanEvent FaceDown(EventLoop* loop) const;
 
   /**
    * Read the value of the East Face button on the controller.
@@ -254,14 +254,14 @@ class Gamepad : public GenericHID,
   bool GetEastFaceButtonReleased();
 
   /**
-   * Constructs an event instance around the East Face button's
+   * Constructs an event instance around the Face Right button's
    * digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return an event instance representing the East Face button's
+   * @return an event instance representing the Face Right button's
    * digital signal attached to the given loop.
    */
-  BooleanEvent EastFace(EventLoop* loop) const;
+  BooleanEvent FaceRight(EventLoop* loop) const;
 
   /**
    * Read the value of the West Face button on the controller.
@@ -285,14 +285,14 @@ class Gamepad : public GenericHID,
   bool GetWestFaceButtonReleased();
 
   /**
-   * Constructs an event instance around the West Face button's
+   * Constructs an event instance around the Face Left button's
    * digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return an event instance representing the West Face button's
+   * @return an event instance representing the Face Left button's
    * digital signal attached to the given loop.
    */
-  BooleanEvent WestFace(EventLoop* loop) const;
+  BooleanEvent FaceLeft(EventLoop* loop) const;
 
   /**
    * Read the value of the North Face button on the controller.
@@ -316,14 +316,14 @@ class Gamepad : public GenericHID,
   bool GetNorthFaceButtonReleased();
 
   /**
-   * Constructs an event instance around the North Face button's
+   * Constructs an event instance around the Face Up button's
    * digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return an event instance representing the North Face button's
+   * @return an event instance representing the Face Up button's
    * digital signal attached to the given loop.
    */
-  BooleanEvent NorthFace(EventLoop* loop) const;
+  BooleanEvent FaceUp(EventLoop* loop) const;
 
   /**
    * Read the value of the Back button on the controller.

--- a/wpilibc/src/main/python/semiwrap/Gamepad.yml
+++ b/wpilibc/src/main/python/semiwrap/Gamepad.yml
@@ -24,19 +24,19 @@ classes:
       GetSouthFaceButton:
       GetSouthFaceButtonPressed:
       GetSouthFaceButtonReleased:
-      SouthFace:
+      FaceDown:
       GetEastFaceButton:
       GetEastFaceButtonPressed:
       GetEastFaceButtonReleased:
-      EastFace:
+      FaceRight:
       GetWestFaceButton:
       GetWestFaceButtonPressed:
       GetWestFaceButtonReleased:
-      WestFace:
+      FaceLeft:
       GetNorthFaceButton:
       GetNorthFaceButtonPressed:
       GetNorthFaceButtonReleased:
-      NorthFace:
+      FaceUp:
       GetBackButton:
       GetBackButtonPressed:
       GetBackButtonReleased:

--- a/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/cpp/RobotContainer.cpp
@@ -29,14 +29,14 @@ void RobotContainer::ConfigureButtonBindings() {
       .OnTrue(driveHalfVelocity.get())
       .OnFalse(driveFullVelocity.get());
 
-  // Drive forward by 3 meters when the 'South Face' button is pressed, with a
+  // Drive forward by 3 meters when the 'Face Down' button is pressed, with a
   // timeout of 10 seconds
-  driverController.SouthFace().OnTrue(
+  driverController.FaceDown().OnTrue(
       drive.ProfiledDriveDistance(3_m).WithTimeout(10_s));
 
-  // Do the same thing as above when the 'East Face' button is pressed, but
+  // Do the same thing as above when the 'Face Right' button is pressed, but
   // without resetting the encoders
-  driverController.EastFace().OnTrue(
+  driverController.FaceRight().OnTrue(
       drive.DynamicProfiledDriveDistance(3_m).WithTimeout(10_s));
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/RobotContainer.cpp
@@ -35,10 +35,10 @@ RobotContainer::RobotContainer() {
 void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
 
-  // Grab the hatch when the 'East Face' button is pressed.
-  driverController.EastFace().OnTrue(hatch.GrabHatchCommand());
-  // Release the hatch when the 'West Face' button is pressed.
-  driverController.WestFace().OnTrue(hatch.ReleaseHatchCommand());
+  // Grab the hatch when the 'Face Right' button is pressed.
+  driverController.FaceRight().OnTrue(hatch.GrabHatchCommand());
+  // Release the hatch when the 'Face Left' button is pressed.
+  driverController.FaceLeft().OnTrue(hatch.ReleaseHatchCommand());
   // While holding Right Bumper, drive at half velocity
   driverController.RightBumper()
       .OnTrue(wpi::cmd::RunOnce([this] { drive.SetMaxOutput(0.5); }, {}))

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/RapidReactCommandBot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/RapidReactCommandBot.cpp
@@ -24,13 +24,13 @@ void RapidReactCommandBot::ConfigureBindings() {
       [this] { return -driverController.GetLeftY(); },
       [this] { return -driverController.GetRightX(); }));
 
-  // Deploy the intake with the West Face button
-  driverController.WestFace().OnTrue(intake.IntakeCommand());
-  // Retract the intake with the North Face button
-  driverController.NorthFace().OnTrue(intake.RetractCommand());
+  // Deploy the intake with the Face Left button
+  driverController.FaceLeft().OnTrue(intake.IntakeCommand());
+  // Retract the intake with the Face Up button
+  driverController.FaceUp().OnTrue(intake.RetractCommand());
 
-  // Fire the shooter with the South Face button
-  driverController.SouthFace().OnTrue(
+  // Fire the shooter with the Face Down button
+  driverController.FaceDown().OnTrue(
       wpi::cmd::Parallel(shooter.ShootCommand(ShooterConstants::kShooterTarget),
                          storage.RunCommand())
           // Since we composed this inline we should give it a name

--- a/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/cpp/SysIdRoutineBot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/cpp/SysIdRoutineBot.cpp
@@ -17,27 +17,27 @@ void SysIdRoutineBot::ConfigureBindings() {
 
   // Using bumpers as a modifier and combining it with the buttons so that we
   // can have both sets of bindings at once
-  (driverController.SouthFace() && driverController.RightBumper())
+  (driverController.FaceDown() && driverController.RightBumper())
       .WhileTrue(drive.SysIdQuasistatic(wpi::cmd::sysid::Direction::kForward));
-  (driverController.EastFace() && driverController.RightBumper())
+  (driverController.FaceRight() && driverController.RightBumper())
       .WhileTrue(drive.SysIdQuasistatic(wpi::cmd::sysid::Direction::kReverse));
-  (driverController.WestFace() && driverController.RightBumper())
+  (driverController.FaceLeft() && driverController.RightBumper())
       .WhileTrue(drive.SysIdDynamic(wpi::cmd::sysid::Direction::kForward));
-  (driverController.NorthFace() && driverController.RightBumper())
+  (driverController.FaceUp() && driverController.RightBumper())
       .WhileTrue(drive.SysIdDynamic(wpi::cmd::sysid::Direction::kReverse));
 
   shooter.SetDefaultCommand(shooter.RunShooterCommand(
       [this] { return driverController.GetLeftTriggerAxis(); }));
 
-  (driverController.SouthFace() && driverController.LeftBumper())
+  (driverController.FaceDown() && driverController.LeftBumper())
       .WhileTrue(
           shooter.SysIdQuasistatic(wpi::cmd::sysid::Direction::kForward));
-  (driverController.EastFace() && driverController.LeftBumper())
+  (driverController.FaceRight() && driverController.LeftBumper())
       .WhileTrue(
           shooter.SysIdQuasistatic(wpi::cmd::sysid::Direction::kReverse));
-  (driverController.WestFace() && driverController.LeftBumper())
+  (driverController.FaceLeft() && driverController.LeftBumper())
       .WhileTrue(shooter.SysIdDynamic(wpi::cmd::sysid::Direction::kForward));
-  (driverController.NorthFace() && driverController.LeftBumper())
+  (driverController.FaceUp() && driverController.LeftBumper())
       .WhileTrue(shooter.SysIdDynamic(wpi::cmd::sysid::Direction::kReverse));
 }
 

--- a/wpilibcExamples/src/main/cpp/templates/commandv2/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandv2/cpp/RobotContainer.cpp
@@ -23,9 +23,9 @@ void RobotContainer::ConfigureBindings() {
     return subsystem.ExampleCondition();
   }).OnTrue(ExampleCommand(&subsystem).ToPtr());
 
-  // Schedule `ExampleMethodCommand` when the Gamepad's East Face button is
+  // Schedule `ExampleMethodCommand` when the Gamepad's Face Right button is
   // pressed, cancelling on release.
-  driverController.EastFace().WhileTrue(subsystem.ExampleMethodCommand());
+  driverController.FaceRight().WhileTrue(subsystem.ExampleMethodCommand());
 }
 
 wpi::cmd::CommandPtr RobotContainer::GetAutonomousCommand() {

--- a/wpilibj/src/main/java/org/wpilib/driverstation/Gamepad.java
+++ b/wpilibj/src/main/java/org/wpilib/driverstation/Gamepad.java
@@ -285,13 +285,13 @@ public class Gamepad extends GenericHID implements Sendable {
   }
 
   /**
-   * Constructs an event instance around the South Face button's digital signal.
+   * Constructs an event instance around the Face Down button's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return an event instance representing the South Face button's digital signal attached to the
+   * @return an event instance representing the Face Down button's digital signal attached to the
    *     given loop.
    */
-  public BooleanEvent southFace(EventLoop loop) {
+  public BooleanEvent faceDown(EventLoop loop) {
     return button(Button.SOUTH_FACE, loop);
   }
 
@@ -323,13 +323,13 @@ public class Gamepad extends GenericHID implements Sendable {
   }
 
   /**
-   * Constructs an event instance around the East Face button's digital signal.
+   * Constructs an event instance around the Face Right button's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return an event instance representing the East Face button's digital signal attached to the
+   * @return an event instance representing the Face Right button's digital signal attached to the
    *     given loop.
    */
-  public BooleanEvent eastFace(EventLoop loop) {
+  public BooleanEvent faceRight(EventLoop loop) {
     return button(Button.EAST_FACE, loop);
   }
 
@@ -361,13 +361,13 @@ public class Gamepad extends GenericHID implements Sendable {
   }
 
   /**
-   * Constructs an event instance around the West Face button's digital signal.
+   * Constructs an event instance around the Face Left button's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return an event instance representing the West Face button's digital signal attached to the
+   * @return an event instance representing the Face Left button's digital signal attached to the
    *     given loop.
    */
-  public BooleanEvent westFace(EventLoop loop) {
+  public BooleanEvent faceLeft(EventLoop loop) {
     return button(Button.WEST_FACE, loop);
   }
 
@@ -399,13 +399,13 @@ public class Gamepad extends GenericHID implements Sendable {
   }
 
   /**
-   * Constructs an event instance around the North Face button's digital signal.
+   * Constructs an event instance around the Face Up button's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
-   * @return an event instance representing the North Face button's digital signal attached to the
+   * @return an event instance representing the Face Up button's digital signal attached to the
    *     given loop.
    */
-  public BooleanEvent northFace(EventLoop loop) {
+  public BooleanEvent faceUp(EventLoop loop) {
     return button(Button.NORTH_FACE, loop);
   }
 

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/drivedistanceoffboard/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/drivedistanceoffboard/RobotContainer.java
@@ -56,11 +56,11 @@ public class RobotContainer {
 
     // Drive forward by 3 meters when the 'South Face' button is pressed, with a timeout of 10
     // seconds
-    driverController.southFace().onTrue(robotDrive.profiledDriveDistance(3).withTimeout(10));
+    driverController.faceDown().onTrue(robotDrive.profiledDriveDistance(3).withTimeout(10));
 
     // Do the same thing as above when the 'East Face' button is pressed, but without resetting the
     // encoders
-    driverController.eastFace().onTrue(robotDrive.dynamicProfiledDriveDistance(3).withTimeout(10));
+    driverController.faceRight().onTrue(robotDrive.dynamicProfiledDriveDistance(3).withTimeout(10));
   }
 
   /**

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/drivedistanceoffboard/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/drivedistanceoffboard/RobotContainer.java
@@ -54,11 +54,11 @@ public class RobotContainer {
     // Drive at half velocity when the bumper is held
     driverController.rightBumper().onTrue(driveHalfVelocity).onFalse(driveFullVelocity);
 
-    // Drive forward by 3 meters when the 'South Face' button is pressed, with a timeout of 10
+    // Drive forward by 3 meters when the 'Face Down' button is pressed, with a timeout of 10
     // seconds
     driverController.faceDown().onTrue(robotDrive.profiledDriveDistance(3).withTimeout(10));
 
-    // Do the same thing as above when the 'East Face' button is pressed, but without resetting the
+    // Do the same thing as above when the 'Face Right' button is pressed, but without resetting the
     // encoders
     driverController.faceRight().onTrue(robotDrive.dynamicProfiledDriveDistance(3).withTimeout(10));
   }

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotcmdv3/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotcmdv3/RobotContainer.java
@@ -73,9 +73,9 @@ public class RobotContainer {
    */
   private void configureButtonBindings() {
     // Grab the hatch when the Circle button is pressed.
-    driverController.eastFace().onTrue(hatchSubsystem.grabHatchCommand());
+    driverController.faceRight().onTrue(hatchSubsystem.grabHatchCommand());
     // Release the hatch when the Square button is pressed.
-    driverController.westFace().onTrue(hatchSubsystem.releaseHatchCommand());
+    driverController.faceLeft().onTrue(hatchSubsystem.releaseHatchCommand());
     // While holding R1, drive at half speed
     driverController
         .rightBumper()

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotinlined/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotinlined/RobotContainer.java
@@ -74,9 +74,9 @@ public class RobotContainer {
    * org.wpilib.command2.button.JoystickButton}.
    */
   private void configureButtonBindings() {
-    // Grab the hatch when the east face button is pressed.
+    // Grab the hatch when the right face button is pressed.
     driverController.faceRight().onTrue(hatchSubsystem.grabHatchCommand());
-    // Release the hatch when the west face button is pressed.
+    // Release the hatch when the left face button is pressed.
     driverController.faceLeft().onTrue(hatchSubsystem.releaseHatchCommand());
     // While holding right bumper, drive at half velocity
     driverController

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotinlined/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotinlined/RobotContainer.java
@@ -75,9 +75,9 @@ public class RobotContainer {
    */
   private void configureButtonBindings() {
     // Grab the hatch when the east face button is pressed.
-    driverController.eastFace().onTrue(hatchSubsystem.grabHatchCommand());
+    driverController.faceRight().onTrue(hatchSubsystem.grabHatchCommand());
     // Release the hatch when the west face button is pressed.
-    driverController.westFace().onTrue(hatchSubsystem.releaseHatchCommand());
+    driverController.faceLeft().onTrue(hatchSubsystem.releaseHatchCommand());
     // While holding right bumper, drive at half velocity
     driverController
         .rightBumper()

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/RapidReactCommandBot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/RapidReactCommandBot.java
@@ -59,12 +59,12 @@ public class RapidReactCommandBot {
         drive.arcadeDriveCommand(
             () -> -driverController.getLeftY(), () -> -driverController.getRightX()));
 
-    // Deploy the intake with the west face button
+    // Deploy the intake with the left face button
     driverController.faceLeft().onTrue(intake.intakeCommand());
-    // Retract the intake with the north face button
+    // Retract the intake with the up face button
     driverController.faceUp().onTrue(intake.retractCommand());
 
-    // Fire the shooter with the south face button
+    // Fire the shooter with the down face button
     driverController
         .faceDown()
         .onTrue(

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/RapidReactCommandBot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/RapidReactCommandBot.java
@@ -60,13 +60,13 @@ public class RapidReactCommandBot {
             () -> -driverController.getLeftY(), () -> -driverController.getRightX()));
 
     // Deploy the intake with the west face button
-    driverController.westFace().onTrue(intake.intakeCommand());
+    driverController.faceLeft().onTrue(intake.intakeCommand());
     // Retract the intake with the north face button
-    driverController.northFace().onTrue(intake.retractCommand());
+    driverController.faceUp().onTrue(intake.retractCommand());
 
     // Fire the shooter with the south face button
     driverController
-        .southFace()
+        .faceDown()
         .onTrue(
             parallel(shooter.shootCommand(ShooterConstants.kShooterTargetRPS), storage.runCommand())
                 // Since we composed this inline we should give it a name

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/SysIdRoutineBot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/SysIdRoutineBot.java
@@ -45,19 +45,19 @@ public class SysIdRoutineBot {
     // Using bumpers as a modifier and combining it with the buttons so that we can have both sets
     // of bindings at once
     driverController
-        .southFace()
+        .faceDown()
         .and(driverController.rightBumper())
         .whileTrue(drive.sysIdQuasistatic(SysIdRoutine.Direction.kForward));
     driverController
-        .eastFace()
+        .faceRight()
         .and(driverController.rightBumper())
         .whileTrue(drive.sysIdQuasistatic(SysIdRoutine.Direction.kReverse));
     driverController
-        .westFace()
+        .faceLeft()
         .and(driverController.rightBumper())
         .whileTrue(drive.sysIdDynamic(SysIdRoutine.Direction.kForward));
     driverController
-        .northFace()
+        .faceUp()
         .and(driverController.rightBumper())
         .whileTrue(drive.sysIdDynamic(SysIdRoutine.Direction.kReverse));
 
@@ -65,19 +65,19 @@ public class SysIdRoutineBot {
     shooter.setDefaultCommand(shooter.runShooter(driverController::getLeftTriggerAxis));
 
     driverController
-        .southFace()
+        .faceDown()
         .and(driverController.leftBumper())
         .whileTrue(shooter.sysIdQuasistatic(SysIdRoutine.Direction.kForward));
     driverController
-        .eastFace()
+        .faceRight()
         .and(driverController.leftBumper())
         .whileTrue(shooter.sysIdQuasistatic(SysIdRoutine.Direction.kReverse));
     driverController
-        .westFace()
+        .faceLeft()
         .and(driverController.leftBumper())
         .whileTrue(shooter.sysIdDynamic(SysIdRoutine.Direction.kForward));
     driverController
-        .northFace()
+        .faceUp()
         .and(driverController.leftBumper())
         .whileTrue(shooter.sysIdDynamic(SysIdRoutine.Direction.kReverse));
   }

--- a/wpilibjExamples/src/main/java/org/wpilib/templates/commandv2/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/templates/commandv2/RobotContainer.java
@@ -44,7 +44,7 @@ public class RobotContainer {
 
     // Schedule `exampleMethodCommand` when the Gamepad's east face button is pressed,
     // cancelling on release.
-    driverController.eastFace().whileTrue(exampleSubsystem.exampleMethodCommand());
+    driverController.faceRight().whileTrue(exampleSubsystem.exampleMethodCommand());
   }
 
   /**

--- a/wpilibjExamples/src/main/java/org/wpilib/templates/commandv2/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/templates/commandv2/RobotContainer.java
@@ -42,7 +42,7 @@ public class RobotContainer {
     // Schedule `ExampleCommand` when `exampleCondition` changes to `true`
     new Trigger(exampleSubsystem::exampleCondition).onTrue(new ExampleCommand(exampleSubsystem));
 
-    // Schedule `exampleMethodCommand` when the Gamepad's east face button is pressed,
+    // Schedule `exampleMethodCommand` when the Gamepad's right face button is pressed,
     // cancelling on release.
     driverController.faceRight().whileTrue(exampleSubsystem.exampleMethodCommand());
   }


### PR DESCRIPTION
This updates gamepad trigger naming from cardinal-style face buttons (`northFace/southFace/eastFace/westFace` and `NorthFace/SouthFace/EastFace/WestFace`) to directional naming (`faceUp/faceDown/faceRight/faceLeft` and `FaceUp/FaceDown/FaceRight/FaceLeft`) to match the requested API shape. The change is applied across Java and C++ HID/command layers, along with related examples and binding metadata.

- **API surface updates (Java)**
  - Renamed trigger/event methods in:
    - `wpilibj` `Gamepad`
    - `commandsv2` `CommandGamepad`
    - `commandsv3` `CommandGamepad`
  - Mapping preserved:
    - `southFace` → `faceDown`
    - `eastFace` → `faceRight`
    - `westFace` → `faceLeft`
    - `northFace` → `faceUp`

- **API surface updates (C++)**
  - Renamed trigger/event methods in:
    - `wpilibc` `Gamepad`
    - `commandsv2` `CommandGamepad`
  - Mapping preserved:
    - `SouthFace` → `FaceDown`
    - `EastFace` → `FaceRight`
    - `WestFace` → `FaceLeft`
    - `NorthFace` → `FaceUp`

- **Python semiwrap updates**
  - Updated `wpilibc/src/main/python/semiwrap/Gamepad.yml` method mappings to the renamed C++ method names (`FaceDown/FaceRight/FaceLeft/FaceUp`).

- **Callsite migration**
  - Updated Java examples/template code and C++ examples/template code to use the new method names so samples remain aligned with the API rename.

- **Docs/comments alignment**
  - Updated related Javadoc/reference text and example comments to use directional terminology.

```java
// Before
driverController.southFace().onTrue(command);
driverController.eastFace().onTrue(command);

// After
driverController.faceDown().onTrue(command);
driverController.faceRight().onTrue(command);
```

```cpp
// Before
driverController.SouthFace().OnTrue(command);
driverController.EastFace().OnTrue(command);

// After
driverController.FaceDown().OnTrue(command);
driverController.FaceRight().OnTrue(command);
```

> [!WARNING]
>
>