### PR TITLE
[epilogue,ntcore,wpiunits] Use pattern matching switch expressions where possible

### DIFF
--- a/epilogue-processor/src/main/java/org/wpilib/epilogue/processor/ElementHandler.java
+++ b/epilogue-processor/src/main/java/org/wpilib/epilogue/processor/ElementHandler.java
@@ -47,13 +47,11 @@ public abstract class ElementHandler {
    * @return the logged datatype
    */
   protected TypeMirror dataType(Element element) {
-    if (element instanceof VariableElement field) {
-      return field.asType();
-    } else if (element instanceof ExecutableElement method) {
-      return method.getReturnType();
-    } else {
-      throw new IllegalStateException("Unexpected" + element.getClass().getName());
-    }
+    return switch (element) {
+      case VariableElement field -> field.asType();
+      case ExecutableElement method -> method.getReturnType();
+      default -> throw new IllegalStateException("Unexpected" + element.getClass().getName());
+    };
   }
 
   /**
@@ -118,13 +116,11 @@ public abstract class ElementHandler {
    * @return the generated access snippet
    */
   public String elementAccess(Element element, TypeElement loggedClass) {
-    if (element instanceof VariableElement field) {
-      return fieldAccess(field, loggedClass);
-    } else if (element instanceof ExecutableElement method) {
-      return methodAccess(method);
-    } else {
-      throw new IllegalStateException("Unexpected" + element.getClass().getName());
-    }
+    return switch (element) {
+      case VariableElement field -> fieldAccess(field, loggedClass);
+      case ExecutableElement method -> methodAccess(method);
+      default -> throw new IllegalStateException("Unexpected" + element.getClass().getName());
+    };
   }
 
   private static String fieldAccess(VariableElement field, TypeElement loggedClass) {

--- a/epilogue-processor/src/main/java/org/wpilib/epilogue/processor/LoggableHandler.java
+++ b/epilogue-processor/src/main/java/org/wpilib/epilogue/processor/LoggableHandler.java
@@ -107,14 +107,12 @@ public class LoggableHandler extends ElementHandler {
    */
   private static String cacheVariableName(Element element) {
     // Generate unique names in case a field and a method share the same name
-    if (element instanceof VariableElement) {
-      return "$$%s".formatted(element.getSimpleName().toString());
-    } else if (element instanceof ExecutableElement) {
-      return "__%s".formatted(element.getSimpleName().toString());
-    } else {
+    return switch (element) {
+      case VariableElement field -> "$$%s".formatted(field.getSimpleName().toString());
+      case ExecutableElement method -> "__%s".formatted(method.getSimpleName().toString());
       // Generic fallback (shouldn't get here, since only fields and methods are logged)
-      return element.getSimpleName().toString();
-    }
+      default -> element.getSimpleName().toString();
+    };
   }
 
   /**

--- a/ntcore/src/generate/main/java/GenericEntryImpl.java.jinja
+++ b/ntcore/src/generate/main/java/GenericEntryImpl.java.jinja
@@ -106,42 +106,26 @@ final class GenericEntryImpl extends EntryBase implements GenericEntry {
    */
   @Override
   public boolean setValue(Object value, long time) {
-    if (value instanceof NetworkTableValue) {
-      return set((NetworkTableValue) value);
-    } else if (value instanceof Boolean) {
-      return setBoolean((Boolean) value, time);
-    } else if (value instanceof Long) {
-      return setInteger((Long) value, time);
-    } else if (value instanceof Float) {
-      return setFloat((Float) value, time);
-    } else if (value instanceof Number) {
-      return setNumber((Number) value, time);
-    } else if (value instanceof String) {
-      return setString((String) value, time);
-    } else if (value instanceof byte[]) {
-      return setRaw((byte[]) value, time);
-    } else if (value instanceof boolean[]) {
-      return setBooleanArray((boolean[]) value, time);
-    } else if (value instanceof long[]) {
-      return setIntegerArray((long[]) value, time);
-    } else if (value instanceof float[]) {
-      return setFloatArray((float[]) value, time);
-    } else if (value instanceof double[]) {
-      return setDoubleArray((double[]) value, time);
-    } else if (value instanceof Boolean[]) {
-      return setBooleanArray((Boolean[]) value, time);
-    } else if (value instanceof Long[]) {
-      return setIntegerArray((Long[]) value, time);
-    } else if (value instanceof Float[]) {
-      return setFloatArray((Float[]) value, time);
-    } else if (value instanceof Number[]) {
-      return setNumberArray((Number[]) value, time);
-    } else if (value instanceof String[]) {
-      return setStringArray((String[]) value, time);
-    } else {
-      throw new IllegalArgumentException(
+    return switch (value) {
+      case NetworkTableValue ntValue -> set(ntValue);
+      case Boolean v -> setBoolean(v, time);
+      case Long v -> setInteger(v, time);
+      case Float v -> setFloat(v, time);
+      case Number v -> setNumber(v, time);
+      case String v -> setString(v, time);
+      case byte[] v -> setRaw(v, time);
+      case boolean[] v -> setBooleanArray(v, time);
+      case long[] v -> setIntegerArray(v, time);
+      case float[] v -> setFloatArray(v, time);
+      case double[] v -> setDoubleArray(v, time);
+      case Boolean[] v -> setBooleanArray(v, time);
+      case Long[] v -> setIntegerArray(v, time);
+      case Float[] v -> setFloatArray(v, time);
+      case Number[] v -> setNumberArray(v, time);
+      case String[] v -> setStringArray(v, time);
+      default -> throw new IllegalArgumentException(
           "Value of type " + value.getClass().getName() + " cannot be put into a table");
-    }
+    };
   }
 {% for t in types %}
 {% if t.TypeName == "Raw" %}
@@ -259,42 +243,26 @@ final class GenericEntryImpl extends EntryBase implements GenericEntry {
    */
   @Override
   public boolean setDefaultValue(Object defaultValue) {
-    if (defaultValue instanceof NetworkTableValue) {
-      return setDefault((NetworkTableValue) defaultValue);
-    } else if (defaultValue instanceof Boolean) {
-      return setDefaultBoolean((Boolean) defaultValue);
-    } else if (defaultValue instanceof Integer) {
-      return setDefaultInteger((Integer) defaultValue);
-    } else if (defaultValue instanceof Float) {
-      return setDefaultFloat((Float) defaultValue);
-    } else if (defaultValue instanceof Number) {
-      return setDefaultNumber((Number) defaultValue);
-    } else if (defaultValue instanceof String) {
-      return setDefaultString((String) defaultValue);
-    } else if (defaultValue instanceof byte[]) {
-      return setDefaultRaw((byte[]) defaultValue);
-    } else if (defaultValue instanceof boolean[]) {
-      return setDefaultBooleanArray((boolean[]) defaultValue);
-    } else if (defaultValue instanceof long[]) {
-      return setDefaultIntegerArray((long[]) defaultValue);
-    } else if (defaultValue instanceof float[]) {
-      return setDefaultFloatArray((float[]) defaultValue);
-    } else if (defaultValue instanceof double[]) {
-      return setDefaultDoubleArray((double[]) defaultValue);
-    } else if (defaultValue instanceof Boolean[]) {
-      return setDefaultBooleanArray((Boolean[]) defaultValue);
-    } else if (defaultValue instanceof Long[]) {
-      return setDefaultIntegerArray((Long[]) defaultValue);
-    } else if (defaultValue instanceof Float[]) {
-      return setDefaultFloatArray((Float[]) defaultValue);
-    } else if (defaultValue instanceof Number[]) {
-      return setDefaultNumberArray((Number[]) defaultValue);
-    } else if (defaultValue instanceof String[]) {
-      return setDefaultStringArray((String[]) defaultValue);
-    } else {
-      throw new IllegalArgumentException(
+    return switch (defaultValue) {
+      case NetworkTableValue ntValue -> setDefault(ntValue);
+      case Boolean value -> setDefaultBoolean(value);
+      case Integer value -> setDefaultInteger(value);
+      case Float value -> setDefaultFloat(value);
+      case Number value -> setDefaultNumber(value);
+      case String value -> setDefaultString(value);
+      case byte[] value -> setDefaultRaw(value);
+      case boolean[] value -> setDefaultBooleanArray(value);
+      case long[] value -> setDefaultIntegerArray(value);
+      case float[] value -> setDefaultFloatArray(value);
+      case double[] value -> setDefaultDoubleArray(value);
+      case Boolean[] value -> setDefaultBooleanArray(value);
+      case Long[] value -> setDefaultIntegerArray(value);
+      case Float[] value -> setDefaultFloatArray(value);
+      case Number[] value -> setDefaultNumberArray(value);
+      case String[] value -> setDefaultStringArray(value);
+      default -> throw new IllegalArgumentException(
           "Value of type " + defaultValue.getClass().getName() + " cannot be put into a table");
-    }
+    };
   }
 {% for t in types %}
 {% if t.TypeName == "Raw" %}

--- a/ntcore/src/generate/main/java/GenericEntryImpl.java.jinja
+++ b/ntcore/src/generate/main/java/GenericEntryImpl.java.jinja
@@ -203,35 +203,28 @@ final class GenericEntryImpl extends EntryBase implements GenericEntry {
   public boolean setDefault(NetworkTableValue defaultValue) {
     long time = defaultValue.getTime();
     Object otherValue = defaultValue.getValue();
-    switch (defaultValue.getType()) {
-      case BOOLEAN:
-        return NetworkTablesJNI.setDefaultBoolean(m_handle, time, (Boolean) otherValue);
-      case INTEGER:
-        return NetworkTablesJNI.setDefaultInteger(
+    return switch (defaultValue.getType()) {
+      case BOOLEAN -> NetworkTablesJNI.setDefaultBoolean(m_handle, time, (Boolean) otherValue);
+      case INTEGER -> NetworkTablesJNI.setDefaultInteger(
             m_handle, time, ((Number) otherValue).longValue());
-      case FLOAT:
-        return NetworkTablesJNI.setDefaultFloat(
+      case FLOAT -> NetworkTablesJNI.setDefaultFloat(
             m_handle, time, ((Number) otherValue).floatValue());
-      case DOUBLE:
-        return NetworkTablesJNI.setDefaultDouble(
+      case DOUBLE -> NetworkTablesJNI.setDefaultDouble(
             m_handle, time, ((Number) otherValue).doubleValue());
-      case STRING:
-        return NetworkTablesJNI.setDefaultString(m_handle, time, (String) otherValue);
-      case RAW:
-        return NetworkTablesJNI.setDefaultRaw(m_handle, time, (byte[]) otherValue);
-      case BOOLEAN_ARRAY:
-        return NetworkTablesJNI.setDefaultBooleanArray(m_handle, time, (boolean[]) otherValue);
-      case INTEGER_ARRAY:
-        return NetworkTablesJNI.setDefaultIntegerArray(m_handle, time, (long[]) otherValue);
-      case FLOAT_ARRAY:
-        return NetworkTablesJNI.setDefaultFloatArray(m_handle, time, (float[]) otherValue);
-      case DOUBLE_ARRAY:
-        return NetworkTablesJNI.setDefaultDoubleArray(m_handle, time, (double[]) otherValue);
-      case STRING_ARRAY:
-        return NetworkTablesJNI.setDefaultStringArray(m_handle, time, (String[]) otherValue);
-      default:
-        return true;
-    }
+      case STRING -> NetworkTablesJNI.setDefaultString(m_handle, time, (String) otherValue);
+      case RAW -> NetworkTablesJNI.setDefaultRaw(m_handle, time, (byte[]) otherValue);
+      case BOOLEAN_ARRAY -> NetworkTablesJNI.setDefaultBooleanArray(
+          m_handle, time, (boolean[]) otherValue);
+      case INTEGER_ARRAY -> NetworkTablesJNI.setDefaultIntegerArray(
+          m_handle, time, (long[]) otherValue);
+      case FLOAT_ARRAY -> NetworkTablesJNI.setDefaultFloatArray(
+          m_handle, time, (float[]) otherValue);
+      case DOUBLE_ARRAY -> NetworkTablesJNI.setDefaultDoubleArray(
+          m_handle, time, (double[]) otherValue);
+      case STRING_ARRAY -> NetworkTablesJNI.setDefaultStringArray(
+          m_handle, time, (String[]) otherValue);
+      default -> true;
+    };
   }
 
   /**

--- a/ntcore/src/generate/main/java/NetworkTableEntry.java.jinja
+++ b/ntcore/src/generate/main/java/NetworkTableEntry.java.jinja
@@ -193,21 +193,16 @@ public final class NetworkTableEntry implements Publisher, Subscriber {
    * @return true if the data can be placed in an entry, false if it cannot
    */
   public static boolean isValidDataType(Object data) {
-    return data instanceof Number
-        || data instanceof Boolean
-        || data instanceof String
-        || data instanceof long[]
-        || data instanceof Long[]
-        || data instanceof float[]
-        || data instanceof Float[]
-        || data instanceof double[]
-        || data instanceof Double[]
-        || data instanceof Number[]
-        || data instanceof boolean[]
-        || data instanceof Boolean[]
-        || data instanceof String[]
-        || data instanceof byte[]
-        || data instanceof Byte[];
+    return switch (data) {
+      case Number _, Boolean _, String _ -> true;
+      case byte[] _, Byte[] _ -> true;
+      case boolean[] _, Boolean[] _ -> true;
+      case long[] _, Long[] _ -> true;
+      case float[] _, Float[] _ -> true;
+      case double[] _, Double[] _, Number[] _ -> true;
+      case String[] _ -> true;
+      case null, default -> false;
+    };
   }
 
   /**
@@ -218,72 +213,51 @@ public final class NetworkTableEntry implements Publisher, Subscriber {
    * @throws IllegalArgumentException if the value is not a known type
    */
   public boolean setDefaultValue(Object defaultValue) {
-    if (defaultValue instanceof NetworkTableValue) {
-      long time = ((NetworkTableValue) defaultValue).getTime();
-      Object otherValue = ((NetworkTableValue) defaultValue).getValue();
-      switch (((NetworkTableValue) defaultValue).getType()) {
-        case BOOLEAN:
-          return NetworkTablesJNI.setDefaultBoolean(m_handle, time, (Boolean) otherValue);
-        case INTEGER:
-          return NetworkTablesJNI.setDefaultInteger(
+    return switch (defaultValue) {
+      case NetworkTableValue ntValue -> {
+        long time = ntValue.getTime();
+        Object otherValue = ntValue.getValue();
+        yield switch (ntValue.getType()) {
+          case BOOLEAN -> NetworkTablesJNI.setDefaultBoolean(m_handle, time, (Boolean) otherValue);
+          case INTEGER -> NetworkTablesJNI.setDefaultInteger(
               m_handle, time, ((Number) otherValue).longValue());
-        case FLOAT:
-          return NetworkTablesJNI.setDefaultFloat(
+          case FLOAT -> NetworkTablesJNI.setDefaultFloat(
               m_handle, time, ((Number) otherValue).floatValue());
-        case DOUBLE:
-          return NetworkTablesJNI.setDefaultDouble(
+          case DOUBLE -> NetworkTablesJNI.setDefaultDouble(
               m_handle, time, ((Number) otherValue).doubleValue());
-        case STRING:
-          return NetworkTablesJNI.setDefaultString(m_handle, time, (String) otherValue);
-        case RAW:
-          return NetworkTablesJNI.setDefaultRaw(m_handle, time, (byte[]) otherValue);
-        case BOOLEAN_ARRAY:
-          return NetworkTablesJNI.setDefaultBooleanArray(m_handle, time, (boolean[]) otherValue);
-        case INTEGER_ARRAY:
-          return NetworkTablesJNI.setDefaultIntegerArray(m_handle, time, (long[]) otherValue);
-        case FLOAT_ARRAY:
-          return NetworkTablesJNI.setDefaultFloatArray(m_handle, time, (float[]) otherValue);
-        case DOUBLE_ARRAY:
-          return NetworkTablesJNI.setDefaultDoubleArray(m_handle, time, (double[]) otherValue);
-        case STRING_ARRAY:
-          return NetworkTablesJNI.setDefaultStringArray(m_handle, time, (String[]) otherValue);
-        default:
-          return true;
+          case STRING -> NetworkTablesJNI.setDefaultString(m_handle, time, (String) otherValue);
+          case RAW -> NetworkTablesJNI.setDefaultRaw(m_handle, time, (byte[]) otherValue);
+          case BOOLEAN_ARRAY -> NetworkTablesJNI.setDefaultBooleanArray(
+              m_handle, time, (boolean[]) otherValue);
+          case INTEGER_ARRAY -> NetworkTablesJNI.setDefaultIntegerArray(
+              m_handle, time, (long[]) otherValue);
+          case FLOAT_ARRAY -> NetworkTablesJNI.setDefaultFloatArray(
+              m_handle, time, (float[]) otherValue);
+          case DOUBLE_ARRAY -> NetworkTablesJNI.setDefaultDoubleArray(
+              m_handle, time, (double[]) otherValue);
+          case STRING_ARRAY -> NetworkTablesJNI.setDefaultStringArray(
+              m_handle, time, (String[]) otherValue);
+          default -> true;
+        };
       }
-    } else if (defaultValue instanceof Boolean) {
-      return setDefaultBoolean((Boolean) defaultValue);
-    } else if (defaultValue instanceof Integer) {
-      return setDefaultInteger((Integer) defaultValue);
-    } else if (defaultValue instanceof Float) {
-      return setDefaultFloat((Float) defaultValue);
-    } else if (defaultValue instanceof Number) {
-      return setDefaultNumber((Number) defaultValue);
-    } else if (defaultValue instanceof String) {
-      return setDefaultString((String) defaultValue);
-    } else if (defaultValue instanceof byte[]) {
-      return setDefaultRaw((byte[]) defaultValue);
-    } else if (defaultValue instanceof boolean[]) {
-      return setDefaultBooleanArray((boolean[]) defaultValue);
-    } else if (defaultValue instanceof long[]) {
-      return setDefaultIntegerArray((long[]) defaultValue);
-    } else if (defaultValue instanceof float[]) {
-      return setDefaultFloatArray((float[]) defaultValue);
-    } else if (defaultValue instanceof double[]) {
-      return setDefaultDoubleArray((double[]) defaultValue);
-    } else if (defaultValue instanceof Boolean[]) {
-      return setDefaultBooleanArray((Boolean[]) defaultValue);
-    } else if (defaultValue instanceof Long[]) {
-      return setDefaultIntegerArray((Long[]) defaultValue);
-    } else if (defaultValue instanceof Float[]) {
-      return setDefaultFloatArray((Float[]) defaultValue);
-    } else if (defaultValue instanceof Number[]) {
-      return setDefaultNumberArray((Number[]) defaultValue);
-    } else if (defaultValue instanceof String[]) {
-      return setDefaultStringArray((String[]) defaultValue);
-    } else {
-      throw new IllegalArgumentException(
+      case Boolean value -> setDefaultBoolean(value);
+      case Integer value -> setDefaultInteger(value);
+      case Float value -> setDefaultFloat(value);
+      case Number value -> setDefaultNumber(value);
+      case String value -> setDefaultString(value);
+      case byte[] value -> setDefaultRaw(value);
+      case boolean[] value -> setDefaultBooleanArray(value);
+      case long[] value -> setDefaultIntegerArray(value);
+      case float[] value -> setDefaultFloatArray(value);
+      case double[] value -> setDefaultDoubleArray(value);
+      case Boolean[] value -> setDefaultBooleanArray(value);
+      case Long[] value -> setDefaultIntegerArray(value);
+      case Float[] value -> setDefaultFloatArray(value);
+      case Number[] value -> setDefaultNumberArray(value);
+      case String[] value -> setDefaultStringArray(value);
+      default -> throw new IllegalArgumentException(
           "Value of type " + defaultValue.getClass().getName() + " cannot be put into a table");
-    }
+    };
   }
 {% for t in types %}
   /**
@@ -371,72 +345,51 @@ public final class NetworkTableEntry implements Publisher, Subscriber {
    * @throws IllegalArgumentException if the value is not a known type
    */
   public boolean setValue(Object value) {
-    if (value instanceof NetworkTableValue) {
-      long time = ((NetworkTableValue) value).getTime();
-      Object otherValue = ((NetworkTableValue) value).getValue();
-      switch (((NetworkTableValue) value).getType()) {
-        case BOOLEAN:
-          return NetworkTablesJNI.setBoolean(m_handle, time, (Boolean) otherValue);
-        case INTEGER:
-          return NetworkTablesJNI.setInteger(
+    return switch (value) {
+      case NetworkTableValue ntValue -> {
+        long time = ntValue.getTime();
+        Object otherValue = ntValue.getValue();
+        yield switch (ntValue.getType()) {
+          case BOOLEAN -> NetworkTablesJNI.setBoolean(m_handle, time, (Boolean) otherValue);
+          case INTEGER -> NetworkTablesJNI.setInteger(
               m_handle, time, ((Number) otherValue).longValue());
-        case FLOAT:
-          return NetworkTablesJNI.setFloat(
+          case FLOAT -> NetworkTablesJNI.setFloat(
               m_handle, time, ((Number) otherValue).floatValue());
-        case DOUBLE:
-          return NetworkTablesJNI.setDouble(
+          case DOUBLE -> NetworkTablesJNI.setDouble(
               m_handle, time, ((Number) otherValue).doubleValue());
-        case STRING:
-          return NetworkTablesJNI.setString(m_handle, time, (String) otherValue);
-        case RAW:
-          return NetworkTablesJNI.setRaw(m_handle, time, (byte[]) otherValue);
-        case BOOLEAN_ARRAY:
-          return NetworkTablesJNI.setBooleanArray(m_handle, time, (boolean[]) otherValue);
-        case INTEGER_ARRAY:
-          return NetworkTablesJNI.setIntegerArray(m_handle, time, (long[]) otherValue);
-        case FLOAT_ARRAY:
-          return NetworkTablesJNI.setFloatArray(m_handle, time, (float[]) otherValue);
-        case DOUBLE_ARRAY:
-          return NetworkTablesJNI.setDoubleArray(m_handle, time, (double[]) otherValue);
-        case STRING_ARRAY:
-          return NetworkTablesJNI.setStringArray(m_handle, time, (String[]) otherValue);
-        default:
-          return true;
+          case STRING -> NetworkTablesJNI.setString(m_handle, time, (String) otherValue);
+          case RAW -> NetworkTablesJNI.setRaw(m_handle, time, (byte[]) otherValue);
+          case BOOLEAN_ARRAY -> NetworkTablesJNI.setBooleanArray(
+              m_handle, time, (boolean[]) otherValue);
+          case INTEGER_ARRAY -> NetworkTablesJNI.setIntegerArray(
+              m_handle, time, (long[]) otherValue);
+          case FLOAT_ARRAY -> NetworkTablesJNI.setFloatArray(
+              m_handle, time, (float[]) otherValue);
+          case DOUBLE_ARRAY -> NetworkTablesJNI.setDoubleArray(
+              m_handle, time, (double[]) otherValue);
+          case STRING_ARRAY -> NetworkTablesJNI.setStringArray(
+              m_handle, time, (String[]) otherValue);
+          default -> true;
+        };
       }
-    } else if (value instanceof Boolean) {
-      return setBoolean((Boolean) value);
-    } else if (value instanceof Long) {
-      return setInteger((Long) value);
-    } else if (value instanceof Float) {
-      return setFloat((Float) value);
-    } else if (value instanceof Number) {
-      return setNumber((Number) value);
-    } else if (value instanceof String) {
-      return setString((String) value);
-    } else if (value instanceof byte[]) {
-      return setRaw((byte[]) value);
-    } else if (value instanceof boolean[]) {
-      return setBooleanArray((boolean[]) value);
-    } else if (value instanceof long[]) {
-      return setIntegerArray((long[]) value);
-    } else if (value instanceof float[]) {
-      return setFloatArray((float[]) value);
-    } else if (value instanceof double[]) {
-      return setDoubleArray((double[]) value);
-    } else if (value instanceof Boolean[]) {
-      return setBooleanArray((Boolean[]) value);
-    } else if (value instanceof Long[]) {
-      return setIntegerArray((Long[]) value);
-    } else if (value instanceof Float[]) {
-      return setFloatArray((Float[]) value);
-    } else if (value instanceof Number[]) {
-      return setNumberArray((Number[]) value);
-    } else if (value instanceof String[]) {
-      return setStringArray((String[]) value);
-    } else {
-      throw new IllegalArgumentException(
+      case Boolean v -> setBoolean(v);
+      case Long v -> setInteger(v);
+      case Float v -> setFloat(v);
+      case Number v -> setNumber(v);
+      case String v -> setString(v);
+      case byte[] v -> setRaw(v);
+      case boolean[] v -> setBooleanArray(v);
+      case long[] v -> setIntegerArray(v);
+      case float[] v -> setFloatArray(v);
+      case double[] v -> setDoubleArray(v);
+      case Boolean[] v -> setBooleanArray(v);
+      case Long[] v -> setIntegerArray(v);
+      case Float[] v -> setFloatArray(v);
+      case Number[] v -> setNumberArray(v);
+      case String[] v -> setStringArray(v);
+      default -> throw new IllegalArgumentException(
           "Value of type " + value.getClass().getName() + " cannot be put into a table");
-    }
+    };
   }
 {% for t in types %}
   /**

--- a/ntcore/src/generated/main/java/org/wpilib/networktables/GenericEntryImpl.java
+++ b/ntcore/src/generated/main/java/org/wpilib/networktables/GenericEntryImpl.java
@@ -501,35 +501,28 @@ final class GenericEntryImpl extends EntryBase implements GenericEntry {
   public boolean setDefault(NetworkTableValue defaultValue) {
     long time = defaultValue.getTime();
     Object otherValue = defaultValue.getValue();
-    switch (defaultValue.getType()) {
-      case BOOLEAN:
-        return NetworkTablesJNI.setDefaultBoolean(m_handle, time, (Boolean) otherValue);
-      case INTEGER:
-        return NetworkTablesJNI.setDefaultInteger(
+    return switch (defaultValue.getType()) {
+      case BOOLEAN -> NetworkTablesJNI.setDefaultBoolean(m_handle, time, (Boolean) otherValue);
+      case INTEGER -> NetworkTablesJNI.setDefaultInteger(
             m_handle, time, ((Number) otherValue).longValue());
-      case FLOAT:
-        return NetworkTablesJNI.setDefaultFloat(
+      case FLOAT -> NetworkTablesJNI.setDefaultFloat(
             m_handle, time, ((Number) otherValue).floatValue());
-      case DOUBLE:
-        return NetworkTablesJNI.setDefaultDouble(
+      case DOUBLE -> NetworkTablesJNI.setDefaultDouble(
             m_handle, time, ((Number) otherValue).doubleValue());
-      case STRING:
-        return NetworkTablesJNI.setDefaultString(m_handle, time, (String) otherValue);
-      case RAW:
-        return NetworkTablesJNI.setDefaultRaw(m_handle, time, (byte[]) otherValue);
-      case BOOLEAN_ARRAY:
-        return NetworkTablesJNI.setDefaultBooleanArray(m_handle, time, (boolean[]) otherValue);
-      case INTEGER_ARRAY:
-        return NetworkTablesJNI.setDefaultIntegerArray(m_handle, time, (long[]) otherValue);
-      case FLOAT_ARRAY:
-        return NetworkTablesJNI.setDefaultFloatArray(m_handle, time, (float[]) otherValue);
-      case DOUBLE_ARRAY:
-        return NetworkTablesJNI.setDefaultDoubleArray(m_handle, time, (double[]) otherValue);
-      case STRING_ARRAY:
-        return NetworkTablesJNI.setDefaultStringArray(m_handle, time, (String[]) otherValue);
-      default:
-        return true;
-    }
+      case STRING -> NetworkTablesJNI.setDefaultString(m_handle, time, (String) otherValue);
+      case RAW -> NetworkTablesJNI.setDefaultRaw(m_handle, time, (byte[]) otherValue);
+      case BOOLEAN_ARRAY -> NetworkTablesJNI.setDefaultBooleanArray(
+          m_handle, time, (boolean[]) otherValue);
+      case INTEGER_ARRAY -> NetworkTablesJNI.setDefaultIntegerArray(
+          m_handle, time, (long[]) otherValue);
+      case FLOAT_ARRAY -> NetworkTablesJNI.setDefaultFloatArray(
+          m_handle, time, (float[]) otherValue);
+      case DOUBLE_ARRAY -> NetworkTablesJNI.setDefaultDoubleArray(
+          m_handle, time, (double[]) otherValue);
+      case STRING_ARRAY -> NetworkTablesJNI.setDefaultStringArray(
+          m_handle, time, (String[]) otherValue);
+      default -> true;
+    };
   }
 
   /**

--- a/ntcore/src/generated/main/java/org/wpilib/networktables/GenericEntryImpl.java
+++ b/ntcore/src/generated/main/java/org/wpilib/networktables/GenericEntryImpl.java
@@ -264,42 +264,26 @@ final class GenericEntryImpl extends EntryBase implements GenericEntry {
    */
   @Override
   public boolean setValue(Object value, long time) {
-    if (value instanceof NetworkTableValue) {
-      return set((NetworkTableValue) value);
-    } else if (value instanceof Boolean) {
-      return setBoolean((Boolean) value, time);
-    } else if (value instanceof Long) {
-      return setInteger((Long) value, time);
-    } else if (value instanceof Float) {
-      return setFloat((Float) value, time);
-    } else if (value instanceof Number) {
-      return setNumber((Number) value, time);
-    } else if (value instanceof String) {
-      return setString((String) value, time);
-    } else if (value instanceof byte[]) {
-      return setRaw((byte[]) value, time);
-    } else if (value instanceof boolean[]) {
-      return setBooleanArray((boolean[]) value, time);
-    } else if (value instanceof long[]) {
-      return setIntegerArray((long[]) value, time);
-    } else if (value instanceof float[]) {
-      return setFloatArray((float[]) value, time);
-    } else if (value instanceof double[]) {
-      return setDoubleArray((double[]) value, time);
-    } else if (value instanceof Boolean[]) {
-      return setBooleanArray((Boolean[]) value, time);
-    } else if (value instanceof Long[]) {
-      return setIntegerArray((Long[]) value, time);
-    } else if (value instanceof Float[]) {
-      return setFloatArray((Float[]) value, time);
-    } else if (value instanceof Number[]) {
-      return setNumberArray((Number[]) value, time);
-    } else if (value instanceof String[]) {
-      return setStringArray((String[]) value, time);
-    } else {
-      throw new IllegalArgumentException(
+    return switch (value) {
+      case NetworkTableValue ntValue -> set(ntValue);
+      case Boolean v -> setBoolean(v, time);
+      case Long v -> setInteger(v, time);
+      case Float v -> setFloat(v, time);
+      case Number v -> setNumber(v, time);
+      case String v -> setString(v, time);
+      case byte[] v -> setRaw(v, time);
+      case boolean[] v -> setBooleanArray(v, time);
+      case long[] v -> setIntegerArray(v, time);
+      case float[] v -> setFloatArray(v, time);
+      case double[] v -> setDoubleArray(v, time);
+      case Boolean[] v -> setBooleanArray(v, time);
+      case Long[] v -> setIntegerArray(v, time);
+      case Float[] v -> setFloatArray(v, time);
+      case Number[] v -> setNumberArray(v, time);
+      case String[] v -> setStringArray(v, time);
+      default -> throw new IllegalArgumentException(
           "Value of type " + value.getClass().getName() + " cannot be put into a table");
-    }
+    };
   }
 
 
@@ -557,42 +541,26 @@ final class GenericEntryImpl extends EntryBase implements GenericEntry {
    */
   @Override
   public boolean setDefaultValue(Object defaultValue) {
-    if (defaultValue instanceof NetworkTableValue) {
-      return setDefault((NetworkTableValue) defaultValue);
-    } else if (defaultValue instanceof Boolean) {
-      return setDefaultBoolean((Boolean) defaultValue);
-    } else if (defaultValue instanceof Integer) {
-      return setDefaultInteger((Integer) defaultValue);
-    } else if (defaultValue instanceof Float) {
-      return setDefaultFloat((Float) defaultValue);
-    } else if (defaultValue instanceof Number) {
-      return setDefaultNumber((Number) defaultValue);
-    } else if (defaultValue instanceof String) {
-      return setDefaultString((String) defaultValue);
-    } else if (defaultValue instanceof byte[]) {
-      return setDefaultRaw((byte[]) defaultValue);
-    } else if (defaultValue instanceof boolean[]) {
-      return setDefaultBooleanArray((boolean[]) defaultValue);
-    } else if (defaultValue instanceof long[]) {
-      return setDefaultIntegerArray((long[]) defaultValue);
-    } else if (defaultValue instanceof float[]) {
-      return setDefaultFloatArray((float[]) defaultValue);
-    } else if (defaultValue instanceof double[]) {
-      return setDefaultDoubleArray((double[]) defaultValue);
-    } else if (defaultValue instanceof Boolean[]) {
-      return setDefaultBooleanArray((Boolean[]) defaultValue);
-    } else if (defaultValue instanceof Long[]) {
-      return setDefaultIntegerArray((Long[]) defaultValue);
-    } else if (defaultValue instanceof Float[]) {
-      return setDefaultFloatArray((Float[]) defaultValue);
-    } else if (defaultValue instanceof Number[]) {
-      return setDefaultNumberArray((Number[]) defaultValue);
-    } else if (defaultValue instanceof String[]) {
-      return setDefaultStringArray((String[]) defaultValue);
-    } else {
-      throw new IllegalArgumentException(
+    return switch (defaultValue) {
+      case NetworkTableValue ntValue -> setDefault(ntValue);
+      case Boolean value -> setDefaultBoolean(value);
+      case Integer value -> setDefaultInteger(value);
+      case Float value -> setDefaultFloat(value);
+      case Number value -> setDefaultNumber(value);
+      case String value -> setDefaultString(value);
+      case byte[] value -> setDefaultRaw(value);
+      case boolean[] value -> setDefaultBooleanArray(value);
+      case long[] value -> setDefaultIntegerArray(value);
+      case float[] value -> setDefaultFloatArray(value);
+      case double[] value -> setDefaultDoubleArray(value);
+      case Boolean[] value -> setDefaultBooleanArray(value);
+      case Long[] value -> setDefaultIntegerArray(value);
+      case Float[] value -> setDefaultFloatArray(value);
+      case Number[] value -> setDefaultNumberArray(value);
+      case String[] value -> setDefaultStringArray(value);
+      default -> throw new IllegalArgumentException(
           "Value of type " + defaultValue.getClass().getName() + " cannot be put into a table");
-    }
+    };
   }
 
 

--- a/ntcore/src/generated/main/java/org/wpilib/networktables/NetworkTableEntry.java
+++ b/ntcore/src/generated/main/java/org/wpilib/networktables/NetworkTableEntry.java
@@ -338,21 +338,16 @@ public final class NetworkTableEntry implements Publisher, Subscriber {
    * @return true if the data can be placed in an entry, false if it cannot
    */
   public static boolean isValidDataType(Object data) {
-    return data instanceof Number
-        || data instanceof Boolean
-        || data instanceof String
-        || data instanceof long[]
-        || data instanceof Long[]
-        || data instanceof float[]
-        || data instanceof Float[]
-        || data instanceof double[]
-        || data instanceof Double[]
-        || data instanceof Number[]
-        || data instanceof boolean[]
-        || data instanceof Boolean[]
-        || data instanceof String[]
-        || data instanceof byte[]
-        || data instanceof Byte[];
+    return switch (data) {
+      case Number _, Boolean _, String _ -> true;
+      case byte[] _, Byte[] _ -> true;
+      case boolean[] _, Boolean[] _ -> true;
+      case long[] _, Long[] _ -> true;
+      case float[] _, Float[] _ -> true;
+      case double[] _, Double[] _, Number[] _ -> true;
+      case String[] _ -> true;
+      case null, default -> false;
+    };
   }
 
   /**
@@ -363,72 +358,51 @@ public final class NetworkTableEntry implements Publisher, Subscriber {
    * @throws IllegalArgumentException if the value is not a known type
    */
   public boolean setDefaultValue(Object defaultValue) {
-    if (defaultValue instanceof NetworkTableValue) {
-      long time = ((NetworkTableValue) defaultValue).getTime();
-      Object otherValue = ((NetworkTableValue) defaultValue).getValue();
-      switch (((NetworkTableValue) defaultValue).getType()) {
-        case BOOLEAN:
-          return NetworkTablesJNI.setDefaultBoolean(m_handle, time, (Boolean) otherValue);
-        case INTEGER:
-          return NetworkTablesJNI.setDefaultInteger(
+    return switch (defaultValue) {
+      case NetworkTableValue ntValue -> {
+        long time = ntValue.getTime();
+        Object otherValue = ntValue.getValue();
+        yield switch (ntValue.getType()) {
+          case BOOLEAN -> NetworkTablesJNI.setDefaultBoolean(m_handle, time, (Boolean) otherValue);
+          case INTEGER -> NetworkTablesJNI.setDefaultInteger(
               m_handle, time, ((Number) otherValue).longValue());
-        case FLOAT:
-          return NetworkTablesJNI.setDefaultFloat(
+          case FLOAT -> NetworkTablesJNI.setDefaultFloat(
               m_handle, time, ((Number) otherValue).floatValue());
-        case DOUBLE:
-          return NetworkTablesJNI.setDefaultDouble(
+          case DOUBLE -> NetworkTablesJNI.setDefaultDouble(
               m_handle, time, ((Number) otherValue).doubleValue());
-        case STRING:
-          return NetworkTablesJNI.setDefaultString(m_handle, time, (String) otherValue);
-        case RAW:
-          return NetworkTablesJNI.setDefaultRaw(m_handle, time, (byte[]) otherValue);
-        case BOOLEAN_ARRAY:
-          return NetworkTablesJNI.setDefaultBooleanArray(m_handle, time, (boolean[]) otherValue);
-        case INTEGER_ARRAY:
-          return NetworkTablesJNI.setDefaultIntegerArray(m_handle, time, (long[]) otherValue);
-        case FLOAT_ARRAY:
-          return NetworkTablesJNI.setDefaultFloatArray(m_handle, time, (float[]) otherValue);
-        case DOUBLE_ARRAY:
-          return NetworkTablesJNI.setDefaultDoubleArray(m_handle, time, (double[]) otherValue);
-        case STRING_ARRAY:
-          return NetworkTablesJNI.setDefaultStringArray(m_handle, time, (String[]) otherValue);
-        default:
-          return true;
+          case STRING -> NetworkTablesJNI.setDefaultString(m_handle, time, (String) otherValue);
+          case RAW -> NetworkTablesJNI.setDefaultRaw(m_handle, time, (byte[]) otherValue);
+          case BOOLEAN_ARRAY -> NetworkTablesJNI.setDefaultBooleanArray(
+              m_handle, time, (boolean[]) otherValue);
+          case INTEGER_ARRAY -> NetworkTablesJNI.setDefaultIntegerArray(
+              m_handle, time, (long[]) otherValue);
+          case FLOAT_ARRAY -> NetworkTablesJNI.setDefaultFloatArray(
+              m_handle, time, (float[]) otherValue);
+          case DOUBLE_ARRAY -> NetworkTablesJNI.setDefaultDoubleArray(
+              m_handle, time, (double[]) otherValue);
+          case STRING_ARRAY -> NetworkTablesJNI.setDefaultStringArray(
+              m_handle, time, (String[]) otherValue);
+          default -> true;
+        };
       }
-    } else if (defaultValue instanceof Boolean) {
-      return setDefaultBoolean((Boolean) defaultValue);
-    } else if (defaultValue instanceof Integer) {
-      return setDefaultInteger((Integer) defaultValue);
-    } else if (defaultValue instanceof Float) {
-      return setDefaultFloat((Float) defaultValue);
-    } else if (defaultValue instanceof Number) {
-      return setDefaultNumber((Number) defaultValue);
-    } else if (defaultValue instanceof String) {
-      return setDefaultString((String) defaultValue);
-    } else if (defaultValue instanceof byte[]) {
-      return setDefaultRaw((byte[]) defaultValue);
-    } else if (defaultValue instanceof boolean[]) {
-      return setDefaultBooleanArray((boolean[]) defaultValue);
-    } else if (defaultValue instanceof long[]) {
-      return setDefaultIntegerArray((long[]) defaultValue);
-    } else if (defaultValue instanceof float[]) {
-      return setDefaultFloatArray((float[]) defaultValue);
-    } else if (defaultValue instanceof double[]) {
-      return setDefaultDoubleArray((double[]) defaultValue);
-    } else if (defaultValue instanceof Boolean[]) {
-      return setDefaultBooleanArray((Boolean[]) defaultValue);
-    } else if (defaultValue instanceof Long[]) {
-      return setDefaultIntegerArray((Long[]) defaultValue);
-    } else if (defaultValue instanceof Float[]) {
-      return setDefaultFloatArray((Float[]) defaultValue);
-    } else if (defaultValue instanceof Number[]) {
-      return setDefaultNumberArray((Number[]) defaultValue);
-    } else if (defaultValue instanceof String[]) {
-      return setDefaultStringArray((String[]) defaultValue);
-    } else {
-      throw new IllegalArgumentException(
+      case Boolean value -> setDefaultBoolean(value);
+      case Integer value -> setDefaultInteger(value);
+      case Float value -> setDefaultFloat(value);
+      case Number value -> setDefaultNumber(value);
+      case String value -> setDefaultString(value);
+      case byte[] value -> setDefaultRaw(value);
+      case boolean[] value -> setDefaultBooleanArray(value);
+      case long[] value -> setDefaultIntegerArray(value);
+      case float[] value -> setDefaultFloatArray(value);
+      case double[] value -> setDefaultDoubleArray(value);
+      case Boolean[] value -> setDefaultBooleanArray(value);
+      case Long[] value -> setDefaultIntegerArray(value);
+      case Float[] value -> setDefaultFloatArray(value);
+      case Number[] value -> setDefaultNumberArray(value);
+      case String[] value -> setDefaultStringArray(value);
+      default -> throw new IllegalArgumentException(
           "Value of type " + defaultValue.getClass().getName() + " cannot be put into a table");
-    }
+    };
   }
 
   /**
@@ -644,72 +618,51 @@ public final class NetworkTableEntry implements Publisher, Subscriber {
    * @throws IllegalArgumentException if the value is not a known type
    */
   public boolean setValue(Object value) {
-    if (value instanceof NetworkTableValue) {
-      long time = ((NetworkTableValue) value).getTime();
-      Object otherValue = ((NetworkTableValue) value).getValue();
-      switch (((NetworkTableValue) value).getType()) {
-        case BOOLEAN:
-          return NetworkTablesJNI.setBoolean(m_handle, time, (Boolean) otherValue);
-        case INTEGER:
-          return NetworkTablesJNI.setInteger(
+    return switch (value) {
+      case NetworkTableValue ntValue -> {
+        long time = ntValue.getTime();
+        Object otherValue = ntValue.getValue();
+        yield switch (ntValue.getType()) {
+          case BOOLEAN -> NetworkTablesJNI.setBoolean(m_handle, time, (Boolean) otherValue);
+          case INTEGER -> NetworkTablesJNI.setInteger(
               m_handle, time, ((Number) otherValue).longValue());
-        case FLOAT:
-          return NetworkTablesJNI.setFloat(
+          case FLOAT -> NetworkTablesJNI.setFloat(
               m_handle, time, ((Number) otherValue).floatValue());
-        case DOUBLE:
-          return NetworkTablesJNI.setDouble(
+          case DOUBLE -> NetworkTablesJNI.setDouble(
               m_handle, time, ((Number) otherValue).doubleValue());
-        case STRING:
-          return NetworkTablesJNI.setString(m_handle, time, (String) otherValue);
-        case RAW:
-          return NetworkTablesJNI.setRaw(m_handle, time, (byte[]) otherValue);
-        case BOOLEAN_ARRAY:
-          return NetworkTablesJNI.setBooleanArray(m_handle, time, (boolean[]) otherValue);
-        case INTEGER_ARRAY:
-          return NetworkTablesJNI.setIntegerArray(m_handle, time, (long[]) otherValue);
-        case FLOAT_ARRAY:
-          return NetworkTablesJNI.setFloatArray(m_handle, time, (float[]) otherValue);
-        case DOUBLE_ARRAY:
-          return NetworkTablesJNI.setDoubleArray(m_handle, time, (double[]) otherValue);
-        case STRING_ARRAY:
-          return NetworkTablesJNI.setStringArray(m_handle, time, (String[]) otherValue);
-        default:
-          return true;
+          case STRING -> NetworkTablesJNI.setString(m_handle, time, (String) otherValue);
+          case RAW -> NetworkTablesJNI.setRaw(m_handle, time, (byte[]) otherValue);
+          case BOOLEAN_ARRAY -> NetworkTablesJNI.setBooleanArray(
+              m_handle, time, (boolean[]) otherValue);
+          case INTEGER_ARRAY -> NetworkTablesJNI.setIntegerArray(
+              m_handle, time, (long[]) otherValue);
+          case FLOAT_ARRAY -> NetworkTablesJNI.setFloatArray(
+              m_handle, time, (float[]) otherValue);
+          case DOUBLE_ARRAY -> NetworkTablesJNI.setDoubleArray(
+              m_handle, time, (double[]) otherValue);
+          case STRING_ARRAY -> NetworkTablesJNI.setStringArray(
+              m_handle, time, (String[]) otherValue);
+          default -> true;
+        };
       }
-    } else if (value instanceof Boolean) {
-      return setBoolean((Boolean) value);
-    } else if (value instanceof Long) {
-      return setInteger((Long) value);
-    } else if (value instanceof Float) {
-      return setFloat((Float) value);
-    } else if (value instanceof Number) {
-      return setNumber((Number) value);
-    } else if (value instanceof String) {
-      return setString((String) value);
-    } else if (value instanceof byte[]) {
-      return setRaw((byte[]) value);
-    } else if (value instanceof boolean[]) {
-      return setBooleanArray((boolean[]) value);
-    } else if (value instanceof long[]) {
-      return setIntegerArray((long[]) value);
-    } else if (value instanceof float[]) {
-      return setFloatArray((float[]) value);
-    } else if (value instanceof double[]) {
-      return setDoubleArray((double[]) value);
-    } else if (value instanceof Boolean[]) {
-      return setBooleanArray((Boolean[]) value);
-    } else if (value instanceof Long[]) {
-      return setIntegerArray((Long[]) value);
-    } else if (value instanceof Float[]) {
-      return setFloatArray((Float[]) value);
-    } else if (value instanceof Number[]) {
-      return setNumberArray((Number[]) value);
-    } else if (value instanceof String[]) {
-      return setStringArray((String[]) value);
-    } else {
-      throw new IllegalArgumentException(
+      case Boolean v -> setBoolean(v);
+      case Long v -> setInteger(v);
+      case Float v -> setFloat(v);
+      case Number v -> setNumber(v);
+      case String v -> setString(v);
+      case byte[] v -> setRaw(v);
+      case boolean[] v -> setBooleanArray(v);
+      case long[] v -> setIntegerArray(v);
+      case float[] v -> setFloatArray(v);
+      case double[] v -> setDoubleArray(v);
+      case Boolean[] v -> setBooleanArray(v);
+      case Long[] v -> setIntegerArray(v);
+      case Float[] v -> setFloatArray(v);
+      case Number[] v -> setNumberArray(v);
+      case String[] v -> setStringArray(v);
+      default -> throw new IllegalArgumentException(
           "Value of type " + value.getClass().getName() + " cannot be put into a table");
-    }
+    };
   }
 
   /**

--- a/ntcore/src/main/java/org/wpilib/networktables/NetworkTableType.java
+++ b/ntcore/src/main/java/org/wpilib/networktables/NetworkTableType.java
@@ -110,33 +110,23 @@ public enum NetworkTableType {
    * @return type string of the data, or empty string if no match
    */
   public static String getStringFromObject(Object data) {
-    if (data instanceof Boolean) {
-      return "boolean";
-    } else if (data instanceof Float) {
-      return "float";
-    } else if (data instanceof Long) {
+    return switch (data) {
+      case Boolean _ -> "boolean";
+      case Float _ -> "float";
       // Checking Long because NT supports 64-bit integers
-      return "int";
-    } else if (data instanceof Double || data instanceof Number) {
+      case Long _ -> "int";
       // If typeof Number class, return "double" as the type. Functions as a "catch-all".
-      return "double";
-    } else if (data instanceof String) {
-      return "string";
-    } else if (data instanceof boolean[] || data instanceof Boolean[]) {
-      return "boolean[]";
-    } else if (data instanceof float[] || data instanceof Float[]) {
-      return "float[]";
-    } else if (data instanceof long[] || data instanceof Long[]) {
-      return "int[]";
-    } else if (data instanceof double[] || data instanceof Double[] || data instanceof Number[]) {
+      case Number _ -> "double";
+      case String _ -> "string";
+      case boolean[] _, Boolean[] _ -> "boolean[]";
+      case float[] _, Float[] _ -> "float[]";
+      case long[] _, Long[] _ -> "int[]";
       // If typeof Number class, return "double[]" as the type. Functions as a "catch-all".
-      return "double[]";
-    } else if (data instanceof String[]) {
-      return "string[]";
-    } else if (data instanceof byte[] || data instanceof Byte[]) {
-      return "raw";
-    } else {
-      return "";
-    }
+      case double[] _, Double[] _, Number[] _ -> "double[]";
+      case String[] _ -> "string[]";
+      case byte[] _ -> "raw";
+      case null -> "";
+      default -> "";
+    };
   }
 }

--- a/ntcore/src/main/java/org/wpilib/networktables/NetworkTableType.java
+++ b/ntcore/src/main/java/org/wpilib/networktables/NetworkTableType.java
@@ -118,7 +118,7 @@ public enum NetworkTableType {
       // If typeof Number class, return "double" as the type. Functions as a "catch-all".
       case Number _ -> "double";
       case String _ -> "string";
-      case byte[] _ -> "raw";
+      case byte[] _, Byte[] _ -> "raw";
       case boolean[] _, Boolean[] _ -> "boolean[]";
       case float[] _, Float[] _ -> "float[]";
       case long[] _, Long[] _ -> "int[]";

--- a/ntcore/src/main/java/org/wpilib/networktables/NetworkTableType.java
+++ b/ntcore/src/main/java/org/wpilib/networktables/NetworkTableType.java
@@ -125,8 +125,7 @@ public enum NetworkTableType {
       // If typeof Number class, return "double[]" as the type. Functions as a "catch-all".
       case double[] _, Double[] _, Number[] _ -> "double[]";
       case String[] _ -> "string[]";
-      case null -> "";
-      default -> "";
+      case null, default -> "";
     };
   }
 }

--- a/ntcore/src/main/java/org/wpilib/networktables/NetworkTableType.java
+++ b/ntcore/src/main/java/org/wpilib/networktables/NetworkTableType.java
@@ -118,13 +118,13 @@ public enum NetworkTableType {
       // If typeof Number class, return "double" as the type. Functions as a "catch-all".
       case Number _ -> "double";
       case String _ -> "string";
+      case byte[] _ -> "raw";
       case boolean[] _, Boolean[] _ -> "boolean[]";
       case float[] _, Float[] _ -> "float[]";
       case long[] _, Long[] _ -> "int[]";
       // If typeof Number class, return "double[]" as the type. Functions as a "catch-all".
       case double[] _, Double[] _, Number[] _ -> "double[]";
       case String[] _ -> "string[]";
-      case byte[] _ -> "raw";
       case null -> "";
       default -> "";
     };

--- a/wpiunits/src/main/java/org/wpilib/units/Measure.java
+++ b/wpiunits/src/main/java/org/wpilib/units/Measure.java
@@ -205,60 +205,36 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
       return multiplier.times(baseUnitMagnitude());
     }
 
-    if (multiplier instanceof Acceleration<?> acceleration) {
-      return times(acceleration);
-    } else if (multiplier instanceof Angle angle) {
-      return times(angle);
-    } else if (multiplier instanceof AngularAcceleration angularAcceleration) {
-      return times(angularAcceleration);
-    } else if (multiplier instanceof AngularMomentum angularMomentum) {
-      return times(angularMomentum);
-    } else if (multiplier instanceof AngularVelocity angularVelocity) {
-      return times(angularVelocity);
-    } else if (multiplier instanceof Current current) {
-      return times(current);
-    } else if (multiplier instanceof Dimensionless dimensionless) {
+    return switch (multiplier) {
+      case Acceleration<?> acceleration -> times(acceleration);
+      case Angle angle -> times(angle);
+      case AngularAcceleration angularAcceleration -> times(angularAcceleration);
+      case AngularMomentum angularMomentum -> times(angularMomentum);
+      case AngularVelocity angularVelocity -> times(angularVelocity);
+      case Current current -> times(current);
       // n.b. this case should already be covered
-      return times(dimensionless);
-    } else if (multiplier instanceof Distance distance) {
-      return times(distance);
-    } else if (multiplier instanceof Energy energy) {
-      return times(energy);
-    } else if (multiplier instanceof Force force) {
-      return times(force);
-    } else if (multiplier instanceof Frequency frequency) {
-      return times(frequency);
-    } else if (multiplier instanceof LinearAcceleration linearAcceleration) {
-      return times(linearAcceleration);
-    } else if (multiplier instanceof LinearVelocity linearVelocity) {
-      return times(linearVelocity);
-    } else if (multiplier instanceof Mass mass) {
-      return times(mass);
-    } else if (multiplier instanceof MomentOfInertia momentOfInertia) {
-      return times(momentOfInertia);
-    } else if (multiplier instanceof Mult<?, ?> mult) {
-      return times(mult);
-    } else if (multiplier instanceof Per<?, ?> per) {
-      return times(per);
-    } else if (multiplier instanceof Power power) {
-      return times(power);
-    } else if (multiplier instanceof Temperature temperature) {
-      return times(temperature);
-    } else if (multiplier instanceof Time time) {
-      return times(time);
-    } else if (multiplier instanceof Torque torque) {
-      return times(torque);
-    } else if (multiplier instanceof Velocity<?> velocity) {
-      return times(velocity);
-    } else if (multiplier instanceof Voltage voltage) {
-      return times(voltage);
-    } else if (multiplier instanceof Resistance resistance) {
-      return times(resistance);
-    } else {
+      case Dimensionless dimensionless -> times(dimensionless);
+      case Distance distance -> times(distance);
+      case Energy energy -> times(energy);
+      case Force force -> times(force);
+      case Frequency frequency -> times(frequency);
+      case LinearAcceleration linearAcceleration -> times(linearAcceleration);
+      case LinearVelocity linearVelocity -> times(linearVelocity);
+      case Mass mass -> times(mass);
+      case MomentOfInertia momentOfInertia -> times(momentOfInertia);
+      case Mult<?, ?> mult -> times(mult);
+      case Per<?, ?> per -> times(per);
+      case Power power -> times(power);
+      case Temperature temperature -> times(temperature);
+      case Time time -> times(time);
+      case Torque torque -> times(torque);
+      case Velocity<?> velocity -> times(velocity);
+      case Voltage voltage -> times(voltage);
+      case Resistance resistance -> times(resistance);
       // Dimensional analysis fallthrough or a generic input measure type
       // Do a basic unit multiplication
-      return MultUnit.combine(unit(), multiplier.unit()).ofBaseUnits(baseUnitResult);
-    }
+      default -> MultUnit.combine(unit(), multiplier.unit()).ofBaseUnits(baseUnitResult);
+    };
   }
 
   /**
@@ -653,60 +629,36 @@ public interface Measure<U extends Unit> extends Comparable<Measure<U>> {
       return VelocityUnit.combine(unit(), time).ofBaseUnits(baseUnitResult);
     }
 
-    if (divisor instanceof Acceleration<?> acceleration) {
-      return div(acceleration);
-    } else if (divisor instanceof Angle angle) {
-      return div(angle);
-    } else if (divisor instanceof AngularAcceleration angularAcceleration) {
-      return div(angularAcceleration);
-    } else if (divisor instanceof AngularMomentum angularMomentum) {
-      return div(angularMomentum);
-    } else if (divisor instanceof AngularVelocity angularVelocity) {
-      return div(angularVelocity);
-    } else if (divisor instanceof Current current) {
-      return div(current);
-    } else if (divisor instanceof Dimensionless dimensionless) {
+    return switch (divisor) {
+      case Acceleration<?> acceleration -> div(acceleration);
+      case Angle angle -> div(angle);
+      case AngularAcceleration angularAcceleration -> div(angularAcceleration);
+      case AngularMomentum angularMomentum -> div(angularMomentum);
+      case AngularVelocity angularVelocity -> div(angularVelocity);
+      case Current current -> div(current);
       // n.b. this case should already be covered
-      return div(dimensionless);
-    } else if (divisor instanceof Distance distance) {
-      return div(distance);
-    } else if (divisor instanceof Energy energy) {
-      return div(energy);
-    } else if (divisor instanceof Force force) {
-      return div(force);
-    } else if (divisor instanceof Frequency frequency) {
-      return div(frequency);
-    } else if (divisor instanceof LinearAcceleration linearAcceleration) {
-      return div(linearAcceleration);
-    } else if (divisor instanceof LinearVelocity linearVelocity) {
-      return div(linearVelocity);
-    } else if (divisor instanceof Mass mass) {
-      return div(mass);
-    } else if (divisor instanceof MomentOfInertia momentOfInertia) {
-      return div(momentOfInertia);
-    } else if (divisor instanceof Mult<?, ?> mult) {
-      return div(mult);
-    } else if (divisor instanceof Per<?, ?> per) {
-      return div(per);
-    } else if (divisor instanceof Power power) {
-      return div(power);
-    } else if (divisor instanceof Temperature temperature) {
-      return div(temperature);
-    } else if (divisor instanceof Time time) {
-      return div(time);
-    } else if (divisor instanceof Torque torque) {
-      return div(torque);
-    } else if (divisor instanceof Velocity<?> velocity) {
-      return div(velocity);
-    } else if (divisor instanceof Voltage voltage) {
-      return div(voltage);
-    } else if (divisor instanceof Resistance resistance) {
-      return div(resistance);
-    } else {
+      case Dimensionless dimensionless -> div(dimensionless);
+      case Distance distance -> div(distance);
+      case Energy energy -> div(energy);
+      case Force force -> div(force);
+      case Frequency frequency -> div(frequency);
+      case LinearAcceleration linearAcceleration -> div(linearAcceleration);
+      case LinearVelocity linearVelocity -> div(linearVelocity);
+      case Mass mass -> div(mass);
+      case MomentOfInertia momentOfInertia -> div(momentOfInertia);
+      case Mult<?, ?> mult -> div(mult);
+      case Per<?, ?> per -> div(per);
+      case Power power -> div(power);
+      case Temperature temperature -> div(temperature);
+      case Time time -> div(time);
+      case Torque torque -> div(torque);
+      case Velocity<?> velocity -> div(velocity);
+      case Voltage voltage -> div(voltage);
+      case Resistance resistance -> div(resistance);
       // Dimensional analysis fallthrough or a generic input measure type
       // Do a basic unit multiplication
-      return PerUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitResult);
-    }
+      default -> PerUnit.combine(unit(), divisor.unit()).ofBaseUnits(baseUnitResult);
+    };
   }
 
   /**


### PR DESCRIPTION
Use [pattern matching switch expressions](https://docs.oracle.com/en/java/javase/17/language/pattern-matching-switch.html) where possible. This is a JVM 21+ feature which wasn't available until recently.

If you look at the Java bytecode, this improves performance from an O(n) runtime check of literally each of the `if (x instanceof y)` checks to instead be an O(1) tableswitch.