### PR TITLE
[ntcore] Fix unbounded memory size tracker

### DIFF
--- a/ntcore/src/main/native/cpp/net/ClientMessageQueue.hpp
+++ b/ntcore/src/main/native/cpp/net/ClientMessageQueue.hpp
@@ -106,14 +106,15 @@ class ClientMessageQueueImpl final : public ClientMessageHandler,
   void ClientSetValue(int pubuid, const Value& value) final {
     std::scoped_lock lock{m_mutex};
     if constexpr (MaxValueSize != 0) {
-      m_valueSize.size += sizeof(ClientMessage) + value.size();
-      if (m_valueSize.size > MaxValueSize) {
+      size_t addedSize = sizeof(ClientMessage) + value.size();
+      if (m_valueSize.size + addedSize > MaxValueSize) {
         if (!m_valueSize.errored) {
           WPI_ERROR(m_logger, "NT: dropping value set due to memory limits");
           m_valueSize.errored = true;
         }
         return;  // avoid potential out of memory
       }
+      m_valueSize.size += addedSize;
     }
     m_queue.enqueue(ClientMessage{ClientValueMsg{pubuid, value}});
   }


### PR DESCRIPTION
If a `ClientMessageQueue` in `ntcore` (as typically underlies NetworkTables topics and seemingly other related machinery) is at a memory limit, `ClientMessageQueueImpl::ClientSetValue` will still increment `m_valueSize.size` even though no element has actually been actually been added.

This quickly results in things like topics completely shutting down under high load, as no new elements can be added as `m_valueSize.size` explodes to infinity unless `ClearQueue()` is explicitly called. You can see this pretty easily with the following code, be it in sim or on a robot:

```cpp
#include "wpi/framework/TimedRobot.hpp"
#include "wpi/smartdashboard/SmartDashboard.hpp"
class Robot : public wpi::TimedRobot {
  public:
  // ...
  uint64_t value{0};
  /**
   * This function is called periodically during all modes
   */
  void RobotPeriodic() override {
    for (int i = 0; i < 1'000'000; i++) {
      value += 1;
      wpi::SmartDashboard::PutNumber("value", value);
    }
  }
}
```

Connecting via your favorite dashboard quickly reveals that no new values get added after a while. However, with this patch implemented, values do still continue to increment as updates gradually get serviced.

Notably, **SystemCore's increased resources wouldn't fix this at all**, as any sufficient data shoved into NT in a short amount of time will hit this bug. I ran the above reproducer on an AMD Ryzen 7950x3d running at up to 5.7 GHz, which is moderately more powerful than either a roboRIO or a SystemCore.

This seems to be the likely fix for issues like these:
* https://www.chiefdelphi.com/t/network-tables-dropping-value-due-to-memory-limit/515407
* https://discord.com/channels/176186766946992128/1365422855378178048/1494041773993889953

It also seems to explain our [need to restart our robot code whenever connection to our vision coprocessor interrupted](https://youtu.be/_z2VioVj00E&t=30) as whatever was happening on coprocessor reconnect was immediately bricking critical `ntcore` queues because of this bug.

-----

I, personally, would be very, _very_ interested in the prospect of backporting this fix to 2026 somehow. I don't want to suffer through all of offseason constantly restarting robot code. I know that 2026 development is dead at this point, but the Rio isn't dead to me until my team can actually hold a SystemCore and put it on a robot. 