### PR TITLE
[ntcore] NetworkClient: Add IsLoopClosing() guard in deferred disconnect timer

### DIFF
--- a/ntcore/src/main/native/cpp/NetworkClient.cpp
+++ b/ntcore/src/main/native/cpp/NetworkClient.cpp
@@ -285,11 +285,11 @@ void NetworkClient::WsConnected(wpi::net::WebSocket& ws, uv::Tcp& tcp,
       uv::Timer::SingleShot(
           m_loop, uv::Timer::Time{0},
           [this, reason = std::string{reason}, keepws = ws.shared_from_this()] {
-            // Check that the connection is still alive (this may fire after
-            // ~NetworkClient if the loop processes the timer between
-            // ExecSync and Stop). keepws ensures the WebSocket object is
-            // still valid for this check.
-            if (keepws->GetStream().IsLoopClosing()) {
+            // Check that the loop is not shutting down. keepws->GetStream()
+            // would dereference the underlying uv::Tcp which may have been
+            // destroyed after Handle::Close() released its self-reference.
+            // m_loop is safe to access as long as `this` is alive.
+            if (m_loop.IsClosing()) {
               return;
             }
             DoDisconnect(reason);

--- a/ntcore/src/main/native/cpp/NetworkClient.cpp
+++ b/ntcore/src/main/native/cpp/NetworkClient.cpp
@@ -285,6 +285,13 @@ void NetworkClient::WsConnected(wpi::net::WebSocket& ws, uv::Tcp& tcp,
       uv::Timer::SingleShot(
           m_loop, uv::Timer::Time{0},
           [this, reason = std::string{reason}, keepws = ws.shared_from_this()] {
+            // Check that the connection is still alive (this may fire after
+            // ~NetworkClient if the loop processes the timer between
+            // ExecSync and Stop). keepws ensures the WebSocket object is
+            // still valid for this check.
+            if (keepws->GetStream().IsLoopClosing()) {
+              return;
+            }
             DoDisconnect(reason);
           });
     }


### PR DESCRIPTION
## Issue
The deferred disconnect timer uses `SingleShot(m_loop, Time{0}, ...)` which fires on the next loop iteration. If the `NetworkClient` is destroyed between scheduling and firing (destructor runs `ExecSync` then `Stop`), the captured `this` pointer becomes dangling, causing a use-after-free when the callback calls `DoDisconnect()`.

## Fix
Add an `IsLoopClosing()` check via the captured `keepws` shared_ptr before calling `DoDisconnect()`. When the loop is closing (as during `Stop()`), the callback returns safely without accessing the potentially-destroyed `this`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)