### PR TITLE
[build] Add WPILIB_ prefix to CMake options

### DIFF
--- a/.github/workflows/cmake-android.yml
+++ b/.github/workflows/cmake-android.yml
@@ -40,7 +40,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ninja-build
 
       - name: configure
-        run: cmake --preset with-sccache -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_WPILIB=OFF -DWITH_GUI=OFF -DWITH_CSCORE=OFF -DWITH_TESTS=OFF -DWITH_SIMULATION_MODULES=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_TOOLCHAIN_FILE=${{ steps.setup-ndk.outputs.ndk-path }}/build/cmake/android.toolchain.cmake -DANDROID_ABI="${{ matrix.abi }}" -DANDROID_PLATFORM=android-24
+        run: cmake --preset with-sccache -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWPILIB_WITH_WPILIB=OFF -DWPILIB_WITH_GUI=OFF -DWPILIB_WITH_CSCORE=OFF -DWPILIB_WITH_TESTS=OFF -DWPILIB_WITH_SIMULATION_MODULES=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_TOOLCHAIN_FILE=${{ steps.setup-ndk.outputs.ndk-path }}/build/cmake/android.toolchain.cmake -DANDROID_ABI="${{ matrix.abi }}" -DANDROID_PLATFORM=android-24
         env:
           SCCACHE_WEBDAV_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           SCCACHE_WEBDAV_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,15 +19,15 @@ jobs:
           - os: ubuntu-24.04
             name: Linux
             container: wpilib/systemcore-cross-debian:trixie
-            flags: "--preset with-sccache -DCMAKE_BUILD_TYPE=Release -DWITH_EXAMPLES=ON"
+            flags: "--preset with-sccache -DCMAKE_BUILD_TYPE=Release -DWPILIB_WITH_EXAMPLES=ON"
           - os: macOS-15
             name: macOS
             container: ""
-            flags: "--preset with-sccache -DCMAKE_BUILD_TYPE=Release -DWITH_EXAMPLES=ON"
+            flags: "--preset with-sccache -DCMAKE_BUILD_TYPE=Release -DWPILIB_WITH_EXAMPLES=ON"
           - os: windows-2022
             name: Windows
             container: ""
-            flags: '--preset with-sccache -DCMAKE_BUILD_TYPE=Release -DWITH_EXAMPLES=ON -DUSE_SYSTEM_FMTLIB=ON -DUSE_SYSTEM_LIBUV=ON -DUSE_SYSTEM_EIGEN=OFF -DCMAKE_TOOLCHAIN_FILE="$Env:RUNNER_WORKSPACE/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_INSTALL_OPTIONS=--clean-after-build -DVCPKG_TARGET_TRIPLET=x64-windows-release -DVCPKG_HOST_TRIPLET=x64-windows-release'
+            flags: '--preset with-sccache -DCMAKE_BUILD_TYPE=Release -DWPILIB_WITH_EXAMPLES=ON -DWPILIB_USE_SYSTEM_FMTLIB=ON -DWPILIB_USE_SYSTEM_LIBUV=ON -DWPILIB_USE_SYSTEM_EIGEN=OFF -DCMAKE_TOOLCHAIN_FILE="$Env:RUNNER_WORKSPACE/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_INSTALL_OPTIONS=--clean-after-build -DVCPKG_TARGET_TRIPLET=x64-windows-release -DVCPKG_HOST_TRIPLET=x64-windows-release'
 
     name: "Build - ${{ matrix.name }}"
     runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,53 +64,56 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Options for building certain parts of the repo. Everything is built by default.
 option(BUILD_SHARED_LIBS "Build with shared libs" ON)
-option(WITH_DOCS "Build Doxygen docs (needs Git for versioning)" OFF)
+option(WPILIB_WITH_DOCS "Build Doxygen docs (needs Git for versioning)" OFF)
 cmake_dependent_option(
     DOCS_WARNINGS_AS_ERRORS
     "Make docs warnings into errors"
     OFF
-    WITH_DOCS
+    WPILIB_WITH_DOCS
     OFF
 )
