### PR TITLE
[wpilib] Add GameCube and Steam gamepad types

### DIFF
--- a/wpilibc/src/generated/main/native/cpp/simulation/GameCubeControllerSim.cpp
+++ b/wpilibc/src/generated/main/native/cpp/simulation/GameCubeControllerSim.cpp
@@ -15,7 +15,7 @@ GameCubeControllerSim::GameCubeControllerSim(const GameCubeController& joystick)
   SetAxesAvailable(0x3F);
   SetButtonsAvailable(0xC07C4FULL);
   SetPOVsAvailable(0);
-  SetGamepadType(GenericHID::HIDType::STANDARD);
+  SetGamepadType(GenericHID::HIDType::GAMECUBE);
   SetSupportedOutputs(GameCubeController::SUPPORTED_OUTPUTS);
 }
 
@@ -23,7 +23,7 @@ GameCubeControllerSim::GameCubeControllerSim(int port) : GenericHIDSim{port} {
   SetAxesAvailable(0x3F);
   SetButtonsAvailable(0xC07C4FULL);
   SetPOVsAvailable(0);
-  SetGamepadType(GenericHID::HIDType::STANDARD);
+  SetGamepadType(GenericHID::HIDType::GAMECUBE);
   SetSupportedOutputs(GameCubeController::SUPPORTED_OUTPUTS);
 }
 

--- a/wpilibc/src/generated/main/native/cpp/simulation/SteamControllerSim.cpp
+++ b/wpilibc/src/generated/main/native/cpp/simulation/SteamControllerSim.cpp
@@ -15,7 +15,7 @@ SteamControllerSim::SteamControllerSim(const SteamController& joystick)
   SetAxesAvailable(0x3F);
   SetButtonsAvailable(0x3FFFFFFULL);
   SetPOVsAvailable(0);
-  SetGamepadType(GenericHID::HIDType::STANDARD);
+  SetGamepadType(GenericHID::HIDType::STEAM);
   SetSupportedOutputs(SteamController::SUPPORTED_OUTPUTS);
 }
 
@@ -23,7 +23,7 @@ SteamControllerSim::SteamControllerSim(int port) : GenericHIDSim{port} {
   SetAxesAvailable(0x3F);
   SetButtonsAvailable(0x3FFFFFFULL);
   SetPOVsAvailable(0);
-  SetGamepadType(GenericHID::HIDType::STANDARD);
+  SetGamepadType(GenericHID::HIDType::STEAM);
   SetSupportedOutputs(SteamController::SUPPORTED_OUTPUTS);
 }
 

