### PR TITLE
[build] Allow unknown warning flags for Bazel+macOS

### DIFF
--- a/shared/bazel/compiler_flags/osx_flags.rc
+++ b/shared/bazel/compiler_flags/osx_flags.rc
@@ -5,7 +5,7 @@ common:macos --host_per_file_copt=external/.*@-Wno-deprecated-non-prototype,-Wno
 common:macos --repo_env=BAZEL_CXXOPTS="-std=c++23:-pedantic:-fPIC:-Wno-unused-parameter:-Wno-error=deprecated-enum-enum-conversion:-Wno-missing-field-initializers:-Wno-unused-private-field:-Wno-unused-const-variable:-Wno-error=c11-extensions:-pthread:-Wno-deprecated-anon-enum-enum-conversion"
 
 # C only
-common:macos --repo_env=BAZEL_CONLYOPTS="-pedantic:-fPIC:-Wno-unused-parameter:-Wno-missing-field-initializers:-Wno-unused-private-field:-Wno-fixed-enum-extension"
+common:macos --repo_env=BAZEL_CONLYOPTS="-pedantic:-fPIC:-Wno-unknown-warning-option:-Wno-unused-parameter:-Wno-missing-field-initializers:-Wno-unused-private-field:-Wno-fixed-enum-extension"
 
 common:macos --repo_env=BAZEL_LINKOPTS="-Wl,-rpath,'@loader_path'"
 


### PR DESCRIPTION
Clang 21 dropped support for `-Wno-fixed-enum-extension` (see #8751), so this allows unknown warning flags when building with Bazel since Bazel does not support checking the compiler version.