-option(WITH_CSCORE "Build cscore (needs OpenCV)" ON)
-option(WITH_NTCORE "Build ntcore" ON)
-option(WITH_WPICAL "Build wpical" OFF)
-option(WITH_WPIMATH "Build wpimath" ON)
-option(WITH_WPILIB "Build hal, wpilibc/j, and developerRobot (needs OpenCV)" ON)
-option(WITH_EXAMPLES "Build examples" OFF)
-option(WITH_TESTS "Build unit tests (requires internet connection)" ON)
-option(WITH_GUI "Build GUI items" ON)
-option(WITH_SIMULATION_MODULES "Build simulation modules" ON)
-option(WITH_BENCHMARK "Build the benchmark project" ON)
+option(WPILIB_WITH_CSCORE "Build cscore (needs OpenCV)" ON)
+option(WPILIB_WITH_NTCORE "Build ntcore" ON)
+option(WPILIB_WITH_WPICAL "Build wpical" OFF)
+option(WPILIB_WITH_WPIMATH "Build wpimath" ON)
+option(WPILIB_WITH_WPILIB "Build hal, wpilibc/j, and developerRobot (needs OpenCV)" ON)
+option(WPILIB_WITH_EXAMPLES "Build examples" OFF)
+option(WPILIB_WITH_TESTS "Build unit tests (requires internet connection)" ON)
+option(WPILIB_WITH_GUI "Build GUI items" ON)
+option(WPILIB_WITH_SIMULATION_MODULES "Build simulation modules" ON)
+option(WPILIB_WITH_BENCHMARK "Build the benchmark project" ON)
 
 # Options for using a package manager (e.g., vcpkg) for certain dependencies.
-option(USE_SYSTEM_EIGEN "Use system Eigen" OFF)
-option(USE_SYSTEM_FMTLIB "Use system fmtlib" OFF)
-option(USE_SYSTEM_LIBUV "Use system libuv" OFF)
-option(USE_SYSTEM_SLEIPNIR "Use system Sleipnir" OFF)
-option(USE_LINKED_AVAHI "Use directly linked Avahi instead of loading at runtime" OFF)
+option(WPILIB_USE_SYSTEM_EIGEN "Use system Eigen" OFF)
+option(WPILIB_USE_SYSTEM_FMTLIB "Use system fmtlib" OFF)
+option(WPILIB_USE_SYSTEM_LIBUV "Use system libuv" OFF)
+option(WPILIB_USE_SYSTEM_SLEIPNIR "Use system Sleipnir" OFF)
+option(WPILIB_USE_LINKED_AVAHI "Use directly linked Avahi instead of loading at runtime" OFF)
 
 # Options for compilation flags.
-option(NO_WERROR "Disable -Werror flag during compilation" OFF)
+option(WPILIB_NO_WERROR "Disable -Werror flag during compilation" OFF)
 
-wpilib_config(OPTIONS WITH_SIMULATION_MODULES REQUIRES BUILD_SHARED_LIBS WITH_WPILIB WITH_NTCORE)
+wpilib_config(
+    OPTIONS WPILIB_WITH_SIMULATION_MODULES
+    REQUIRES BUILD_SHARED_LIBS WPILIB_WITH_WPILIB WPILIB_WITH_NTCORE
+)
 
-wpilib_config(OPTIONS WITH_CSCORE REQUIRES WITH_NTCORE)
+wpilib_config(OPTIONS WPILIB_WITH_CSCORE REQUIRES WPILIB_WITH_NTCORE)
 
-wpilib_config(OPTIONS WITH_GUI REQUIRES WITH_NTCORE WITH_WPIMATH)
+wpilib_config(OPTIONS WPILIB_WITH_GUI REQUIRES WPILIB_WITH_NTCORE WPILIB_WITH_WPIMATH)
 
