### PR TITLE
[bazel] Fix sandbox leaks and add support for remote execution

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -65,7 +65,8 @@ build --strategy=CopyToDirectory=remote,standalone
 # All tests have a strategy of TestRunner.  Enable standalone for only tests.
 # See the following for more details:
 # https://github.com/bazelbuild/bazel/issues/7480
-build --strategy=TestRunner=remote,sandboxed,standalone
+build:linux --strategy=TestRunner=remote,sandboxed,standalone
+build:macos --strategy=TestRunner=remote,sandboxed,standalone
 build --strategy=NpmLifecycleHook=remote,sandboxed,standalone
 
 common:remote --config=common_cache

--- a/.bazelrc
+++ b/.bazelrc
@@ -56,6 +56,23 @@ build:remote_cache --remote_cache=grpcs://gitlib-bazel.wpi.edu
 
 common:remote_cache_readonly --noremote_upload_local_results
 
+# Stubs for remote execution.
+build:linux --strategy=TsProject=remote,sandboxed
+build --strategy=CopyFile=remote,standalone
+build --strategy=CopyDirectory=remote,standalone
+build --strategy=TestRunner=remote,standalone
+build:linux --strategy=NpmLifecycleHook=remote,sandboxed,standalone
+
+common:common_cache --experimental_remote_merkle_tree_cache
+common:remote --config=common_cache
+build:remote --incompatible_strict_action_env --experimental_inmemory_dotd_files --experimental_inmemory_jdeps_files --experimental_remote_merkle_tree_cache --incompatible_allow_tags_propagation
+# Specify your cluster as follows:
+# build:remote --remote_executor=grpcs://engflow.example.com --bes_backend=grpcs://engflow.example.com --bes_results_url=https://engflow.example.com/invocation/
+build:remote --jobs=100
+build:remote --remote_timeout=1500
+build:remote --spawn_strategy=remote,sandboxed,standalone
+build:remote --grpc_keepalive_time=30s
+
 # This config should be used locally. It downloads more than the CI version
 build:remote_user --config=remote_cache
 build:remote_user --config=remote_cache_readonly

--- a/.bazelrc
+++ b/.bazelrc
@@ -38,6 +38,7 @@ build:build_buddy_bes --bes_backend=grpcs://remote.buildbuddy.io
 build:common_cache --remote_timeout=3600
 build:common_cache --remote_cache_compression
 build:common_cache --experimental_remote_cache_compression_threshold=100
+common:common_cache --experimental_remote_merkle_tree_cache
 
 # Build Buddy Cache Setup
 build:build_buddy --config=common_cache
@@ -57,14 +58,13 @@ build:remote_cache --remote_cache=grpcs://gitlib-bazel.wpi.edu
 common:remote_cache_readonly --noremote_upload_local_results
 
 # Stubs for remote execution.
-build:linux --strategy=TsProject=remote,sandboxed
-build --strategy=CopyFile=remote,standalone
-build --strategy=CopyDirectory=remote,standalone
-build --strategy=CopyToDirectory=remote,standalone
-build --strategy=TestRunner=remote,sandboxed,standalone
-build:linux --strategy=NpmLifecycleHook=remote,sandboxed,standalone
+build:remote --strategy=TsProject=remote,sandboxed
+build:remote --strategy=CopyFile=remote,standalone
+build:remote --strategy=CopyDirectory=remote,standalone
+build:remote --strategy=CopyToDirectory=remote,standalone
+build:remote --strategy=TestRunner=remote,sandboxed,standalone
+build:remote --strategy=NpmLifecycleHook=remote,sandboxed,standalone
 
-common:common_cache --experimental_remote_merkle_tree_cache
 common:remote --config=common_cache
 build:remote --incompatible_strict_action_env --experimental_inmemory_dotd_files --experimental_inmemory_jdeps_files --experimental_remote_merkle_tree_cache --incompatible_allow_tags_propagation
 # Specify your cluster as follows:

--- a/.bazelrc
+++ b/.bazelrc
@@ -60,7 +60,8 @@ common:remote_cache_readonly --noremote_upload_local_results
 build:linux --strategy=TsProject=remote,sandboxed
 build --strategy=CopyFile=remote,standalone
 build --strategy=CopyDirectory=remote,standalone
-build --strategy=TestRunner=remote,standalone
+build --strategy=CopyToDirectory=remote,standalone
+build --strategy=TestRunner=remote,sandboxed,standalone
 build:linux --strategy=NpmLifecycleHook=remote,sandboxed,standalone
 
 common:common_cache --experimental_remote_merkle_tree_cache
