### PR TITLE
[build] Refactor generation scripts

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,7 @@ load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load("@rules_java//java:java_binary.bzl", "java_binary")
 load("@rules_java//java:java_plugin.bzl", "java_plugin")
 load("@rules_pkg//:mappings.bzl", "pkg_files")
+load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("//shared/bazel/rules:publishing.bzl", "publish_all")
 load("//shared/bazel/rules/robotpy:compatibility_select.bzl", "robotpy_compatibility_select")
@@ -20,6 +21,12 @@ exports_files([
     "LICENSE.md",
     "ThirdPartyNotices.txt",
 ])
+
+py_library(
+    name = "generation",
+    srcs = ["shared/generation.py"],
+    visibility = ["//visibility:public"],
+)
 
 pkg_files(
     name = "license_pkg_files",

--- a/commandsv2/BUILD.bazel
+++ b/commandsv2/BUILD.bazel
@@ -26,7 +26,10 @@ py_binary(
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
-    deps = [requirement("jinja2")],
+    deps = [
+        requirement("jinja2"),
+        "//:generation",
+    ],
 )
 
 filegroup(

--- a/commandsv2/generate_hids.py
+++ b/commandsv2/generate_hids.py
@@ -4,18 +4,17 @@
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
 
-import argparse
 import json
 import re
+import sys
 from pathlib import Path
 
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
+
 from jinja2 import Environment, FileSystemLoader
-
-
-def write_controller_file(output_dir: Path, controller_name: str, contents: str):
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_file = output_dir / controller_name
-    output_file.write_text(contents, encoding="utf-8", newline="\n")
+from shared.generation import write_file, add_jinja_args, make_arg_parser
 
 
 def generate_hids(
@@ -38,8 +37,7 @@ def generate_hids(
     template = env.get_template("commandhid.java.jinja")
     for controller in controllers:
         controllerName = f"Command{controller['ConsoleName']}Controller.java"
-        output = template.render(controller)
-        write_controller_file(root_path, controllerName, output)
+        write_file(root_path, controllerName, template.render(controller))
 
     # C++ headers
     hdr_subdirectory = "main/native/include/wpi/commands2/button"
@@ -52,8 +50,7 @@ def generate_hids(
     template = env.get_template("commandhid.hpp.jinja")
     for controller in controllers:
         controllerName = f"Command{controller['ConsoleName']}Controller.hpp"
-        output = template.render(controller)
-        write_controller_file(root_path, controllerName, output)
+        write_file(root_path, controllerName, template.render(controller))
 
     # C++ files
     cpp_subdirectory = "main/native/cpp/wpi/commands2/button"
@@ -65,8 +62,7 @@ def generate_hids(
     template = env.get_template("commandhid.cpp.jinja")
     for controller in controllers:
         controllerName = f"Command{controller['ConsoleName']}Controller.cpp"
-        output = template.render(controller)
-        write_controller_file(root_path, controllerName, output)
+        write_file(root_path, controllerName, template.render(controller))
 
 
 def _capitalize_first(name: str) -> str:
@@ -181,8 +177,7 @@ def generate_first_ds_hids(
         template = env.get_template("first_ds_commandhid.java.jinja")
         for controller in controllers:
             controller_name = f"Command{controller['ClassName']}Controller.java"
-            output = template.render(controller)
-            write_controller_file(root_path, controller_name, output)
+            write_file(root_path, controller_name, template.render(controller))
 
         # C++ headers
         hdr_subdirectory = "main/native/include/wpi/commands2/button"
@@ -195,8 +190,7 @@ def generate_first_ds_hids(
         template = env.get_template("first_ds_commandhid.hpp.jinja")
         for controller in controllers:
             controller_name = f"Command{controller['ClassName']}Controller.hpp"
-            output = template.render(controller)
-            write_controller_file(root_path, controller_name, output)
+            write_file(root_path, controller_name, template.render(controller))
 
         # C++ files
         cpp_subdirectory = "main/native/cpp/wpi/commands2/button"
@@ -209,8 +203,7 @@ def generate_first_ds_hids(
         template = env.get_template("first_ds_commandhid.cpp.jinja")
         for controller in controllers:
             controller_name = f"Command{controller['ClassName']}Controller.cpp"
-            output = template.render(controller)
-            write_controller_file(root_path, controller_name, output)
+            write_file(root_path, controller_name, template.render(controller))
 
     if python_output_directory is not None:
         python_subdirectory = "commands2/button"
@@ -223,33 +216,15 @@ def generate_first_ds_hids(
         template = env.get_template("first_ds_commandhid.py.jinja")
         for controller in controllers:
             controller_name = f"command{controller['ClassName'].lower()}controller.py"
-            output = template.render(controller)
-            write_controller_file(root_path, controller_name, output)
+            write_file(root_path, controller_name, template.render(controller))
 
 
 def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated",
-        type=Path,
-    )
-    parser.add_argument(
-        "--template_root",
-        help="Optional. If set, will use this directory as the root for the jinja templates",
-        default=dirname / "src/generate",
-        type=Path,
-    )
-    parser.add_argument(
-        "--schema_file",
-        help="Optional. If set, will use this file for the joystick schema",
-        default="wpilibj/src/generate/hids.json",
-        type=Path,
-    )
+    parser = make_arg_parser(dirname, dirname.parent)
+    add_jinja_args(parser, dirname, "wpilibj/src/generate/hids.json")
     parser.add_argument(
         "--first_ds_schema_file",
         help="Optional. If set, will use this file for the FIRST Driver Station HID schema",

--- a/commandsv3/BUILD.bazel
+++ b/commandsv3/BUILD.bazel
@@ -12,7 +12,10 @@ py_binary(
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
-    deps = [requirement("jinja2")],
+    deps = [
+        requirement("jinja2"),
+        "//:generation",
+    ],
 )
 
 filegroup(

--- a/commandsv3/generate_files.py
+++ b/commandsv3/generate_files.py
@@ -4,20 +4,24 @@
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
 
-import argparse
 import json
 import re
-import subprocess
+import sys
 from pathlib import Path
+
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
 
 from jinja2 import Environment, FileSystemLoader
 
-
-def write_controller_file(output_dir: Path, controller_name: str, contents: str):
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_file = output_dir / controller_name
-    output_file.write_text(contents, encoding="utf-8", newline="\n")
-    print("Writing to ", output_file)
+from shared.generation import (
+    GeneratorTypes,
+    add_jinja_args,
+    generate_quickbuf,
+    make_arg_parser,
+    write_file,
+)
 
 
 def generate_hids(output_directory: Path, template_directory: Path, schema_file: Path):
@@ -35,8 +39,7 @@ def generate_hids(output_directory: Path, template_directory: Path, schema_file:
     template = env.get_template("commandhid.java.jinja")
     for controller in controllers:
         controllerName = f"Command{controller['ConsoleName']}Controller.java"
-        output = template.render(controller)
-        write_controller_file(root_path, controllerName, output)
+        write_file(root_path, controllerName, template.render(controller))
 
 
 def _capitalize_first(name: str) -> str:
@@ -130,85 +133,23 @@ def generate_first_ds_hids(
     template = env.get_template("first_ds_commandhid.java.jinja")
     for controller in controllers:
         controller_name = f"Command{controller['ClassName']}Controller.java"
-        output = template.render(controller)
-        write_controller_file(root_path, controller_name, output)
-
-
-def generate_quickbuf(
-    protoc, quickbuf_plugin: Path, output_directory: Path, proto_dir: Path
-):
-    proto_files = proto_dir.glob("*.proto")
-    for path in proto_files:
-        absolute_filename = path.absolute()
-        args = [protoc]
-        if quickbuf_plugin:
-            # Optional on macOS if using protoc-quickbuf
-            args += [f"--plugin=protoc-gen-quickbuf={quickbuf_plugin}"]
-        args += [
-            f"--quickbuf_out=gen_descriptors=true:{output_directory.absolute()}",
-            f"-I{absolute_filename.parent}",
-            absolute_filename,
-        ]
-        subprocess.check_call(args)
-    java_files = (output_directory / "org/wpilib/command3/proto").glob("*.java")
-    for java_file in java_files:
-        with (java_file).open(encoding="utf-8") as f:
-            content = f.read()
-
-        java_file.write_text(
-            "// Copyright (c) FIRST and other WPILib contributors.\n// Open Source Software; you can modify and/or share it under the terms of\n// the WPILib BSD license file in the root directory of this project.\n"
-            + content,
-            encoding="utf-8",
-            newline="\n",
-        )
+        print(root_path, controller_name)
+        write_file(root_path, controller_name, template.render(controller))
 
 
 def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated",
-        type=Path,
-    )
-    parser.add_argument(
-        "--template_root",
-        help="Optional. If set, will use this directory as the root for the jinja templates",
-        default=dirname / "src/generate",
-        type=Path,
-    )
-    parser.add_argument(
-        "--schema_file",
-        help="Optional. If set, will use this file for the joystick schema",
-        default="wpilibj/src/generate/hids.json",
-        type=Path,
-    )
+    parser = make_arg_parser(dirname, dirname.parent, GeneratorTypes.QUICKBUF)
+    add_jinja_args(parser, dirname, "wpilibj/src/generate/hids.json")
     parser.add_argument(
         "--first_ds_schema_file",
         help="Optional. If set, will use this file for the FIRST Driver Station HID schema",
         default="wpilibj/src/generate/first_ds_hids.json",
         type=Path,
     )
-    parser.add_argument(
-        "--protoc",
-        help="Protoc executable command",
-        default="protoc",
-    )
-    parser.add_argument(
-        "--quickbuf_plugin",
-        help="Path to the quickbuf protoc plugin",
-    )
-    parser.add_argument(
-        "--proto_directory",
-        help="Optional. If set, will use this directory to glob for protobuf files",
-        default=dirname / "src/main/proto",
-        type=Path,
-    )
     args = parser.parse_args()
-
     generate_hids(args.output_directory, args.template_root, args.schema_file)
     generate_first_ds_hids(
         args.output_directory, args.template_root, args.first_ds_schema_file

--- a/copy.bara.sky
+++ b/copy.bara.sky
@@ -116,7 +116,7 @@ def define_mostrobotpy_to_allwpilib():
     for project_info in MOSTROBOTPY_PROJECTS:
         project_excludes = EXCLUDES
         if project_info.wpilib_name == "commandsv2":
-            project_excludes = project_excludes + ["subprojects/robotpy-commands-v2/tools/hids/**"]
+            project_excludes = project_excludes + ["subprojects/robotpy-commands-v2/tools/hids/**", "subprojects/robotpy-commands-v2/tools/shared/**"]
 
         origin_files += glob([
             "subprojects/" + project_info.robotpy_name + "/**",
@@ -235,12 +235,14 @@ def define_allwpilib_to_mostrobotpy():
     origin_files += [
         "commandsv2/generate_hids.py",
         "commandsv2/src/generate/main/python/first_ds_commandhid.py.jinja",
+        "shared/generation.py",
         "wpilibj/src/generate/first_ds_hids.json",
         "wpilibj/src/generate/first_ds_hids.schema.json",
     ]
     destination_files += [
         "subprojects/robotpy-commands-v2/tools/hids/generate_hids.py",
         "subprojects/robotpy-commands-v2/tools/hids/templates/main/python/first_ds_commandhid.py.jinja",
+        "subprojects/robotpy-commands-v2/tools/shared/generation.py",
         "subprojects/robotpy-commands-v2/tools/hids/first_ds_hids.json",
         "subprojects/robotpy-commands-v2/tools/hids/first_ds_hids.schema.json",
     ]
@@ -251,6 +253,10 @@ def define_allwpilib_to_mostrobotpy():
     transformations.append(core.move(
         "commandsv2/src/generate/main/python/first_ds_commandhid.py.jinja",
         "subprojects/robotpy-commands-v2/tools/hids/templates/main/python/first_ds_commandhid.py.jinja",
+    ))
+    transformations.append(core.move(
+        "shared/generation.py",
+        "subprojects/robotpy-commands-v2/tools/shared/generation.py",
     ))
     transformations.append(core.move(
         "wpilibj/src/generate/first_ds_hids.json",

--- a/ntcore/BUILD.bazel
+++ b/ntcore/BUILD.bazel
@@ -42,7 +42,10 @@ py_binary(
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
-    deps = [requirement("jinja2")],
+    deps = [
+        requirement("jinja2"),
+        "//:generation",
+    ],
 )
 
 write_source_files(

--- a/ntcore/generate_topics.py
+++ b/ntcore/generate_topics.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
 
-import argparse
 import json
+import sys
 from pathlib import Path
 
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
+
 from jinja2 import Environment, FileSystemLoader
-
-
-def Output(output_dir: Path, controller_name: str, contents: str):
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_file = output_dir / controller_name
-    output_file.write_text(contents, encoding="utf-8", newline="\n")
+from shared.generation import add_jinja_args, make_arg_parser, write_file
 
 
 def generate_topics(
@@ -30,16 +29,14 @@ def generate_topics(
         template = env.get_template(fn.name)
         outfn = fn.stem
         if outfn.startswith("NetworkTable") or outfn.startswith("Generic"):
-            output = template.render(types=types)
-            Output(generated_output_dir, outfn, output)
+            write_file(generated_output_dir, outfn, template.render(types=types))
         else:
             for replacements in types:
-                output = template.render(replacements)
                 if outfn == "Timestamped.java":
                     outfn2 = f"Timestamped{replacements['TypeName']}.java"
                 else:
                     outfn2 = f"{replacements['TypeName']}{outfn}"
-                Output(generated_output_dir, outfn2, output)
+                write_file(generated_output_dir, outfn2, template.render(replacements))
 
     # C++ classes
     cpp_subdirectory = "main/native/include/wpi/nt"
@@ -56,7 +53,7 @@ def generate_topics(
         for replacements in types:
             output = template.render(replacements)
             outfn2 = f"{replacements['TypeName']}{outfn}"
-            Output(generated_output_dir, outfn2, output)
+            write_file(generated_output_dir, outfn2, output)
 
     # C++ handle API (header)
     hdr_subdirectory = "main/native/include"
@@ -66,11 +63,10 @@ def generate_topics(
         autoescape=False,
     )
     template = env.get_template("ntcore_cpp_types.hpp.jinja")
-    output = template.render(types=types)
-    Output(
+    write_file(
         output_directory / hdr_subdirectory / "wpi/nt",
         "ntcore_cpp_types.hpp",
-        output,
+        template.render(types=types),
     )
 
     # C++ handle API (source)
@@ -81,11 +77,10 @@ def generate_topics(
         autoescape=False,
     )
     template = env.get_template("ntcore_cpp_types.cpp.jinja")
-    output = template.render(types=types)
-    Output(
+    write_file(
         output_directory / cpp_subdirectory,
         "ntcore_cpp_types.cpp",
-        output,
+        template.render(types=types),
     )
 
     # C handle API (header)
@@ -96,8 +91,11 @@ def generate_topics(
         autoescape=False,
     )
     template = env.get_template("ntcore_c_types.h.jinja")
-    output = template.render(types=types)
-    Output(output_directory / hdr_subdirectory / "wpi/nt", "ntcore_c_types.h", output)
+    write_file(
+        output_directory / hdr_subdirectory / "wpi/nt",
+        "ntcore_c_types.h",
+        template.render(types=types),
+    )
 
     # C handle API (source)
     c_subdirectory = "main/native/cpp"
@@ -107,8 +105,11 @@ def generate_topics(
         autoescape=False,
     )
     template = env.get_template("ntcore_c_types.cpp.jinja")
-    output = template.render(types=types)
-    Output(output_directory / c_subdirectory, "ntcore_c_types.cpp", output)
+    write_file(
+        output_directory / c_subdirectory,
+        "ntcore_c_types.cpp",
+        template.render(types=types),
+    )
 
     # JNI
     jni_subdirectory = "main/native/cpp/jni"
@@ -118,36 +119,22 @@ def generate_topics(
         autoescape=False,
     )
     template = env.get_template("types_jni.cpp.jinja")
-    output = template.render(types=types)
-    Output(output_directory / jni_subdirectory, "types_jni.cpp", output)
+    write_file(
+        output_directory / jni_subdirectory,
+        "types_jni.cpp",
+        template.render(types=types),
+    )
 
 
 def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated",
-        type=Path,
-    )
-    parser.add_argument(
-        "--types_schema_file",
-        help="Optional. If set, this file will be used to load the types schema",
-        default=dirname / "src/generate/types.json",
-        type=Path,
-    )
-    parser.add_argument(
-        "--template_root",
-        help="Optional. If set, will use this directory as the root for the jinja templates",
-        default=dirname / "src/generate",
-        type=Path,
-    )
+    parser = make_arg_parser(dirname, dirname.parent)
+    add_jinja_args(parser, dirname, dirname / "src/generate/types.json")
     args = parser.parse_args()
 
-    generate_topics(args.output_directory, args.template_root, args.types_schema_file)
+    generate_topics(args.output_directory, args.template_root, args.schema_file)
 
 
 if __name__ == "__main__":

--- a/shared/generation.py
+++ b/shared/generation.py
@@ -1,0 +1,184 @@
+# Copyright (c) FIRST and other WPILib contributors.
+# Open Source Software; you can modify and/or share it under the terms of
+# the WPILib BSD license file in the root directory of this project.
+import argparse
+import subprocess
+import sys
+from enum import Enum, auto
+from pathlib import Path
+
+
+class GeneratorTypes(Enum):
+    QUICKBUF = auto()
+    NANOPB = auto()
+
+
+def make_arg_parser(
+    subproject_root: Path, repo_root: Path, *args
+) -> argparse.ArgumentParser:
+    """Creates an ArgumentParser configured for QuickBuffers or nanopb generation.
+
+    Keyword arguments:
+    subproject_root -- Path to the subproject root. Determines default output and proto directories.
+    repo_root -- Path to the repo root. Used to find the nanopb generator.
+
+    Returns:
+    The ArgumentParser with the necessary arguments.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output_directory",
+        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
+        default=subproject_root / "src/generated",
+        type=Path,
+    )
+    if GeneratorTypes.QUICKBUF in args or GeneratorTypes.NANOPB in args:
+        parser.add_argument(
+            "--proto_directory",
+            help="Optional. If set, will use this directory to glob for protobuf files",
+            default=subproject_root / "src/main/proto",
+            type=Path,
+        )
+    if GeneratorTypes.QUICKBUF in args:
+        parser.add_argument(
+            "--protoc",
+            help="Protoc executable command",
+            default="protoc",
+        )
+        parser.add_argument(
+            "--quickbuf_plugin",
+            help="Optional if you use protoc-quickbuf as protoc. Path to the quickbuf protoc plugin.",
+        )
+    if GeneratorTypes.NANOPB in args:
+        parser.add_argument(
+            "--nanopb",
+            help="Nanopb generator command",
+            default=repo_root
+            / "wpiutil/src/main/native/thirdparty/nanopb/generator/nanopb_generator.py",
+        )
+    return parser
+
+
+def add_jinja_args(
+    parser: argparse.ArgumentParser,
+    subproject_root: Path,
+    default_schema_file: str | Path | None,
+) -> None:
+    """Configures an ArgumentParser for Jinja generation.
+
+    Keyword arguments:
+    parser -- The ArgumentParser to configure.
+    subproject_root -- Path to the subproject root. Determines default template directory.
+    default_schema_file -- The path to the schema file, or None to skip using a schema file.
+    """
+    parser.add_argument(
+        "--template_root",
+        help="Optional. If set, will use this directory as the root for the jinja templates",
+        default=subproject_root / "src/generate",
+        type=Path,
+    )
+    if default_schema_file is not None:
+        parser.add_argument(
+            "--schema_file",
+            help="Optional. If set, will use this file for the joystick schema",
+            default=default_schema_file,
+            type=Path,
+        )
+
+
+def write_file(output_dir: Path, outfn: str, contents: str) -> None:
+    """Writes contents to a file.
+
+    Keyword arguments:
+    output_dir -- The output directory.
+    outfn -- The output file name.
+    contents -- The contents of the file.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_file = output_dir / outfn
+    output_file.write_text(contents, encoding="utf-8", newline="\n")
+
+
+def generate_quickbuf(
+    protoc: Path, quickbuf_plugin: Path | None, output_directory: Path, proto_dir: Path
+) -> None:
+    """Generates QuickBuffers files.
+
+    Keyword arguments:
+    protoc -- The Protocol Buffers compiler.
+    quickbuf_plugin -- The QuickBuffers protoc plugin, or None if using protoc-quickbuf.
+    output_directory -- The base output directory to write generated files to.
+    proto_dir -- The base directory with protobuf files.
+    """
+    # Wipe away all protobuf files (and only protobuf files) first to ensure correctness
+    for file in output_directory.glob("**/Protobuf*.java"):
+        file.unlink()
+    # Nice to have if you delete the whole generated directory
+    output_directory.mkdir(parents=True, exist_ok=True)
+    for path in proto_dir.glob("**/*.proto"):
+        args = [str(protoc)]
+        if quickbuf_plugin:
+            # Optional if using protoc-quickbuf
+            args += [f"--plugin=protoc-gen-quickbuf={quickbuf_plugin}"]
+        args += [
+            f"--quickbuf_out=gen_descriptors=true:{str(output_directory.absolute())}",
+            f"-I{proto_dir.absolute()}",
+            str(path.absolute()),
+        ]
+        subprocess.check_call(args)
+    # Prepend files with license
+    for java_file in output_directory.glob("**/Protobuf*.java"):
+        with java_file.open(encoding="utf-8") as f:
+            content = f.read()
+
+        java_file.write_text(
+            "// Copyright (c) FIRST and other WPILib contributors.\n// Open Source Software; you can modify and/or share it under the terms of\n// the WPILib BSD license file in the root directory of this project.\n"
+            + content,
+            encoding="utf-8",
+            newline="\n",
+        )
+
+
+def generate_nanopb(
+    nanopb: Path,
+    output_directory: Path,
+    proto_dir: Path,
+    extra_search_dirs: list[Path] = [],
+) -> None:
+    """Generates QuickBuffers files.
+
+    Keyword arguments:
+    nanopb -- The nanopb generator.
+    output_directory -- The base output directory to write generated files to.
+    proto_dir -- The base directory with protobuf files.
+    extra_search_dirs -- Extra directories to search for protobuf files.,
+    """
+    # Wipe away all protobuf files (and only protobuf files) first to ensure correctness
+    for file in output_directory.glob("**/*.npb.*"):
+        file.unlink()
+    # Nice to have if you delete the whole generated directory
+    output_directory.mkdir(parents=True, exist_ok=True)
+    for path in proto_dir.glob("**/*.proto"):
+        subprocess.check_call(
+            ([sys.executable] if str(nanopb).endswith(".py") else [])
+            + [
+                str(nanopb),
+                *extra_search_dirs,
+                f"-I{proto_dir.absolute()}",
+                f"-D{output_directory.absolute()}",
+                "-S.cpp",
+                "-e.npb",
+                str(path.absolute()),
+            ],
+        )
+    # Prepend files with license
+    for file in output_directory.glob("**/*.npb.*"):
+        with file.open(encoding="utf-8") as f:
+            content = f.read()
+
+        file.write_text(
+            "// Copyright (c) FIRST and other WPILib contributors.\n// Open Source Software; you can modify and/or share it under the terms of\n// the WPILib BSD license file in the root directory of this project.\n"
+            + content,
+            encoding="utf-8",
+            newline="\n",
+        )

--- a/wpilibc/BUILD.bazel
+++ b/wpilibc/BUILD.bazel
@@ -28,7 +28,10 @@ py_binary(
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
-    deps = [requirement("jinja2")],
+    deps = [
+        requirement("jinja2"),
+        "//:generation",
+    ],
 )
 
 py_binary(
@@ -38,7 +41,10 @@ py_binary(
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
-    deps = [requirement("jinja2")],
+    deps = [
+        requirement("jinja2"),
+        "//:generation",
+    ],
 )
 
 py_binary(
@@ -48,7 +54,10 @@ py_binary(
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
-    deps = [requirement("jinja2")],
+    deps = [
+        requirement("jinja2"),
+        "//:generation",
+    ],
 )
 
 py_binary(

--- a/wpilibc/generate_first_ds_hids.py
+++ b/wpilibc/generate_first_ds_hids.py
@@ -4,18 +4,17 @@
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
 
-import argparse
 import json
 import re
+import sys
 from pathlib import Path
 
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
+
 from jinja2 import Environment, FileSystemLoader
-
-
-def write_controller_file(output_dir: Path, controller_name: str, contents: str):
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_file = output_dir / controller_name
-    output_file.write_text(contents, encoding="utf-8", newline="\n")
+from shared.generation import write_file, add_jinja_args, make_arg_parser
 
 
 def _capitalize_first(name: str) -> str:
@@ -133,8 +132,7 @@ def generate_first_ds_hids(
     template = env.get_template("first_ds_hid.hpp.jinja")
     for controller in controllers:
         controller_name = f"{controller['ClassName']}Controller.hpp"
-        output = template.render(controller)
-        write_controller_file(root_path, controller_name, output)
+        write_file(root_path, controller_name, template.render(controller))
 
     cpp_subdirectory = "main/native/cpp/driverstation"
     env = Environment(
@@ -146,8 +144,7 @@ def generate_first_ds_hids(
     template = env.get_template("first_ds_hid.cpp.jinja")
     for controller in controllers:
         controller_name = f"{controller['ClassName']}Controller.cpp"
-        output = template.render(controller)
-        write_controller_file(root_path, controller_name, output)
+        write_file(root_path, controller_name, template.render(controller))
 
     sim_hdr_subdirectory = "main/native/include/wpi/simulation"
     env = Environment(
@@ -159,8 +156,7 @@ def generate_first_ds_hids(
     template = env.get_template("first_ds_hidsim.hpp.jinja")
     for controller in controllers:
         controller_name = f"{controller['ClassName']}ControllerSim.hpp"
-        output = template.render(controller)
-        write_controller_file(root_path, controller_name, output)
+        write_file(root_path, controller_name, template.render(controller))
 
     sim_cpp_subdirectory = "main/native/cpp/simulation"
     env = Environment(
@@ -172,8 +168,7 @@ def generate_first_ds_hids(
     template = env.get_template("first_ds_hidsim.cpp.jinja")
     for controller in controllers:
         controller_name = f"{controller['ClassName']}ControllerSim.cpp"
-        output = template.render(controller)
-        write_controller_file(root_path, controller_name, output)
+        write_file(root_path, controller_name, template.render(controller))
 
     if test_output_directory is not None:
         env = Environment(
@@ -185,33 +180,15 @@ def generate_first_ds_hids(
         template = env.get_template("first_ds_hid_test.cpp.jinja")
         for controller in controllers:
             controller_name = f"{controller['ClassName']}ControllerTest.cpp"
-            output = template.render(controller)
-            write_controller_file(root_path, controller_name, output)
+            write_file(root_path, controller_name, template.render(controller))
 
 
 def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated",
-        type=Path,
-    )
-    parser.add_argument(
-        "--template_root",
-        help="Optional. If set, will use this directory as the root for the jinja templates",
-        default=dirname / "src/generate",
-        type=Path,
-    )
-    parser.add_argument(
-        "--schema_file",
-        help="Optional. If set, will use this file for the FIRST Driver Station HID schema",
-        default="wpilibj/src/generate/first_ds_hids.json",
-        type=Path,
-    )
+    parser = make_arg_parser(dirname, dirname.parent)
+    add_jinja_args(parser, dirname, "wpilibj/src/generate/first_ds_hids.json")
     parser.add_argument(
         "--test_output_directory",
         help="Optional. If set, will output generated tests to this directory",

--- a/wpilibc/generate_hids.py
+++ b/wpilibc/generate_hids.py
@@ -4,17 +4,16 @@
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
 
-import argparse
 import json
+import sys
 from pathlib import Path
 
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
+
 from jinja2 import Environment, FileSystemLoader
-
-
-def write_controller_file(output_dir: Path, controller_name: str, contents: str):
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_file = output_dir / controller_name
-    output_file.write_text(contents, encoding="utf-8", newline="\n")
+from shared.generation import write_file, add_jinja_args, make_arg_parser
 
 
 def generate_hids(output_directory: Path, template_directory: Path, schema_file: Path):
@@ -32,8 +31,7 @@ def generate_hids(output_directory: Path, template_directory: Path, schema_file:
     template = env.get_template("hid.hpp.jinja")
     for controller in controllers:
         controllerName = f"{controller['ConsoleName']}Controller.hpp"
-        output = template.render(controller)
-        write_controller_file(root_path, controllerName, output)
+        write_file(root_path, controllerName, template.render(controller))
 
     # C++ files
     cpp_subdirectory = "main/native/cpp/driverstation"
@@ -45,8 +43,7 @@ def generate_hids(output_directory: Path, template_directory: Path, schema_file:
     template = env.get_template("hid.cpp.jinja")
     for controller in controllers:
         controllerName = f"{controller['ConsoleName']}Controller.cpp"
-        output = template.render(controller)
-        write_controller_file(root_path, controllerName, output)
+        write_file(root_path, controllerName, template.render(controller))
 
     # C++ simulation headers
     sim_hdr_subdirectory = "main/native/include/wpi/simulation"
@@ -59,8 +56,7 @@ def generate_hids(output_directory: Path, template_directory: Path, schema_file:
     template = env.get_template("hidsim.hpp.jinja")
     for controller in controllers:
         controllerName = f"{controller['ConsoleName']}ControllerSim.hpp"
-        output = template.render(controller)
-        write_controller_file(root_path, controllerName, output)
+        write_file(root_path, controllerName, template.render(controller))
 
     # C++ simulation files
     sim_cpp_subdirectory = "main/native/cpp/simulation"
@@ -72,33 +68,15 @@ def generate_hids(output_directory: Path, template_directory: Path, schema_file:
     template = env.get_template("hidsim.cpp.jinja")
     for controller in controllers:
         controllerName = f"{controller['ConsoleName']}ControllerSim.cpp"
-        output = template.render(controller)
-        write_controller_file(root_path, controllerName, output)
+        write_file(root_path, controllerName, template.render(controller))
 
 
 def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated",
-        type=Path,
-    )
-    parser.add_argument(
-        "--template_root",
-        help="Optional. If set, will use this directory as the root for the jinja templates",
-        default=dirname / "src/generate",
-        type=Path,
-    )
-    parser.add_argument(
-        "--schema_file",
-        help="Optional. If set, will use this file for the joystick schema",
-        default="wpilibj/src/generate/hids.json",
-        type=Path,
-    )
+    parser = make_arg_parser(dirname, dirname.parent)
+    add_jinja_args(parser, dirname, "wpilibj/src/generate/hids.json")
     args = parser.parse_args()
 
     generate_hids(args.output_directory, args.template_root, args.schema_file)

--- a/wpilibc/generate_pwm_motor_controllers.py
+++ b/wpilibc/generate_pwm_motor_controllers.py
@@ -4,23 +4,18 @@
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
 
-import argparse
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any, Dict
 
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
+
 from jinja2 import Environment, FileSystemLoader
-from jinja2.environment import Template
-
-
-def render_template(
-    template: Template, output_dir: Path, filename: str, controller: Dict[str, Any]
-):
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    output_file = output_dir / filename
-    output_file.write_text(template.render(controller), encoding="utf-8", newline="\n")
+from shared.generation import write_file, add_jinja_args, make_arg_parser
 
 
 def generate_cpp_headers(
@@ -38,7 +33,7 @@ def generate_cpp_headers(
 
     for controller in pwm_motor_controllers:
         controller_name = os.path.basename(f"{controller['name']}.hpp")
-        render_template(template, root_path, controller_name, controller)
+        write_file(root_path, controller_name, template.render(controller))
 
 
 def generate_cpp_sources(output_root, template_root, pwm_motor_controllers):
@@ -54,13 +49,13 @@ def generate_cpp_sources(output_root, template_root, pwm_motor_controllers):
 
     for controller in pwm_motor_controllers:
         controller_name = os.path.basename(f"{controller['name']}.cpp")
-        render_template(template, root_path, controller_name, controller)
+        write_file(root_path, controller_name, template.render(controller))
 
 
 def generate_pwm_motor_controllers(
-    output_root: Path, template_root: Path, schema_root: Path
+    output_root: Path, template_root: Path, schema_file: Path
 ):
-    with (schema_root / "pwm_motor_controllers.json").open(encoding="utf-8") as f:
+    with schema_file.open(encoding="utf-8") as f:
         controllers = json.load(f)
 
     generate_cpp_headers(output_root, template_root, controllers)
@@ -71,29 +66,12 @@ def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated",
-        type=Path,
-    )
-    parser.add_argument(
-        "--schema_root",
-        help="Optional. If set, will use this directory as the root for discovering the pwm controller schema",
-        default=dirname / "../wpilibj/src/generate",
-        type=Path,
-    )
-    parser.add_argument(
-        "--template_root",
-        help="Optional. If set, will use this directory as the root for the jinja templates",
-        default=dirname / "src/generate",
-        type=Path,
-    )
+    parser = make_arg_parser(dirname, dirname.parent)
+    add_jinja_args(parser, dirname, "wpilibj/src/generate/pwm_motor_controllers.json")
     args = parser.parse_args()
 
     generate_pwm_motor_controllers(
-        args.output_directory, args.template_root, args.schema_root
+        args.output_directory, args.template_root, args.schema_file
     )
 
 

--- a/wpilibc/generate_wpilibc.py
+++ b/wpilibc/generate_wpilibc.py
@@ -52,7 +52,9 @@ def main():
         test_output_directory,
     )
     generate_pwm_motor_controllers(
-        args.output_directory, args.template_root, args.schema_root
+        args.output_directory,
+        args.template_root,
+        args.schema_root / "pwm_motor_controllers.json",
     )
 
 

--- a/wpilibj/BUILD.bazel
+++ b/wpilibj/BUILD.bazel
@@ -15,7 +15,10 @@ py_binary(
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
-    deps = [requirement("jinja2")],
+    deps = [
+        requirement("jinja2"),
+        "//:generation",
+    ],
 )
 
 py_binary(
@@ -25,7 +28,10 @@ py_binary(
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
-    deps = [requirement("jinja2")],
+    deps = [
+        requirement("jinja2"),
+        "//:generation",
+    ],
 )
 
 py_binary(
@@ -35,7 +41,10 @@ py_binary(
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
-    deps = [requirement("jinja2")],
+    deps = [
+        requirement("jinja2"),
+        "//:generation",
+    ],
 )
 
 py_binary(

--- a/wpilibj/generate_first_ds_hids.py
+++ b/wpilibj/generate_first_ds_hids.py
@@ -4,18 +4,18 @@
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
 
-import argparse
 import json
 import re
+import sys
 from pathlib import Path
 
+
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
+
 from jinja2 import Environment, FileSystemLoader
-
-
-def write_controller_file(output_dir: Path, controller_name: str, contents: str):
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_file = output_dir / controller_name
-    output_file.write_text(contents, encoding="utf-8", newline="\n")
+from shared.generation import write_file, add_jinja_args, make_arg_parser
 
 
 def _capitalize_first(name: str) -> str:
@@ -132,15 +132,13 @@ def generate_first_ds_hids(
     template = env.get_template("first_ds_hid.java.jinja")
     for controller in controllers:
         controller_name = f"{controller['ClassName']}Controller.java"
-        output = template.render(controller)
-        write_controller_file(root_path, controller_name, output)
+        write_file(root_path, controller_name, template.render(controller))
 
     root_path = output_directory / "main/java/org/wpilib/simulation"
     template = env.get_template("first_ds_hidsim.java.jinja")
     for controller in controllers:
         controller_name = f"{controller['ClassName']}ControllerSim.java"
-        output = template.render(controller)
-        write_controller_file(root_path, controller_name, output)
+        write_file(root_path, controller_name, template.render(controller))
 
     if test_output_directory is not None:
         env = Environment(
@@ -153,27 +151,15 @@ def generate_first_ds_hids(
         template = env.get_template("first_ds_hid_test.java.jinja")
         for controller in controllers:
             controller_name = f"{controller['ClassName']}ControllerTest.java"
-            output = template.render(controller)
-            write_controller_file(root_path, controller_name, output)
+            write_file(root_path, controller_name, template.render(controller))
 
 
 def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated",
-        type=Path,
-    )
-    parser.add_argument(
-        "--template_root",
-        help="Optional. If set, will use this directory as the root for the jinja templates",
-        default=dirname / "src/generate",
-        type=Path,
-    )
+    parser = make_arg_parser(dirname, dirname.parent)
+    add_jinja_args(parser, dirname, None)
     parser.add_argument(
         "--test_output_directory",
         help="Optional. If set, will output generated tests to this directory",

--- a/wpilibj/generate_hids.py
+++ b/wpilibj/generate_hids.py
@@ -4,17 +4,17 @@
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
 
-import argparse
 import json
+import sys
 from pathlib import Path
 
+
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
+
 from jinja2 import Environment, FileSystemLoader
-
-
-def write_controller_file(output_dir: Path, controller_name: str, contents: str):
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_file = output_dir / controller_name
-    output_file.write_text(contents, encoding="utf-8", newline="\n")
+from shared.generation import write_file, add_jinja_args, make_arg_parser
 
 
 def generate_hids(output_directory: Path, template_directory: Path):
@@ -31,35 +31,22 @@ def generate_hids(output_directory: Path, template_directory: Path):
     template = env.get_template("hid.java.jinja")
     for controller in controllers:
         controllerName = f"{controller['ConsoleName']}Controller.java"
-        output = template.render(controller)
-        write_controller_file(rootPath, controllerName, output)
+        write_file(rootPath, controllerName, template.render(controller))
 
     # Java simulation files
     rootPath = output_directory / "main/java/org/wpilib/simulation"
     template = env.get_template("hidsim.java.jinja")
     for controller in controllers:
         controllerName = f"{controller['ConsoleName']}ControllerSim.java"
-        output = template.render(controller)
-        write_controller_file(rootPath, controllerName, output)
+        write_file(rootPath, controllerName, template.render(controller))
 
 
 def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated",
-        type=Path,
-    )
-    parser.add_argument(
-        "--template_root",
-        help="Optional. If set, will use this directory as the root for the jinja templates",
-        default=dirname / "src/generate",
-        type=Path,
-    )
+    parser = make_arg_parser(dirname, dirname.parent)
+    add_jinja_args(parser, dirname, None)
     args = parser.parse_args()
 
     generate_hids(args.output_directory, args.template_root)

--- a/wpilibj/generate_pwm_motor_controllers.py
+++ b/wpilibj/generate_pwm_motor_controllers.py
@@ -4,22 +4,17 @@
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
 
-import argparse
 import json
+import sys
 from pathlib import Path
-from typing import Any, Dict
+
+
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
 
 from jinja2 import Environment, FileSystemLoader
-from jinja2.environment import Template
-
-
-def render_template(
-    template: Template, output_dir: Path, filename: str, controller: Dict[str, Any]
-):
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    output_file = output_dir / filename
-    output_file.write_text(template.render(controller), encoding="utf-8", newline="\n")
+from shared.generation import write_file, add_jinja_args, make_arg_parser
 
 
 def generate_pwm_motor_controllers(output_root, template_root):
@@ -37,26 +32,15 @@ def generate_pwm_motor_controllers(output_root, template_root):
 
     for controller in controllers:
         controller_name = f"{controller['name']}.java"
-        render_template(template, root_path, controller_name, controller)
+        write_file(root_path, controller_name, template.render(controller))
 
 
 def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated",
-        type=Path,
-    )
-    parser.add_argument(
-        "--template_root",
-        help="Optional. If set, will use this directory as the root for the jinja templates",
-        default=dirname / "src/generate",
-        type=Path,
-    )
+    parser = make_arg_parser(dirname, dirname.parent)
+    add_jinja_args(parser, dirname, None)
     args = parser.parse_args()
 
     generate_pwm_motor_controllers(args.output_directory, args.template_root)

--- a/wpimath/BUILD.bazel
+++ b/wpimath/BUILD.bazel
@@ -43,6 +43,10 @@ py_binary(
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    deps = [
+        requirement("jinja2"),
+        "//:generation",
+    ],
 )
 
 py_binary(
@@ -53,7 +57,10 @@ py_binary(
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
-    deps = [requirement("jinja2")],
+    deps = [
+        requirement("jinja2"),
+        "//:generation",
+    ],
 )
 
 py_binary(
@@ -63,6 +70,9 @@ py_binary(
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    deps = [
+        "//:generation",
+    ],
 )
 
 py_binary(

--- a/wpimath/generate_nanopb.py
+++ b/wpimath/generate_nanopb.py
@@ -4,82 +4,26 @@
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
 
-import argparse
-import os
-import shutil
-import subprocess
 import sys
 from pathlib import Path
 
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
 
-def generate_nanopb(nanopb: Path, output_directory: Path, proto_dir: Path):
-    shutil.rmtree(output_directory.absolute(), ignore_errors=True)
-    os.makedirs(output_directory.absolute())
-
-    proto_files = proto_dir.glob("**/*.proto")
-    for path in proto_files:
-        subprocess.check_call(
-            ([sys.executable] if nanopb.endswith(".py") else [])
-            + [
-                nanopb,
-                f"-I{proto_dir.absolute()}",
-                f"-D{output_directory.absolute()}",
-                "-S.cpp",
-                "-e.npb",
-                path.absolute(),
-            ],
-        )
-    java_files = (output_directory).glob("**/*.*")
-    for java_file in java_files:
-        with (java_file).open(encoding="utf-8") as f:
-            content = f.read()
-
-        java_file.write_text(
-            "// Copyright (c) FIRST and other WPILib contributors.\n// Open Source Software; you can modify and/or share it under the terms of\n// the WPILib BSD license file in the root directory of this project.\n"
-            + content,
-            encoding="utf-8",
-            newline="\n",
-        )
+from shared.generation import GeneratorTypes, generate_nanopb, make_arg_parser
 
 
 def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    root_path = dirname.parent
-    nanopb_path = os.path.join(
-        root_path,
-        "wpiutil",
-        "src",
-        "main",
-        "native",
-        "thirdparty",
-        "nanopb",
-        "generator",
-        "nanopb_generator.py",
-    )
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--nanopb",
-        help="Nanopb generator command",
-        default=nanopb_path,
-    )
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated/main/native/cpp",
-        type=Path,
-    )
-    parser.add_argument(
-        "--proto_directory",
-        help="Optional. If set, will use this directory to glob for protobuf files",
-        default=dirname / "src/main/proto",
-        type=Path,
-    )
+    parser = make_arg_parser(dirname, dirname.parent, GeneratorTypes.NANOPB)
     args = parser.parse_args()
 
-    generate_nanopb(args.nanopb, args.output_directory, args.proto_directory)
+    generate_nanopb(
+        args.nanopb, args.output_directory / "main/native/cpp", args.proto_directory
+    )
 
 
 if __name__ == "__main__":

--- a/wpimath/generate_numbers.py
+++ b/wpimath/generate_numbers.py
@@ -4,16 +4,16 @@
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
 
-import argparse
+import sys
 from pathlib import Path
 
+
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
+
 from jinja2 import Environment, FileSystemLoader
-
-
-def output(output_dir: Path, outfn: str, contents: str):
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_file = output_dir / outfn
-    output_file.write_text(contents, encoding="utf-8", newline="\n")
+from shared.generation import make_arg_parser, add_jinja_args, write_file
 
 
 def generate_numbers(output_directory: Path, template_root: Path):
@@ -30,31 +30,20 @@ def generate_numbers(output_directory: Path, template_root: Path):
 
     for i in range(MAX_NUM + 1):
         contents = template.render(num=i)
-        output(rootPath, f"N{i}.java", contents)
+        write_file(rootPath, f"N{i}.java", contents)
 
     template = env.get_template("Nat.java.jinja")
     rootPath = output_directory / "main/java/org/wpilib/math/util"
     contents = template.render(nums=range(MAX_NUM + 1))
-    output(rootPath, "Nat.java", contents)
+    write_file(rootPath, "Nat.java", contents)
 
 
 def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated",
-        type=Path,
-    )
-    parser.add_argument(
-        "--template_root",
-        help="Optional. If set, will use this directory as the root for the jinja templates",
-        default=dirname / "src/generate",
-        type=Path,
-    )
+    parser = make_arg_parser(dirname, dirname.parent)
+    add_jinja_args(parser, dirname, None)
     args = parser.parse_args()
 
     generate_numbers(args.output_directory, args.template_root)

--- a/wpimath/generate_quickbuf.py
+++ b/wpimath/generate_quickbuf.py
@@ -4,70 +4,28 @@
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
 
-import argparse
-import subprocess
+import sys
 from pathlib import Path
 
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
 
-def generate_quickbuf(
-    protoc, quickbuf_plugin: Path, output_directory: Path, proto_dir: Path
-):
-    proto_files = proto_dir.glob("**/*.proto")
-    for path in proto_files:
-        absolute_filename = path.absolute()
-        subprocess.check_call(
-            [
-                protoc,
-                f"--plugin=protoc-gen-quickbuf={quickbuf_plugin}",
-                f"--quickbuf_out=gen_descriptors=true:{output_directory.absolute()}",
-                f"-I{proto_dir.absolute()}",
-                absolute_filename,
-            ]
-        )
-    java_files = (output_directory / "org/wpilib/math/proto").glob("*.java")
-    for java_file in java_files:
-        with (java_file).open(encoding="utf-8") as f:
-            content = f.read()
-
-        java_file.write_text(
-            "// Copyright (c) FIRST and other WPILib contributors.\n// Open Source Software; you can modify and/or share it under the terms of\n// the WPILib BSD license file in the root directory of this project.\n"
-            + content,
-            encoding="utf-8",
-            newline="\n",
-        )
+from shared.generation import GeneratorTypes, generate_quickbuf, make_arg_parser
 
 
 def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--protoc",
-        help="Protoc executable command",
-        default="protoc",
-    )
-    parser.add_argument(
-        "--quickbuf_plugin",
-        help="Path to the quickbuf protoc plugin",
-        required=True,
-    )
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated/main/java",
-        type=Path,
-    )
-    parser.add_argument(
-        "--proto_directory",
-        help="Optional. If set, will use this directory to glob for protobuf files",
-        default=dirname / "src/main/proto",
-        type=Path,
-    )
+    parser = make_arg_parser(dirname, dirname.parent, GeneratorTypes.QUICKBUF)
     args = parser.parse_args()
 
     generate_quickbuf(
-        args.protoc, args.quickbuf_plugin, args.output_directory, args.proto_directory
+        args.protoc,
+        args.quickbuf_plugin,
+        args.output_directory / "main/java",
+        args.proto_directory,
     )
 
 

--- a/wpiunits/BUILD.bazel
+++ b/wpiunits/BUILD.bazel
@@ -13,7 +13,10 @@ py_binary(
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
-    deps = [requirement("jinja2")],
+    deps = [
+        requirement("jinja2"),
+        "//:generation",
+    ],
 )
 
 generate_wpiunits(

--- a/wpiunits/generate_units.py
+++ b/wpiunits/generate_units.py
@@ -9,19 +9,18 @@
 #
 # Generated files will be located in wpiunits/src/generated/main/
 
-import argparse
 import inspect
 import re
+import sys
 from pathlib import Path
 
+
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
+
 from jinja2 import Environment, FileSystemLoader
-
-
-def output(output_dir, outfn: str, contents: str):
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_file = output_dir / outfn
-    output_file.write_text(contents, encoding="utf-8", newline="\n")
-
+from shared.generation import add_jinja_args, make_arg_parser, write_file
 
 # The units for which multiply and divide mathematical operations are defined
 MATH_OPERATION_UNITS = [
@@ -362,26 +361,15 @@ def generate_units(output_directory: Path, template_directory: Path):
             helpers=helpers,
         )
 
-        output(rootPath / "measure", f"{unit_name}.java", interfaceContents)
+        write_file(rootPath / "measure", f"{unit_name}.java", interfaceContents)
 
 
 def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated",
-        type=Path,
-    )
-    parser.add_argument(
-        "--template_root",
-        help="Optional. If set, will use this directory as the root for the jinja templates",
-        default=dirname / "src/generate",
-        type=Path,
-    )
+    parser = make_arg_parser(dirname, dirname.parent)
+    add_jinja_args(parser, dirname, None)
     args = parser.parse_args()
 
     generate_units(args.output_directory, args.template_root)

--- a/wpiutil/BUILD.bazel
+++ b/wpiutil/BUILD.bazel
@@ -59,6 +59,9 @@ py_binary(
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    deps = [
+        "//:generation",
+    ],
 )
 
 filegroup(

--- a/wpiutil/generate_nanopb.py
+++ b/wpiutil/generate_nanopb.py
@@ -4,79 +4,24 @@
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
 
-import argparse
-import os
-import shutil
-import subprocess
 import sys
 from pathlib import Path
 
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
 
-def generate_nanopb(nanopb: Path, output_directory: Path, proto_dir: Path):
-    shutil.rmtree(output_directory.absolute(), ignore_errors=True)
-    os.makedirs(output_directory.absolute())
-
-    proto_files = proto_dir.glob("*.proto")
-    for path in proto_files:
-        absolute_filename = path.absolute()
-        subprocess.check_call(
-            ([sys.executable] if nanopb.endswith(".py") else [])
-            + [
-                nanopb,
-                f"-I{absolute_filename.parent}",
-                f"-D{output_directory.absolute()}",
-                "-S.cpp",
-                "-e.npb",
-                absolute_filename,
-            ],
-        )
-    java_files = (output_directory).glob("*")
-    for java_file in java_files:
-        with (java_file).open(encoding="utf-8") as f:
-            content = f.read()
-
-        java_file.write_text(
-            "// Copyright (c) FIRST and other WPILib contributors.\n// Open Source Software; you can modify and/or share it under the terms of\n// the WPILib BSD license file in the root directory of this project.\n"
-            + content,
-            encoding="utf-8",
-            newline="\n",
-        )
+from shared.generation import make_arg_parser, generate_nanopb, GeneratorTypes
 
 
 def main():
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    root_path = dirname.parent
-    nanopb_path = os.path.join(
-        root_path,
-        "wpiutil",
-        "src",
-        "main",
-        "native",
-        "thirdparty",
-        "nanopb",
-        "generator",
-        "nanopb_generator.py",
-    )
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--nanopb",
-        help="Nanopb generator command",
-        default=nanopb_path,
-    )
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated/test/native/cpp",
-        type=Path,
-    )
-    parser.add_argument(
-        "--proto_directory",
-        help="Optional. If set, will use this directory to glob for protobuf files",
-        default=dirname / "src/test/proto",
-        type=Path,
+    parser = make_arg_parser(dirname, dirname.parent, GeneratorTypes.NANOPB)
+    parser.set_defaults(
+        proto_directory=dirname / "src/test/proto",
+        output_directory=dirname / "src/generated/test/native/cpp",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Our generation scripts duplicate a lot of lines, and there's already divergence in the exact implementations. Extract common logic out into a shared "generation" module and use that instead to provide generation capabilities (except for Jinja templates, which require too much custom logic to deduplicate effectively). This also fixes some correctness issues when files are outdated.