-wpilib_config(OPTIONS WITH_WPILIB REQUIRES WITH_NTCORE WITH_WPIMATH)
+wpilib_config(OPTIONS WPILIB_WITH_WPILIB REQUIRES WPILIB_WITH_NTCORE WPILIB_WITH_WPIMATH)
 
 set(include_dest include)
 
-if(WITH_DOCS)
+if(WPILIB_WITH_DOCS)
     find_package(Doxygen REQUIRED)
     find_package(Git REQUIRED)
     include(AddDoxygenDocs)
     add_doxygen_docs()
 endif()
 
-if(WITH_WPICAL)
+if(WPILIB_WITH_WPICAL)
     find_package(Ceres CONFIG REQUIRED)
 endif()
 
@@ -229,7 +232,7 @@ set(CMAKE_SHARED_LINKER_FLAGS_UBSAN
     FORCE
 )
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     enable_testing()
     add_subdirectory(thirdparty/googletest)
     include(GoogleTest)
@@ -238,11 +241,11 @@ if(WITH_TESTS)
     include(Catch)
 endif()
 
-if(USE_SYSTEM_LIBUV)
+if(WPILIB_USE_SYSTEM_LIBUV)
     set(LIBUV_SYSTEM_REPLACE "find_dependency(libuv CONFIG)")
 endif()
 
-if(USE_SYSTEM_EIGEN)
+if(WPILIB_USE_SYSTEM_EIGEN)
     set(EIGEN_SYSTEM_REPLACE "find_package(Eigen3 CONFIG)")
 endif()
 
@@ -255,26 +258,26 @@ add_subdirectory(wpiutil)
 
 add_subdirectory(datalog)
 
-if(WITH_NTCORE)
+if(WPILIB_WITH_NTCORE)
     set(NTCORE_DEP_REPLACE "find_dependency(ntcore)")
     set(WPINET_DEP_REPLACE "find_dependency(wpinet)")
     add_subdirectory(wpinet)
     add_subdirectory(ntcore)
 endif()
 
-if(WITH_WPIMATH)
+if(WPILIB_WITH_WPIMATH)
     set(WPIMATH_DEP_REPLACE "find_dependency(wpimath)")
     add_subdirectory(wpimath)
 endif()
 
-if(WITH_GUI)
+if(WPILIB_WITH_GUI)
     add_subdirectory(fields)
     add_subdirectory(thirdparty/imgui_suite)
     add_subdirectory(wpigui)
     add_subdirectory(glass)
     add_subdirectory(tools/outlineviewer)
     add_subdirectory(tools/sysid)
-    if(WITH_WPICAL)
+    if(WPILIB_WITH_WPICAL)
         add_subdirectory(tools/wpical)
     endif()
     if(LIBSSH_FOUND)
@@ -282,12 +285,12 @@ if(WITH_GUI)
     endif()
 endif()
 
-if(WITH_WPILIB OR WITH_SIMULATION_MODULES)
+if(WPILIB_WITH_WPILIB OR WPILIB_WITH_SIMULATION_MODULES)
     set(HAL_DEP_REPLACE "find_dependency(hal)")
     add_subdirectory(hal)
 endif()
 
-if(WITH_CSCORE)
+if(WPILIB_WITH_CSCORE)
     set(CAMERASERVER_DEP_REPLACE "find_dependency(cameraserver)")
     set(CSCORE_DEP_REPLACE "find_dependency(cscore)")
     find_package(OpenCV REQUIRED)
@@ -295,7 +298,7 @@ if(WITH_CSCORE)
     add_subdirectory(cameraserver)
 endif()
 
