### PR TITLE
Switch robot construction back to supplier

### DIFF
--- a/developerRobot/src/main/java/wpilib/robot/Main.java
+++ b/developerRobot/src/main/java/wpilib/robot/Main.java
@@ -15,6 +15,6 @@ public final class Main {
    * <p>If you change your main robot class, change the parameter type.
    */
   public static void main(String... args) {
-    RobotBase.startRobot(Robot.class);
+    RobotBase.startRobot(Robot::new);
   }
 }

--- a/wpilibj/src/main/java/org/wpilib/framework/RobotBase.java
+++ b/wpilibj/src/main/java/org/wpilib/framework/RobotBase.java
@@ -6,7 +6,6 @@ package org.wpilib.framework;
 
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
-
 import org.wpilib.driverstation.DriverStationErrors;
 import org.wpilib.driverstation.RobotState;
 import org.wpilib.driverstation.internal.DriverStationBackend;

--- a/wpilibj/src/main/java/org/wpilib/framework/RobotBase.java
+++ b/wpilibj/src/main/java/org/wpilib/framework/RobotBase.java
@@ -4,8 +4,9 @@
 
 package org.wpilib.framework;
 
-import java.util.Optional;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
 import org.wpilib.driverstation.DriverStationErrors;
 import org.wpilib.driverstation.RobotState;
 import org.wpilib.driverstation.internal.DriverStationBackend;
@@ -20,7 +21,6 @@ import org.wpilib.networktables.PubSubOption;
 import org.wpilib.system.RuntimeType;
 import org.wpilib.system.Timer;
 import org.wpilib.system.WPILibVersion;
-import org.wpilib.util.ConstructorMatch;
 import org.wpilib.util.WPIUtilJNI;
 import org.wpilib.vision.stream.CameraServerShared;
 import org.wpilib.vision.stream.CameraServerSharedStore;
