### PR TITLE
[robotpy] Update semiwrap to 0.6.0

### DIFF
--- a/apriltag/robotpy_pybind_build_info.bzl
+++ b/apriltag/robotpy_pybind_build_info.bzl
@@ -6,6 +6,9 @@ load("//shared/bazel/rules/robotpy:semiwrap_helpers.bzl", "gen_libinit", "gen_mo
 load("//shared/bazel/rules/robotpy:semiwrap_tool_helpers.bzl", "scan_headers", "update_yaml_files")
 
 def apriltag_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes = []):
+    NAME_TRANSFORMS = [
+    ]
+
     APRILTAG_HEADER_GEN = [
         struct(
             class_name = "AprilTag",
@@ -124,6 +127,7 @@ def apriltag_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], incl
             "//wpimath:robotpy-native-wpimath.copy_headers",
             "//wpiutil:robotpy-native-wpiutil.copy_headers",
         ],
+        name_transforms = NAME_TRANSFORMS,
     )
 
     create_pybind_library(

--- a/datalog/robotpy_pybind_build_info.bzl
+++ b/datalog/robotpy_pybind_build_info.bzl
@@ -6,6 +6,9 @@ load("//shared/bazel/rules/robotpy:semiwrap_helpers.bzl", "gen_libinit", "gen_mo
 load("//shared/bazel/rules/robotpy:semiwrap_tool_helpers.bzl", "scan_headers", "update_yaml_files")
 
 def wpilog_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes = []):
+    NAME_TRANSFORMS = [
+    ]
+
     WPILOG_HEADER_GEN = [
         struct(
             class_name = "DataLog",
@@ -122,6 +125,7 @@ def wpilog_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includ
             "//datalog:robotpy-native-datalog.copy_headers",
             "//wpiutil:robotpy-native-wpiutil.copy_headers",
         ],
+        name_transforms = NAME_TRANSFORMS,
     )
 
     create_pybind_library(

--- a/hal/robotpy_pybind_build_info.bzl
+++ b/hal/robotpy_pybind_build_info.bzl
@@ -6,6 +6,9 @@ load("//shared/bazel/rules/robotpy:semiwrap_helpers.bzl", "gen_libinit", "gen_mo
 load("//shared/bazel/rules/robotpy:semiwrap_tool_helpers.bzl", "scan_headers", "update_yaml_files")
 
 def hal_simulation_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes = []):
+    NAME_TRANSFORMS = [
+    ]
+
     HAL_SIMULATION_HEADER_GEN = [
         struct(
             class_name = "DriverStationData",
@@ -103,6 +106,7 @@ def hal_simulation_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = []
             "//wpinet:robotpy-native-wpinet.copy_headers",
             "//wpiutil:robotpy-native-wpiutil.copy_headers",
         ],
+        name_transforms = NAME_TRANSFORMS,
     )
 
     create_pybind_library(
@@ -142,6 +146,9 @@ def hal_simulation_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = []
     )
 
 def wpihal_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes = []):
+    NAME_TRANSFORMS = [
+    ]
+
     WPIHAL_HEADER_GEN = [
         struct(
             class_name = "CANAPITypes",
@@ -326,6 +333,7 @@ def wpihal_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includ
             "//wpinet:robotpy-native-wpinet.copy_headers",
             "//wpiutil:robotpy-native-wpiutil.copy_headers",
         ],
+        name_transforms = NAME_TRANSFORMS,
     )
 
     create_pybind_library(

--- a/ntcore/robotpy_pybind_build_info.bzl
+++ b/ntcore/robotpy_pybind_build_info.bzl
@@ -6,6 +6,9 @@ load("//shared/bazel/rules/robotpy:semiwrap_helpers.bzl", "gen_libinit", "gen_mo
 load("//shared/bazel/rules/robotpy:semiwrap_tool_helpers.bzl", "scan_headers", "update_yaml_files")
 
 def ntcore_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes = []):
+    NAME_TRANSFORMS = [
+    ]
+
     NTCORE_HEADER_GEN = [
         struct(
             class_name = "BooleanArrayTopic",
@@ -391,6 +394,7 @@ def ntcore_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includ
             "//wpinet:robotpy-native-wpinet.copy_headers",
             "//wpiutil:robotpy-native-wpiutil.copy_headers",
         ],
+        name_transforms = NAME_TRANSFORMS,
     )
 
     create_pybind_library(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jinja2==3.1.6
 protobuf==5.28.3
 grpcio-tools==1.68.0
-semiwrap==0.3.0
+semiwrap==0.6.0
 pytest>=3.9
 pytest-reraise
 numpy

--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -566,9 +566,9 @@ ruamel-yaml-clib==0.2.15 \
     --hash=sha256:fd4c928ddf6bce586285daa6d90680b9c291cfd045fc40aad34e445d57b1bf51 \
     --hash=sha256:fe239bdfdae2302e93bd6e8264bd9b71290218fff7084a9db250b55caaccf43f
     # via ruamel-yaml
-semiwrap==0.3.0 \
-    --hash=sha256:106a3fc09e31068645bd4c3eab799517bf392ab15a4aa896e947b7a885d79412 \
-    --hash=sha256:e215261e387169aacb3c8cf39c711fbcaa59fb9b029d4f1d8d81db9d015c68f3
+semiwrap==0.6.0 \
+    --hash=sha256:66783c100e8005f8f6477742683c64663799082df932a8c938c68467d7ba408a \
+    --hash=sha256:caabfefa94999e199e2db9e29a88c8ac24f668abe4b81b9e30ef69b4b45a3adb
     # via -r requirements.txt
 sphinxify==0.12 \
     --hash=sha256:3ec299e78babac7d3457f47bf263411b48e10b9c8add18d7159fa0327cc4a061 \

--- a/requirements_windows_lock.txt
+++ b/requirements_windows_lock.txt
@@ -570,9 +570,9 @@ ruamel-yaml-clib==0.2.15 \
     --hash=sha256:fd4c928ddf6bce586285daa6d90680b9c291cfd045fc40aad34e445d57b1bf51 \
     --hash=sha256:fe239bdfdae2302e93bd6e8264bd9b71290218fff7084a9db250b55caaccf43f
     # via ruamel-yaml
-semiwrap==0.3.0 \
-    --hash=sha256:106a3fc09e31068645bd4c3eab799517bf392ab15a4aa896e947b7a885d79412 \
-    --hash=sha256:e215261e387169aacb3c8cf39c711fbcaa59fb9b029d4f1d8d81db9d015c68f3
+semiwrap==0.6.0 \
+    --hash=sha256:66783c100e8005f8f6477742683c64663799082df932a8c938c68467d7ba408a \
+    --hash=sha256:caabfefa94999e199e2db9e29a88c8ac24f668abe4b81b9e30ef69b4b45a3adb
     # via -r requirements.txt
 sphinxify==0.12 \
     --hash=sha256:3ec299e78babac7d3457f47bf263411b48e10b9c8add18d7159fa0327cc4a061 \

--- a/romiVendordep/robotpy_pybind_build_info.bzl
+++ b/romiVendordep/robotpy_pybind_build_info.bzl
@@ -6,6 +6,9 @@ load("//shared/bazel/rules/robotpy:semiwrap_helpers.bzl", "gen_libinit", "gen_mo
 load("//shared/bazel/rules/robotpy:semiwrap_tool_helpers.bzl", "scan_headers", "update_yaml_files")
 
 def romi_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes = []):
+    NAME_TRANSFORMS = [
+    ]
+
     ROMI_HEADER_GEN = [
         struct(
             class_name = "OnBoardIO",
@@ -96,6 +99,7 @@ def romi_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes
             "//wpinet:robotpy-native-wpinet.copy_headers",
             "//wpiutil:robotpy-native-wpiutil.copy_headers",
         ],
+        name_transforms = NAME_TRANSFORMS,
     )
 
     create_pybind_library(

--- a/shared/bazel/rules/robotpy/generate_pybind_build_file.py
+++ b/shared/bazel/rules/robotpy/generate_pybind_build_file.py
@@ -53,9 +53,13 @@ class HeaderToDatConfig:
         transforms = []
         while True:
             if header_to_dat_args.args[idx] in [
+                "--name-transform-attribute",
                 "--name-transform-default",
-                "--name-transform-known-word",
                 "--name-transform-enum-value",
+                "--name-transform-function",
+                "--name-transform-known-word",
+                "--name-transform-method",
+                "--name-transform-parameter",
             ]:
                 transforms.append(
                     (header_to_dat_args.args[idx], header_to_dat_args.args[idx + 1])

--- a/shared/bazel/rules/robotpy/generate_pybind_build_file.py
+++ b/shared/bazel/rules/robotpy/generate_pybind_build_file.py
@@ -3,7 +3,7 @@ import collections
 import json
 import pathlib
 import re
-from typing import Dict, List, Union
+from typing import Dict, List, Tuple, Union
 
 import jinja2
 import tomli
@@ -30,7 +30,11 @@ from shared.bazel.rules.robotpy.hack_pkgcfgs import hack_pkgconfig
 
 
 class HeaderToDatConfig:
-    def __init__(self, header_to_dat_args: BuildTarget):
+    def __init__(
+        self,
+        header_to_dat_args: BuildTarget,
+        extension_name_transforms: List[Tuple[str, str]],
+    ):
         includes = []
         defines = []
 
@@ -45,6 +49,26 @@ class HeaderToDatConfig:
             idx += 2
         if header_to_dat_args.args[idx] == "--cpp":
             idx += 2
+
+        transforms = []
+        while True:
+            if header_to_dat_args.args[idx] in [
+                "--name-transform-default",
+                "--name-transform-known-word",
+                "--name-transform-enum-value",
+            ]:
+                transforms.append(
+                    (header_to_dat_args.args[idx], header_to_dat_args.args[idx + 1])
+                )
+                idx += 2
+            else:
+                break
+
+        # We assume that the transforms remain the same in a given extension
+        if extension_name_transforms:
+            assert extension_name_transforms == transforms
+        else:
+            extension_name_transforms.extend(transforms)
 
         args = header_to_dat_args.args[idx:]
         self.class_name = args[0]
@@ -159,7 +183,10 @@ class BazelExtensionModule:
         self.package_name = extension_module.package_name
         self.install_path = extension_module.install_path
 
-        self.generation_data = self._extract_header_generation(extension_module.sources)
+        self.extension_name_transforms: List[Tuple[str, str]] = []
+        self.generation_data = self._extract_header_generation(
+            extension_module.sources, self.extension_name_transforms
+        )
         self.resolve_casters = ResolveCastersConfig(
             additional_extension_targets["resolve-casters"]
         )
@@ -241,11 +268,13 @@ class BazelExtensionModule:
             else:
                 raise
 
-    def _extract_header_generation(self, sources) -> Dict[str, HeaderToDatConfig]:
+    def _extract_header_generation(
+        self, sources, extension_name_transforms: List[Tuple[str, str]]
+    ) -> Dict[str, HeaderToDatConfig]:
         generation_data: Dict[str, HeaderToDatConfig] = {}
 
         def get_h2d_config(target_info: BuildTarget) -> HeaderToDatConfig:
-            config = HeaderToDatConfig(target_info)
+            config = HeaderToDatConfig(target_info, extension_name_transforms)
             if config.class_name not in generation_data:
                 generation_data[config.class_name] = config
             return generation_data[config.class_name]

--- a/shared/bazel/rules/robotpy/pybind_build_file_template.jinja2
+++ b/shared/bazel/rules/robotpy/pybind_build_file_template.jinja2
@@ -13,6 +13,11 @@ load("//shared/bazel/rules/robotpy:semiwrap_helpers.bzl", "gen_libinit", "gen_mo
 load("//shared/bazel/rules/robotpy:semiwrap_tool_helpers.bzl", "scan_headers", "update_yaml_files")
 {% for extension_module in extension_modules%}
 def {{extension_module.name}}_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes = []):
+    NAME_TRANSFORMS = [{% for transform in extension_module.extension_name_transforms %}
+        "{{ transform[0] }}", "{{ transform[1] }}",
+        {%- endfor %}
+    ]
+
     {{extension_module.name|upper}}_HEADER_GEN = [
     {%- for header_cfg in extension_module.generation_data.values() %}
         struct(
@@ -84,6 +89,7 @@ def {{extension_module.name}}_extension(srcs = [], header_to_dat_deps = [], extr
             "{{header_path}}",
         {%- endfor %}
         ],
+        name_transforms = NAME_TRANSFORMS,
         {%- if extension_module.get_defines() %}
         generation_defines = [{%-for da in extension_module.get_defines() %}"{{da.replace("=", " ")}}"{% endfor %}],
         {%- endif %}

--- a/shared/bazel/rules/robotpy/semiwrap_helpers.bzl
+++ b/shared/bazel/rules/robotpy/semiwrap_helpers.bzl
@@ -144,7 +144,8 @@ def header_to_dat(
         generation_includes = [],
         header_to_dat_deps = [],
         extra_defines = [],
-        deps = []):
+        deps = [],
+        name_transforms = []):
     """
     Sugar wrapper for the semiwrap.cmd.header2dat tool
     """
@@ -159,6 +160,8 @@ def header_to_dat(
         cmd += " -I " + inc
     for d in extra_defines:
         cmd += " -D '" + d + "'"
+    for t in name_transforms:
+        cmd += " " + t + " "
     cmd += " " + header_location
 
     cmd += " " + include_root
@@ -266,7 +269,7 @@ def gen_modinit_hpp(
         target_compatible_with = robotpy_compatibility_select(),
     )
 
-def run_header_gen(name, casters_pickle, trampoline_subpath, header_gen_config, deps = [], generation_defines = [], local_native_libraries = [], header_to_dat_deps = [], yml_prefix = "src/main/python/"):
+def run_header_gen(name, casters_pickle, trampoline_subpath, header_gen_config, deps = [], generation_defines = [], local_native_libraries = [], header_to_dat_deps = [], name_transforms = [], yml_prefix = "src/main/python/"):
     generation_includes = []
     header_to_dat_deps = list(header_to_dat_deps)
 
@@ -286,6 +289,7 @@ def run_header_gen(name, casters_pickle, trampoline_subpath, header_gen_config, 
             generation_includes = generation_includes,
             extra_defines = generation_defines,
             header_to_dat_deps = header_to_dat_deps,
+            name_transforms = name_transforms,
         )
 
     generated_cc_files = []

--- a/shared/bazel/rules/robotpy/semiwrap_helpers.bzl
+++ b/shared/bazel/rules/robotpy/semiwrap_helpers.bzl
@@ -161,7 +161,7 @@ def header_to_dat(
     for d in extra_defines:
         cmd += " -D '" + d + "'"
     for t in name_transforms:
-        cmd += " " + t + " "
+        cmd += " '" + t + "' "
     cmd += " " + header_location
 
     cmd += " " + include_root

--- a/wpilibc/robotpy_pybind_build_info.bzl
+++ b/wpilibc/robotpy_pybind_build_info.bzl
@@ -7,6 +7,9 @@ load("//shared/bazel/rules/robotpy:semiwrap_helpers.bzl", "gen_libinit", "gen_mo
 load("//shared/bazel/rules/robotpy:semiwrap_tool_helpers.bzl", "scan_headers", "update_yaml_files")
 
 def wpilib_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes = []):
+    NAME_TRANSFORMS = [
+    ]
+
     WPILIB_HEADER_GEN = [
         struct(
             class_name = "Filesystem",
@@ -1290,6 +1293,7 @@ def wpilib_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includ
             "//wpinet:robotpy-native-wpinet.copy_headers",
             "//wpiutil:robotpy-native-wpiutil.copy_headers",
         ],
+        name_transforms = NAME_TRANSFORMS,
         generation_defines = ["DYNAMIC_CAMERA_SERVER 1"],
     )
 
@@ -1337,6 +1341,9 @@ def wpilib_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includ
     )
 
 def wpilib_simulation_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes = []):
+    NAME_TRANSFORMS = [
+    ]
+
     WPILIB_SIMULATION_HEADER_GEN = [
         struct(
             class_name = "ADXL345Sim",
@@ -1907,6 +1914,7 @@ def wpilib_simulation_extension(srcs = [], header_to_dat_deps = [], extra_hdrs =
             "//wpinet:robotpy-native-wpinet.copy_headers",
             "//wpiutil:robotpy-native-wpiutil.copy_headers",
         ],
+        name_transforms = NAME_TRANSFORMS,
     )
 
     create_pybind_library(

--- a/wpimath/robotpy_pybind_build_info.bzl
+++ b/wpimath/robotpy_pybind_build_info.bzl
@@ -7,6 +7,9 @@ load("//shared/bazel/rules/robotpy:semiwrap_helpers.bzl", "gen_libinit", "gen_mo
 load("//shared/bazel/rules/robotpy:semiwrap_tool_helpers.bzl", "scan_headers", "update_yaml_files")
 
 def wpimath_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes = []):
+    NAME_TRANSFORMS = [
+    ]
+
     WPIMATH_HEADER_GEN = [
         struct(
             class_name = "ComputerVisionUtil",
@@ -1272,6 +1275,7 @@ def wpimath_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], inclu
             "//wpimath:robotpy-native-wpimath.copy_headers",
             "//wpiutil:robotpy-native-wpiutil.copy_headers",
         ],
+        name_transforms = NAME_TRANSFORMS,
     )
 
     create_pybind_library(

--- a/wpimath/robotpy_pybind_test_info.bzl
+++ b/wpimath/robotpy_pybind_test_info.bzl
@@ -5,6 +5,9 @@ load("//shared/bazel/rules/robotpy:semiwrap_helpers.bzl", "gen_libinit", "gen_mo
 load("//shared/bazel/rules/robotpy:semiwrap_tool_helpers.bzl", "scan_headers", "update_yaml_files")
 
 def wpimath_test_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes = []):
+    NAME_TRANSFORMS = [
+    ]
+
     WPIMATH_TEST_HEADER_GEN = [
         struct(
             class_name = "module",
@@ -57,6 +60,7 @@ def wpimath_test_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], 
         deps = header_to_dat_deps,
         local_native_libraries = [
         ],
+        name_transforms = NAME_TRANSFORMS,
         yml_prefix = "src/test/python/cpp/",
     )
 

--- a/wpinet/robotpy_pybind_build_info.bzl
+++ b/wpinet/robotpy_pybind_build_info.bzl
@@ -6,6 +6,9 @@ load("//shared/bazel/rules/robotpy:semiwrap_helpers.bzl", "gen_libinit", "gen_mo
 load("//shared/bazel/rules/robotpy:semiwrap_tool_helpers.bzl", "scan_headers", "update_yaml_files")
 
 def wpinet_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes = []):
+    NAME_TRANSFORMS = [
+    ]
+
     WPINET_HEADER_GEN = [
         struct(
             class_name = "PortForwarder",
@@ -70,6 +73,7 @@ def wpinet_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includ
             "//wpinet:robotpy-native-wpinet.copy_headers",
             "//wpiutil:robotpy-native-wpiutil.copy_headers",
         ],
+        name_transforms = NAME_TRANSFORMS,
     )
 
     create_pybind_library(

--- a/wpiutil/robotpy_pybind_build_info.bzl
+++ b/wpiutil/robotpy_pybind_build_info.bzl
@@ -7,6 +7,9 @@ load("//shared/bazel/rules/robotpy:semiwrap_helpers.bzl", "gen_libinit", "gen_mo
 load("//shared/bazel/rules/robotpy:semiwrap_tool_helpers.bzl", "scan_headers", "update_yaml_files")
 
 def wpiutil_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes = []):
+    NAME_TRANSFORMS = [
+    ]
+
     WPIUTIL_HEADER_GEN = [
         struct(
             class_name = "Color",
@@ -156,6 +159,7 @@ def wpiutil_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], inclu
         local_native_libraries = [
             "//wpiutil:robotpy-native-wpiutil.copy_headers",
         ],
+        name_transforms = NAME_TRANSFORMS,
     )
 
     create_pybind_library(

--- a/xrpVendordep/robotpy_pybind_build_info.bzl
+++ b/xrpVendordep/robotpy_pybind_build_info.bzl
@@ -6,6 +6,9 @@ load("//shared/bazel/rules/robotpy:semiwrap_helpers.bzl", "gen_libinit", "gen_mo
 load("//shared/bazel/rules/robotpy:semiwrap_tool_helpers.bzl", "scan_headers", "update_yaml_files")
 
 def xrp_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes = []):
+    NAME_TRANSFORMS = [
+    ]
+
     XRP_HEADER_GEN = [
         struct(
             class_name = "XRPGyro",
@@ -116,6 +119,7 @@ def xrp_extension(srcs = [], header_to_dat_deps = [], extra_hdrs = [], includes 
             "//wpiutil:robotpy-native-wpiutil.copy_headers",
             "//xrpVendordep:robotpy-native-xrp.copy_headers",
         ],
+        name_transforms = NAME_TRANSFORMS,
     )
 
     create_pybind_library(


### PR DESCRIPTION
This updates semiwrap to the latest version in preparation for the camel_case change. This version allows you to specify name changes and known words that get passed to the header2dat step of the build, which required some changes to the bazel setup.

This should be basically a no-op at the moment, but makes it easier to copybara things over once https://github.com/robotpy/mostrobotpy/pull/275 lands. 