--- a/wpilibc/src/main/native/cpp/driverstation/GenericHID.cpp
+++ b/wpilibc/src/main/native/cpp/driverstation/GenericHID.cpp
@@ -138,8 +138,11 @@ bool GenericHID::IsConnected() const {
 }
 
 GenericHID::HIDType GenericHID::GetGamepadType() const {
-  return static_cast<HIDType>(
-      wpi::internal::DriverStationBackend::GetJoystickGamepadType(m_port));
+  int type = wpi::internal::DriverStationBackend::GetJoystickGamepadType(m_port);
+  if (type < 0 || type >= static_cast<int>(HIDType::COUNT)) {
+    return HIDType::UNKNOWN;
+  }
+  return static_cast<HIDType>(type);
 }
 
 GenericHID::SupportedOutputs GenericHID::GetSupportedOutputs() const {

--- a/wpilibc/src/main/native/cpp/driverstation/GenericHID.cpp
+++ b/wpilibc/src/main/native/cpp/driverstation/GenericHID.cpp
@@ -138,7 +138,8 @@ bool GenericHID::IsConnected() const {
 }
 
 GenericHID::HIDType GenericHID::GetGamepadType() const {
-  int type = wpi::internal::DriverStationBackend::GetJoystickGamepadType(m_port);
+  int type =
+      wpi::internal::DriverStationBackend::GetJoystickGamepadType(m_port);
   if (type < 0 || type >= static_cast<int>(HIDType::COUNT)) {
     return HIDType::UNKNOWN;
   }

--- a/wpilibc/src/main/native/include/wpi/driverstation/GenericHID.hpp
+++ b/wpilibc/src/main/native/include/wpi/driverstation/GenericHID.hpp
@@ -88,7 +88,13 @@ class GenericHID final : public HIDDevice {
     /// Nintendo Switch Joycon Right controller.
     SWITCH_JOYCON_RIGHT,
     /// Nintendo Switch Joycon controller pair.
-    SWITCH_JOYCON_PAIR
+    SWITCH_JOYCON_PAIR,
+    /// GameCube controller.
+    GAMECUBE,
+    /// Steam Controller.
+    STEAM,
+    /// Count of HID types.
+    COUNT,
   };
 
   ~GenericHID() override = default;

--- a/wpilibj/src/generate/first_ds_hids.json
+++ b/wpilibj/src/generate/first_ds_hids.json
@@ -231,7 +231,7 @@
   },
   {
     "ClassName": "GameCube",
-    "HIDType": "STANDARD",
+    "HIDType": "GAMECUBE",
     "axes": {
       "leftX": 0,
       "leftY": 1,
@@ -335,7 +335,7 @@
   },
   {
     "ClassName": "Steam",
-    "HIDType": "STANDARD",
+    "HIDType": "STEAM",
     "axes": {
       "leftX": 0,
       "leftY": 1,

--- a/wpilibj/src/generated/main/java/org/wpilib/simulation/GameCubeControllerSim.java
+++ b/wpilibj/src/generated/main/java/org/wpilib/simulation/GameCubeControllerSim.java
@@ -38,7 +38,7 @@ public class GameCubeControllerSim extends GenericHIDSim {
     setAxesAvailable(0x3F);
     setButtonsAvailable(0xC07C4FL);
     setPOVsAvailable(0);
-    setGamepadType(GenericHID.HIDType.STANDARD);
+    setGamepadType(GenericHID.HIDType.GAMECUBE);
     setSupportedOutputs(GameCubeController.getSupportedOutputCapabilities());
   }
 

--- a/wpilibj/src/generated/main/java/org/wpilib/simulation/SteamControllerSim.java
+++ b/wpilibj/src/generated/main/java/org/wpilib/simulation/SteamControllerSim.java
@@ -38,7 +38,7 @@ public class SteamControllerSim extends GenericHIDSim {
     setAxesAvailable(0x3F);
     setButtonsAvailable(0x3FFFFFFL);
     setPOVsAvailable(0);
-    setGamepadType(GenericHID.HIDType.STANDARD);
+    setGamepadType(GenericHID.HIDType.STEAM);
     setSupportedOutputs(SteamController.getSupportedOutputCapabilities());
   }
 

--- a/wpilibj/src/main/java/org/wpilib/driverstation/GenericHID.java
+++ b/wpilibj/src/main/java/org/wpilib/driverstation/GenericHID.java
@@ -87,7 +87,11 @@ public final class GenericHID implements HIDDevice {
     /** Switch Joycon Right. */
     SWITCH_JOYCON_RIGHT(9),
     /** Switch Joycon Pair. */
-    SWITCH_JOYCON_PAIR(10);
+    SWITCH_JOYCON_PAIR(10),
+    /** GameCube controller. */
+    GAMECUBE(11),
+    /** Steam Controller. */
+    STEAM(12);
 
     /** HIDType value. */
     public final int value;
@@ -111,7 +115,7 @@ public final class GenericHID implements HIDDevice {
      * @return HIDType with the given value.
      */
     public static HIDType of(int value) {
-      return map.get(value);
+      return map.getOrDefault(value, UNKNOWN);
     }
   }
 


### PR DESCRIPTION
Also return UNKNOWN instead of an arbitrary integer (C++) or null (Java) to maintain forward compatibility for DS updates.