### PR TITLE
Crash robot program if an exception occurs during opmode construction

### DIFF
--- a/wpilibj/src/main/java/org/wpilib/framework/OpModeRobot.java
+++ b/wpilibj/src/main/java/org/wpilib/framework/OpModeRobot.java
@@ -118,7 +118,8 @@ public abstract class OpModeRobot extends RobotBase {
     try {
       return constructor.get().newInstance(this);
     } catch (ReflectiveOperationException e) {
-      throw new RuntimeException("Could not instantiate OpMode " + cls.getSimpleName(), e.getCause());
+      throw new RuntimeException(
+          "Could not instantiate OpMode " + cls.getSimpleName(), e.getCause());
     }
   }
 

--- a/wpilibj/src/main/java/org/wpilib/framework/OpModeRobot.java
+++ b/wpilibj/src/main/java/org/wpilib/framework/OpModeRobot.java
@@ -118,9 +118,7 @@ public abstract class OpModeRobot extends RobotBase {
     try {
       return constructor.get().newInstance(this);
     } catch (ReflectiveOperationException e) {
-      DriverStationErrors.reportError(
-          "Could not instantiate OpMode " + cls.getSimpleName(), e.getStackTrace());
-      return null;
+      throw new RuntimeException("Could not instantiate OpMode " + cls.getSimpleName(), e.getCause());
     }
   }
 


### PR DESCRIPTION
There's essentially nothing the user can do here, other then switch opmodes. It will make it clearer that something is very wrong