### PR TITLE
[wpiutil] Add protobuf List pack/unpack for Java

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/trajectory/proto/TrajectoryProto.java
+++ b/wpimath/src/main/java/org/wpilib/math/trajectory/proto/TrajectoryProto.java
@@ -4,9 +4,7 @@
 
 package org.wpilib.math.trajectory.proto;
 
-import java.util.ArrayList;
 import org.wpilib.math.proto.ProtobufTrajectory;
-import org.wpilib.math.proto.ProtobufTrajectoryState;
 import org.wpilib.math.trajectory.Trajectory;
 import org.wpilib.util.protobuf.Protobuf;
 import us.hebi.quickbuf.Descriptors.Descriptor;
@@ -29,19 +27,11 @@ public class TrajectoryProto implements Protobuf<Trajectory, ProtobufTrajectory>
 
   @Override
   public Trajectory unpack(ProtobufTrajectory msg) {
-    ArrayList<Trajectory.State> states = new ArrayList<>(msg.getStates().length());
-    for (ProtobufTrajectoryState protoState : msg.getStates()) {
-      states.add(Trajectory.State.proto.unpack(protoState));
-    }
-
-    return new Trajectory(states);
+    return new Trajectory(Protobuf.unpackList(msg.getStates(), Trajectory.State.proto));
   }
 
   @Override
   public void pack(ProtobufTrajectory msg, Trajectory value) {
-    var states = msg.getMutableStates().reserve(value.getStates().size());
-    for (var item : value.getStates()) {
-      Trajectory.State.proto.pack(states.next(), item);
-    }
+    Protobuf.packList(msg.getMutableStates(), value.getStates(), Trajectory.State.proto);
   }
 }

--- a/wpiutil/src/main/java/org/wpilib/util/protobuf/Protobuf.java
+++ b/wpiutil/src/main/java/org/wpilib/util/protobuf/Protobuf.java
@@ -5,6 +5,8 @@
 package org.wpilib.util.protobuf;
 
 import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import us.hebi.quickbuf.Descriptors.Descriptor;
@@ -181,6 +183,24 @@ public interface Protobuf<T, MessageType extends ProtoMessage<?>> {
   }
 
   /**
+   * Unpack a serialized protobuf array message to a list.
+   *
+   * @param <T> object type
+   * @param <MessageType> element type of the protobuf array
+   * @param msg protobuf array message
+   * @param proto protobuf implementation
+   * @return Deserialized list
+   */
+  static <T, MessageType extends ProtoMessage<MessageType>> List<T> unpackList(
+      RepeatedMessage<MessageType> msg, Protobuf<T, MessageType> proto) {
+    ArrayList<T> result = new ArrayList<>(msg.length());
+    for (var item : msg) {
+      result.add(proto.unpack(item));
+    }
+    return result;
+  }
+
+  /**
    * Pack a serialized protobuf array message.
    *
    * @param <T> object type
@@ -208,5 +228,23 @@ public interface Protobuf<T, MessageType extends ProtoMessage<?>> {
     msg.clear();
     msg.reserve(arr.length);
     msg.addAll(arr);
+  }
+
+  /**
+   * Pack a serialized protobuf array message to a list.
+   *
+   * @param <T> object type
+   * @param <MessageType> element type of the protobuf array
+   * @param msg protobuf array message
+   * @param list list of objects
+   * @param proto protobuf implementation
+   */
+  static <T, MessageType extends ProtoMessage<MessageType>> void packList(
+      RepeatedMessage<MessageType> msg, List<T> list, Protobuf<T, MessageType> proto) {
+    msg.clear();
+    msg.reserve(list.size());
+    for (var obj : list) {
+      proto.pack(msg.next(), obj);
+    }
   }
 }


### PR DESCRIPTION
To aid in simplifying the packing/unpacking of Lists to protobuf, this adds helper methods that put the iteration logic in `Protobuf.java`, similar to arrays. This makes packing/unpacking a List a single line, similar to other types. Useful for #8776 and #8172.