### PR TITLE
[wpilib] ElevatorSimTest.MinMax: Fix random failure

### DIFF
--- a/wpilibc/src/test/native/cpp/simulation/ElevatorSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/ElevatorSimTest.cpp
@@ -55,13 +55,13 @@ TEST(ElevatorSimTest, InitialState) {
 
 TEST(ElevatorSimTest, MinMax) {
   wpi::sim::ElevatorSim sim(wpi::math::DCMotor::Vex775Pro(4), 14.67, 8_kg,
-                            0.75_in, 0_m, 1_m, true, 0_m, {0.01});
+                            0.75_in, 0_m, 1_m, true, 0_m);
   for (size_t i = 0; i < 100; ++i) {
     sim.SetInput(wpi::math::Vectord<1>{0.0});
     sim.Update(20_ms);
 
     auto height = sim.GetPosition();
-    EXPECT_TRUE(height > -0.05_m);
+    EXPECT_GE(height, 0_m);
   }
 
   for (size_t i = 0; i < 100; ++i) {
@@ -69,7 +69,7 @@ TEST(ElevatorSimTest, MinMax) {
     sim.Update(20_ms);
 
     auto height = sim.GetPosition();
-    EXPECT_TRUE(height < 1.05_m);
+    EXPECT_LE(height, 1_m);
   }
 }
 

--- a/wpilibj/src/test/java/org/wpilib/simulation/ElevatorSimTest.java
+++ b/wpilibj/src/test/java/org/wpilib/simulation/ElevatorSimTest.java
@@ -85,22 +85,20 @@ class ElevatorSimTest {
             0.0,
             1.0,
             true,
-            0.0,
-            0.01,
             0.0);
 
     for (int i = 0; i < 100; i++) {
       sim.setInput(VecBuilder.fill(0));
       sim.update(0.020);
       var height = sim.getPosition();
-      assertTrue(height >= -0.05);
+      assertTrue(height >= 0.0);
     }
 
     for (int i = 0; i < 100; i++) {
       sim.setInput(VecBuilder.fill(12.0));
       sim.update(0.020);
       var height = sim.getPosition();
-      assertTrue(height <= 1.05);
+      assertTrue(height <= 1.0);
     }
   }
 

--- a/wpilibj/src/test/java/org/wpilib/simulation/ElevatorSimTest.java
+++ b/wpilibj/src/test/java/org/wpilib/simulation/ElevatorSimTest.java
@@ -78,14 +78,7 @@ class ElevatorSimTest {
   void testMinMax() {
     var sim =
         new ElevatorSim(
-            DCMotor.getVex775Pro(4),
-            14.67,
-            8.0,
-            0.75 * 25.4 / 1000.0,
-            0.0,
-            1.0,
-            true,
-            0.0);
+            DCMotor.getVex775Pro(4), 14.67, 8.0, 0.75 * 25.4 / 1000.0, 0.0, 1.0, true, 0.0);
 
     for (int i = 0; i < 100; i++) {
       sim.setInput(VecBuilder.fill(0));


### PR DESCRIPTION
The test randomly failed at the height > -0.05 check. This is due to enabling measurement noise while asserting on GetPosition(), which returns the noisy output.  A rare negative >5 sigma sample can push the reported height below the assertion.

Instead, remove measurement noise and tighten the assertions to the actual bounds.