### PR TITLE
[wpilibj] Remove null test for SetGameData

### DIFF
--- a/wpilibj/src/test/java/org/wpilib/simulation/DriverStationSimTest.java
+++ b/wpilibj/src/test/java/org/wpilib/simulation/DriverStationSimTest.java
@@ -289,16 +289,6 @@ class DriverStationSimTest {
   }
 
   @Test
-  void testSetGameDataNull() {
-    HAL.initialize(500, 0);
-    DriverStationSim.resetData();
-
-    DriverStationSim.setGameData(null);
-    DriverStationSim.notifyNewData();
-    assertTrue(MatchState.getGameData().isEmpty());
-  }
-
-  @Test
   void testSetEventName() {
     HAL.initialize(500, 0);
     DriverStationSim.resetData();


### PR DESCRIPTION
This produces a noisy error message in CI and none of the other DriverStation methods are tested the same way, so it makes more sense to remove the test instead of adjusting the other methods and tests.