### PR TITLE
[robotpy] Run black on robotpy files

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -236,7 +236,7 @@ jobs:
 
   # RobotPy does not want to run the additional python linting that wpiformat
   # implements, only the black linter. Here we run black on only the files
-  # that get transfered to the upstream mostrobotpy repository
+  # that get transferred to the upstream mostrobotpy repository
   robotpy_format:
     name: "RobotPy Formatting"
     runs-on: ubuntu-24.04

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -233,3 +233,42 @@ jobs:
           name: robotpy-pregeneration-fixes
           path: robotpy-pregeneration.patch
         if: ${{ failure() }}
+
+  # RobotPy does not want to run the additional python linting that wpiformat
+  # implements, only the black linter. Here we run black on only the files
+  # that get transfered to the upstream mostrobotpy repository
+  robotpy_format:
+    name: "RobotPy Formatting"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install black
+        run: |
+          python -m venv ${{ runner.temp }}/black
+          # Keep version in sync with .github/workflows/lint-format.yml
+          ${{ runner.temp }}/black/bin/pip3 install black
+      - name: Run black on RobotPy files
+        run: ${{ runner.temp }}/black/bin/black **/src/main/python/**/*.py **/src/test/python/**/*.py robotpyExamples --force-exclude "thirdparty"
+      - name: Check output
+        run: git --no-pager diff --exit-code HEAD
+      - name: Generate diff
+        run: git diff HEAD > robotpy-format-fixes.patch
+        if: ${{ failure() }}
+      - uses: actions/upload-artifact@v7
+        with:
+          archive: false
+          path: robotpy-format-fixes.patch
+        if: ${{ failure() }}
+      - name: Write to job summary
+        run: |
+          echo '```diff' >> $GITHUB_STEP_SUMMARY
+          cat robotpy-format-fixes.patch >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+        if: ${{ failure() }}

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -254,7 +254,9 @@ jobs:
           # Keep version in sync with .github/workflows/lint-format.yml
           ${{ runner.temp }}/black/bin/pip3 install black
       - name: Run black on RobotPy files
-        run: ${{ runner.temp }}/black/bin/black **/src/main/python/**/*.py **/src/test/python/**/*.py robotpyExamples --force-exclude "thirdparty"
+        run: |
+          shopt -s globstar
+          ${{ runner.temp }}/black/bin/black **/src/main/python/**/*.py **/src/test/python/**/*.py robotpyExamples --force-exclude "thirdparty"
       - name: Check output
         run: git --no-pager diff --exit-code HEAD
       - name: Generate diff

--- a/robotpyExamples/generate_bazel_files.py
+++ b/robotpyExamples/generate_bazel_files.py
@@ -1,9 +1,9 @@
-
 import sys
 import tomli
 
+
 def load_project_names(toml_filename, project_type):
-    
+
     with open(toml_filename, "rb") as f:
         data = tomli.load(f)
 
@@ -14,6 +14,7 @@ def load_project_names(toml_filename, project_type):
 
     return contents
 
+
 def main():
     output_file = "robotpyExamples/example_projects.bzl"
 
@@ -22,7 +23,7 @@ def main():
 
     if len(sys.argv) == 2:
         output_file = sys.argv[1]
-        
+
     with open(output_file, "w") as f:
         f.write(contents)
 

--- a/wpilibc/src/test/python/driverstation/test_generic_hid.py
+++ b/wpilibc/src/test/python/driverstation/test_generic_hid.py
@@ -3,7 +3,6 @@ import pytest
 from wpilib import DriverStation, DriverStationBackend, GenericHID
 from wpilib.simulation import DriverStationSim, GenericHIDSim
 
-
 RumbleType = GenericHID.RumbleType
 RUMBLE_TYPES = (
     RumbleType.LEFT_RUMBLE,
@@ -30,9 +29,7 @@ def test_rumble_range() -> None:
 
         for rumble_type in RUMBLE_TYPES:
             hid.setRumble(rumble_type, rumble_value)
-            assert sim.getRumble(rumble_type) == pytest.approx(
-                rumble_value, abs=0.0001
-            )
+            assert sim.getRumble(rumble_type) == pytest.approx(rumble_value, abs=0.0001)
 
 
 def test_rumble_types() -> None:
@@ -50,9 +47,7 @@ def test_rumble_types() -> None:
 
         for rumble_type in RUMBLE_TYPES:
             expected = 1 if rumble_type == active_rumble_type else 0
-            assert sim.getRumble(rumble_type) == pytest.approx(
-                expected, abs=0.0001
-            )
+            assert sim.getRumble(rumble_type) == pytest.approx(expected, abs=0.0001)
 
         hid.setRumble(active_rumble_type, 0)
 

--- a/wpimath/src/test/python/test_anti_tipping.py
+++ b/wpimath/src/test/python/test_anti_tipping.py
@@ -48,4 +48,3 @@ def test_left_roll_drives_left():
 
     assert correction.vx == pytest.approx(0.0, abs=1e-6)
     assert correction.vy > 0.0
-    

--- a/wpiutil/src/main/python/examples/writelog.py
+++ b/wpiutil/src/main/python/examples/writelog.py
@@ -5,7 +5,6 @@ import pathlib
 
 from wpiutil.log import DataLog, BooleanLogEntry, StringArrayLogEntry, RawLogEntry
 
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("out", type=pathlib.Path)


### PR DESCRIPTION
This piggy-backs off #8362. `wpiformat` will handle all the non-python files (C++ trailing spaces in yaml files, etc), and the robotpy files (guarded by being under src/main/python or src/test/python) will be handled by black only.