### PR TITLE
Remove clangd from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,11 +239,6 @@ ipch/
 # compile_commands
 compile_commands.json
 
-# clang configuration and clangd cache
-.clang
-.clangd
-.cache/
-
 imgui.ini
 
 # Bazel


### PR DESCRIPTION
Modern versions of clangd put the index in a .cache folder that contains its own .gitignore.