### PR TITLE
[cmd3] Multiple periodic callbacks in the same scope

### DIFF
--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -131,13 +131,16 @@ public final class Scheduler implements ProtobufSerializable {
   private final Stack<CommandState> m_currentCommandAncestry = new Stack<>();
 
   /** The periodic callbacks to run, outside of the command structure. */
-  private final SequencedMap<BindingScope, Coroutine> m_periodicCallbacks = new LinkedHashMap<>();
+  private final List<PeriodicCallback> m_periodicCallbacks = new ArrayList<>();
 
   /** Event loop for trigger bindings. */
   private final EventLoop m_eventLoop = new EventLoop();
 
   /** The scope for continuations to yield to. */
   private final ContinuationScope m_scope = new ContinuationScope("coroutine commands");
+
+  /** Represents a single periodic callback. Stores a coroutine and its scope. */
+  private record PeriodicCallback(BindingScope scope, Coroutine coroutine) {}
 
   // Telemetry
   /** Protobuf serializer for a scheduler. */
@@ -274,7 +277,7 @@ public final class Scheduler implements ProtobufSerializable {
   public void sideload(Consumer<Coroutine> callback) {
     var coroutine = new Coroutine(this, m_scope, callback);
     var scope = BindingScope.createNarrowestScope(this);
-    m_periodicCallbacks.put(scope, coroutine);
+    m_periodicCallbacks.add(new PeriodicCallback(scope, coroutine));
   }
 
   /**
@@ -660,20 +663,21 @@ public final class Scheduler implements ProtobufSerializable {
   }
 
   private void runPeriodicSideloads() {
-    m_periodicCallbacks.entrySet().removeIf(e -> !e.getKey().active());
+    // Remove any periodic callbacks in an inactive scope
+    m_periodicCallbacks.removeIf(e -> !e.scope().active());
 
     // Update periodic callbacks
-    for (Coroutine coroutine : m_periodicCallbacks.values()) {
-      coroutine.mount();
+    for (PeriodicCallback callback : m_periodicCallbacks) {
+      callback.coroutine().mount();
       try {
-        coroutine.runToYieldPoint();
+        callback.coroutine().runToYieldPoint();
       } finally {
         Continuation.mountContinuation(null);
       }
     }
 
     // And remove any periodic callbacks that have completed
-    m_periodicCallbacks.entrySet().removeIf(e -> e.getValue().isDone());
+    m_periodicCallbacks.removeIf(e -> e.coroutine().isDone());
   }
 
   private void runCommands() {

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -663,21 +663,27 @@ public final class Scheduler implements ProtobufSerializable {
   }
 
   private void runPeriodicSideloads() {
-    // Remove any periodic callbacks in an inactive scope
-    m_periodicCallbacks.removeIf(e -> !e.scope().active());
+    for (var iterator = m_periodicCallbacks.iterator(); iterator.hasNext(); ) {
+      PeriodicCallback callback = iterator.next();
+      if (!callback.scope().active()) {
+        // The callback's enclosing scope exited - remove without running it and move on
+        iterator.remove();
+        continue;
+      }
 
-    // Update periodic callbacks
-    for (PeriodicCallback callback : m_periodicCallbacks) {
+      // Update periodic callbacks
       callback.coroutine().mount();
       try {
         callback.coroutine().runToYieldPoint();
       } finally {
         Continuation.mountContinuation(null);
       }
-    }
 
-    // And remove any periodic callbacks that have completed
-    m_periodicCallbacks.removeIf(e -> e.coroutine().isDone());
+      if (callback.coroutine().isDone()) {
+        // Callback finished - remove it from the list
+        iterator.remove();
+      }
+    }
   }
 
   private void runCommands() {

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerSideloadFunctionTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerSideloadFunctionTests.java
@@ -40,6 +40,21 @@ class SchedulerSideloadFunctionTests extends CommandTestBase {
   }
 
   @Test
+  void multiplePeriodicSideloads() {
+    int periodicCount = 4;
+    AtomicInteger count = new AtomicInteger(0);
+    for (int i = 0; i < periodicCount; i++) {
+      m_scheduler.addPeriodic(count::incrementAndGet);
+    }
+    assertEquals(0, count.get());
+
+    m_scheduler.run();
+    assertEquals(periodicCount, count.get());
+    m_scheduler.run();
+    assertEquals(periodicCount * 2, count.get());
+  }
+
+  @Test
   void sideloadSchedulingCommand() {
     var command = Command.noRequirements(Coroutine::park).named("Command");
     // one-shot sideload forks a command and immediately exits


### PR DESCRIPTION
Changes `m_periodicCallbacks` into a list of (scope, coroutine) pairs. 
Currently, having it as a `BindingScope`-keyed list only allows for one periodic/sideload to run per scope. Multiple `addPeriodic` calls in the same scope overwrite each other.