-if(WITH_WPILIB)
+if(WPILIB_WITH_WPILIB)
     set(APRILTAG_DEP_REPLACE "find_dependency(apriltag)")
     set(WPILIBC_DEP_REPLACE "find_dependency(wpilibc)")
     set(COMMAND_DEP_REPLACE "find_dependency(commandsv2)")
@@ -304,17 +307,17 @@ if(WITH_WPILIB)
     add_subdirectory(commandsv2)
     add_subdirectory(romiVendordep)
     add_subdirectory(xrpVendordep)
-    if(WITH_EXAMPLES)
+    if(WPILIB_WITH_EXAMPLES)
         add_subdirectory(wpilibcExamples)
     endif()
     add_subdirectory(developerRobot)
 endif()
 
-if(WITH_BENCHMARK)
+if(WPILIB_WITH_BENCHMARK)
     add_subdirectory(benchmark)
 endif()
 
-if(WITH_SIMULATION_MODULES)
+if(WPILIB_WITH_SIMULATION_MODULES)
     add_subdirectory(simulation)
 endif()
 

--- a/README-CMake.md
+++ b/README-CMake.md
@@ -40,23 +40,23 @@ The following build options are available:
 
 * `BUILD_SHARED_LIBS` (ON Default)
   * This option will cause CMake to build static libraries instead of shared libraries.
-* `WITH_CSCORE` (ON Default)
+* `WPILIB_WITH_CSCORE` (ON Default)
   * This option will cause cscore to be built. Turning this off will implicitly disable cameraserver. If this is off, the OpenCV build requirement is removed.
-* `WITH_EXAMPLES` (OFF Default)
+* `WPILIB_WITH_EXAMPLES` (OFF Default)
   * This option will build C++ examples.
-* `WITH_GUI` (ON Default)
-  * This option will build GUI items. If this is off, and `WITH_SIMULATION_MODULES` is on, the simulation GUI will not be built.
-* `WITH_NTCORE` (ON Default)
-  * This option will cause ntcore to be built. Turning this off will implicitly disable wpinet, and will cause an error if `WITH_WPILIB` is enabled.
-* `WITH_SIMULATION_MODULES` (ON Default)
+* `WPILIB_WITH_GUI` (ON Default)
+  * This option will build GUI items. If this is off, and `WPILIB_WITH_SIMULATION_MODULES` is on, the simulation GUI will not be built.
+* `WPILIB_WITH_NTCORE` (ON Default)
+  * This option will cause ntcore to be built. Turning this off will implicitly disable wpinet, and will cause an error if `WPILIB_WITH_WPILIB` is enabled.
+* `WPILIB_WITH_SIMULATION_MODULES` (ON Default)
   * This option will build simulation modules.
-* `WITH_TESTS` (ON Default)
+* `WPILIB_WITH_TESTS` (ON Default)
   * This option will build C++ unit tests. These can be run via `ctest -C <config>`, where `<config>` is the build configuration, e.g. `Debug` or `Release`.
-* `WITH_WPILIB` (ON Default)
+* `WPILIB_WITH_WPILIB` (ON Default)
   * This option will build the HAL and wpilibc during the build. The HAL is the simulation HAL, unless the external HAL options are used. The CMake build has no capability to build for Systemcore.
-* `WITH_WPIMATH` (ON Default)
+* `WPILIB_WITH_WPIMATH` (ON Default)
   * This option will build the wpimath library. This option must be on to build wpilib.
-* `NO_WERROR` (OFF Default)
+* `WPILIB_NO_WERROR` (OFF Default)
   * This option will disable the `-Werror` compilation flag for non-MSVC builds.
 * `WPILIB_TARGET_WARNINGS`
   * Add compiler flags to this option to customize compiler options like warnings.

