### PR TITLE
[hal] Add Python wpistruct support for ControlWord

### DIFF
--- a/hal/src/main/python/semiwrap/DriverStationTypes.yml
+++ b/hal/src/main/python/semiwrap/DriverStationTypes.yml
@@ -3,6 +3,7 @@ strip_prefixes:
 
 extra_includes:
 - src/ds_types_fmt.h
+- wpystruct.h
 
 enums:
   AllianceStationID:
@@ -33,3 +34,6 @@ classes:
       IsUtility:
       IsUtilityEnabled:
       GetValue:
+
+inline_code: |
+  SetupWPyStruct<wpi::hal::ControlWord>(cls_ControlWord);


### PR DESCRIPTION
Both C++ and Java already have Struct support for `ControlWord`.