### PR TITLE
[ci] Enable merge queue support

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,6 +1,6 @@
 name: Bazel
 
-on: [pull_request, push]
+on: [merge_group, pull_request, push]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -1,6 +1,7 @@
 name: Lint and Format
 
 on:
+  merge_group:
   pull_request:
   push:
     branches-ignore:

--- a/.github/workflows/pregenerate.yml
+++ b/.github/workflows/pregenerate.yml
@@ -1,6 +1,7 @@
 name: Check Pregenerated Files
 
 on:
+  merge_group:
   pull_request:
   push:
     branches-ignore:

--- a/.github/workflows/upstream-utils.yml
+++ b/.github/workflows/upstream-utils.yml
@@ -1,6 +1,7 @@
 name: Upstream utils
 
 on:
+  merge_group:
   pull_request:
   push:
     branches-ignore:


### PR DESCRIPTION
Run Bazel and other repo cleanliness checks on merge queue additions to ensure PRs are good before merging.