--- a/apriltag/CMakeLists.txt
+++ b/apriltag/CMakeLists.txt
@@ -76,7 +76,7 @@ configure_file(apriltag-config.cmake.in ${WPILIB_BINARY_DIR}/apriltag-config.cma
 install(FILES ${WPILIB_BINARY_DIR}/apriltag-config.cmake DESTINATION share/apriltag)
 install(EXPORT apriltag DESTINATION share/apriltag)
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     wpilib_add_test_catch2(apriltag src/test/native/cpp)
     target_include_directories(apriltag_test PRIVATE src/test/native/include)
     target_link_libraries(apriltag_test apriltag)

--- a/cameraserver/CMakeLists.txt
+++ b/cameraserver/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(multiCameraServer cameraserver)
 
 set_property(TARGET multiCameraServer PROPERTY FOLDER "examples")
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     wpilib_add_test(cameraserver src/test/native/cpp)
     target_link_libraries(cameraserver_test cameraserver googletest)
 endif()

--- a/cmake/modules/CompileWarnings.cmake
+++ b/cmake/modules/CompileWarnings.cmake
@@ -8,7 +8,7 @@ macro(wpilib_target_warnings target)
             -Wformat=2
             ${WPILIB_TARGET_WARNINGS}
         )
-        if(NOT NO_WERROR)
+        if(NOT WPILIB_NO_WERROR)
             set(WARNING_FLAGS ${WARNING_FLAGS} -Werror)
         endif()
 
@@ -23,7 +23,7 @@ macro(wpilib_target_warnings target)
             /D_CRT_SECURE_NO_WARNINGS
             ${WPILIB_TARGET_WARNINGS}
         )
-        if(NOT NO_WERROR)
+        if(NOT WPILIB_NO_WERROR)
             set(WARNING_FLAGS ${WARNING_FLAGS} /WX)
         endif()
 