@@ -289,20 +289,6 @@ public abstract class RobotBase implements AutoCloseable {
   private static RobotBase m_robotCopy;
   private static boolean m_suppressExitWarning;
 
-  private static <T extends RobotBase> T constructRobot(Class<T> robotClass) throws Throwable {
-    Optional<ConstructorMatch<T>> constructorMatch =
-        ConstructorMatch.findBestConstructor(robotClass);
-
-    if (constructorMatch.isEmpty()) {
-      throw new IllegalArgumentException(
-          "No valid constructor found in robot class " + robotClass.getName());
-    }
-
-    T robot = constructorMatch.get().newInstance();
-
-    return robot;
-  }
-
   /**
    * Gets the Robot subclass name from a stack trace.
    *
@@ -330,12 +316,12 @@ public abstract class RobotBase implements AutoCloseable {
 
   /** Run the robot main loop. */
   @SuppressWarnings("PMD.AvoidCatchingGenericException")
-  private static <T extends RobotBase> void runRobot(Class<T> robotClass) {
+  private static <T extends RobotBase> void runRobot(Supplier<T> robotConstructor) {
     System.out.println("********** Robot program starting **********");
 
     T robot;
     try {
-      robot = constructRobot(robotClass);
+      robot = robotConstructor.get();
     } catch (Throwable throwable) {
       Throwable cause = throwable.getCause();
       if (cause != null) {
@@ -413,9 +399,9 @@ public abstract class RobotBase implements AutoCloseable {
    * Starting point for the applications.
    *
    * @param <T> Robot subclass.
-   * @param robotClass Robot subclass type.
+   * @param robotConstructor Robot constructor.
    */
-  public static <T extends RobotBase> void startRobot(Class<T> robotClass) {
+  public static <T extends RobotBase> void startRobot(Supplier<T> robotConstructor) {
     // Check that the MSVC runtime is valid.
     WPIUtilJNI.checkMsvcRuntime();
 
@@ -433,7 +419,7 @@ public abstract class RobotBase implements AutoCloseable {
       Thread thread =
           new Thread(
               () -> {
-                runRobot(robotClass);
+                runRobot(robotConstructor);
                 HAL.exitMain();
               },
               "robot main");
@@ -453,7 +439,7 @@ public abstract class RobotBase implements AutoCloseable {
         Thread.currentThread().interrupt();
       }
     } else {
-      runRobot(robotClass);
+      runRobot(robotConstructor);
     }
 
     // On RIO, this will just terminate rather than shutting down cleanly (it's a no-op in sim).

--- a/wpilibjExamples/src/main/java/org/wpilib/Executor.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/Executor.java
@@ -25,12 +25,12 @@ public final class Executor {
     System.out.println("Starting robot: " + robotClass.getName());
 
     RobotBase.startRobot(
-      () -> {
-        try {
-          return ConstructorMatch.findBestConstructor(robotClass).get().newInstance();
-        } catch (ReflectiveOperationException e) {
-          throw new RuntimeException("Failed to construct robot", e.getCause());
-        }
-      });
+        () -> {
+          try {
+            return ConstructorMatch.findBestConstructor(robotClass).get().newInstance();
+          } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to construct robot", e.getCause());
+          }
+        });
   }
 }

--- a/wpilibjExamples/src/main/java/org/wpilib/Executor.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/Executor.java
@@ -19,18 +19,18 @@ public final class Executor {
 
     System.out.println("Loading robot class: " + packagePath);
 
-    Class<? extends RobotBase> robotClass = classLoader.loadClass(packagePath).asSubclass(RobotBase.class);
+    Class<? extends RobotBase> robotClass =
+        classLoader.loadClass(packagePath).asSubclass(RobotBase.class);
 
     System.out.println("Starting robot: " + robotClass.getName());
 
-    ConstructorMatch.findBestConstructor(robotClass).get();
-
-    RobotBase.startRobot(() -> {
-      try {
-        return ConstructorMatch.findBestConstructor(robotClass).get().newInstance();
-      } catch (ReflectiveOperationException e) {
-        throw new RuntimeException("Failed to construct robot", e);
-      }
-    });
+    RobotBase.startRobot(
+      () -> {
+        try {
+          return ConstructorMatch.findBestConstructor(robotClass).get().newInstance();
+        } catch (ReflectiveOperationException e) {
+          throw new RuntimeException("Failed to construct robot", e.getCause());
+        }
+      });
   }
 }

--- a/wpilibjExamples/src/main/java/org/wpilib/Executor.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/Executor.java
@@ -5,6 +5,7 @@
 package org.wpilib;
 
 import org.wpilib.framework.RobotBase;
+import org.wpilib.util.ConstructorMatch;
 
 /** This is the executor to launch template projects. */
 public final class Executor {
@@ -18,10 +19,18 @@ public final class Executor {
 
     System.out.println("Loading robot class: " + packagePath);
 
-    Class<?> robotClass = classLoader.loadClass(packagePath);
+    Class<? extends RobotBase> robotClass = classLoader.loadClass(packagePath).asSubclass(RobotBase.class);
 
     System.out.println("Starting robot: " + robotClass.getName());
 
-    RobotBase.startRobot(robotClass.asSubclass(RobotBase.class));
+    ConstructorMatch.findBestConstructor(robotClass).get();
+
+    RobotBase.startRobot(() -> {
+      try {
+        return ConstructorMatch.findBestConstructor(robotClass).get().newInstance();
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException("Failed to construct robot", e);
+      }
+    });
   }
 }

--- a/wpilibjExamples/src/main/java/org/wpilib/Main.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/Main.java
@@ -20,6 +20,6 @@ public final class Main {
    * <p>If you change your main robot class, change the parameter type.
    */
   public static void main(String... args) {
-    RobotBase.startRobot(org.wpilib.templates.timed.Robot.class);
+    RobotBase.startRobot(org.wpilib.templates.timed.Robot::new);
   }
 }


### PR DESCRIPTION
Moving to reflection was done for the DriverStationInstance change, which has since been removed. That means we can safely move back to supplier, which is more reliable and easier to use cross language.