### PR TITLE
[wpilib] Rename FMSInfo table to DriverStation

### DIFF
--- a/glass/src/lib/native/cpp/other/DS.cpp
+++ b/glass/src/lib/native/cpp/other/DS.cpp
@@ -2,7 +2,7 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include "wpi/glass/other/FMS.hpp"
+#include "wpi/glass/other/DS.hpp"
 
 #include <string>
 
@@ -19,9 +19,9 @@ static const char* stations[] = {"Invalid", "Red 1",  "Red 2", "Red 3",
 static const char* robotModes[] = {"Unknown", "Autonomous", "Teleoperated",
                                    "Utility"};
 
-void wpi::glass::DisplayFMS(FMSModel* model, bool editableDsAttached) {
+void wpi::glass::DisplayDS(DSModel* model, bool editableDsAttached) {
   if (!model->Exists() || model->IsReadOnly()) {
-    return DisplayFMSReadOnly(model);
+    return DisplayDSReadOnly(model);
   }
 
   // FMS Attached
@@ -91,7 +91,7 @@ void wpi::glass::DisplayFMS(FMSModel* model, bool editableDsAttached) {
   }
 }
 
-void wpi::glass::DisplayFMSReadOnly(FMSModel* model) {
+void wpi::glass::DisplayDSReadOnly(DSModel* model) {
   bool exists = model->Exists();
   if (!exists) {
     ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));

--- a/glass/src/lib/native/include/wpi/glass/other/DS.hpp
+++ b/glass/src/lib/native/include/wpi/glass/other/DS.hpp
@@ -20,7 +20,7 @@ class DoubleSource;
 class IntegerSource;
 class StringSource;
 
-class FMSModel : public Model {
+class DSModel : public Model {
  public:
   enum RobotMode {
     kUnknown = 0,
@@ -49,13 +49,13 @@ class FMSModel : public Model {
 };
 
 /**
- * Displays FMS view.
+ * Displays DS view.
  *
  * @param matchTimeEnabled If not null, a checkbox is displayed for
  *                         "enable match time" linked to this value
  * @param editableDsAttached If true, DS attached should be editable
  */
-void DisplayFMS(FMSModel* model, bool editableDsAttached);
-void DisplayFMSReadOnly(FMSModel* model);
+void DisplayDS(DSModel* model, bool editableDsAttached);
+void DisplayDSReadOnly(DSModel* model);
 
 }  // namespace wpi::glass

--- a/glass/src/libnt/native/cpp/NTDS.cpp
+++ b/glass/src/libnt/native/cpp/NTDS.cpp
@@ -2,7 +2,7 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include "wpi/glass/networktables/NTFMS.hpp"
+#include "wpi/glass/networktables/NTDS.hpp"
 
 #include <stdint.h>
 
@@ -24,11 +24,10 @@
 
 using namespace wpi::glass;
 
-NTFMSModel::NTFMSModel(std::string_view path)
-    : NTFMSModel{wpi::nt::NetworkTableInstance::GetDefault(), path} {}
+NTDSModel::NTDSModel(std::string_view path)
+    : NTDSModel{wpi::nt::NetworkTableInstance::GetDefault(), path} {}
 
-NTFMSModel::NTFMSModel(wpi::nt::NetworkTableInstance inst,
-                       std::string_view path)
+NTDSModel::NTDSModel(wpi::nt::NetworkTableInstance inst, std::string_view path)
     : m_inst{inst},
       m_gameDataSubscriber{
           inst.GetStringTopic(fmt::format("{}/GameData", path)).Subscribe("")},
@@ -37,15 +36,15 @@ NTFMSModel::NTFMSModel(wpi::nt::NetworkTableInstance inst,
               .Subscribe(0)},
       m_controlWord{inst.GetRawTopic(fmt::format("{}/ControlWord", path))
                         .Subscribe("struct:ControlWord", {})},
-      m_fmsAttached{fmt::format("NT_FMS:FMSAttached:{}", path)},
-      m_dsAttached{fmt::format("NT_FMS:DSAttached:{}", path)},
-      m_allianceStationId{fmt::format("NT_FMS:AllianceStationID:{}", path)},
-      m_estop{fmt::format("NT_FMS:EStop:{}", path)},
-      m_enabled{fmt::format("NT_FMS:RobotEnabled:{}", path)},
-      m_robotMode{fmt::format("NT_FMS:RobotMode:{}", path)},
-      m_gameData{fmt::format("NT_FMS:GameData:{}", path)} {}
+      m_fmsAttached{fmt::format("NT_DS:FMSAttached:{}", path)},
+      m_dsAttached{fmt::format("NT_DS:DSAttached:{}", path)},
+      m_allianceStationId{fmt::format("NT_DS:AllianceStationID:{}", path)},
+      m_estop{fmt::format("NT_DS:EStop:{}", path)},
+      m_enabled{fmt::format("NT_DS:RobotEnabled:{}", path)},
+      m_robotMode{fmt::format("NT_DS:RobotMode:{}", path)},
+      m_gameData{fmt::format("NT_DS:GameData:{}", path)} {}
 
-void NTFMSModel::Update() {
+void NTDSModel::Update() {
   for (auto&& v : m_allianceStation.ReadQueue()) {
     m_allianceStationId.SetValue(v.value, v.time);
   }
@@ -74,6 +73,6 @@ void NTFMSModel::Update() {
   }
 }
 
-bool NTFMSModel::Exists() {
+bool NTDSModel::Exists() {
   return m_controlWord.Exists();
 }

--- a/glass/src/libnt/native/cpp/StandardNetworkTables.cpp
+++ b/glass/src/libnt/native/cpp/StandardNetworkTables.cpp
@@ -7,10 +7,10 @@
 #include "wpi/glass/networktables/NTAlerts.hpp"
 #include "wpi/glass/networktables/NTCommandScheduler.hpp"
 #include "wpi/glass/networktables/NTCommandSelector.hpp"
+#include "wpi/glass/networktables/NTDS.hpp"
 #include "wpi/glass/networktables/NTDifferentialDrive.hpp"
 #include "wpi/glass/networktables/NTDigitalInput.hpp"
 #include "wpi/glass/networktables/NTDigitalOutput.hpp"
-#include "wpi/glass/networktables/NTFMS.hpp"
 #include "wpi/glass/networktables/NTField2D.hpp"
 #include "wpi/glass/networktables/NTGyro.hpp"
 #include "wpi/glass/networktables/NTMecanumDrive.hpp"
@@ -70,14 +70,14 @@ void wpi::glass::AddStandardNetworkTablesViews(
         });
       });
   provider.Register(
-      NTFMSModel::kType,
+      NTDSModel::kType,
       [](wpi::nt::NetworkTableInstance inst, const char* path) {
-        return std::make_unique<NTFMSModel>(inst, path);
+        return std::make_unique<NTDSModel>(inst, path);
       },
       [](Window* win, Model* model, const char*) {
         win->SetFlags(ImGuiWindowFlags_AlwaysAutoResize);
         return MakeFunctionView(
-            [=] { DisplayFMS(static_cast<FMSModel*>(model), true); });
+            [=] { DisplayDS(static_cast<DSModel*>(model), true); });
       });
   provider.Register(
       NTDigitalInputModel::kType,

--- a/glass/src/libnt/native/include/wpi/glass/networktables/NTDS.hpp
+++ b/glass/src/libnt/native/include/wpi/glass/networktables/NTDS.hpp
@@ -7,7 +7,7 @@
 #include <string_view>
 
 #include "wpi/glass/DataSource.hpp"
-#include "wpi/glass/other/FMS.hpp"
+#include "wpi/glass/other/DS.hpp"
 #include "wpi/nt/BooleanTopic.hpp"
 #include "wpi/nt/IntegerTopic.hpp"
 #include "wpi/nt/NetworkTableInstance.hpp"
@@ -16,13 +16,13 @@
 
 namespace wpi::glass {
 
-class NTFMSModel : public FMSModel {
+class NTDSModel : public DSModel {
  public:
-  static constexpr const char* kType = "FMSInfo";
+  static constexpr const char* kType = "DriverStation";
 
   // path is to the table containing ".type", excluding the trailing /
-  explicit NTFMSModel(std::string_view path);
-  NTFMSModel(wpi::nt::NetworkTableInstance inst, std::string_view path);
+  explicit NTDSModel(std::string_view path);
+  NTDSModel(wpi::nt::NetworkTableInstance inst, std::string_view path);
 
   BooleanSource* GetFmsAttachedData() override { return &m_fmsAttached; }
   BooleanSource* GetDsAttachedData() override { return &m_dsAttached; }

--- a/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
@@ -21,7 +21,7 @@
 #include "wpi/glass/Context.hpp"
 #include "wpi/glass/Storage.hpp"
 #include "wpi/glass/other/AnsiDisplay.hpp"
-#include "wpi/glass/other/FMS.hpp"
+#include "wpi/glass/other/DS.hpp"
 #include "wpi/glass/support/ExtraGuiWidgets.hpp"
 #include "wpi/glass/support/NameSetting.hpp"
 #include "wpi/gui/wpigui.hpp"
@@ -214,9 +214,9 @@ class JoystickModel {
   int32_t m_callback;
 };
 
-class FMSSimModel : public wpi::glass::FMSModel {
+class DSSimModel : public wpi::glass::DSModel {
  public:
-  FMSSimModel();
+  DSSimModel();
 
   wpi::glass::BooleanSource* GetFmsAttachedData() override {
     return &m_fmsAttached;
@@ -257,15 +257,15 @@ class FMSSimModel : public wpi::glass::FMSModel {
   bool IsReadOnly() override;
 
  private:
-  wpi::glass::BooleanSource m_fmsAttached{"FMS:FMSAttached"};
-  wpi::glass::BooleanSource m_dsAttached{"FMS:DSAttached"};
-  wpi::glass::IntegerSource m_allianceStationId{"FMS:AllianceStationID"};
-  wpi::glass::DoubleSource m_matchTime{"FMS:MatchTime"};
-  wpi::glass::BooleanSource m_estop{"FMS:EStop"};
-  wpi::glass::BooleanSource m_enabled{"FMS:RobotEnabled"};
-  wpi::glass::IntegerSource m_robotMode{"FMS:RobotMode"};
+  wpi::glass::BooleanSource m_fmsAttached{"DS:FMSAttached"};
+  wpi::glass::BooleanSource m_dsAttached{"DS:DSAttached"};
+  wpi::glass::IntegerSource m_allianceStationId{"DS:AllianceStationID"};
+  wpi::glass::DoubleSource m_matchTime{"DS:MatchTime"};
+  wpi::glass::BooleanSource m_estop{"DS:EStop"};
+  wpi::glass::BooleanSource m_enabled{"DS:RobotEnabled"};
+  wpi::glass::IntegerSource m_robotMode{"DS:RobotMode"};
   double m_startMatchTime = -1.0;
-  wpi::glass::StringSource m_gameMessage{"FMS:GameData"};
+  wpi::glass::StringSource m_gameMessage{"DS:GameData"};
 };
 
 }  // namespace
@@ -279,8 +279,8 @@ static std::vector<std::unique_ptr<GlfwKeyboardJoystick>> gKeyboardJoysticks;
 static std::vector<RobotJoystick> gRobotJoysticks;
 static std::unique_ptr<JoystickModel> gJoystickSources[HAL_MAX_JOYSTICKS];
 
-// FMS
-static std::unique_ptr<FMSSimModel> gFMSModel;
+// DS
+static std::unique_ptr<DSSimModel> gDSModel;
 static std::unique_ptr<wpi::glass::AnsiDisplayModel> gDisplayModel;
 
 // Window management
@@ -1042,11 +1042,11 @@ void RobotJoystick::GetHAL(int i) {
 
 static void DriverStationSetRobotMode(HAL_RobotMode mode) {
   if (!HALSIM_GetDriverStationDsAttached()) {
-    // initialize FMS bits too
-    gFMSModel->SetDsAttached(true);
-    gFMSModel->SetEnabled(false);
-    gFMSModel->SetRobotMode(static_cast<FMSSimModel::RobotMode>(mode));
-    gFMSModel->UpdateHAL();
+    // initialize DS bits too
+    gDSModel->SetDsAttached(true);
+    gDSModel->SetEnabled(false);
+    gDSModel->SetRobotMode(static_cast<DSSimModel::RobotMode>(mode));
+    gDSModel->UpdateHAL();
   }
   HALSIM_SetDriverStationDsAttached(true);
   HALSIM_SetDriverStationEnabled(false);
@@ -1055,8 +1055,8 @@ static void DriverStationSetRobotMode(HAL_RobotMode mode) {
 }
 
 static void DriverStationSetEnabled(bool enabled) {
-  gFMSModel->SetEnabled(enabled);
-  gFMSModel->UpdateHAL();
+  gDSModel->SetEnabled(enabled);
+  gDSModel->UpdateHAL();
   HALSIM_SetDriverStationEnabled(enabled);
 }
 
@@ -1101,7 +1101,7 @@ static void DriverStationExecute() {
   }
   prevDisableDS = disableDS;
   if (disableDS) {
-    gFMSModel->Update();
+    gDSModel->Update();
     return;
   }
 
@@ -1171,7 +1171,7 @@ static void DriverStationExecute() {
       HALSIM_SetDriverStationOpMode(0);
       HALSIM_SetDriverStationDsAttached(false);
       isAttached = false;
-      gFMSModel->Update();
+      gDSModel->Update();
     }
     if (ImGui::Selectable(
             "Autonomous",
@@ -1277,17 +1277,17 @@ static void DriverStationExecute() {
   if ((curTime - lastNewDataTime) > 0.02 && !HALSIM_IsTimingPaused() &&
       isAttached) {
     lastNewDataTime = curTime;
-    gFMSModel->Update();
+    gDSModel->Update();
     HALSIM_NotifyDriverStationNewData();
   }
 }
 
-FMSSimModel::FMSSimModel() {
+DSSimModel::DSSimModel() {
   m_matchTime.SetValue(-1.0);
   m_allianceStationId.SetValue(HAL_ALLIANCE_STATION_RED_1);
 }
 
-void FMSSimModel::UpdateHAL() {
+void DSSimModel::UpdateHAL() {
   HALSIM_SetDriverStationFmsAttached(m_fmsAttached.GetValue());
   HALSIM_SetDriverStationAllianceStationId(
       static_cast<HAL_AllianceStationID>(m_allianceStationId.GetValue()));
@@ -1302,7 +1302,7 @@ void FMSSimModel::UpdateHAL() {
   HALSIM_SetDriverStationDsAttached(m_dsAttached.GetValue());
 }
 
-void FMSSimModel::Update() {
+void DSSimModel::Update() {
   bool enabled = HALSIM_GetDriverStationEnabled();
   m_fmsAttached.SetValue(HALSIM_GetDriverStationFmsAttached());
   m_dsAttached.SetValue(HALSIM_GetDriverStationDsAttached());
@@ -1337,7 +1337,7 @@ void FMSSimModel::Update() {
       std::string_view{reinterpret_cast<const char*>(info.gameData)});
 }
 
-bool FMSSimModel::IsReadOnly() {
+bool DSSimModel::IsReadOnly() {
   return IsDSDisabled();
 }
 
@@ -1557,7 +1557,7 @@ void DriverStationGui::GlobalInit() {
 
   dsManager->GlobalInit();
 
-  gFMSModel = std::make_unique<FMSSimModel>();
+  gDSModel = std::make_unique<DSSimModel>();
   gDisplayModel = std::make_unique<wpi::glass::AnsiDisplayModel>();
 
   HALSIM_RegisterOpModeOptionsCallback(UpdateOpModes, nullptr, true);
@@ -1613,11 +1613,11 @@ void DriverStationGui::GlobalInit() {
         win->SetDefaultSize(300, 560);
       }
     }
-    if (auto win = dsManager->AddWindow("FMS", [] {
+    if (auto win = dsManager->AddWindow("DS", [] {
           if (HALSIM_GetDriverStationDsAttached()) {
-            DisplayFMSReadOnly(gFMSModel.get());
+            DisplayDSReadOnly(gDSModel.get());
           } else {
-            DisplayFMS(gFMSModel.get(), false);
+            DisplayDS(gDSModel.get(), false);
           }
         })) {
       win->DisableRenamePopup();

--- a/wpilibc/src/main/native/cpp/driverstation/internal/DriverStationBackend.cpp
+++ b/wpilibc/src/main/native/cpp/driverstation/internal/DriverStationBackend.cpp
@@ -80,7 +80,7 @@ class MatchDataSenderEntry {
   typename Topic::ValueType prevVal;
 };
 
-static constexpr std::string_view kSmartDashboardType = "FMSInfo";
+static constexpr std::string_view kSmartDashboardType = "DriverStation";
 
 struct MatchDataSender {
   MatchDataSender()
@@ -92,7 +92,7 @@ struct MatchDataSender {
   }
 
   std::shared_ptr<wpi::nt::NetworkTable> table =
-      wpi::nt::NetworkTableInstance::GetDefault().GetTable("FMSInfo");
+      wpi::nt::NetworkTableInstance::GetDefault().GetTable("DriverStation");
   MatchDataSenderEntry<wpi::nt::StringTopic> typeMetaData{
       table, ".type", kSmartDashboardType,
       wpi::util::json::object("SmartDashboard", kSmartDashboardType)};

--- a/wpilibj/src/main/java/org/wpilib/driverstation/internal/DriverStationBackend.java
+++ b/wpilibj/src/main/java/org/wpilib/driverstation/internal/DriverStationBackend.java
@@ -152,7 +152,7 @@ public final class DriverStationBackend {
   }
 
   private static class MatchDataSender {
-    private static final String kSmartDashboardType = "FMSInfo";
+    private static final String kSmartDashboardType = "DriverStation";
 
     final StringPublisher gameData;
     final StringPublisher eventName;
@@ -176,7 +176,7 @@ public final class DriverStationBackend {
     final ControlWord currentControlWord = new ControlWord();
 
     MatchDataSender() {
-      var table = NetworkTableInstance.getDefault().getTable("FMSInfo");
+      var table = NetworkTableInstance.getDefault().getTable("DriverStation");
       table
           .getStringTopic(".type")
           .publishEx(


### PR DESCRIPTION
FMSInfo is confusing, because none of the info is actually from FMS. DriverStation is a better name for it, since all the info is sent from the DS.