### PR TITLE
[wpimath] Use triangular solves to compute UKF Kalman gain

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/estimator/UnscentedKalmanFilter.java
+++ b/wpimath/src/main/java/org/wpilib/math/estimator/UnscentedKalmanFilter.java
@@ -564,19 +564,14 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
       Pxy = Pxy.plus(dx.times(dy).times(m_pts.getWc(i)));
     }
 
-    // Compute the Kalman gain. We use Eigen's QR decomposition to solve. This
-    // is equivalent to MATLAB's \ operator, so we need to rearrange to use
-    // that.
+    // Compute the Kalman gain
     //
     //   K = (P_{xy} / S_{y}ᵀ) / S_{y}
     //   K = (S_{y} \ P_{xy})ᵀ / S_{y}
     //   K = (S_{y}ᵀ \ (S_{y} \ P_{xy}ᵀ))ᵀ
     //
     // equation (27)
-    Matrix<States, R> K =
-        Sy.transpose()
-            .solveFullPivHouseholderQr(Sy.solveFullPivHouseholderQr(Pxy.transpose()))
-            .transpose();
+    Matrix<States, R> K = Sy.transpose().solve(Sy.solve(Pxy.transpose())).transpose();
 
     // Compute the posterior state mean
     //

--- a/wpimath/src/main/native/include/wpi/math/estimator/UnscentedKalmanFilter.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/UnscentedKalmanFilter.hpp
@@ -437,9 +437,7 @@ class UnscentedKalmanFilter {
               .transpose();
     }
 
-    // Compute the Kalman gain. We use Eigen's QR decomposition to solve. This
-    // is equivalent to MATLAB's \ operator, so we need to rearrange to use
-    // that.
+    // Compute the Kalman gain
     //
     //   K = (P_{xy} / S_{y}ᵀ) / S_{y}
     //   K = (S_{y} \ P_{xy})ᵀ / S_{y}
@@ -448,8 +446,9 @@ class UnscentedKalmanFilter {
     // equation (27)
     Matrixd<States, Rows> K =
         Sy.transpose()
-            .fullPivHouseholderQr()
-            .solve(Sy.fullPivHouseholderQr().solve(Pxy.transpose()))
+            .template triangularView<Eigen::Upper>()
+            .solve(Sy.template triangularView<Eigen::Lower>().solve(
+                Pxy.transpose()))
             .transpose();
 
     // Compute the posterior state mean


### PR DESCRIPTION
Sy is already triangular, so we can use triangular solves directly instead of performing a QR decomposition first.