### PR TITLE
[wpimath] Quaternion::Log(): Avoid potential divide-by-zero

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/geometry/Quaternion.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/Quaternion.java
@@ -258,11 +258,16 @@ public final class Quaternion implements ProtobufSerializable, StructSerializabl
    */
   public Quaternion log() {
     var norm = norm();
+    if (norm == 0.0) {
+      return new Quaternion(0.0, 0.0, 0.0, 0.0);
+    }
+
     var scalar = Math.log(norm);
 
     var v_norm = Math.sqrt(getX() * getX() + getY() * getY() + getZ() * getZ());
 
-    var s_norm = getW() / norm;
+    var w = getW();
+    var s_norm = w / norm;
 
     if (Math.abs(s_norm + 1) < 1e-9) {
       return new Quaternion(scalar, -Math.PI, 0, 0);
@@ -270,13 +275,15 @@ public final class Quaternion implements ProtobufSerializable, StructSerializabl
 
     double v_scalar;
 
-    if (v_norm < 1e-9) {
+    if (v_norm < 1e-9 && w != 0.0) {
       // Taylor series expansion of atan2(y/x)/y at y = 0:
       //
       //   1/x - 1/3 y²/x³ + O(y⁴)
-      v_scalar = 1.0 / getW() - 1.0 / 3.0 * v_norm * v_norm / (getW() * getW() * getW());
+      v_scalar = 1.0 / w - 1.0 / 3.0 * v_norm * v_norm / (w * w * w);
+    } else if (v_norm == 0.0) {
+      v_scalar = 0.0;
     } else {
-      v_scalar = Math.atan2(v_norm, getW()) / v_norm;
+      v_scalar = Math.atan2(v_norm, w) / v_norm;
     }
 
     return new Quaternion(scalar, v_scalar * getX(), v_scalar * getY(), v_scalar * getZ());

--- a/wpimath/src/main/native/include/wpi/math/geometry/Quaternion.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Quaternion.hpp
@@ -201,7 +201,7 @@ class WPILIB_DLLEXPORT Quaternion final {
   constexpr Quaternion Log() const {
     double norm = Norm();
     if (norm == 0.0) {
-      return Quaternion{};
+      return Quaternion{0.0, 0.0, 0.0, 0.0};
     }
 
     double scalar = gcem::log(norm);

--- a/wpimath/src/main/native/include/wpi/math/geometry/Quaternion.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Quaternion.hpp
@@ -200,11 +200,16 @@ class WPILIB_DLLEXPORT Quaternion final {
    */
   constexpr Quaternion Log() const {
     double norm = Norm();
+    if (norm == 0.0) {
+      return Quaternion{};
+    }
+
     double scalar = gcem::log(norm);
 
     double v_norm = gcem::hypot(m_x, m_y, m_z);
 
-    double s_norm = W() / norm;
+    double w = W();
+    double s_norm = w / norm;
 
     if (gcem::abs(s_norm + 1) < 1e-9) {
       return Quaternion{scalar, -std::numbers::pi, 0, 0};
@@ -212,13 +217,15 @@ class WPILIB_DLLEXPORT Quaternion final {
 
     double v_scalar;
 
-    if (v_norm < 1e-9) {
+    if (v_norm < 1e-9 && w != 0.0) {
       // Taylor series expansion of atan2(y/x)/y at y = 0:
       //
       //   1/x - 1/3 y²/x³ + O(y⁴)
-      v_scalar = 1.0 / W() - 1.0 / 3.0 * v_norm * v_norm / (W() * W() * W());
+      v_scalar = 1.0 / w - 1.0 / 3.0 * v_norm * v_norm / (w * w * w);
+    } else if (v_norm == 0.0) {
+      v_scalar = 0.0;
     } else {
-      v_scalar = gcem::atan2(v_norm, W()) / v_norm;
+      v_scalar = gcem::atan2(v_norm, w) / v_norm;
     }
 
     return Quaternion{scalar, v_scalar * m_x, v_scalar * m_y, v_scalar * m_z};

--- a/wpimath/src/test/java/org/wpilib/math/geometry/QuaternionTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/geometry/QuaternionTest.java
@@ -188,6 +188,7 @@ class QuaternionTest {
     var zero = new Quaternion(0, 0, 0, 0);
     var one = new Quaternion();
 
+    assertEquals(zero, zero.log());
     assertEquals(zero, one.log());
 
     var i = new Quaternion(0, 1, 0, 0);

--- a/wpimath/src/test/native/cpp/geometry/QuaternionTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/QuaternionTest.cpp
@@ -177,6 +177,7 @@ TEST(QuaternionTest, Logarithm) {
   Quaternion k{0, 0, 0, 1};
   Quaternion ln_half{std::log(0.5), -std::numbers::pi, 0, 0};
 
+  EXPECT_EQ(zero, zero.Log());
   EXPECT_EQ(zero, one.Log());
   EXPECT_EQ(i * std::numbers::pi / 2, i.Log());
   EXPECT_EQ(j * std::numbers::pi / 2, j.Log());


### PR DESCRIPTION
Add an explicit zero-norm guard and rewrite the small-vector Taylor branch so it only divides by W() when W() is nonzero.

Windows warned about this in https://github.com/wpilibsuite/allwpilib/actions/runs/28768445045/job/85297232208?pr=9008