### PR TITLE
[robotpy] Remove last references to robotInit()

### DIFF
--- a/robotpyExamples/snippets/QuickVision/robot.py
+++ b/robotpyExamples/snippets/QuickVision/robot.py
@@ -13,7 +13,7 @@ class MyRobot(wpilib.TimedRobot):
     """
     Uses the CameraServer class to automatically capture video from a USB webcam and send it to the
     dashboard without doing any vision processing. This is the easiest way to get camera images
-    to the dashboard. Just add this to robot class constructor.
+    to the dashboard. Just add this to the robot class constructor.
     """
 
     def __init__(self) -> None:

--- a/robotpyExamples/snippets/QuickVision/robot.py
+++ b/robotpyExamples/snippets/QuickVision/robot.py
@@ -13,9 +13,9 @@ class MyRobot(wpilib.TimedRobot):
     """
     Uses the CameraServer class to automatically capture video from a USB webcam and send it to the
     dashboard without doing any vision processing. This is the easiest way to get camera images
-    to the dashboard. Just add this to the robot_init() method in your program.
+    to the dashboard. Just add this to robot class constructor.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         CameraServer().launch()

--- a/wpilibc/src/main/python/semiwrap/DifferentialDrive.yml
+++ b/wpilibc/src/main/python/semiwrap/DifferentialDrive.yml
@@ -38,6 +38,8 @@ classes:
 
         class Robot(wpilib.TimedRobot):
             def __init__(self) -> None:
+                super().__init__()
+
                 self.front_left = wpilib.PWMVictorSPX(1)
                 self.rear_left = wpilib.PWMVictorSPX(2)
                 self.left = wpilib.MotorControllerGroup(self.front_left, self.rear_left)
@@ -54,6 +56,8 @@ classes:
 
         class Robot(wpilib.TimedRobot):
             def __init__(self) -> None:
+                super().__init__()
+
                 self.front_left = wpilib.PWMVictorSPX(1)
                 self.mid_left = wpilib.PWMVictorSPX(2)
                 self.rear_left = wpilib.PWMVictorSPX(3)

--- a/wpilibc/src/main/python/semiwrap/DifferentialDrive.yml
+++ b/wpilibc/src/main/python/semiwrap/DifferentialDrive.yml
@@ -37,7 +37,7 @@ classes:
         import wpilib.drive
 
         class Robot(wpilib.TimedRobot):
-            def robotInit(self):
+            def __init__(self) -> None:
                 self.front_left = wpilib.PWMVictorSPX(1)
                 self.rear_left = wpilib.PWMVictorSPX(2)
                 self.left = wpilib.MotorControllerGroup(self.front_left, self.rear_left)
@@ -53,7 +53,7 @@ classes:
         import wpilib.drive
 
         class Robot(wpilib.TimedRobot):
-            def robotInit(self):
+            def __init__(self) -> None:
                 self.front_left = wpilib.PWMVictorSPX(1)
                 self.mid_left = wpilib.PWMVictorSPX(2)
                 self.rear_left = wpilib.PWMVictorSPX(3)


### PR DESCRIPTION
All the examples now use the robot class constructor (`__init__`).