### PR TITLE
Fix extra initial JSON indentation

### DIFF
--- a/cscore/src/main/native/cpp/SinkImpl.cpp
+++ b/cscore/src/main/native/cpp/SinkImpl.cpp
@@ -149,7 +149,7 @@ bool SinkImpl::SetConfigJson(const wpi::util::json& config, CS_Status* status) {
 std::string SinkImpl::GetConfigJson(CS_Status* status) {
   std::string rv;
   wpi::util::raw_string_ostream os(rv);
-  GetConfigJsonObject(status).marshal(os, true, 4);
+  GetConfigJsonObject(status).marshal(os, true);
   os.flush();
   return rv;
 }

--- a/cscore/src/main/native/cpp/SourceImpl.cpp
+++ b/cscore/src/main/native/cpp/SourceImpl.cpp
@@ -347,7 +347,7 @@ bool SourceImpl::SetConfigJson(const wpi::util::json& config,
 std::string SourceImpl::GetConfigJson(CS_Status* status) {
   std::string rv;
   wpi::util::raw_string_ostream os(rv);
-  GetConfigJsonObject(status).marshal(os, true, 4);
+  GetConfigJsonObject(status).marshal(os, true);
   return rv;
 }
 

--- a/glass/src/lib/native/cpp/Context.cpp
+++ b/glass/src/lib/native/cpp/Context.cpp
@@ -249,7 +249,7 @@ bool SaveWindowStorageImpl(const std::string& filename) {
                    ec.message().c_str());
     return false;
   }
-  WindowToJson().marshal(os, true, 2);
+  WindowToJson().marshal(os, true);
   os << '\n';
   return true;
 }
@@ -263,7 +263,7 @@ static bool SaveStorageRootImpl(Context* ctx, const std::string& filename,
                    ec.message().c_str());
     return false;
   }
-  storage.ToJson().marshal(os, true, 2);
+  storage.ToJson().marshal(os, true);
   os << '\n';
   return true;
 }

--- a/ntcore/src/main/native/cpp/server/ServerStorage.cpp
+++ b/ntcore/src/main/native/cpp/server/ServerStorage.cpp
@@ -355,7 +355,7 @@ void ServerStorage::DumpPersistent(wpi::util::raw_ostream& os) {
     os << ",\n    \"value\": ";
     DumpValue(os, topic->lastValue);
     os << ",\n    \"properties\": ";
-    topic->properties.marshal(os, true, 2);
+    topic->properties.marshal(os, true);
     os << "\n  }";
   }
   os << "\n]\n";

--- a/tools/wpical/src/main/native/cpp/WPIcal.cpp
+++ b/tools/wpical/src/main/native/cpp/WPIcal.cpp
@@ -257,13 +257,13 @@ void SaveCalibratedField(const wpi::apriltag::AprilTagFieldLayout& field,
     wpi::util::raw_fd_ostream out(saveDir + "/" + outputName + ".json", ec,
                                   fs::OF_Text);
     if (!ec) {
-      wpi::util::json{field}.marshal(out, true, 4);
+      wpi::util::json{field}.marshal(out, true);
     }
 
     wpi::util::raw_fd_ostream fmap(saveDir + "/" + outputName + ".fmap", ec,
                                    fs::OF_Text);
     if (!ec) {
-      wpi::util::json{fmap::Fieldmap(field)}.marshal(fmap, true, 4);
+      wpi::util::json{fmap::Fieldmap(field)}.marshal(fmap, true);
     }
 
     saveDir.clear();
@@ -324,7 +324,7 @@ void CalibrateCamera() {
         wpi::util::raw_fd_ostream output_file(outputPath.string(), ec,
                                               fs::OF_Text);
         if (!ec) {
-          wpi::util::json{gCameraModel}.marshal(output_file, true, 4);
+          wpi::util::json{gCameraModel}.marshal(output_file, true);
         }
         ImGui::CloseCurrentPopup();
         calibrating = false;

--- a/tools/wpical/src/test/native/cpp/test_calibrate.cpp
+++ b/tools/wpical/src/test/native/cpp/test_calibrate.cpp
@@ -65,7 +65,7 @@ TEST_CASE("CameraCalibrationTest Typical", "[wpical]") {
   std::error_code ec;
   wpi::util::raw_fd_ostream output_file(calSavePath + "/cameracalibration.json",
                                         ec, fs::OF_Text);
-  wpi::util::json(ret).marshal(output_file, true, 4);
+  wpi::util::json(ret).marshal(output_file, true);
 }
 
 TEST_CASE("CameraCalibrationTest Atypical", "[wpical]") {


### PR DESCRIPTION
The `indent` parameter is actually describing the initial number of indents to start with, which we don't want. The `marshal` function always does 2 space indents, so `indent` should be 0.