### PR TITLE
[wpimath,wpiutil] Switch std::is_constant_evaluated() to consteval

### DIFF
--- a/wpimath/src/main/native/include/wpi/math/controller/BangBangController.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/BangBangController.hpp
@@ -43,7 +43,7 @@ class WPILIB_DLLEXPORT BangBangController
   constexpr explicit BangBangController(
       double tolerance = std::numeric_limits<double>::infinity())
       : m_tolerance(tolerance) {
-    if (!std::is_constant_evaluated()) {
+    if !consteval {
       ++instances;
       wpi::math::MathSharedStore::ReportUsage("BangBangController",
                                               std::to_string(instances));

--- a/wpimath/src/main/native/include/wpi/math/controller/PIDController.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/PIDController.hpp
@@ -70,7 +70,7 @@ class WPILIB_DLLEXPORT PIDController
       wpi::math::MathSharedStore::ReportWarning(
           "Controller period defaulted to 20ms.");
     }
-    if (!std::is_constant_evaluated()) {
+    if !consteval {
       ++instances;
 
       wpi::math::MathSharedStore::ReportUsage("PIDController",

--- a/wpimath/src/main/native/include/wpi/math/controller/ProfiledPIDController.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/ProfiledPIDController.hpp
@@ -61,7 +61,7 @@ class ProfiledPIDController
       : m_controller{Kp, Ki, Kd, period},
         m_constraints{constraints},
         m_profile{m_constraints} {
-    if (!std::is_constant_evaluated()) {
+    if !consteval {
       int instances = detail::IncrementAndGetProfiledPIDControllerInstances();
       wpi::math::MathSharedStore::ReportUsage("ProfiledPIDController",
                                               std::to_string(instances));

--- a/wpimath/src/main/native/include/wpi/math/filter/LinearFilter.hpp
+++ b/wpimath/src/main/native/include/wpi/math/filter/LinearFilter.hpp
@@ -99,7 +99,7 @@ class LinearFilter {
       m_outputs.emplace_front(0.0);
     }
 
-    if (!std::is_constant_evaluated()) {
+    if !consteval {
       ++instances;
       wpi::math::MathSharedStore::ReportUsage("LinearFilter",
                                               std::to_string(instances));

--- a/wpimath/src/main/native/include/wpi/math/geometry/Rotation2d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Rotation2d.hpp
@@ -58,7 +58,7 @@ class WPILIB_DLLEXPORT Rotation2d final {
     } else {
       m_cos = 1.0;
       m_sin = 0.0;
-      if (!std::is_constant_evaluated()) {
+      if !consteval {
         wpi::math::MathSharedStore::ReportError(
             "x and y components of Rotation2d are zero\n{}",
             wpi::util::GetStackTrace(1));
@@ -94,7 +94,7 @@ class WPILIB_DLLEXPORT Rotation2d final {
       return {R(0, 0), R(1, 0)};
     };
 
-    if (std::is_constant_evaluated()) {
+    if consteval {
       auto cossin = impl(ct_matrix2d{rotationMatrix});
       m_cos = std::get<0>(cossin);
       m_sin = std::get<1>(cossin);

--- a/wpimath/src/main/native/include/wpi/math/geometry/Rotation3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Rotation3d.hpp
@@ -205,7 +205,7 @@ class WPILIB_DLLEXPORT Rotation3d final {
       return Quaternion{w, x, y, z};
     };
 
-    if (std::is_constant_evaluated()) {
+    if consteval {
       m_q = impl(ct_matrix3d{rotationMatrix});
     } else {
       m_q = impl(rotationMatrix);

--- a/wpimath/src/main/native/include/wpi/math/geometry/Transform3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Transform3d.hpp
@@ -264,7 +264,7 @@ constexpr Twist3d Transform3d::Log() const {
                    wpi::units::radian_t{rvec(2)}};
   };
 
-  if (std::is_constant_evaluated()) {
+  if consteval {
     return impl.template operator()<ct_matrix3d, ct_vector3d>();
   }
   return impl.template operator()<Eigen::Matrix3d, Eigen::Vector3d>();

--- a/wpimath/src/main/native/include/wpi/math/geometry/Twist3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Twist3d.hpp
@@ -155,7 +155,7 @@ constexpr Transform3d Twist3d::Exp() const {
     return transform;
   };
 
-  if (std::is_constant_evaluated()) {
+  if consteval {
     return impl.template operator()<ct_matrix3d, ct_vector3d>();
   }
   return impl.template operator()<Eigen::Matrix3d, Eigen::Vector3d>();

--- a/wpimath/src/main/native/include/wpi/math/kinematics/DifferentialDriveKinematics.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/DifferentialDriveKinematics.hpp
@@ -42,7 +42,7 @@ class WPILIB_DLLEXPORT DifferentialDriveKinematics
    */
   constexpr explicit DifferentialDriveKinematics(wpi::units::meter_t trackwidth)
       : trackwidth(trackwidth) {
-    if (!std::is_constant_evaluated()) {
+    if !consteval {
       wpi::math::MathSharedStore::ReportUsage("DifferentialDriveKinematics",
                                               "");
     }

--- a/wpimath/src/main/native/include/wpi/math/linalg/ct_matrix.hpp
+++ b/wpimath/src/main/native/include/wpi/math/linalg/ct_matrix.hpp
@@ -104,7 +104,7 @@ class ct_matrix {
    */
   friend constexpr ct_matrix<Scalar, Rows, Cols> operator*(
       Scalar lhs, const ct_matrix<Scalar, Rows, Cols>& rhs) {
-    if (std::is_constant_evaluated()) {
+    if consteval {
       ct_matrix<Scalar, Rows, Cols> result;
 
       for (int i = 0; i < rhs.rows(); ++i) {
@@ -131,7 +131,7 @@ class ct_matrix {
   friend constexpr ct_matrix<Scalar, Rows, Cols2> operator*(
       const ct_matrix<Scalar, Rows, Cols>& lhs,
       const ct_matrix<Scalar, Rows, Cols2>& rhs) {
-    if (std::is_constant_evaluated()) {
+    if consteval {
       ct_matrix<Scalar, Rows, Cols2> result;
 
       for (int i = 0; i < lhs.rows(); ++i) {
@@ -160,7 +160,7 @@ class ct_matrix {
   friend constexpr ct_matrix<Scalar, Rows, Cols> operator+(
       const ct_matrix<Scalar, Rows, Cols>& lhs,
       const ct_matrix<Scalar, Rows, Cols>& rhs) {
-    if (std::is_constant_evaluated()) {
+    if consteval {
       ct_matrix<Scalar, Rows, Cols> result;
 
       for (int row = 0; row < rhs.rows(); ++row) {
@@ -185,7 +185,7 @@ class ct_matrix {
   friend constexpr ct_matrix<Scalar, Rows, Cols> operator-(
       const ct_matrix<Scalar, Rows, Cols>& lhs,
       const ct_matrix<Scalar, Rows, Cols>& rhs) {
-    if (std::is_constant_evaluated()) {
+    if consteval {
       ct_matrix<Scalar, Rows, Cols> result;
 
       for (int row = 0; row < rhs.rows(); ++row) {
@@ -206,7 +206,7 @@ class ct_matrix {
    * @return Transpose of matrix.
    */
   constexpr ct_matrix<Scalar, Cols, Rows> transpose() const {
-    if (std::is_constant_evaluated()) {
+    if consteval {
       ct_matrix<Scalar, Cols, Rows> result;
 
       for (int row = 0; row < rows(); ++row) {
@@ -229,7 +229,7 @@ class ct_matrix {
   static constexpr ct_matrix<Scalar, Rows, Cols> Identity()
     requires(Rows != Eigen::Dynamic && Cols != Eigen::Dynamic)
   {
-    if (std::is_constant_evaluated()) {
+    if consteval {
       ct_matrix<Scalar, Rows, Cols> result;
 
       for (int row = 0; row < Rows; ++row) {
@@ -260,7 +260,7 @@ class ct_matrix {
     requires(Rows == 1 || Cols == 1) && (RhsRows == 1 || RhsCols == 1) &&
             (Rows * Cols == RhsRows * RhsCols)
   constexpr Scalar dot(const ct_matrix<Scalar, RhsRows, RhsCols>& rhs) const {
-    if (std::is_constant_evaluated()) {
+    if consteval {
       Scalar sum = 0.0;
 
       for (int index = 0; index < rows() * rhs.cols(); ++index) {
@@ -279,7 +279,7 @@ class ct_matrix {
    * @return Norm of matrix.
    */
   constexpr Scalar norm() const {
-    if (std::is_constant_evaluated()) {
+    if consteval {
       Scalar sum = 0.0;
 
       for (int row = 0; row < rows(); ++row) {

--- a/wpimath/src/main/native/include/wpi/math/system/LinearSystem.hpp
+++ b/wpimath/src/main/native/include/wpi/math/system/LinearSystem.hpp
@@ -52,7 +52,7 @@ class LinearSystem {
                          const Matrixd<Outputs, States>& C,
                          const Matrixd<Outputs, Inputs>& D) {
     auto allFinite = [](const auto& mat) {
-      if (std::is_constant_evaluated()) {
+      if consteval {
         for (int row = 0; row < mat.rows(); ++row) {
           for (int col = 0; col < mat.cols(); ++col) {
             if (!gcem::internal::is_finite(mat(row, col))) {

--- a/wpimath/src/main/native/include/wpi/math/trajectory/TrapezoidProfile.hpp
+++ b/wpimath/src/main/native/include/wpi/math/trajectory/TrapezoidProfile.hpp
@@ -70,7 +70,7 @@ class TrapezoidProfile {
      * Default constructor.
      */
     constexpr Constraints() {
-      if (!std::is_constant_evaluated()) {
+      if !consteval {
         wpi::math::MathSharedStore::ReportUsage("TrapezoidProfile", "");
       }
     }
@@ -84,7 +84,7 @@ class TrapezoidProfile {
     constexpr Constraints(Velocity_t maxVelocity,
                           Acceleration_t maxAcceleration)
         : maxVelocity{maxVelocity}, maxAcceleration{maxAcceleration} {
-      if (!std::is_constant_evaluated()) {
+      if !consteval {
         wpi::math::MathSharedStore::ReportUsage("TrapezoidProfile", "");
       }
 

--- a/wpiutil/src/main/native/include/wpi/util/Color.hpp
+++ b/wpiutil/src/main/native/include/wpi/util/Color.hpp
@@ -24,7 +24,7 @@ constexpr double ceil_int(double x, double x_whole) noexcept {
 }
 
 constexpr double ceil(double x) noexcept {
-  if (std::is_constant_evaluated()) {
+  if consteval {
     return ((x < 0.0 ? -x : x) >= 4503599627370496.
                 ? x
                 : ceil_int(x, static_cast<double>(static_cast<int64_t>(x))));

--- a/wpiutil/src/main/native/include/wpi/util/sendable/SendableHelper.hpp
+++ b/wpiutil/src/main/native/include/wpi/util/sendable/SendableHelper.hpp
@@ -28,7 +28,7 @@ class SendableHelper {
   __attribute__((no_sanitize("vptr")))
 #endif
   constexpr SendableHelper(SendableHelper&& rhs) {
-    if (!std::is_constant_evaluated()) {
+    if !consteval {
       // it is safe to call Move() multiple times with the same rhs
       SendableRegistry::Move(static_cast<Derived*>(this),
                              static_cast<Derived*>(&rhs));
@@ -40,7 +40,7 @@ class SendableHelper {
   __attribute__((no_sanitize("vptr")))
 #endif
   constexpr SendableHelper& operator=(SendableHelper&& rhs) {
-    if (!std::is_constant_evaluated()) {
+    if !consteval {
       // it is safe to call Move() multiple times with the same rhs
       SendableRegistry::Move(static_cast<Derived*>(this),
                              static_cast<Derived*>(&rhs));
@@ -52,7 +52,7 @@ class SendableHelper {
   constexpr SendableHelper() = default;
 
   constexpr ~SendableHelper() {
-    if (!std::is_constant_evaluated()) {
+    if !consteval {
       // it is safe to call Remove() multiple times with the same object
       SendableRegistry::Remove(static_cast<Derived*>(this));
     }


### PR DESCRIPTION
Works around an ICE in the newest MSVC

gcem still uses the old method, because I'm not near a fast enough computer to update the upstream_utils thing.