### PR TITLE
[wpiutil] avoid Unsafe in ProtobufBuffer

### DIFF
--- a/wpiutil/src/main/java/org/wpilib/util/protobuf/ProtobufBuffer.java
+++ b/wpiutil/src/main/java/org/wpilib/util/protobuf/ProtobufBuffer.java
@@ -19,9 +19,9 @@ import us.hebi.quickbuf.ProtoSource;
 public final class ProtobufBuffer<T, MessageType extends ProtoMessage<?>> {
   private ProtobufBuffer(Protobuf<T, MessageType> proto) {
     m_buf = ByteBuffer.allocateDirect(1024);
-    m_sink = ProtoSink.newDirectSink();
+    m_sink = ProtoSink.newBufferSink();
     m_sink.setOutput(m_buf);
-    m_source = ProtoSource.newDirectSource();
+    m_source = ProtoSource.newBufferSource();
     m_msg = proto.createMessage();
     m_proto = proto;
   }

--- a/wpiutil/src/main/java/org/wpilib/util/protobuf/ProtobufBuffer.java
+++ b/wpiutil/src/main/java/org/wpilib/util/protobuf/ProtobufBuffer.java
@@ -58,8 +58,8 @@ public final class ProtobufBuffer<T, MessageType extends ProtoMessage<?>> {
   }
 
   /**
-   * Serializes a value to a ByteBuffer. The returned ByteBuffer has its
-   * position set to the end of the serialized data.
+   * Serializes a value to a ByteBuffer. The returned ByteBuffer has its position set to the end of
+   * the serialized data.
    *
    * @param value value
    * @return byte buffer

--- a/wpiutil/src/main/java/org/wpilib/util/protobuf/ProtobufBuffer.java
+++ b/wpiutil/src/main/java/org/wpilib/util/protobuf/ProtobufBuffer.java
@@ -18,10 +18,10 @@ import us.hebi.quickbuf.ProtoSource;
  */
 public final class ProtobufBuffer<T, MessageType extends ProtoMessage<?>> {
   private ProtobufBuffer(Protobuf<T, MessageType> proto) {
-    m_buf = ByteBuffer.allocateDirect(1024);
-    m_sink = ProtoSink.newBufferSink();
+    m_buf = new byte[1024];
+    m_sink = ProtoSink.newInstance(m_buf);
     m_sink.setOutput(m_buf);
-    m_source = ProtoSource.newBufferSource();
+    m_source = ProtoSource.newArraySource();
     m_msg = proto.createMessage();
     m_proto = proto;
   }
@@ -58,7 +58,7 @@ public final class ProtobufBuffer<T, MessageType extends ProtoMessage<?>> {
   }
 
   /**
-   * Serializes a value to a ByteBuffer. The returned ByteBuffer is a direct byte buffer with the
+   * Serializes a value to a ByteBuffer. The returned ByteBuffer has its
    * position set to the end of the serialized data.
    *
    * @param value value
@@ -68,15 +68,19 @@ public final class ProtobufBuffer<T, MessageType extends ProtoMessage<?>> {
   public ByteBuffer write(T value) throws IOException {
     m_msg.clearQuick();
     m_proto.pack(m_msg, value);
+
     int size = m_msg.getSerializedSize();
-    if (size > m_buf.capacity()) {
-      m_buf = ByteBuffer.allocateDirect(size * 2);
+    if (size > m_buf.length) {
+      m_buf = new byte[size * 2];
       m_sink.setOutput(m_buf);
     }
+
     m_sink.reset();
     m_msg.writeTo(m_sink);
-    m_buf.position(m_sink.getTotalBytesWritten());
-    return m_buf;
+
+    ByteBuffer byteBuf = ByteBuffer.wrap(m_buf);
+    byteBuf.position(m_sink.getTotalBytesWritten());
+    return byteBuf;
   }
 
   /**
@@ -164,7 +168,7 @@ public final class ProtobufBuffer<T, MessageType extends ProtoMessage<?>> {
     m_proto.unpackInto(out, m_msg);
   }
 
-  private ByteBuffer m_buf;
+  private byte[] m_buf;
   private final ProtoSink m_sink;
   private final ProtoSource m_source;
   private final MessageType m_msg;

--- a/wpiutil/src/main/java/org/wpilib/util/protobuf/ProtobufBuffer.java
+++ b/wpiutil/src/main/java/org/wpilib/util/protobuf/ProtobufBuffer.java
@@ -19,9 +19,10 @@ import us.hebi.quickbuf.ProtoSource;
 public final class ProtobufBuffer<T, MessageType extends ProtoMessage<?>> {
   private ProtobufBuffer(Protobuf<T, MessageType> proto) {
     m_buf = new byte[1024];
+    m_bufView = ByteBuffer.wrap(m_buf);
     m_sink = ProtoSink.newInstance(m_buf);
-    m_sink.setOutput(m_buf);
     m_source = ProtoSource.newArraySource();
+    m_bufferSource = ProtoSource.newBufferSource();
     m_msg = proto.createMessage();
     m_proto = proto;
   }
@@ -72,15 +73,16 @@ public final class ProtobufBuffer<T, MessageType extends ProtoMessage<?>> {
     int size = m_msg.getSerializedSize();
     if (size > m_buf.length) {
       m_buf = new byte[size * 2];
+      m_bufView = ByteBuffer.wrap(m_buf);
       m_sink.setOutput(m_buf);
     }
 
     m_sink.reset();
     m_msg.writeTo(m_sink);
 
-    ByteBuffer byteBuf = ByteBuffer.wrap(m_buf);
-    byteBuf.position(m_sink.getTotalBytesWritten());
-    return byteBuf;
+    m_bufView.clear();
+    m_bufView.position(m_sink.getTotalBytesWritten());
+    return m_bufView;
   }
 
   /**
@@ -119,8 +121,8 @@ public final class ProtobufBuffer<T, MessageType extends ProtoMessage<?>> {
    */
   public T read(ByteBuffer buf) throws IOException {
     m_msg.clearQuick();
-    m_source.setInput(buf);
-    m_msg.mergeFrom(m_source);
+    m_bufferSource.setInput(buf);
+    m_msg.mergeFrom(m_bufferSource);
     return m_proto.unpack(m_msg);
   }
 
@@ -163,14 +165,16 @@ public final class ProtobufBuffer<T, MessageType extends ProtoMessage<?>> {
    */
   public void readInto(T out, ByteBuffer buf) throws IOException {
     m_msg.clearQuick();
-    m_source.setInput(buf);
-    m_msg.mergeFrom(m_source);
+    m_bufferSource.setInput(buf);
+    m_msg.mergeFrom(m_bufferSource);
     m_proto.unpackInto(out, m_msg);
   }
 
   private byte[] m_buf;
+  private ByteBuffer m_bufView;
   private final ProtoSink m_sink;
   private final ProtoSource m_source;
+  private final ProtoSource m_bufferSource;
   private final MessageType m_msg;
   private final Protobuf<T, MessageType> m_proto;
 }


### PR DESCRIPTION
Replaces the direct source/sink implementations with the buffer-based implementations to avoid calls to `sun.misc.Unsafe`.

Fixes wpilibsuite/allwpilib#9081.