### PR TITLE
[wpimath] Add const qualifier to C++ SwerveModuleVelocity Optimize and CosineScale

### DIFF
--- a/wpimath/src/main/native/include/wpi/math/kinematics/SwerveModuleVelocity.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/SwerveModuleVelocity.hpp
@@ -46,7 +46,8 @@ struct WPILIB_DLLEXPORT SwerveModuleVelocity {
    * @return The optimized SwerveModuleVelocity.
    */
   [[nodiscard]]
-  constexpr SwerveModuleVelocity Optimize(const Rotation2d& currentAngle) {
+  constexpr SwerveModuleVelocity Optimize(
+      const Rotation2d& currentAngle) const {
     auto delta = angle - currentAngle;
     if (wpi::units::math::abs(delta.Degrees()) > 90_deg) {
       return {-velocity, angle + Rotation2d{180_deg}};
@@ -64,7 +65,8 @@ struct WPILIB_DLLEXPORT SwerveModuleVelocity {
    * @return The scaled SwerveModuleVelocity.
    */
   [[nodiscard]]
-  constexpr SwerveModuleVelocity CosineScale(const Rotation2d& currentAngle) {
+  constexpr SwerveModuleVelocity CosineScale(
+      const Rotation2d& currentAngle) const {
     return {velocity * (angle - currentAngle).Cos(), angle};
   }
 };


### PR DESCRIPTION
These two functions were changed to return new objects instead of modifying in-place, so the `const` qualifier should be added. Otherwise, users with a const reference to a `SwerveModuleVelocity` need to make a temporary copy first.