### PR TITLE
[wpilibc] Change `DriverStationSim` to use `wpi::hal::RobotMode`

### DIFF
--- a/commandsv2/src/test/native/cpp/wpi/command/button/RobotModeTriggersTest.cpp
+++ b/commandsv2/src/test/native/cpp/wpi/command/button/RobotModeTriggersTest.cpp
@@ -15,7 +15,7 @@ class RobotModeTriggersTest : public CommandTestBase {};
 
 TEST(RobotModeTriggersTest, Autonomous) {
   DriverStationSim::ResetData();
-  DriverStationSim::SetRobotMode(HAL_ROBOT_MODE_AUTONOMOUS);
+  DriverStationSim::SetRobotMode(wpi::hal::RobotMode::AUTONOMOUS);
   DriverStationSim::SetEnabled(true);
   DriverStationSim::NotifyNewData();
   Trigger autonomous = RobotModeTriggers::Autonomous();
@@ -24,7 +24,7 @@ TEST(RobotModeTriggersTest, Autonomous) {
 
 TEST(RobotModeTriggersTest, Teleop) {
   DriverStationSim::ResetData();
-  DriverStationSim::SetRobotMode(HAL_ROBOT_MODE_TELEOPERATED);
+  DriverStationSim::SetRobotMode(wpi::hal::RobotMode::TELEOPERATED);
   DriverStationSim::SetEnabled(true);
   DriverStationSim::NotifyNewData();
   Trigger teleop = RobotModeTriggers::Teleop();
@@ -41,7 +41,7 @@ TEST(RobotModeTriggersTest, Disabled) {
 
 TEST(RobotModeTriggersTest, UtilityMode) {
   DriverStationSim::ResetData();
-  DriverStationSim::SetRobotMode(HAL_ROBOT_MODE_UTILITY);
+  DriverStationSim::SetRobotMode(wpi::hal::RobotMode::UTILITY);
   DriverStationSim::SetEnabled(true);
   DriverStationSim::NotifyNewData();
   Trigger test = RobotModeTriggers::Utility();

--- a/wpilibc/src/main/native/cpp/simulation/DriverStationSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/DriverStationSim.cpp
@@ -42,12 +42,12 @@ std::unique_ptr<CallbackStore> DriverStationSim::RegisterRobotModeCallback(
   return store;
 }
 
-HAL_RobotMode DriverStationSim::GetRobotMode() {
-  return HALSIM_GetDriverStationRobotMode();
+hal::RobotMode DriverStationSim::GetRobotMode() {
+  return static_cast<hal::RobotMode>(HALSIM_GetDriverStationRobotMode());
 }
 
-void DriverStationSim::SetRobotMode(HAL_RobotMode robotMode) {
-  HALSIM_SetDriverStationRobotMode(robotMode);
+void DriverStationSim::SetRobotMode(hal::RobotMode robotMode) {
+  HALSIM_SetDriverStationRobotMode(static_cast<HAL_RobotMode>(robotMode));
 }
 
 std::unique_ptr<CallbackStore> DriverStationSim::RegisterEStopCallback(

--- a/wpilibc/src/main/native/include/wpi/simulation/DriverStationSim.hpp
+++ b/wpilibc/src/main/native/include/wpi/simulation/DriverStationSim.hpp
@@ -9,7 +9,7 @@
 #include <memory>
 
 #include "wpi/driverstation/internal/DriverStationBackend.hpp"
-#include "wpi/hal/DriverStationTypes.h"
+#include "wpi/hal/DriverStationTypes.hpp"
 #include "wpi/hal/simulation/DriverStationData.h"
 #include "wpi/simulation/CallbackStore.hpp"
 
@@ -91,14 +91,14 @@ class DriverStationSim {
    *
    * @return robot mode
    */
-  static HAL_RobotMode GetRobotMode();
+  static hal::RobotMode GetRobotMode();
 
   /**
    * Change the robot mode set by the DS.
    *
    * @param robotMode the new value
    */
-  static void SetRobotMode(HAL_RobotMode robotMode);
+  static void SetRobotMode(hal::RobotMode robotMode);
 
   /**
    * Register a callback on the eStop state.

--- a/wpilibc/src/main/python/wpilib/testing/controller.py
+++ b/wpilibc/src/main/python/wpilib/testing/controller.py
@@ -12,7 +12,7 @@ from ..simulation import (
     stepTimingAsync,
     getProgramStarted,
 )
-from hal._wpiHal import _RobotMode as RobotMode
+from hal import RobotMode
 
 
 class RobotTestController:

--- a/wpilibc/src/main/python/wpilib/testing/pytest_plugin.py
+++ b/wpilibc/src/main/python/wpilib/testing/pytest_plugin.py
@@ -5,9 +5,9 @@ import weakref
 
 import pytest
 
+from hal import RobotMode
 import hal
 import hal.simulation
-from hal._wpiHal import _RobotMode as RobotMode
 import ntcore
 import wpilib
 from wpilib.simulation import DriverStationSim, pauseTiming, restartTiming

--- a/wpilibc/src/test/native/cpp/TimedRobotTest.cpp
+++ b/wpilibc/src/test/native/cpp/TimedRobotTest.cpp
@@ -165,7 +165,7 @@ TEST_F(TimedRobotTest, AutonomousMode) {
   wpi::sim::WaitForProgramStart();
 
   wpi::sim::DriverStationSim::SetEnabled(true);
-  wpi::sim::DriverStationSim::SetRobotMode(HAL_ROBOT_MODE_AUTONOMOUS);
+  wpi::sim::DriverStationSim::SetRobotMode(hal::RobotMode::AUTONOMOUS);
   wpi::sim::DriverStationSim::NotifyNewData();
 
   EXPECT_EQ(1u, robot.m_simulationInitCount);
@@ -237,7 +237,7 @@ TEST_F(TimedRobotTest, TeleopMode) {
   wpi::sim::WaitForProgramStart();
 
   wpi::sim::DriverStationSim::SetEnabled(true);
-  wpi::sim::DriverStationSim::SetRobotMode(HAL_ROBOT_MODE_TELEOPERATED);
+  wpi::sim::DriverStationSim::SetRobotMode(hal::RobotMode::TELEOPERATED);
   wpi::sim::DriverStationSim::NotifyNewData();
 
   EXPECT_EQ(1u, robot.m_simulationInitCount);
@@ -308,7 +308,7 @@ TEST_F(TimedRobotTest, UtilityMode) {
   wpi::sim::WaitForProgramStart();
 
   wpi::sim::DriverStationSim::SetEnabled(true);
-  wpi::sim::DriverStationSim::SetRobotMode(HAL_ROBOT_MODE_UTILITY);
+  wpi::sim::DriverStationSim::SetRobotMode(hal::RobotMode::UTILITY);
   wpi::sim::DriverStationSim::NotifyNewData();
 
   EXPECT_EQ(1u, robot.m_simulationInitCount);
@@ -429,7 +429,7 @@ TEST_F(TimedRobotTest, ModeChange) {
 
   // Transition to autonomous
   wpi::sim::DriverStationSim::SetEnabled(true);
-  wpi::sim::DriverStationSim::SetRobotMode(HAL_ROBOT_MODE_AUTONOMOUS);
+  wpi::sim::DriverStationSim::SetRobotMode(hal::RobotMode::AUTONOMOUS);
   wpi::sim::DriverStationSim::NotifyNewData();
 
   wpi::sim::StepTiming(kPeriod);
@@ -446,7 +446,7 @@ TEST_F(TimedRobotTest, ModeChange) {
 
   // Transition to teleop
   wpi::sim::DriverStationSim::SetEnabled(true);
-  wpi::sim::DriverStationSim::SetRobotMode(HAL_ROBOT_MODE_TELEOPERATED);
+  wpi::sim::DriverStationSim::SetRobotMode(hal::RobotMode::TELEOPERATED);
   wpi::sim::DriverStationSim::NotifyNewData();
 
   wpi::sim::StepTiming(kPeriod);
@@ -463,7 +463,7 @@ TEST_F(TimedRobotTest, ModeChange) {
 
   // Transition to utility
   wpi::sim::DriverStationSim::SetEnabled(true);
-  wpi::sim::DriverStationSim::SetRobotMode(HAL_ROBOT_MODE_UTILITY);
+  wpi::sim::DriverStationSim::SetRobotMode(hal::RobotMode::UTILITY);
   wpi::sim::DriverStationSim::NotifyNewData();
 
   wpi::sim::StepTiming(kPeriod);

--- a/wpilibc/src/test/native/cpp/simulation/DriverStationSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/DriverStationSimTest.cpp
@@ -24,7 +24,7 @@ TEST(DriverStationTest, Enabled) {
   BooleanCallback callback;
   auto cb =
       DriverStationSim::RegisterEnabledCallback(callback.GetCallback(), false);
-  DriverStationSim::SetRobotMode(HAL_ROBOT_MODE_TELEOPERATED);
+  DriverStationSim::SetRobotMode(RobotMode::TELEOPERATED);
   DriverStationSim::SetEnabled(true);
   DriverStationSim::NotifyNewData();
   EXPECT_TRUE(DriverStationSim::GetEnabled());
@@ -41,9 +41,9 @@ TEST(DriverStationTest, AutonomousMode) {
   EnumCallback callback;
   auto cb = DriverStationSim::RegisterRobotModeCallback(callback.GetCallback(),
                                                         false);
-  DriverStationSim::SetRobotMode(HAL_ROBOT_MODE_AUTONOMOUS);
+  DriverStationSim::SetRobotMode(RobotMode::AUTONOMOUS);
   DriverStationSim::NotifyNewData();
-  EXPECT_EQ(DriverStationSim::GetRobotMode(), HAL_ROBOT_MODE_AUTONOMOUS);
+  EXPECT_EQ(DriverStationSim::GetRobotMode(), RobotMode::AUTONOMOUS);
   EXPECT_TRUE(RobotState::IsAutonomous());
   EXPECT_EQ(RobotState::GetRobotMode(), RobotMode::AUTONOMOUS);
   EXPECT_TRUE(callback.WasTriggered());
@@ -58,9 +58,9 @@ TEST(DriverStationTest, Mode) {
   EnumCallback callback;
   auto cb = DriverStationSim::RegisterRobotModeCallback(callback.GetCallback(),
                                                         false);
-  DriverStationSim::SetRobotMode(HAL_ROBOT_MODE_UTILITY);
+  DriverStationSim::SetRobotMode(RobotMode::UTILITY);
   DriverStationSim::NotifyNewData();
-  EXPECT_EQ(DriverStationSim::GetRobotMode(), HAL_ROBOT_MODE_UTILITY);
+  EXPECT_EQ(DriverStationSim::GetRobotMode(), RobotMode::UTILITY);
   EXPECT_TRUE(RobotState::IsUtility());
   EXPECT_EQ(RobotState::GetRobotMode(), RobotMode::UTILITY);
   EXPECT_TRUE(callback.WasTriggered());

--- a/wpilibcExamples/src/test/cpp/examples/ArmSimulation/cpp/ArmSimulationTest.cpp
+++ b/wpilibcExamples/src/test/cpp/examples/ArmSimulation/cpp/ArmSimulationTest.cpp
@@ -56,7 +56,7 @@ TEST_P(ArmSimulationTest, Teleop) {
 
   // teleop init
   {
-    wpi::sim::DriverStationSim::SetRobotMode(HAL_ROBOT_MODE_TELEOPERATED);
+    wpi::sim::DriverStationSim::SetRobotMode(wpi::hal::RobotMode::TELEOPERATED);
     wpi::sim::DriverStationSim::SetEnabled(true);
     wpi::sim::DriverStationSim::NotifyNewData();
 

--- a/wpilibcExamples/src/test/cpp/examples/ElevatorSimulation/cpp/ElevatorSimulationTest.cpp
+++ b/wpilibcExamples/src/test/cpp/examples/ElevatorSimulation/cpp/ElevatorSimulationTest.cpp
@@ -52,7 +52,7 @@ class ElevatorSimulationTest : public testing::Test {
 TEST_F(ElevatorSimulationTest, Teleop) {
   // teleop init
   {
-    wpi::sim::DriverStationSim::SetRobotMode(HAL_ROBOT_MODE_TELEOPERATED);
+    wpi::sim::DriverStationSim::SetRobotMode(wpi::hal::RobotMode::TELEOPERATED);
     wpi::sim::DriverStationSim::SetEnabled(true);
     wpi::sim::DriverStationSim::NotifyNewData();
 

--- a/wpilibcExamples/src/test/cpp/snippets/DigitalCommunication/cpp/DigitalCommunicationTest.cpp
+++ b/wpilibcExamples/src/test/cpp/snippets/DigitalCommunication/cpp/DigitalCommunicationTest.cpp
@@ -122,7 +122,8 @@ class AutonomousTest : public DigitalCommunicationTest<bool> {};
 TEST_P(AutonomousTest, Autonomous) {
   auto autonomous = GetParam();
   wpi::sim::DriverStationSim::SetRobotMode(
-      autonomous ? HAL_ROBOT_MODE_AUTONOMOUS : HAL_ROBOT_MODE_TELEOPERATED);
+      autonomous ? wpi::hal::RobotMode::AUTONOMOUS
+                 : wpi::hal::RobotMode::TELEOPERATED);
   wpi::sim::DriverStationSim::NotifyNewData();
 
   EXPECT_TRUE(autonomousOutput.GetInitialized());

--- a/wpilibcExamples/src/test/cpp/snippets/I2CCommunication/cpp/I2CCommunicationTest.cpp
+++ b/wpilibcExamples/src/test/cpp/snippets/I2CCommunication/cpp/I2CCommunicationTest.cpp
@@ -132,7 +132,8 @@ class AutonomousTest : public I2CCommunicationTest<bool> {};
 TEST_P(AutonomousTest, Autonomous) {
   auto autonomous = GetParam();
   wpi::sim::DriverStationSim::SetRobotMode(
-      autonomous ? HAL_ROBOT_MODE_AUTONOMOUS : HAL_ROBOT_MODE_TELEOPERATED);
+      autonomous ? wpi::hal::RobotMode::AUTONOMOUS
+                 : wpi::hal::RobotMode::TELEOPERATED);
   wpi::sim::DriverStationSim::NotifyNewData();
 
   EXPECT_TRUE(HALSIM_GetI2CInitialized(port));


### PR DESCRIPTION
The `RobotState::GetRobotMode()` API returns this enum class, but `DriverStationSim` was using the `HAL_RobotMode` enum instead. This commonizes the two APIs to return the same `RobotMode` enum class.

This difference in the APIs also affected Python, as the `hal.RobotMode` and `hal._wpiHal._RobotMode` types are not compatible with each other.