### PR TITLE
[hal] Port last GoogleTest unit test to Catch2

### DIFF
--- a/hal/src/test/native/cpp/WriteDisplayAnsiTest.cpp
+++ b/hal/src/test/native/cpp/WriteDisplayAnsiTest.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 
-#include <gtest/gtest.h>
+#include <catch2/catch_test_macros.hpp>
 
 #include "wpi/hal/DriverStation.h"
 #include "wpi/hal/simulation/MockHooks.h"
@@ -19,7 +19,8 @@ int32_t CaptureDisplayAnsi(const struct WPI_String* data) {
 }
 }  // namespace
 
-TEST(DriverStationDisplayAnsiTest, WriteDisplayAnsiUsesSimulationHook) {
+TEST_CASE("DriverStationDisplayAnsiTest WriteDisplayAnsiUsesSimulationHook",
+          "[hal]") {
   HALSIM_SetWriteDisplayAnsi(nullptr);
   gDisplayAnsi.clear();
   HALSIM_SetWriteDisplayAnsi(CaptureDisplayAnsi);
@@ -28,5 +29,5 @@ TEST(DriverStationDisplayAnsiTest, WriteDisplayAnsiUsesSimulationHook) {
   HAL_WriteDisplayAnsi(&data);
 
   HALSIM_SetWriteDisplayAnsi(nullptr);
-  EXPECT_EQ("Robot display", gDisplayAnsi);
+  CHECK("Robot display" == gDisplayAnsi);
 }


### PR DESCRIPTION
This fixes a linker error I got for gtest.