### PR TITLE
[cmd3] Add Coroutine.waitUntil overload with timeout

### DIFF
--- a/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
@@ -316,6 +316,11 @@ public final class Coroutine {
     },
     ;
 
+    /**
+     * Checks if the wait has timed out.
+     *
+     * @return true if this result was a timeout, false if the condition was met without timing out.
+     */
     public abstract boolean timedOut();
   }
 

--- a/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
@@ -296,12 +296,41 @@ public final class Coroutine {
   }
 
   /**
-   * Yields until a condition is met.
+   * Represents the result of a call to {@link Coroutine#waitUntil(BooleanSupplier)} or {@link
+   * Coroutine#waitUntil(BooleanSupplier, Time)}.
+   */
+  public enum WaitResult {
+    /** A call to {@code waitUntil} has met its condition. */
+    CONDITION_MET {
+      @Override
+      public boolean timedOut() {
+        return false;
+      }
+    },
+    /** A call to {@link Coroutine#waitUntil(BooleanSupplier, Time)} has timed out. */
+    TIMED_OUT {
+      @Override
+      public boolean timedOut() {
+        return true;
+      }
+    },
+    ;
+
+    public abstract boolean timedOut();
+  }
+
+  /**
+   * Yields until a condition is met. This method will <b>only</b> return once the condition is met;
+   * if the condition never becomes true or is delayed longer than you expect, this method will
+   * block indefinitely. {@link #waitUntil(BooleanSupplier, Time)} is an alternative that will only
+   * wait up until a maximum duration before exiting.
    *
    * @param condition The condition to wait for
+   * @return {@link WaitResult#CONDITION_MET}
    * @throws IllegalStateException if called anywhere other than the coroutine's running command
+   * @see #waitUntil(BooleanSupplier, Time)
    */
