### PR TITLE
[examples,cscore] Don't use assertTimeoutPreemptively in tests

### DIFF
--- a/cscore/src/test/java/org/wpilib/vision/camera/UsbCameraTest.java
+++ b/cscore/src/test/java/org/wpilib/vision/camera/UsbCameraTest.java
@@ -5,10 +5,8 @@
 package org.wpilib.vision.camera;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -23,16 +21,15 @@ class UsbCameraTest {
   @EnabledOnOs(OS.LINUX)
   static class ConnectVerbose {
     @Test
-    void setConnectVerboseEnabledTest() {
+    void setConnectVerboseEnabledTest() throws Exception {
       try (UsbCamera camera = new UsbCamera("Nonexistent Camera", getNonexistentCameraDev())) {
         camera.setConnectVerbose(1);
 
         CompletableFuture<String> result = new CompletableFuture<>();
         CameraServerJNI.setLogger((level, file, line, message) -> result.complete(message), 20);
 
-        assertTimeoutPreemptively(
-            Duration.ofSeconds(5),
-            () -> assertTrue(result.get().contains("Attempting to connect to USB camera on ")));
+        assertTrue(
+            result.get(5, TimeUnit.SECONDS).contains("Attempting to connect to USB camera on "));
       }
     }
 

--- a/wpilibjExamples/src/test/java/org/wpilib/snippets/i2ccommunication/I2CCommunicationTest.java
+++ b/wpilibjExamples/src/test/java/org/wpilib/snippets/i2ccommunication/I2CCommunicationTest.java
@@ -5,11 +5,9 @@
 package org.wpilib.snippets.i2ccommunication;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,6 +63,11 @@ class I2CCommunicationTest {
     i2c.resetData();
   }
 
+  private String getWriteString() {
+    assertTrue(future.isDone(), "I2C write callback did not run during timing step");
+    return future.join();
+  }
+
   @EnumSource(AllianceStationID.class)
   @ParameterizedTest(name = "alliance[{index}]: {0}")
   void allianceTest(AllianceStationID alliance) {
@@ -75,7 +78,7 @@ class I2CCommunicationTest {
 
     SimHooks.stepTiming(0.02);
 
-    String str = assertTimeoutPreemptively(Duration.ofMillis(20L), () -> future.get());
+    String str = getWriteString();
     char expected = alliance.name().startsWith("RED") ? 'R' : 'B';
     if (alliance.name().startsWith("UNKNOWN")) {
       expected = 'U';
@@ -94,7 +97,7 @@ class I2CCommunicationTest {
 
     SimHooks.stepTiming(0.02);
 
-    String str = assertTimeoutPreemptively(Duration.ofMillis(20L), () -> future.get());
+    String str = getWriteString();
     char expected = enabled ? 'E' : 'D';
 
     assertEquals(expected, str.charAt(1));
@@ -110,7 +113,7 @@ class I2CCommunicationTest {
 
     SimHooks.stepTiming(0.02);
 
-    String str = assertTimeoutPreemptively(Duration.ofMillis(20L), () -> future.get());
+    String str = getWriteString();
     char expected = autonomous ? 'A' : 'T';
 
     assertEquals(expected, str.charAt(2));
@@ -125,7 +128,7 @@ class I2CCommunicationTest {
 
     SimHooks.stepTiming(0.02);
 
-    String str = assertTimeoutPreemptively(Duration.ofMillis(20L), () -> future.get());
+    String str = getWriteString();
     String expected = String.format("%03d", (int) MatchState.getMatchTime());
 
     assertEquals(expected, str.substring(3));


### PR DESCRIPTION
Particularly with short timeouts, this results in spurious failures under high CPU load.