### PR TITLE
[wpiutil] Add `Struct<char>` support in C++

### DIFF
--- a/wpiutil/src/main/native/include/wpi/util/struct/Struct.hpp
+++ b/wpiutil/src/main/native/include/wpi/util/struct/Struct.hpp
@@ -550,6 +550,19 @@ struct Struct<bool> {
 };
 
 /**
+ * Raw struct support for char values.
+ * Primarily useful for higher level struct implementations.
+ */
+template <>
+struct Struct<char> {
+  static constexpr std::string_view GetTypeName() { return "char"; }
+  static constexpr size_t GetSize() { return 1; }
+  static constexpr std::string_view GetSchema() { return "char value"; }
+  static char Unpack(std::span<const uint8_t> data) { return data[0]; }
+  static void Pack(std::span<uint8_t> data, char value) { data[0] = value; }
+};
+
+/**
  * Raw struct support for uint8_t values.
  * Primarily useful for higher level struct implementations.
  */


### PR DESCRIPTION
`char`, `signed char`, and `unsigned char` are three distinct types in C++ (see "Character types" at https://en.cppreference.com/cpp/language/types). `int8_t` should be defined as `signed char` and `uint8_t` as `unsigned char`, as that's the only cross-architecture way to define them, so we should be able to separately specialize `Struct<char>`.