-  public void waitUntil(BooleanSupplier condition) {
+  public WaitResult waitUntil(BooleanSupplier condition) {
     requireMounted();
 
     requireNonNullParam(condition, "condition", "Coroutine.waitUntil");
@@ -309,6 +338,64 @@ public final class Coroutine {
     while (!condition.getAsBoolean()) {
       this.yield();
     }
+
+    return WaitResult.CONDITION_MET;
+  }
+
+  /**
+   * Yields until a condition is met, waiting for up to a specified duration. If the condition is
+   * not met before the timeout duration elapses, this method stops waiting and returns {@link
+   * WaitResult#TIMED_OUT}.
+   *
+   * <p>Teams may use this method for waiting for conditions in autonomous or automated routines to
+   * be resilient to hardware faults (e.g., a mechanism not reaching a target state or a faulty
+   * sensor).
+   *
+   * <pre>{@code
+   * Command.noRequirements(coroutine -> {
+   *   coroutine.fork(elevator.up());
+   *   Coroutine.WaitResult upResult = coroutine.waitUntil(elevator::atTop, Seconds.of(1.25));
+   *   if (upResult.timedOut()) {
+   *     // We've waited 1.25 seconds and the elevator still has not reached the top. It may have
+   *     // jammed or there may be a fault with the sensors. In this example, we set a driverstation
+   *     // alert and exit early - team code may want to take other approaches like retrying the
+   *     // command or falling back to a secondary behavior that doesn't need the elevator to be up.
+   *     elevator.setJamAlert();
+   *     return;
+   *   }
+   *
+   *   // The elevator reached the top within 1.25 seconds. Clear the alert and continue.
+   *   elevator.clearJamAlert();
+   *
+   *   // ... more commands ...
+   * })
+   * }</pre>
+   *
+   * @param condition The condition to wait for
+   * @param timeout The maximum duration to wait
+   * @return {@link WaitResult#CONDITION_MET} if the condition was met within the specified timeout,
+   *     or {@link WaitResult#TIMED_OUT} if the timeout duration elapsed before the condition was
+   *     met.
+   * @see #waitUntil(BooleanSupplier)
+   */
+  public WaitResult waitUntil(BooleanSupplier condition, Time timeout) {
+    requireMounted();
+
+    requireNonNullParam(condition, "condition", "Coroutine.waitUntil");
+    requireNonNullParam(timeout, "timeout", "Coroutine.waitUntil");
+
+    Timer timer = new Timer();
+    timer.start();
+
+    while (!condition.getAsBoolean()) {
+      if (timer.hasElapsed(timeout)) {
+        return WaitResult.TIMED_OUT;
+      } else {
+        this.yield();
+      }
+    }
+
+    return WaitResult.CONDITION_MET;
   }
 
   /**

--- a/commandsv3/src/test/java/org/wpilib/command3/CoroutineTest.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/CoroutineTest.java
@@ -5,8 +5,10 @@
 package org.wpilib.command3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wpilib.units.Units.Seconds;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -15,8 +17,122 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.junit.jupiter.api.Test;
+import org.wpilib.system.RobotController;
 
 class CoroutineTest extends CommandTestBase {
+  @Test
+  void waitUntilConditionMet() {
+    AtomicBoolean condition = new AtomicBoolean(false);
+    AtomicReference<Coroutine.WaitResult> result = new AtomicReference<>();
+
+    var command =
+        Command.noRequirements(co -> result.set(co.waitUntil(condition::get, Seconds.of(1.0))))
+            .named("Wait Until Condition Met");
+
+    m_scheduler.schedule(command);
+    m_scheduler.run();
+
+    // Condition not met yet, should still be running
+    assertTrue(m_scheduler.isRunning(command));
+
+    condition.set(true);
+    m_scheduler.run();
+
+    // Condition met, should have finished
+    assertEquals(Coroutine.WaitResult.CONDITION_MET, result.get());
+    assertFalse(m_scheduler.isRunning(command));
+  }
+
+  @Test
+  void waitUntilTimeout() {
+    AtomicBoolean condition = new AtomicBoolean(false);
+    AtomicReference<Coroutine.WaitResult> result = new AtomicReference<>();
+    AtomicReference<Long> currentTime = new AtomicReference<>(0L);
+
+    RobotController.setTimeSource(currentTime::get);
+
+    var command =
+        Command.noRequirements(co -> result.set(co.waitUntil(condition::get, Seconds.of(1.0))))
+            .named("Wait Until Timeout");
+
+    m_scheduler.schedule(command);
+    m_scheduler.run();
+
+    // Still running, time is 0
+    assertTrue(m_scheduler.isRunning(command));
+
+    // Advance time to 0.5s
+    currentTime.set(500_000L);
+    m_scheduler.run();
+    assertTrue(m_scheduler.isRunning(command));
+
+    // Advance time to 1.1s (past 1.0s timeout)
+    currentTime.set(1_100_000L);
+    m_scheduler.run();
+
+    // Should have timed out
+    assertEquals(Coroutine.WaitResult.TIMED_OUT, result.get());
+    assertFalse(m_scheduler.isRunning(command));
+  }
+
+  @Test
+  void waitUntilImmediateConditionMet() {
+    AtomicReference<Coroutine.WaitResult> result = new AtomicReference<>();
+
+    var command =
+        Command.noRequirements(co -> result.set(co.waitUntil(() -> true, Seconds.of(1.0))))
+            .named("Wait Until Immediate Condition Met");
+
+    m_scheduler.schedule(command);
+    m_scheduler.run();
+
+    // Condition met immediately, should have finished in one run
+    assertEquals(Coroutine.WaitResult.CONDITION_MET, result.get());
+    assertFalse(m_scheduler.isRunning(command));
+  }
+
+  @Test
+  void waitUntilConditionMetExactlyAtTimeout() {
+    AtomicBoolean condition = new AtomicBoolean(false);
+    AtomicReference<Coroutine.WaitResult> result = new AtomicReference<>();
+    AtomicReference<Long> currentTime = new AtomicReference<>(0L);
+
+    RobotController.setTimeSource(currentTime::get);
+
+    var command =
+        Command.noRequirements(co -> result.set(co.waitUntil(condition::get, Seconds.of(1.0))))
+            .named("Wait Until Condition Met Exactly At Timeout");
+
+    m_scheduler.schedule(command);
+    m_scheduler.run();
+
+    // Advance time to exactly 1.0s and set condition
+    currentTime.set(1_000_000L);
+    condition.set(true);
+    m_scheduler.run();
+
+    // Condition met, even though time is exactly at timeout.
+    // The implementation checks the condition BEFORE the timeout in the while loop.
+    assertEquals(Coroutine.WaitResult.CONDITION_MET, result.get());
+    assertFalse(m_scheduler.isRunning(command));
+  }
+
+  @Test
+  void waitUntilNullParamThrows() {
+    var command =
+        Command.noRequirements(
+                co -> {
+                  assertThrows(
+                      NullPointerException.class, () -> co.waitUntil(null, Seconds.of(1.0)));
+                  assertThrows(NullPointerException.class, () -> co.waitUntil(() -> true, null));
+                })
+            .named("Wait Until Null Param Throws");
+
+    m_scheduler.schedule(command);
+    m_scheduler.run();
+    assertFalse(m_scheduler.isRunning(command));
+  }
+
   @Test
   void forkMany() {
     var a = new NullCommand();


### PR DESCRIPTION
This helps simplify logic in automated routines or autonomous modes where you don't want to be stuck waiting for a signal that will never come (or is too delayed to still be relevant when it arrives) - for example, waiting for a mechanism to reach a goal may want to add a timeout so you can reattempt or fall back to a secondary behavior