### PR TITLE
[datalog] Avoid using moved-from struct info in datalog entries

### DIFF
--- a/datalog/src/main/native/include/wpi/datalog/DataLog.hpp
+++ b/datalog/src/main/native/include/wpi/datalog/DataLog.hpp
@@ -1312,9 +1312,14 @@ class StructLogEntry : public DataLogEntry {
                  I... info, int64_t timestamp = 0)
       : m_info{std::move(info)...} {
     m_log = &log;
-    log.AddStructSchema<T, I...>(info..., timestamp);
-    m_entry = log.Start(name, wpi::util::GetStructTypeString<T>(info...),
+    std::apply(
+        [&](const I&... storedInfo) {
+          log.AddStructSchema<T, I...>(storedInfo..., timestamp);
+          m_entry =
+              log.Start(name, wpi::util::GetStructTypeString<T>(storedInfo...),
                         metadata, timestamp);
+        },
+        m_info);
   }
 
   StructLogEntry(StructLogEntry&& rhs)
@@ -1441,11 +1446,16 @@ class StructArrayLogEntry : public DataLogEntry {
                       int64_t timestamp = 0)
       : m_info{std::move(info)...} {
     m_log = &log;
-    log.AddStructSchema<T, I...>(info..., timestamp);
-    m_entry = log.Start(
-        name,
-        wpi::util::MakeStructArrayTypeString<T, std::dynamic_extent>(info...),
-        metadata, timestamp);
+    std::apply(
+        [&](const I&... storedInfo) {
+          log.AddStructSchema<T, I...>(storedInfo..., timestamp);
+          m_entry = log.Start(
+              name,
+              wpi::util::MakeStructArrayTypeString<T, std::dynamic_extent>(
+                  storedInfo...),
+              metadata, timestamp);
+        },
+        m_info);
   }
 
   StructArrayLogEntry(StructArrayLogEntry&& rhs)


### PR DESCRIPTION
StructLogEntry and StructArrayLogEntry store their serializer info in m_info by moving from the constructor parameter pack. The constructors then reused the original info pack to register schemas and compute the data type string.

That works only for info types that remain usable after move. Stateful info objects, such as language binding adapters that own shared converter state, can be left empty by the move and fail when AddStructSchema or type-string generation dereferences them.

Use the stored m_info tuple for all post-initialization schema and type-string operations. This keeps the move into storage as the single ownership transition and avoids relying on moved-from constructor parameters.

---

Fixes weird behavior noticed in robotpy wpilog tests. I'm not able to build this locally due to bazel, but it seems right?