### PR TITLE
[wpiutil] Fix priority_queue constructors to use stored container

### DIFF
--- a/wpiutil/src/main/native/include/wpi/util/priority_queue.hpp
+++ b/wpiutil/src/main/native/include/wpi/util/priority_queue.hpp
@@ -38,28 +38,28 @@ class priority_queue {
   priority_queue() {}
 
   priority_queue(const Compare& comp, const Sequence& c) : c(c), comp(comp) {
-    std::make_heap(c.begin(), c.end(), comp);
+    std::make_heap(this->c.begin(), this->c.end(), comp);
   }
 
   explicit priority_queue(const Compare& comp, Sequence&& c = Sequence{})
       : c(std::move(c)), comp(comp) {
-    std::make_heap(c.begin(), c.end(), comp);
+    std::make_heap(this->c.begin(), this->c.end(), comp);
   }
 
   template <typename InputIterator>
   priority_queue(InputIterator first, InputIterator last, const Compare& comp,
                  const Sequence& c)
       : c(c), comp(comp) {
-    c.insert(c.end(), first, last);
-    std::make_heap(c.begin(), c.end(), comp);
+    this->c.insert(this->c.end(), first, last);
+    std::make_heap(this->c.begin(), this->c.end(), comp);
   }
 
   template <typename InputIterator>
   priority_queue(InputIterator first, InputIterator last,
                  const Compare& comp = Compare{}, Sequence&& c = Sequence{})
       : c(std::move(c)), comp(comp) {
-    c.insert(c.end(), first, last);
-    std::make_heap(c.begin(), c.end(), comp);
+    this->c.insert(this->c.end(), first, last);
+    std::make_heap(this->c.begin(), this->c.end(), comp);
   }
 
   [[nodiscard]]

--- a/wpiutil/src/test/native/cpp/PriorityQueueTest.cpp
+++ b/wpiutil/src/test/native/cpp/PriorityQueueTest.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <functional>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "wpi/util/priority_queue.hpp"
+
+TEST(PriorityQueueTest, RvalueContainerConstructorHeapifiesStoredContainer) {
+  wpi::util::priority_queue<int> queue{std::less<int>{},
+                                       std::vector<int>{1, 3, 2}};
+
+  EXPECT_EQ(3, queue.top());
+}
+
+TEST(PriorityQueueTest, IteratorRvalueContainerConstructorUsesStoredContainer) {
+  std::vector<int> values{4, 5};
+  wpi::util::priority_queue<int> queue{values.begin(), values.end(),
+                                       std::less<int>{},
+                                       std::vector<int>{1, 3, 2}};
+
+  EXPECT_EQ(5, queue.top());
+  EXPECT_EQ(5u, queue.size());
+}
+
+TEST(PriorityQueueTest, ConstContainerConstructorsUseStoredContainer) {
+  const std::vector<int> base{1, 3, 2};
+  wpi::util::priority_queue<int> queue{std::less<int>{}, base};
+
+  EXPECT_EQ(3, queue.top());
+
+  std::vector<int> values{4, 5};
+  wpi::util::priority_queue<int> rangeQueue{values.begin(), values.end(),
+                                            std::less<int>{}, base};
+
+  EXPECT_EQ(5, rangeQueue.top());
+  EXPECT_EQ(5u, rangeQueue.size());
+}


### PR DESCRIPTION
I asked GPT to look for other constructor/move bugs and it found this one. I... think this is right?

---

The constructor parameters are named c, the same as the underlying container member. After the member initializer copies or moves the parameter into the member, unqualified uses of c in the constructor body still refer to the parameter, not the member.

This means the rvalue-container constructors heapified or inserted into a moved-from parameter while leaving the stored container unheapified and, for iterator constructors, missing the inserted range. The const-container constructors also attempted to mutate the const parameter instead of the stored member when instantiated.

Qualify constructor body accesses as this->c so heap construction and iterator-range insertion operate on the stored container. Add regression coverage for rvalue and const container constructors.