### PR TITLE
[wpical] Fix race conditions and unnecessary alignment

### DIFF
--- a/tools/wpical/src/main/native/cpp/cameracalibration.cpp
+++ b/tools/wpical/src/main/native/cpp/cameracalibration.cpp
@@ -80,6 +80,7 @@ class Data {
    */
   std::optional<cv::Mat> GetFrame();
 
+  std::atomic_bool m_isFinished;
   std::optional<CameraModel> cameraModel;
   std::queue<cv::Mat> queue;
   wpi::util::mutex mutex;
@@ -139,6 +140,7 @@ class Worker {
       cv::aruco::getPredefinedDictionary(cv::aruco::DICT_5X5_1000);
   cv::aruco::CharucoBoard m_charucoBoard;
   cv::aruco::CharucoDetector m_charucoDetector;
+  std::thread m_thread;
 };
 
 Worker::Worker(std::shared_ptr<Data> data, float squareWidth, float markerWidth,
@@ -148,22 +150,22 @@ Worker::Worker(std::shared_ptr<Data> data, float squareWidth, float markerWidth,
       m_squareWidth(squareWidth * 0.0254),
       m_charucoBoard(cv::Size(boardWidth, boardHeight), squareWidth * 0.0254,
                      markerWidth * 0.0254, m_arucoDict),
-      m_charucoDetector(m_charucoBoard) {
-  std::thread([this, data] {
-    while (!m_isDone) {
-      std::optional<cv::Mat> mat = data->GetFrame();
-      if (mat) {
-        ProcessNextImage(*mat);
-        ++m_framesProcessed;
-      } else {
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      }
-    }
-  }).detach();
-}
+      m_charucoDetector(m_charucoBoard),
+      m_thread([this, data] {
+        while (!m_isDone) {
+          std::optional<cv::Mat> mat = data->GetFrame();
+          if (mat) {
+            ProcessNextImage(*mat);
+            ++m_framesProcessed;
+          } else {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+          }
+        }
+      }) {}
 
 Worker::~Worker() {
   Stop();
+  m_thread.join();
 }
 
 void Worker::ProcessNextImage(cv::Mat image) {
@@ -235,17 +237,17 @@ CameraCalibrator::CameraCalibrator(size_t numWorkers, double squareWidth,
     cv::Size frameShape{
         static_cast<int>(capture.get(cv::CAP_PROP_FRAME_WIDTH)),
         static_cast<int>(capture.get(cv::CAP_PROP_FRAME_HEIGHT))};
-    while (capture.grab() && !m_isFinished) {
+    while (capture.grab() && !state->m_isFinished) {
       cv::Mat frame;
       capture.retrieve(frame);
       cv::Mat frameGray;
       cv::cvtColor(frame, frameGray, cv::COLOR_BGR2GRAY);
       state->AddFrame(std::move(frameGray));
     }
-    while (TotalFramesProcessed() < TotalFrames() && !m_isFinished) {
+    while (!state->m_isFinished && TotalFramesProcessed() < TotalFrames()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    if (m_isFinished) {
+    if (state->m_isFinished) {
       state->cameraModel = std::nullopt;
       return;
     }
@@ -259,14 +261,14 @@ CameraCalibrator::CameraCalibrator(size_t numWorkers, double squareWidth,
                               data.second.end());
     }
     if (allObservationBoards.empty()) {
-      m_isFinished = true;
+      state->m_isFinished = true;
       return;
     }
     auto result = mrcal_main(allObservationBoards, allFramesRtToref,
                              cv::Size(boardWidth - 1, boardHeight - 1),
                              squareWidth * 0.0254, frameShape, 1000);
     state->cameraModel = MrcalResultToCameraModel(*result);
-    m_isFinished = true;
+    state->m_isFinished = true;
   }).detach();
 }
 
@@ -275,7 +277,7 @@ CameraCalibrator::~CameraCalibrator() {
 }
 
 bool CameraCalibrator::IsFinished() {
-  return m_isFinished;
+  return m_state->m_isFinished;
 }
 
 std::optional<CameraModel> CameraCalibrator::GetCameraModel() {
@@ -295,7 +297,7 @@ int CameraCalibrator::TotalFrames() {
 }
 
 void CameraCalibrator::Stop() {
-  m_isFinished = true;
+  m_state->m_isFinished = true;
   for (auto& workers : m_workers) {
     workers->Stop();
   }

--- a/tools/wpical/src/main/native/cpp/fieldcalibration.cpp
+++ b/tools/wpical/src/main/native/cpp/fieldcalibration.cpp
@@ -27,18 +27,17 @@
 #include "wpi/apriltag/AprilTagDetector.hpp"
 #include "wpi/apriltag/AprilTagDetector_cv.hpp"
 #include "wpi/apriltag/AprilTagFieldLayout.hpp"
+#include "wpi/math/geometry/Pose3d.hpp"
 
 struct Pose {
   Eigen::Vector3d p;
   Eigen::Quaterniond q;
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 struct Constraint {
   int idBegin;
   int idEnd;
   Pose tBeginEnd;
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 class PoseGraphError {
@@ -82,8 +81,6 @@ class PoseGraphError {
     return new ceres::AutoDiffCostFunction<PoseGraphError, 6, 3, 4, 3, 4>(
         new PoseGraphError(t_ab_observed));
   }
-
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
  private:
   const Pose m_t_ab_observed;
@@ -190,14 +187,12 @@ inline void DrawTagCube(cv::Mat& frame, Eigen::Matrix4d cameraToTag,
   }
 }
 
-inline bool ProcessVideoFile(
-    wpi::apriltag::AprilTagDetector& detector,
-    const wpical::CameraModel& cameraModel, double tagSize,
-    const std::string& path,
-    std::map<int, Pose, std::less<int>,
-             Eigen::aligned_allocator<std::pair<const int, Pose>>>& poses,
-    std::vector<Constraint, Eigen::aligned_allocator<Constraint>>& constraints,
-    bool showDebugWindow) {
+inline bool ProcessVideoFile(wpi::apriltag::AprilTagDetector& detector,
+                             const wpical::CameraModel& cameraModel,
+                             double tagSize, const std::string& path,
+                             std::map<int, Pose, std::less<int>>& poses,
+                             std::vector<Constraint>& constraints,
+                             bool showDebugWindow) {
   if (showDebugWindow) {
     cv::namedWindow("Processing Frame", cv::WINDOW_NORMAL);
   }
@@ -330,10 +325,8 @@ std::optional<wpi::apriltag::AprilTagFieldLayout> wpical::calibrate(
   detector.AddFamily("tag36h11");
 
   // Find tag poses
-  std::map<int, Pose, std::less<int>,
-           Eigen::aligned_allocator<std::pair<const int, Pose>>>
-      poses;
-  std::vector<Constraint, Eigen::aligned_allocator<Constraint>> constraints;
+  std::map<int, Pose, std::less<int>> poses;
+  std::vector<Constraint> constraints;
 
   for (const auto& entry : std::filesystem::directory_iterator(inputDirPath)) {
     if (entry.path().filename().string()[0] == '.') {
@@ -384,11 +377,11 @@ std::optional<wpi::apriltag::AprilTagFieldLayout> wpical::calibrate(
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);
 
-  Eigen::Matrix4d correctionA;
-  correctionA << 0, 0, -1, 0, 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 1;
+  Eigen::Matrix4d correctionA{
+      {0, 0, -1, 0}, {1, 0, 0, 0}, {0, -1, 0, 0}, {0, 0, 0, 1}};
 
-  Eigen::Matrix4d correctionB;
-  correctionB << 0, 1, 0, 0, 0, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 1;
+  Eigen::Matrix4d correctionB{
+      {0, 1, 0, 0}, {0, 0, -1, 0}, {-1, 0, 0, 0}, {0, 0, 0, 1}};
 
   Eigen::Matrix4d pinnedTagTransform =
       idealLayout.GetTagPose(pinnedTagId)->ToMatrix();

--- a/tools/wpical/src/main/native/include/cameracalibration.hpp
+++ b/tools/wpical/src/main/native/include/cameracalibration.hpp
@@ -88,7 +88,6 @@ class CameraCalibrator {
   // Ensures that shared state lives until everything else is destroyed
   std::shared_ptr<Data> m_state;
 
-  std::atomic_bool m_isFinished{false};
   std::atomic_int m_totalFrames;
   std::vector<std::shared_ptr<Worker>> m_workers;
 };


### PR DESCRIPTION
Alignment code isn't needed since C++17.

Bazel tests were segfaulting and asan traced this to use-after-frees related to some of the atomic booleans. Worker threads are now joined to ensure the thread is completely stopped and destroyed before the atomic boolean is freed. The primary camera calibration thread also has had its finished flag moved to a shared_ptr to ensure it lives long enough.