### PR TITLE
[xrp] Fix motor support

### DIFF
--- a/simulation/halsim_xrp/src/main/native/cpp/XRP.cpp
+++ b/simulation/halsim_xrp/src/main/native/cpp/XRP.cpp
@@ -144,9 +144,9 @@ void XRP::HandleMotorSimValueChanged(const wpi::util::json& data) {
     deviceId = 3;
   }
 
-  auto dutyCycle = motorData->lookup("<duty_cycle");
-  if (deviceId != -1 && dutyCycle && dutyCycle->is_number()) {
-    m_motor_outputs[deviceId] = dutyCycle->get_number();
+  auto throttle = motorData->lookup("<throttle");
+  if (deviceId != -1 && throttle && throttle->is_number()) {
+    m_motor_outputs[deviceId] = throttle->get_number();
   }
 }
 


### PR DESCRIPTION
The protocol layer got out of sync with the rename to throttle.