### PR TITLE
Fix #H1-H3: Fix valuePos staleness in NetworkOutgoingQueue

### DIFF
--- a/ntcore/src/main/native/cpp/net/NetworkOutgoingQueue.hpp
+++ b/ntcore/src/main/native/cpp/net/NetworkOutgoingQueue.hpp
@@ -95,29 +95,38 @@ class NetworkOutgoingQueue {
     auto [infoIt, created] = m_idMap.try_emplace(id);
     if (!created && infoIt->getSecond().queueIndex != queueIndex) {
       // need to move any items from old queue to new queue
-      auto& oldMsgs = m_queues[infoIt->getSecond().queueIndex].msgs;
+      auto oldQueueIndex = infoIt->getSecond().queueIndex;
+      auto& oldMsgs = m_queues[oldQueueIndex].msgs;
+
+      // Before stable_partition, recompute valuePos for every publisher in
+      // the old queue. stable_partition shifts non-removed elements toward
+      // the front, so a saved index that falls after any removed element is
+      // now too large by the number of removed elements before it.
+      // Entries whose saved slot is itself being moved out are invalidated.
+      for (auto&& kv : m_idMap) {
+        auto& info = kv.getSecond();
+        if (info.queueIndex == oldQueueIndex && info.valuePos != -1) {
+          size_t vp = static_cast<size_t>(info.valuePos);
+          if (vp < oldMsgs.size() && oldMsgs[vp].id == id) {
+            info.valuePos = -1;  // this publisher's slot is being moved out
+          } else {
+            // shift left by the number of 'id' elements before vp
+            int shift = static_cast<int>(
+                std::count_if(oldMsgs.begin(), oldMsgs.begin() + vp,
+                              [id](const auto& e) { return e.id == id; }));
+            info.valuePos -= shift;
+          }
+        }
+      }
+
       auto it =
           std::stable_partition(oldMsgs.begin(), oldMsgs.end(),
                                 [&](const auto& e) { return e.id != id; });
-      // save partition point for valuePos adjustment
-      size_t partIdx = it - oldMsgs.begin();
       auto& newMsgs = m_queues[queueIndex].msgs;
       for (auto i = it; i != oldMsgs.end(); ++i) {
         newMsgs.emplace_back(std::move(*i));
       }
-      oldMsgs.erase(oldMsgs.begin() + partIdx, oldMsgs.end());
-
-      // adjust valuePos for other publishers still in the old queue:
-      // any valuePos that pointed to or past the partition boundary
-      // (into the removed region) is now stale
-      auto oldQueueIndex = infoIt->getSecond().queueIndex;
-      for (auto&& kv : m_idMap) {
-        auto& info = kv.getSecond();
-        if (info.queueIndex == oldQueueIndex && info.valuePos != -1 &&
-            static_cast<size_t>(info.valuePos) >= partIdx) {
-          info.valuePos = -1;
-        }
-      }
+      oldMsgs.erase(it, oldMsgs.end());
     }
 
     infoIt->getSecond().queueIndex = queueIndex;

--- a/ntcore/src/main/native/cpp/net/NetworkOutgoingQueue.hpp
+++ b/ntcore/src/main/native/cpp/net/NetworkOutgoingQueue.hpp
@@ -99,11 +99,25 @@ class NetworkOutgoingQueue {
       auto it =
           std::stable_partition(oldMsgs.begin(), oldMsgs.end(),
                                 [&](const auto& e) { return e.id != id; });
+      // save partition point for valuePos adjustment
+      size_t partIdx = it - oldMsgs.begin();
       auto& newMsgs = m_queues[queueIndex].msgs;
-      for (auto i = it, end = oldMsgs.end(); i != end; ++i) {
+      for (auto i = it; i != oldMsgs.end(); ++i) {
         newMsgs.emplace_back(std::move(*i));
       }
-      oldMsgs.erase(it, oldMsgs.end());
+      oldMsgs.erase(oldMsgs.begin() + partIdx, oldMsgs.end());
+
+      // adjust valuePos for other publishers still in the old queue:
+      // any valuePos that pointed to or past the partition boundary
+      // (into the removed region) is now stale
+      auto oldQueueIndex = infoIt->getSecond().queueIndex;
+      for (auto&& kv : m_idMap) {
+        auto& info = kv.getSecond();
+        if (info.queueIndex == oldQueueIndex && info.valuePos != -1 &&
+            static_cast<size_t>(info.valuePos) >= partIdx) {
+          info.valuePos = -1;
+        }
+      }
     }
 
     infoIt->getSecond().queueIndex = queueIndex;
@@ -261,7 +275,13 @@ class NetworkOutgoingQueue {
       for (auto&& kv : m_idMap) {
         auto& info = kv.getSecond();
         if (info.queueIndex == queueIndex) {
-          if (info.valuePos < delta) {
+          // guard against stale valuePos: if it was already out of range
+          // (e.g. from a prior SetPeriod move), invalidate rather than
+          // compounding the error with an incorrect adjustment
+          if (info.valuePos != -1 &&
+              static_cast<size_t>(info.valuePos) >= msgs.size() + delta) {
+            info.valuePos = -1;
+          } else if (info.valuePos < delta) {
             info.valuePos = -1;
           } else {
             info.valuePos -= delta;

--- a/ntcore/src/test/native/cpp/net/NetworkOutgoingQueueTest.cpp
+++ b/ntcore/src/test/native/cpp/net/NetworkOutgoingQueueTest.cpp
@@ -1,0 +1,114 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "net/NetworkOutgoingQueue.hpp"
+
+#include <algorithm>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "MockWireConnection.hpp"
+#include "net/Message.hpp"
+#include "net/WireEncoder.hpp"
+#include "wpi/nt/NetworkTableValue.hpp"
+#include "wpi/util/raw_ostream.hpp"
+
+using namespace wpi::nt;
+using namespace wpi::nt::net;
+using ::testing::_;
+using ::testing::Return;
+
+// Encode a single binary value update into bytes for comparison.
+static std::vector<uint8_t> EncodeValue(int id, const Value& v) {
+  std::vector<uint8_t> buf;
+  wpi::util::raw_uvector_ostream os{buf};
+  WireEncodeBinary(os, id, v.time(), v);
+  return buf;
+}
+
+// Returns true if 'needle' appears as a contiguous substring of 'haystack'.
+static bool Contains(const std::vector<uint8_t>& haystack,
+                     const std::vector<uint8_t>& needle) {
+  return std::search(haystack.begin(), haystack.end(), needle.begin(),
+                     needle.end()) != haystack.end();
+}
+
+class NetworkOutgoingQueueTest : public ::testing::Test {
+ protected:
+  ::testing::NiceMock<MockWireConnection> m_wire;
+  NetworkOutgoingQueue<ClientMessage> m_queue{m_wire, false};
+
+  // Capture all binary writes from SendOutgoing (flush=true to force all
+  // queues regardless of their nextSendMs).
+  std::vector<uint8_t> Flush(uint64_t curTimeMs) {
+    std::vector<uint8_t> captured;
+    ON_CALL(m_wire, DoWriteBinary(_))
+        .WillByDefault([&](std::span<const uint8_t> data) {
+          captured.insert(captured.end(), data.begin(), data.end());
+          return 0;
+        });
+    ON_CALL(m_wire, Ready()).WillByDefault(Return(true));
+    ON_CALL(m_wire, Flush()).WillByDefault(Return(0));
+    m_queue.SendOutgoing(curTimeMs, true);
+    return captured;
+  }
+};
+
+// When publisher B shares a queue with publisher A and the queue looks like
+// [A, B, A, C], stable_partition produces [B, C, A, A] with partIdx=2.
+//
+// The original fix invalidates valuePos >= partIdx. B.valuePos=1 < 2 so it
+// is NOT invalidated — but B has shifted from original index 1 to new index
+// 0. The subsequent kNormal SendValue(B, newB) checks msgs[1] = C, fails the
+// id check, and APPENDs a second B entry instead of replacing the first.
+// At flush time B's old value is sent before B's new value.
+//
+// The correct fix recomputes positions by counting removed elements before
+// each saved index:
+//   B.valuePos = 1 - count(A before index 1) = 1 - 1 = 0  (correct)
+//   C.valuePos = 3 - count(A before index 3) = 3 - 2 = 1  (correct)
+// so kNormal SendValue(B, newB) replaces at index 0 and no stale entry
+// remains.
+//
+// This test FAILS on the PR-only fix (B's stale value appears in the flush
+// output) and PASSES once the position-recomputation fix is applied.
+TEST_F(NetworkOutgoingQueueTest,
+       SetPeriodCorrectlyUpdatesValuePosForOtherPublishers) {
+  m_queue.SetPeriod(1, 100);
+  m_queue.SetPeriod(2, 100);
+  m_queue.SetPeriod(3, 100);
+
+  Value vA1 = Value::MakeDouble(1.0, 10);
+  Value vB = Value::MakeDouble(2.0, 10);  // B's original value
+  Value vA2 = Value::MakeDouble(1.5, 20);
+  Value vC = Value::MakeDouble(3.0, 10);
+  Value vBnew = Value::MakeDouble(99.0, 30);  // B's updated value
+
+  // Build queue [A(1), B(2), A(1), C(3)] so that B.valuePos(1) < partIdx(2)
+  // after partition, triggering the stale-valuePos bug.
+  m_queue.SendValue(1, vA1, ValueSendMode::kAll);    // index 0 (A)
+  m_queue.SendValue(2, vB, ValueSendMode::kNormal);  // index 1 (B)
+  m_queue.SendValue(1, vA2, ValueSendMode::kAll);    // index 2 (A)
+  m_queue.SendValue(3, vC, ValueSendMode::kNormal);  // index 3 (C)
+
+  // Move A to a different period — triggers stable_partition.
+  // Result: old queue = [B(old), C]; A entries go to the 200 ms queue.
+  m_queue.SetPeriod(1, 200);
+
+  // Update B with kNormal.
+  // Correct: replaces B(old) at index 0 → old queue = [B(new), C].
+  // Buggy:   B.valuePos=1 points to C's slot; appends instead
+  //          → old queue = [B(old), C, B(new)].
+  m_queue.SendValue(2, vBnew, ValueSendMode::kNormal);
+
+  auto data = Flush(200);
+
+  // With the fix B's old value must NOT appear; B's new value must appear.
+  EXPECT_FALSE(Contains(data, EncodeValue(2, vB)))
+      << "B's stale value (2.0) was flushed — stale B.valuePos caused a "
+         "duplicate entry instead of a replacement";
+  EXPECT_TRUE(Contains(data, EncodeValue(2, vBnew)))
+      << "B's updated value (99.0) was not flushed";
+}


### PR DESCRIPTION
## Issues
- **#H1**: After `SetPeriod` adjusts `valuePos`, if `EraseId` moves messages between queues, other publishers' `valuePos` (which point into the old queue) become stale, potentially pointing to invalid positions.
- **#H2**: Missing guard in `valuePos` adjustment — if it was already out of range (e.g. from a prior `SetPeriod` move), the code would compound the error with an incorrect adjustment.
- **#H3**: `valuePos` needs to be invalidated for publishers whose positions pointed into the removed region after `EraseId` moves messages between queues.

## Fix
- After `EraseId` moves messages, invalidate `valuePos` for other publishers that pointed into the removed region.
- In `SetPeriod`, add bounds check: if `valuePos` is already out of range, invalidate rather than adjusting incorrectly.
- Use saved partition index instead of re-computing from iterator after the erase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)