@@ -70,7 +71,7 @@ build:remote --incompatible_strict_action_env --experimental_inmemory_dotd_files
 # build:remote --remote_executor=grpcs://engflow.example.com --bes_backend=grpcs://engflow.example.com --bes_results_url=https://engflow.example.com/invocation/
 build:remote --jobs=100
 build:remote --remote_timeout=1500
-build:remote --spawn_strategy=remote,sandboxed,standalone
+build:remote --spawn_strategy=remote,sandboxed
 build:remote --grpc_keepalive_time=30s
 
 # This config should be used locally. It downloads more than the CI version

--- a/.bazelrc
+++ b/.bazelrc
@@ -67,7 +67,8 @@ build --strategy=CopyToDirectory=remote,standalone
 # https://github.com/bazelbuild/bazel/issues/7480
 build:linux --strategy=TestRunner=remote,sandboxed,standalone
 build:macos --strategy=TestRunner=remote,sandboxed,standalone
-build --strategy=NpmLifecycleHook=remote,sandboxed,standalone
+build:linux --strategy=NpmLifecycleHook=remote,sandboxed,standalone
+build:macos --strategy=NpmLifecycleHook=remote,sandboxed,standalone
 
 common:remote --config=common_cache
 build:remote --incompatible_strict_action_env --experimental_inmemory_dotd_files --experimental_inmemory_jdeps_files --experimental_remote_merkle_tree_cache --incompatible_allow_tags_propagation

--- a/.bazelrc
+++ b/.bazelrc
@@ -59,11 +59,14 @@ common:remote_cache_readonly --noremote_upload_local_results
 
 # Stubs for remote execution.
 build:remote --strategy=TsProject=remote,sandboxed
-build:remote --strategy=CopyFile=remote,standalone
-build:remote --strategy=CopyDirectory=remote,standalone
-build:remote --strategy=CopyToDirectory=remote,standalone
-build:remote --strategy=TestRunner=remote,sandboxed,standalone
-build:remote --strategy=NpmLifecycleHook=remote,sandboxed,standalone
+build --strategy=CopyFile=remote,standalone
+build --strategy=CopyDirectory=remote,standalone
+build --strategy=CopyToDirectory=remote,standalone
+# All tests have a strategy of TestRunner.  Enable standalone for only tests.
+# See the following for more details:
+# https://github.com/bazelbuild/bazel/issues/7480
+build --strategy=TestRunner=remote,sandboxed,standalone
+build --strategy=NpmLifecycleHook=remote,sandboxed,standalone
 
 common:remote --config=common_cache
 build:remote --incompatible_strict_action_env --experimental_inmemory_dotd_files --experimental_inmemory_jdeps_files --experimental_remote_merkle_tree_cache --incompatible_allow_tags_propagation

