### PR TITLE
[javac, wpimath] Add compile time check for matrix sizes

### DIFF
--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/MatrixSizeListener.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/MatrixSizeListener.java
@@ -1,0 +1,169 @@
+package org.wpilib.javacplugin;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LiteralTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.NewArrayTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreeScanner;
+import com.sun.source.util.Trees;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.tools.Diagnostic;
+
+public class MatrixSizeListener implements TaskListener {
+  private final JavacTask m_task;
+  private final Set<CompilationUnitTree> m_visitedCUs = new HashSet<>();
+
+  public MatrixSizeListener(JavacTask task) {
+    m_task = task;
+  }
+
+  @Override
+  public void finished(TaskEvent e) {
+    if (e.getKind() == TaskEvent.Kind.ANALYZE && m_visitedCUs.add(e.getCompilationUnit())) {
+      e.getCompilationUnit().accept(new Scanner(e.getCompilationUnit()), null);
+    }
+  }
+
+  private final class Scanner extends TreeScanner<Void, Void> {
+    private final CompilationUnitTree m_root;
+    private final Trees m_trees;
+
+    Scanner(CompilationUnitTree compilationUnit) {
+      m_root = compilationUnit;
+      m_trees = Trees.instance(m_task);
+    }
+
+    @Override
+    public Void visitMethodInvocation(MethodInvocationTree node, Void unused) {
+      TreePath selectPath = m_trees.getPath(m_root, node.getMethodSelect());
+      Element element = selectPath != null ? m_trees.getElement(selectPath) : null;
+
+      if (element instanceof ExecutableElement method) {
+        Element enclosing = method.getEnclosingElement();
+        if (enclosing instanceof TypeElement typeElem
+            && "org.wpilib.math.linalg.MatBuilder".equals(typeElem.getQualifiedName().toString())
+            && "fill".equals(method.getSimpleName().toString())) {
+          checkMatrixDef(node, node.getArguments(), true);
+        }
+      }
+      return super.visitMethodInvocation(node, unused);
+    }
+
+    @Override
+    public Void visitNewClass(NewClassTree node, Void unused) {
+      TreePath path = m_trees.getPath(m_root, node);
+      Element element = path != null ? m_trees.getElement(path) : null;
+      if (element instanceof ExecutableElement constructor
+          && constructor.getEnclosingElement() instanceof TypeElement typeElem
+          && "org.wpilib.math.linalg.Matrix".equals(typeElem.getQualifiedName().toString())) {
+        checkMatrixDef(node, node.getArguments(), false);
+      }
+      return super.visitNewClass(node, unused);
+    }
+
+    private void checkMatrixDef(
+        ExpressionTree node, List<? extends ExpressionTree> args, boolean isMatBuilderMethod) {
+      if (args.size() < 2) {
+        return;
+      }
+      Integer rows = parseDimension(args.get(0));
+      Integer cols = parseDimension(args.get(1));
+      if (rows == null || cols == null) {
+        return;
+      }
+      int expectedElements = rows * cols;
+
+      Integer actualElements;
+      if (args.size() == 3) {
+        var thirdArg = args.get(2);
+        var thirdArgPath = m_trees.getPath(m_root, thirdArg);
+        actualElements =
+            switch (m_trees.getTypeMirror(thirdArgPath)) {
+              case null -> null;
+              case ArrayType _ -> getArraySize(thirdArg);
+              default -> 1;
+            };
+      } else if (args.size() > 3) {
+        actualElements = args.size() - 2;
+      } else if (!isMatBuilderMethod && args.size() == 2) {
+        return;
+      } else {
+        actualElements = 0;
+      }
+
+      if (actualElements != null && actualElements != expectedElements) {
+        m_trees.printMessage(
+            Diagnostic.Kind.ERROR,
+            String.format(
+                "Invalid matrix data provided. Wanted %d x %d matrix, but got %d elements",
+                rows, cols, actualElements),
+            node,
+            m_root);
+      }
+    }
+
+    private Integer parseDimension(ExpressionTree expr) {
+      if (expr == null) {
+        return null;
+      }
+
+      // Checks for Nat.NX() calls
+      if (expr instanceof MethodInvocationTree methodCall) {
+        TreePath path = m_trees.getPath(m_root, methodCall.getMethodSelect());
+        Element element = path != null ? m_trees.getElement(path) : null;
+        if (element instanceof ExecutableElement method
+            && method.getEnclosingElement() instanceof TypeElement typeElem
+            && "org.wpilib.math.util.Nat".equals(typeElem.getQualifiedName().toString())) {
+          String qualifiedName = method.getSimpleName().toString();
+          if (qualifiedName.matches("^N\\d(\\d?)$")) {
+            return Integer.parseInt(qualifiedName.substring(1));
+          }
+        }
+      }
+
+      // Checks for NX.instance calls (not recommended, but still valid java syntax)
+      TreePath path = m_trees.getPath(m_root, expr);
+      if (path != null
+          && m_trees.getTypeMirror(path) instanceof DeclaredType type
+          && type.asElement() instanceof TypeElement element) {
+        String qualifiedName = element.getQualifiedName().toString();
+        if (qualifiedName.startsWith("org.wpilib.math.numbers.N")) {
+          String suffix = qualifiedName.substring("org.wpilib.math.numbers.N".length());
+          if (suffix.matches("^\\d(\\d?)$")) {
+            return Integer.parseInt(suffix);
+          }
+        }
+      }
+
+      return null;
+    }
+
+    private Integer getArraySize(ExpressionTree expr) {
+      if (expr instanceof NewArrayTree arrayTree) {
+        if (arrayTree.getInitializers() != null) {
+          return arrayTree.getInitializers().size();
+        }
+        var dims = arrayTree.getDimensions();
+        if (!dims.isEmpty()
+            && dims.getFirst() instanceof LiteralTree tree
+            && tree.getValue() instanceof Integer value) {
+          return value;
+        }
+      }
+      return null;
+    }
+  }
+}

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/MatrixSizeListener.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/MatrixSizeListener.java
@@ -1,3 +1,7 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package org.wpilib.javacplugin;
 
 import com.sun.source.tree.CompilationUnitTree;

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/WPILibJavacPlugin.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/WPILibJavacPlugin.java
@@ -27,6 +27,7 @@ public class WPILibJavacPlugin implements Plugin {
     task.addTaskListener(new CodeAfterCoroutineParkDetector(task));
     task.addTaskListener(new IncorrectCoroutineUseDetector(task));
     task.addTaskListener(new IntegerDivisionDetector(task));
+    task.addTaskListener(new MatrixSizeListener(task));
   }
 
   @Override

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/MatrixSizeListenerTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/MatrixSizeListenerTest.java
@@ -1,3 +1,7 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package org.wpilib.javacplugin;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/MatrixSizeListenerTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/MatrixSizeListenerTest.java
@@ -1,0 +1,364 @@
+package org.wpilib.javacplugin;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.Test;
+
+class MatrixSizeListenerTest {
+  private static final JavaFileObject NUM =
+      JavaFileObjects.forSourceString(
+          "org.wpilib.math.util.Num",
+          """
+      package org.wpilib.math.util;
+
+      public class Num {}
+      """);
+
+  private static final JavaFileObject NAT =
+      JavaFileObjects.forSourceString(
+          "org.wpilib.math.util.Nat",
+          """
+      package org.wpilib.math.util;
+
+      public interface Nat<T> {
+        int getNum();
+        static Nat<org.wpilib.math.numbers.N3> N3() { return null; }
+        static Nat<org.wpilib.math.numbers.N2> N2() { return null; }
+        static Nat<org.wpilib.math.numbers.N1> N1() { return null; }
+      }
+      """);
+
+  private static final JavaFileObject N3 =
+      JavaFileObjects.forSourceString(
+          "org.wpilib.math.numbers.N3",
+          """
+      package org.wpilib.math.numbers;
+
+      import org.wpilib.math.util.*;
+
+      public final class N3 extends Num implements Nat<N3> {
+        public int getNum() { return 3; }
+        public static final N3 instance = new N3();
+      }
+      """);
+
+  private static final JavaFileObject N2 =
+      JavaFileObjects.forSourceString(
+          "org.wpilib.math.numbers.N2",
+          """
+      package org.wpilib.math.numbers;
+
+      import org.wpilib.math.util.*;
+
+      public final class N2 extends Num implements Nat<N2> {
+        public int getNum() { return 2; }
+        public static final N2 instance = new N2();
+      }
+      """);
+
+  private static final JavaFileObject MATRIX =
+      JavaFileObjects.forSourceString(
+          "org.wpilib.math.linalg.Matrix",
+          """
+      package org.wpilib.math.linalg;
+
+      import org.wpilib.math.util.*;
+
+      public class Matrix<R extends Num, C extends Num> {
+        public Matrix(Nat<R> rows, Nat<C> cols) {}
+        public Matrix(Nat<R> rows, Nat<C> cols, double[] storage) {}
+      }
+      """);
+
+  private static final JavaFileObject MAT_BUILDER =
+      JavaFileObjects.forSourceString(
+          "org.wpilib.math.linalg.MatBuilder",
+          """
+      package org.wpilib.math.linalg;
+
+      import org.wpilib.math.util.*;
+
+      public final class MatBuilder {
+        public static <R extends Num, C extends Num> Matrix<R, C> fill(
+          Nat<R> rows, Nat<C> cols, double... data
+        ) {
+          return null;
+        }
+      }
+      """);
+
+  @Test
+  void matBuilderFillValid() {
+    String source =
+        """
+        package wpilib.robot;
+
+        import org.wpilib.math.linalg.MatBuilder;
+        import org.wpilib.math.util.Nat;
+        import org.wpilib.math.linalg.Matrix;
+        import org.wpilib.math.numbers.*;
+
+        class Example {
+          Matrix<N3, N2> mat = MatBuilder.fill(Nat.N3(), Nat.N2(), 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+        }
+        """;
+
+    Compilation compilation =
+        javac()
+            .withOptions(CompileTestUtils.kJavaVersionOptions)
+            .compile(
+                NUM,
+                NAT,
+                N3,
+                N2,
+                MATRIX,
+                MAT_BUILDER,
+                JavaFileObjects.forSourceString("wpilib.robot.Example", source));
+
+    assertThat(compilation).succeededWithoutWarnings();
+  }
+
+  @Test
+  void matBuilderFillInvalid() {
+    String source =
+        """
+        package wpilib.robot;
+
+        import org.wpilib.math.linalg.MatBuilder;
+        import org.wpilib.math.util.Nat;
+        import org.wpilib.math.linalg.Matrix;
+        import org.wpilib.math.numbers.*;
+
+        class Example {
+          Matrix<N3, N2> mat = MatBuilder.fill(Nat.N3(), Nat.N2(), 1.0, 2.0, 3.0, 4.0);
+        }
+        """;
+
+    Compilation compilation =
+        javac()
+            .withOptions(CompileTestUtils.kJavaVersionOptions)
+            .compile(
+                NAT,
+                N3,
+                N2,
+                MATRIX,
+                MAT_BUILDER,
+                JavaFileObjects.forSourceString("wpilib.robot.Example", source));
+
+    assertThat(compilation).failed();
+    var errors = compilation.errors();
+    System.out.println(errors);
+    assertEquals(1, errors.size());
+    assertEquals(
+        "Invalid matrix data provided. Wanted 3 x 2 matrix, but got 4 elements",
+        errors.get(0).getMessage(null));
+  }
+
+  @Test
+  void matrixConstructorValid() {
+    String source =
+        """
+        package wpilib.robot;
+
+        import org.wpilib.math.linalg.MatBuilder;
+        import org.wpilib.math.util.Nat;
+        import org.wpilib.math.linalg.Matrix;
+        import org.wpilib.math.numbers.*;
+
+        class Example {
+          Matrix<N3, N2> mat = new Matrix(
+            Nat.N3(), Nat.N2(), new double[] { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 }
+          );
+        }
+        """;
+
+    Compilation compilation =
+        javac()
+            .withOptions(CompileTestUtils.kJavaVersionOptions)
+            .compile(
+                NAT,
+                N3,
+                N2,
+                MATRIX,
+                MAT_BUILDER,
+                JavaFileObjects.forSourceString("wpilib.robot.Example", source));
+
+    assertThat(compilation).succeededWithoutWarnings();
+  }
+
+  @Test
+  void matrixConstructorInvalid() {
+    String source =
+        """
+        package wpilib.robot;
+
+        import org.wpilib.math.linalg.MatBuilder;
+        import org.wpilib.math.util.Nat;
+        import org.wpilib.math.linalg.Matrix;
+        import org.wpilib.math.numbers.*;
+
+        class Example {
+          Matrix<N3, N2> mat = new Matrix(Nat.N3(), Nat.N2(), new double[] { 1.0, 2.0 });
+        }
+        """;
+
+    Compilation compilation =
+        javac()
+            .withOptions(CompileTestUtils.kJavaVersionOptions)
+            .compile(
+                NAT,
+                N3,
+                N2,
+                MATRIX,
+                MAT_BUILDER,
+                JavaFileObjects.forSourceString("wpilib.robot.Example", source));
+
+    assertThat(compilation).failed();
+    var errors = compilation.errors();
+    assertEquals(1, errors.size());
+    assertEquals(
+        "Invalid matrix data provided. Wanted 3 x 2 matrix, but got 2 elements",
+        errors.get(0).getMessage(null));
+  }
+
+  @Test
+  void matBuilderFillWithArrayValid() {
+    String source =
+        """
+        package wpilib.robot;
+
+        import org.wpilib.math.linalg.MatBuilder;
+        import org.wpilib.math.util.Nat;
+        import org.wpilib.math.linalg.Matrix;
+        import org.wpilib.math.numbers.*;
+
+        class Example {
+          Matrix<N3, N2> mat = MatBuilder.fill(
+            Nat.N3(), Nat.N2(), new double[] { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 }
+          );
+        }
+        """;
+
+    Compilation compilation =
+        javac()
+            .withOptions(CompileTestUtils.kJavaVersionOptions)
+            .compile(
+                NAT,
+                N3,
+                N2,
+                MATRIX,
+                MAT_BUILDER,
+                JavaFileObjects.forSourceString("wpilib.robot.Example", source));
+
+    assertThat(compilation).succeededWithoutWarnings();
+  }
+
+  @Test
+  void matBuilderFillWithArrayInvalid() {
+    String source =
+        """
+        package wpilib.robot;
+
+        import org.wpilib.math.linalg.MatBuilder;
+        import org.wpilib.math.util.Nat;
+        import org.wpilib.math.linalg.Matrix;
+        import org.wpilib.math.numbers.*;
+
+        class Example {
+          Matrix<N3, N2> mat = MatBuilder.fill(
+            Nat.N3(), Nat.N2(), new double[] { 1.0, 2.0, 3.0, 4.0 }
+          );
+        }
+        """;
+
+    Compilation compilation =
+        javac()
+            .withOptions(CompileTestUtils.kJavaVersionOptions)
+            .compile(
+                NAT,
+                N3,
+                N2,
+                MATRIX,
+                MAT_BUILDER,
+                JavaFileObjects.forSourceString("wpilib.robot.Example", source));
+
+    assertThat(compilation).failed();
+    var errors = compilation.errors();
+    assertEquals(1, errors.size());
+    assertEquals(
+        "Invalid matrix data provided. Wanted 3 x 2 matrix, but got 4 elements",
+        errors.get(0).getMessage(null));
+  }
+
+  @Test
+  void matBuilderWithNoElementsInvalid() {
+    String source =
+        """
+        package wpilib.robot;
+
+        import org.wpilib.math.linalg.MatBuilder;
+        import org.wpilib.math.util.Nat;
+        import org.wpilib.math.linalg.Matrix;
+        import org.wpilib.math.numbers.*;
+
+        class Example {
+          Matrix<N3, N2> mat = MatBuilder.fill(Nat.N3(), Nat.N2());
+        }
+        """;
+
+    Compilation compilation =
+        javac()
+            .withOptions(CompileTestUtils.kJavaVersionOptions)
+            .compile(
+                NAT,
+                N3,
+                N2,
+                MATRIX,
+                MAT_BUILDER,
+                JavaFileObjects.forSourceString("wpilib.robot.Example", source));
+
+    assertThat(compilation).failed();
+    var errors = compilation.errors();
+    assertEquals(1, errors.size());
+    assertEquals(
+        "Invalid matrix data provided. Wanted 3 x 2 matrix, but got 0 elements",
+        errors.get(0).getMessage(null));
+  }
+
+  @Test
+  void dynamicExpressionIgnored() {
+    String source =
+        """
+        package wpilib.robot;
+
+        import org.wpilib.math.linalg.MatBuilder;
+        import org.wpilib.math.util.Nat;
+        import org.wpilib.math.linalg.Matrix;
+        import org.wpilib.math.numbers.*;
+
+        class Example {
+          double[] getDoubleArray() { return new double[10]; }
+          Matrix<N3, N2> mat1 = new Matrix(Nat.N3(), Nat.N2(), getDoubleArray());
+          Matrix<N3, N2> mat2 = MatBuilder.fill(Nat.N3(), Nat.N2(), getDoubleArray());
+        }
+        """;
+
+    Compilation compilation =
+        javac()
+            .withOptions(CompileTestUtils.kJavaVersionOptions)
+            .compile(
+                NAT,
+                N3,
+                N2,
+                MATRIX,
+                MAT_BUILDER,
+                JavaFileObjects.forSourceString("wpilib.robot.Example", source));
+
+    assertThat(compilation).succeededWithoutWarnings();
+  }
+}


### PR DESCRIPTION
Adds a compile-time check that throws an error if a matrix is defined with an incorrect number of elements. For instance, this will now error during compile-time instead of during runtime:
```
Matrix<N3, N2> incorrectMatrix = MatBuilder.fill(
  Nat.N3(), Nat.N2(),
  1.0, 2.0, 
  3.0, 4.0, 
  5.0, 6.0, 7.0
);
```