### PR TITLE
[commands v3] Automatically assign name to wait command

### DIFF
--- a/commandsv3/src/main/java/org/wpilib/command3/Command.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Command.java
@@ -218,7 +218,7 @@ public interface Command {
   default Command withTimeout(Time timeout) {
     requireNonNullParam(timeout, "timeout", "Command.withTimeout");
 
-    return race(this, waitFor(timeout).named("Timeout: " + timeout.toLongString()))
+    return race(this, wait(timeout))
         .named(name() + " [" + timeout.toLongString() + " timeout]");
   }
 
@@ -338,10 +338,11 @@ public interface Command {
    * @param duration How long to wait
    * @return A command builder
    */
-  static NeedsNameBuilderStage waitFor(Time duration) {
-    requireNonNullParam(duration, "duration", "Command.waitFor");
+  static Command wait(Time duration) {
+    requireNonNullParam(duration, "duration", "Command.wait");
 
-    return noRequirements(coroutine -> coroutine.wait(duration));
+    return noRequirements(coroutine -> coroutine.wait(duration))
+            .named("Wait " + duration.toLongString());
   }
 
   /**

--- a/commandsv3/src/main/java/org/wpilib/command3/Command.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Command.java
@@ -218,8 +218,7 @@ public interface Command {
   default Command withTimeout(Time timeout) {
     requireNonNullParam(timeout, "timeout", "Command.withTimeout");
 
-    return race(this, wait(timeout))
-        .named(name() + " [" + timeout.toLongString() + " timeout]");
+    return race(this, wait(timeout)).named(name() + " [" + timeout.toLongString() + " timeout]");
   }
 
   /**
@@ -342,7 +341,7 @@ public interface Command {
     requireNonNullParam(duration, "duration", "Command.wait");
 
     return noRequirements(coroutine -> coroutine.wait(duration))
-            .named("Wait " + duration.toLongString());
+        .named("Wait " + duration.toLongString());
   }
 
   /**


### PR DESCRIPTION
Also renames Command.waitFor() to Command.wait() for consistency with coroutine.wait(time).