--- a/commandsv2/CMakeLists.txt
+++ b/commandsv2/CMakeLists.txt
@@ -34,7 +34,7 @@ configure_file(commandsv2-config.cmake.in ${WPILIB_BINARY_DIR}/commandsv2-config
 install(FILES ${WPILIB_BINARY_DIR}/commandsv2-config.cmake DESTINATION share/commandsv2)
 install(EXPORT commandsv2 DESTINATION share/commandsv2)
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     wpilib_add_test(commandsv2 src/test/native/cpp)
     target_include_directories(commandsv2_test PRIVATE src/test/native/include)
     target_link_libraries(commandsv2_test commandsv2 googletest)

--- a/cscore/CMakeLists.txt
+++ b/cscore/CMakeLists.txt
@@ -75,7 +75,7 @@ foreach(example ${cscore_examples})
     endif()
 endforeach()
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     wpilib_add_test_catch2(cscore src/test/native/cpp)
     target_link_libraries(cscore_test cscore)
 endif()

--- a/datalog/CMakeLists.txt
+++ b/datalog/CMakeLists.txt
@@ -35,7 +35,7 @@ configure_file(datalog-config.cmake.in ${WPILIB_BINARY_DIR}/datalog-config.cmake
 install(FILES ${WPILIB_BINARY_DIR}/datalog-config.cmake DESTINATION share/datalog)
 install(EXPORT datalog DESTINATION share/datalog)
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     file(GLOB_RECURSE datalog_testlib_src src/test/native/include/*.h)
     add_library(datalog_testlib INTERFACE ${datalog_test_src})
     target_include_directories(datalog_testlib INTERFACE src/test/native/include)

--- a/glass/CMakeLists.txt
+++ b/glass/CMakeLists.txt
@@ -37,7 +37,7 @@ install(
     DESTINATION "${include_dest}/glass"
 )
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     wpilib_add_test_catch2(glass src/test/native/cpp)
     target_link_libraries(glass_test libglass)
 endif()

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -33,7 +33,7 @@ configure_file(hal-config.cmake.in ${WPILIB_BINARY_DIR}/hal-config.cmake)
 install(FILES ${WPILIB_BINARY_DIR}/hal-config.cmake DESTINATION share/hal)
 install(EXPORT hal DESTINATION share/hal)
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     wpilib_add_test_catch2(hal src/test/native/cpp)
     target_link_libraries(hal_test hal)
 endif()

--- a/ntcore/CMakeLists.txt
+++ b/ntcore/CMakeLists.txt
@@ -43,7 +43,7 @@ add_executable(ntcoredev src/dev/native/cpp/main.cpp)
 wpilib_target_warnings(ntcoredev)
 target_link_libraries(ntcoredev ntcore)
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     wpilib_add_test(ntcore src/test/native/cpp)
     target_include_directories(ntcore_test PRIVATE src/main/native/cpp)
     target_link_libraries(ntcore_test ntcore googletest wpiutil_testlib)

--- a/romiVendordep/CMakeLists.txt
+++ b/romiVendordep/CMakeLists.txt
@@ -28,7 +28,7 @@ configure_file(romivendordep-config.cmake.in ${WPILIB_BINARY_DIR}/romivendordep-
 install(FILES ${WPILIB_BINARY_DIR}/romivendordep-config.cmake DESTINATION share/romiVendordep)
 install(EXPORT romivendordep DESTINATION share/romiVendordep)
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     wpilib_add_test_catch2(romiVendordep src/test/native/cpp)
     target_include_directories(romiVendordep_test PRIVATE src/test/native/include)
     target_link_libraries(romiVendordep_test romiVendordep)

--- a/simulation/CMakeLists.txt
+++ b/simulation/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(WITH_GUI)
+if(WPILIB_WITH_GUI)
     add_subdirectory(halsim_gui)
 endif()
 

--- a/tools/sysid/CMakeLists.txt
+++ b/tools/sysid/CMakeLists.txt
@@ -33,7 +33,7 @@ elseif(APPLE)
     set_target_properties(sysid PROPERTIES MACOSX_BUNDLE YES OUTPUT_NAME "SysId")
 endif()
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     wpilib_add_test_catch2(sysid src/test/native/cpp)
     wpilib_link_macos_gui(sysid_test)
     target_sources(sysid_test PRIVATE ${sysid_src})

--- a/tools/wpical/CMakeLists.txt
+++ b/tools/wpical/CMakeLists.txt
@@ -105,7 +105,7 @@ elseif(APPLE)
     set_target_properties(wpical PROPERTIES MACOSX_BUNDLE YES OUTPUT_NAME "wpical")
 endif()
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     wpilib_add_test_catch2(wpical src/test/native/cpp)
     wpilib_link_macos_gui(wpical_test)
     target_sources(wpical_test PRIVATE ${wpical_src} ${wpical_thirdparty_src})

--- a/wpilibc/CMakeLists.txt
+++ b/wpilibc/CMakeLists.txt
@@ -24,7 +24,7 @@ target_include_directories(
 )
 wpilib_target_warnings(wpilibc)
 
-if(WITH_CSCORE)
+if(WPILIB_WITH_CSCORE)
     target_link_libraries(wpilibc PUBLIC cameraserver cscore ${OpenCV_LIBS})
 else()
     target_compile_definitions(wpilibc PRIVATE DYNAMIC_CAMERA_SERVER)
@@ -48,13 +48,13 @@ configure_file(wpilibc-config.cmake.in ${WPILIB_BINARY_DIR}/wpilibc-config.cmake
 install(FILES ${WPILIB_BINARY_DIR}/wpilibc-config.cmake DESTINATION share/wpilibc)
 install(EXPORT wpilibc DESTINATION share/wpilibc)
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     wpilib_add_test(wpilibc src/test/native/cpp)
     file(GLOB_RECURSE wpilibc_generated_test_src src/generated/test/native/cpp/*.cpp)
     target_sources(wpilibc_test PRIVATE ${wpilibc_generated_test_src})
     target_include_directories(wpilibc_test PRIVATE src/test/native/include)
     target_link_libraries(wpilibc_test wpilibc googletest)
-    if(NOT WITH_CSCORE)
+    if(NOT WPILIB_WITH_CSCORE)
         target_compile_definitions(wpilibc_test PRIVATE DYNAMIC_CAMERA_SERVER)
         # Add just the camera server include directory
         target_include_directories(

--- a/wpilibcExamples/CMakeLists.txt
+++ b/wpilibcExamples/CMakeLists.txt
@@ -30,7 +30,10 @@ foreach(example ${EXAMPLES})
     )
     add_dependencies(wpilibcExamples ${example})
 
-    if(WITH_TESTS AND EXISTS ${CMAKE_SOURCE_DIR}/wpilibcExamples/src/test/cpp/examples/${example})
+    if(
+        WPILIB_WITH_TESTS
+        AND EXISTS ${CMAKE_SOURCE_DIR}/wpilibcExamples/src/test/cpp/examples/${example}
+    )
         wpilib_add_test(Example_${example} src/test/cpp/examples/${example}/cpp)
         target_sources(Example_${example}_test PRIVATE ${sources})
         target_include_directories(
@@ -85,7 +88,10 @@ foreach(snippet ${SNIPPETS})
     )
     add_dependencies(wpilibcExamples_snippets snippet${snippet})
 
-    if(WITH_TESTS AND EXISTS ${CMAKE_SOURCE_DIR}/wpilibcExamples/src/test/cpp/snippets/${snippet})
+    if(
+        WPILIB_WITH_TESTS
+        AND EXISTS ${CMAKE_SOURCE_DIR}/wpilibcExamples/src/test/cpp/snippets/${snippet}
+    )
         wpilib_add_test(Snippet_${snippet} src/test/cpp/snippets/${snippet}/cpp)
         target_sources(Snippet_${snippet}_test PRIVATE ${sources})
         target_include_directories(

--- a/wpimath/CMakeLists.txt
+++ b/wpimath/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 wpilib_target_warnings(wpimath)
 target_link_libraries(wpimath wpiutil)
 
-if(NOT USE_SYSTEM_EIGEN)
+if(NOT WPILIB_USE_SYSTEM_EIGEN)
     install(
         DIRECTORY src/main/native/thirdparty/eigen/include/
         DESTINATION "${include_dest}/wpimath"
@@ -91,7 +91,7 @@ target_include_directories(
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/thirdparty/gcem/include>
 )
 
-if(NOT USE_SYSTEM_SLEIPNIR)
+if(NOT WPILIB_USE_SYSTEM_SLEIPNIR)
     target_sources(wpimath PRIVATE ${sleipnir_native_src})
     install(
         DIRECTORY src/main/native/thirdparty/sleipnir/include/
@@ -138,7 +138,7 @@ configure_file(wpimath-config.cmake.in ${WPILIB_BINARY_DIR}/wpimath-config.cmake
 install(FILES ${WPILIB_BINARY_DIR}/wpimath-config.cmake DESTINATION share/wpimath)
 install(EXPORT wpimath DESTINATION share/wpimath)
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     wpilib_add_test(wpimath src/test/native/cpp)
     target_include_directories(wpimath_test PRIVATE src/test/native/include)
     target_link_libraries(wpimath_test wpimath googletest)

--- a/wpimath/wpimath-config.cmake.in
+++ b/wpimath/wpimath-config.cmake.in
@@ -2,11 +2,11 @@ include(CMakeFindDependencyMacro)
 @FILENAME_DEP_REPLACE@
 @WPIUTIL_DEP_REPLACE@
 
-if(@USE_SYSTEM_EIGEN@)
+if(@WPILIB_USE_SYSTEM_EIGEN@)
     find_dependency(Eigen3)
 endif()
 
-if(@USE_SYSTEM_SLEIPNIR@)
+if(@WPILIB_USE_SYSTEM_SLEIPNIR@)
   find_dependency(Sleipnir)
 endif()
 

--- a/wpinet/CMakeLists.txt
+++ b/wpinet/CMakeLists.txt
@@ -80,7 +80,7 @@ target_compile_features(wpinet PUBLIC cxx_std_23)
 wpilib_target_warnings(wpinet)
 target_link_libraries(wpinet PUBLIC wpiutil)
 
-if(USE_LINKED_AVAHI)
+if(WPILIB_USE_LINKED_AVAHI)
     find_library(AVAHI_COMMON REQUIRED NAMES avahi-common)
     if(AVAHI_COMMON)
         message(STATUS "Found avahi common: ${AVAHI_COMMON}")
@@ -95,7 +95,7 @@ if(USE_LINKED_AVAHI)
     target_compile_definitions(wpinet PRIVATE DIRECT_LINK_AVAHI)
 endif()
 
-if(NOT USE_SYSTEM_LIBUV)
+if(NOT WPILIB_USE_SYSTEM_LIBUV)
     target_sources(wpinet PRIVATE ${uv_native_src})
     install(
         DIRECTORY src/main/native/thirdparty/libuv/include/
@@ -186,7 +186,7 @@ target_link_libraries(netconsoleTee wpinet)
 set_property(TARGET netconsoleServer PROPERTY FOLDER "examples")
 set_property(TARGET netconsoleTee PROPERTY FOLDER "examples")
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     wpilib_add_test_catch2(wpinet src/test/native/cpp)
     target_include_directories(wpinet_test PRIVATE src/test/native/include src/main/native/cpp)
     target_link_libraries(wpinet_test wpinet ${LIBUTIL} wpiutil_testlib)

--- a/wpiutil/CMakeLists.txt
+++ b/wpiutil/CMakeLists.txt
@@ -58,7 +58,7 @@ if(ATOMIC)
     target_link_libraries(wpiutil ${ATOMIC})
 endif()
 
-if(NOT USE_SYSTEM_FMTLIB)
+if(NOT WPILIB_USE_SYSTEM_FMTLIB)
     target_sources(wpiutil PRIVATE ${fmtlib_native_src})
     install(
         DIRECTORY src/main/native/thirdparty/fmtlib/include/
@@ -141,7 +141,7 @@ foreach(example ${wpiutil_examples})
     endif()
 endforeach()
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     file(GLOB_RECURSE wpiutil_testlib_src src/test/native/include/*.h)
     add_library(wpiutil_testlib INTERFACE ${wpiutil_test_src})
     target_include_directories(wpiutil_testlib INTERFACE src/test/native/include)

--- a/wpiutil/wpiutil-config.cmake.in
+++ b/wpiutil/wpiutil-config.cmake.in
@@ -4,7 +4,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_dependency(Threads)
 @FMTLIB_SYSTEM_REPLACE@
 
-if(@USE_SYSTEM_FMTLIB@)
+if(@WPILIB_USE_SYSTEM_FMTLIB@)
     find_dependency(fmt)
 endif()
 

--- a/xrpVendordep/CMakeLists.txt
+++ b/xrpVendordep/CMakeLists.txt
@@ -28,7 +28,7 @@ configure_file(xrpvendordep-config.cmake.in ${WPILIB_BINARY_DIR}/xrpvendordep-co
 install(FILES ${WPILIB_BINARY_DIR}/xrpvendordep-config.cmake DESTINATION share/xrpVendordep)
 install(EXPORT xrpvendordep DESTINATION share/xrpVendordep)
 
-if(WITH_TESTS)
+if(WPILIB_WITH_TESTS)
     wpilib_add_test_catch2(xrpVendordep src/test/native/cpp)
     target_include_directories(xrpVendordep_test PRIVATE src/test/native/include)
     target_link_libraries(xrpVendordep_test xrpVendordep)


### PR DESCRIPTION
This is common practice in CMake projects to avoid name collisions.

Fixes #8984.