### PR TITLE
[bazel] Refactor compiler flags and ignore more things

### DIFF
--- a/shared/bazel/BUILD.bazel
+++ b/shared/bazel/BUILD.bazel
@@ -1,20 +1,27 @@
 package(default_visibility = ["//visibility:public"])
 
-platform(
-    name = "systemcore",
-    flags = [
-    ],
-    parents = [
-        "@wpilib_toolchains//platforms/systemcore",
-    ],
-)
-
 windows_flags = [
     "--host_copt=/wd4141",
     "--host_copt=/wd4715",
     "--host_per_file_copt=external/.*\\.c$,external/.*\\.cc$@/wd4047,/wd4267,/wd4244,/wd4334,/wd4646,/wd4018,/wd4200,/wd5287",
     "--per_file_copt=external/.*\\.c$,external/.*\\.cc$@/wd4047,/wd4267,/wd4244,/wd4334,/wd4646,/wd4018,/wd4200,/wd5287",
 ]
+
+gcc_flags = [
+    "--per_file_copt=external/.*,third_party/.*@-Wno-pedantic,-Wno-format-nonliteral,-Wno-sign-compare,-Wno-type-limits,-Wno-maybe-uninitialized,-Wno-missing-field-initializers,-Wno-trigraphs,-Wno-attributes,-Wno-return-type,-Wno-unused-function,-Wno-format-y2k,-Wno-deprecated-declarations,-Wno-cast-function-type,-Wno-implicit-fallthrough,-Wno-empty-body,-Wno-error",
+    "--per_file_copt=external/.*\\.cpp$,external/.*\\.cc$,external/.*\\.h$,third_party/.*\\.cpp$,third_party/.*\\.cc$,third_party/.*\\.h$@-Wno-missing-requires,-Wno-volatile,-Wno-redundant-move,-Wno-class-memaccess,-Wno-ignored-qualifiers,-Wno-stringop-overflow,-Wno-extra,-Wno-pessimizing-move",
+    "--host_per_file_copt=external/.*,third_party/.*@-Wno-pedantic,-Wno-format-nonliteral,-Wno-sign-compare,-Wno-type-limits,-Wno-maybe-uninitialized,-Wno-missing-field-initializers,-Wno-trigraphs,-Wno-attributes,-Wno-return-type,-Wno-unused-function,-Wno-format-y2k,-Wno-deprecated-declarations,-Wno-cast-function-type,-Wno-implicit-fallthrough,-Wno-empty-body,-Wno-error",
+    "--host_per_file_copt=external/.*\\.cpp$,external/.*\\.cc$,external/.*\\.h$,third_party/.*\\.cpp$,third_party/.*\\.cc$,third_party/.*\\.h$@-Wno-missing-requires,-Wno-volatile,-Wno-redundant-move,-Wno-class-memaccess,-Wno-ignored-qualifiers,-Wno-stringop-overflow,-Wno-extra,-Wno-pessimizing-move",
+]
+
+platform(
+    name = "systemcore",
+    flags = [
+    ] + gcc_flags,
+    parents = [
+        "@wpilib_toolchains//platforms/systemcore",
+    ],
+)
 
 platform(
     name = "windows_arm64",
@@ -54,9 +61,7 @@ platform(
         "dockerReuse": "True",
     },
     flags = [
-        "--per_file_copt=external/.*@-Wno-pedantic,-Wno-format-nonliteral,-Wno-sign-compare,-Wno-type-limits,-Wno-maybe-uninitialized,-Wno-missing-field-initializers,-Wno-trigraphs,-Wno-attributes,-Wno-return-type,-Wno-unused-function,-Wno-format-y2k,-Wno-deprecated-declarations",
-        "--per_file_copt=external/.*\\.cpp$,external/.*\\.cc$@-Wno-missing-requires,-Wno-volatile,-Wno-redundant-move,-Wno-class-memaccess,-Wno-ignored-qualifiers,-Wno-stringop-overflow,-Wno-extra",
-    ],
+    ] + gcc_flags,
     parents = [
         "@wpilib_toolchains//platforms/linux_x86_64",
     ],


### PR DESCRIPTION
Some public repositories require more aggressive flags to reverse the effects of -Wpedantic in third party code.