--- a/commandsv3/BUILD.bazel
+++ b/commandsv3/BUILD.bazel
@@ -17,7 +17,10 @@ py_binary(
 
 filegroup(
     name = "templates",
-    srcs = glob(["src/generate/main/**"]) + [
+    srcs = glob([
+        "src/generate/main/**",
+        "src/main/proto/**",
+    ]) + [
         "//wpilibj:hid_schema",
     ],
 )

--- a/commandsv3/generate.bzl
+++ b/commandsv3/generate.bzl
@@ -7,6 +7,7 @@ def __generate_commandsv3_impl(ctx):
     args = ctx.actions.args()
     args.add("--output_directory", output_dir.path)
     args.add("--template_root", "commandsv3/src/generate")
+    args.add("--proto_directory", "commandsv3/src/main/proto")
     args.add("--protoc", ctx.executable._protoc)
     args.add("--quickbuf_plugin", ctx.executable._quickbuf)
 

--- a/hal/generate.bzl
+++ b/hal/generate.bzl
@@ -7,6 +7,8 @@ def __generate_hal_impl(ctx):
     args = ctx.actions.args()
     args.add("--output_directory", output_dir.path + "/main/native/cpp/mrc/protobuf")
     args.add("--nanopb", ctx.executable._nanopb_generator)
+    first_file = ctx.attr.proto_files.files.to_list()[0]
+    args.add("--proto_directory", first_file.dirname)
 
     ctx.actions.run(
         inputs = ctx.attr.proto_files.files.to_list(),

--- a/shared/bazel/BUILD.bazel
+++ b/shared/bazel/BUILD.bazel
@@ -47,6 +47,12 @@ platform(
 
 platform(
     name = "linux_x86_64",
+    exec_properties = {
+        "OSFamily": "Linux",
+        "container-image": "docker://wpilib/debian-base:trixie@sha256:4c20e850c88d9766a3aeaaf12901c9ca5e511b6ce59930046c187ce576fa1eeb",
+        "dockerAddCapabilities": "SYS_PTRACE",
+        "dockerReuse": "True",
+    },
     flags = [
         "--per_file_copt=external/.*@-Wno-pedantic,-Wno-format-nonliteral,-Wno-sign-compare,-Wno-type-limits,-Wno-maybe-uninitialized,-Wno-missing-field-initializers,-Wno-trigraphs,-Wno-attributes,-Wno-return-type,-Wno-unused-function,-Wno-format-y2k,-Wno-deprecated-declarations",
         "--per_file_copt=external/.*\\.cpp$,external/.*\\.cc$@-Wno-missing-requires,-Wno-volatile,-Wno-redundant-move,-Wno-class-memaccess,-Wno-ignored-qualifiers,-Wno-stringop-overflow,-Wno-extra",

--- a/shared/bazel/rules/robotpy/generate_pybind_build_file.py
+++ b/shared/bazel/rules/robotpy/generate_pybind_build_file.py
@@ -51,24 +51,7 @@ class HeaderToDatConfig:
         self.yml_file = args[1].path
         self.defines = defines
 
-        def find_root_dir(include_root):
-            """
-            Somewhat naive attempt to find the "root" directory of the repository,
-            as specified from the runfiles path
-            """
-            if "__main__/" in include_root:
-                return pathlib.Path(
-                    include_root[: include_root.find("__main__/") + len("__main__/")]
-                )
-            elif "_main/" in include_root:
-                return pathlib.Path(
-                    include_root[: include_root.find("_main/") + len("_main/")]
-                )
-            else:
-                return pathlib.Path(include_root)
-
         include_root = str(args[3]).replace("\\", "/")
-        root_dir = find_root_dir(include_root)
         if "native" in include_root:
             # base_include_root = pathlib.Path(*args[3].relative_to(root_dir).parts[3:])
             base_include_file = args[2].relative_to(include_root)
@@ -77,12 +60,9 @@ class HeaderToDatConfig:
             self.include_file = f"$(execpath :{fixup_native_lib_name('robotpy-native-' + base_library)}.copy_headers)/{base_include_file}"
             self.include_root = f"$(execpath :{fixup_native_lib_name('robotpy-native-' + base_library)}.copy_headers)"
         else:
-            if root_dir.is_absolute():
-                self.include_file = args[2].relative_to(root_dir)
-                self.include_root = args[3].relative_to(root_dir)
-            else:
-                self.include_file = args[2]
-                self.include_root = args[3]
+            root_dir = pathlib.Path.cwd().absolute()
+            self.include_file = pathlib.Path(args[2]).absolute().relative_to(root_dir)
+            self.include_root = pathlib.Path(args[3]).absolute().relative_to(root_dir)
         # type casters         = 4
         # dat file             = 5
         # d file               = 6

--- a/wpimath/generate.bzl
+++ b/wpimath/generate.bzl
@@ -6,6 +6,8 @@ def __generate_wpimath_impl(ctx):
 
     args = ctx.actions.args()
     args.add("--output_directory", output_dir.path)
+    args.add("--template_root", "wpimath/src/generate")
+    args.add("--proto_directory", "wpimath/src/main/proto")
     args.add("--protoc", ctx.executable._protoc)
     args.add("--quickbuf_plugin", ctx.executable._quickbuf)
     args.add("--nanopb_generator", ctx.executable._nanopb_generator)

--- a/wpiutil/generate.bzl
+++ b/wpiutil/generate.bzl
@@ -7,6 +7,8 @@ def __generate_wpiutil_impl(ctx):
     args = ctx.actions.args()
     args.add("--output_directory", output_dir.path)
     args.add("--nanopb", ctx.executable._nanopb_generator)
+    first_file = ctx.attr.proto_files.files.to_list()[0]
+    args.add("--proto_directory", first_file.dirname)
 
     ctx.actions.run(
         inputs = ctx.attr.proto_files.files,


### PR DESCRIPTION
These were caught by building on engflow.spacecookies.dev.  This fixes a couple of places where paths were escaping the sandbox and resolving back to the git repo.