### PR TITLE
[wpimath] Fix maybe-uninitialized warnings in odometry classes

### DIFF
--- a/wpimath/src/main/native/cpp/kinematics/DifferentialDriveOdometry.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/DifferentialDriveOdometry.cpp
@@ -6,6 +6,7 @@
 
 #include "wpi/math/geometry/Pose2d.hpp"
 #include "wpi/math/geometry/Rotation2d.hpp"
+#include "wpi/math/kinematics/DifferentialDriveKinematics.hpp"
 #include "wpi/math/kinematics/Odometry.hpp"
 #include "wpi/math/util/MathShared.hpp"
 #include "wpi/units/length.hpp"
@@ -15,7 +16,7 @@ using namespace wpi::math;
 DifferentialDriveOdometry::DifferentialDriveOdometry(
     const Rotation2d& gyroAngle, wpi::units::meter_t leftDistance,
     wpi::units::meter_t rightDistance, const Pose2d& initialPose)
-    : Odometry(m_kinematicsImpl, gyroAngle, {leftDistance, rightDistance},
-               initialPose) {
+    : Odometry(DifferentialDriveKinematics{1_m}, gyroAngle,
+               {leftDistance, rightDistance}, initialPose) {
   wpi::math::MathSharedStore::ReportUsage("DifferentialDriveOdometry", "");
 }

--- a/wpimath/src/main/native/cpp/kinematics/DifferentialDriveOdometry3d.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/DifferentialDriveOdometry3d.cpp
@@ -6,6 +6,7 @@
 
 #include "wpi/math/geometry/Pose3d.hpp"
 #include "wpi/math/geometry/Rotation3d.hpp"
+#include "wpi/math/kinematics/DifferentialDriveKinematics.hpp"
 #include "wpi/math/kinematics/Odometry3d.hpp"
 #include "wpi/math/util/MathShared.hpp"
 #include "wpi/units/length.hpp"
@@ -15,7 +16,7 @@ using namespace wpi::math;
 DifferentialDriveOdometry3d::DifferentialDriveOdometry3d(
     const Rotation3d& gyroAngle, wpi::units::meter_t leftDistance,
     wpi::units::meter_t rightDistance, const Pose3d& initialPose)
-    : Odometry3d(m_kinematicsImpl, gyroAngle, {leftDistance, rightDistance},
-                 initialPose) {
+    : Odometry3d(DifferentialDriveKinematics{1_m}, gyroAngle,
+                 {leftDistance, rightDistance}, initialPose) {
   wpi::math::MathSharedStore::ReportUsage("DifferentialDriveOdometry3d", "");
 }

--- a/wpimath/src/main/native/cpp/kinematics/MecanumDriveOdometry.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/MecanumDriveOdometry.cpp
@@ -16,7 +16,6 @@ using namespace wpi::math;
 MecanumDriveOdometry::MecanumDriveOdometry(
     MecanumDriveKinematics kinematics, const Rotation2d& gyroAngle,
     const MecanumDriveWheelPositions& wheelPositions, const Pose2d& initialPose)
-    : Odometry(m_kinematicsImpl, gyroAngle, wheelPositions, initialPose),
-      m_kinematicsImpl(kinematics) {
+    : Odometry(kinematics, gyroAngle, wheelPositions, initialPose) {
   wpi::math::MathSharedStore::ReportUsage("MecanumDriveOdometry", "");
 }

--- a/wpimath/src/main/native/cpp/kinematics/MecanumDriveOdometry3d.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/MecanumDriveOdometry3d.cpp
@@ -16,7 +16,6 @@ using namespace wpi::math;
 MecanumDriveOdometry3d::MecanumDriveOdometry3d(
     MecanumDriveKinematics kinematics, const Rotation3d& gyroAngle,
     const MecanumDriveWheelPositions& wheelPositions, const Pose3d& initialPose)
-    : Odometry3d(m_kinematicsImpl, gyroAngle, wheelPositions, initialPose),
-      m_kinematicsImpl(kinematics) {
+    : Odometry3d(kinematics, gyroAngle, wheelPositions, initialPose) {
   wpi::math::MathSharedStore::ReportUsage("MecanumDriveOdometry3d", "");
 }

--- a/wpimath/src/main/native/include/wpi/math/estimator/DifferentialDrivePoseEstimator.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/DifferentialDrivePoseEstimator.hpp
@@ -34,7 +34,8 @@ namespace wpi::math {
  * never call it, then this class will behave like regular encoder odometry.
  */
 class WPILIB_DLLEXPORT DifferentialDrivePoseEstimator
-    : public PoseEstimator<DifferentialDriveWheelPositions,
+    : public PoseEstimator<DifferentialDriveKinematics,
+                           DifferentialDriveWheelPositions,
                            DifferentialDriveWheelVelocities,
                            DifferentialDriveWheelAccelerations> {
  public:

--- a/wpimath/src/main/native/include/wpi/math/estimator/DifferentialDrivePoseEstimator3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/DifferentialDrivePoseEstimator3d.hpp
@@ -38,7 +38,8 @@ namespace wpi::math {
  * never call it, then this class will behave like regular encoder odometry.
  */
 class WPILIB_DLLEXPORT DifferentialDrivePoseEstimator3d
-    : public PoseEstimator3d<DifferentialDriveWheelPositions,
+    : public PoseEstimator3d<DifferentialDriveKinematics,
+                             DifferentialDriveWheelPositions,
                              DifferentialDriveWheelVelocities,
                              DifferentialDriveWheelAccelerations> {
  public:

--- a/wpimath/src/main/native/include/wpi/math/estimator/MecanumDrivePoseEstimator.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/MecanumDrivePoseEstimator.hpp
@@ -31,7 +31,7 @@ namespace wpi::math {
  * odometry.
  */
 class WPILIB_DLLEXPORT MecanumDrivePoseEstimator
-    : public PoseEstimator<MecanumDriveWheelPositions,
+    : public PoseEstimator<MecanumDriveKinematics, MecanumDriveWheelPositions,
                            MecanumDriveWheelVelocities,
                            MecanumDriveWheelAccelerations> {
  public:

--- a/wpimath/src/main/native/include/wpi/math/estimator/MecanumDrivePoseEstimator3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/MecanumDrivePoseEstimator3d.hpp
@@ -35,7 +35,7 @@ namespace wpi::math {
  * odometry.
  */
 class WPILIB_DLLEXPORT MecanumDrivePoseEstimator3d
-    : public PoseEstimator3d<MecanumDriveWheelPositions,
+    : public PoseEstimator3d<MecanumDriveKinematics, MecanumDriveWheelPositions,
                              MecanumDriveWheelVelocities,
                              MecanumDriveWheelAccelerations> {
  public:

--- a/wpimath/src/main/native/include/wpi/math/estimator/PoseEstimator.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/PoseEstimator.hpp
@@ -19,7 +19,6 @@
 #include "wpi/math/geometry/Transform2d.hpp"
 #include "wpi/math/geometry/Translation2d.hpp"
 #include "wpi/math/interpolation/TimeInterpolatableBuffer.hpp"
-#include "wpi/math/kinematics/Kinematics.hpp"
 #include "wpi/math/kinematics/Odometry.hpp"
 #include "wpi/math/util/MathShared.hpp"
 #include "wpi/units/angle.hpp"
@@ -43,12 +42,13 @@ namespace wpi::math {
  * AddVisionMeasurement() can be called as infrequently as you want; if you
  * never call it, then this class will behave like regular encoder odometry.
  *
+ * @tparam Kinematics Kinematics type.
  * @tparam WheelPositions Wheel positions type.
  * @tparam WheelVelocities Wheel velocities type.
  * @tparam WheelAccelerations Wheel accelerations type.
  */
-template <typename WheelPositions, typename WheelVelocities,
-          typename WheelAccelerations>
+template <typename Kinematics, typename WheelPositions,
+          typename WheelVelocities, typename WheelAccelerations>
 class WPILIB_DLLEXPORT PoseEstimator {
  public:
   /**
@@ -68,12 +68,11 @@ class WPILIB_DLLEXPORT PoseEstimator {
    *     radians). Increase these numbers to trust the vision pose measurement
    *     less.
    */
-  PoseEstimator(
-      Kinematics<WheelPositions, WheelVelocities, WheelAccelerations>&
-          kinematics,
-      Odometry<WheelPositions, WheelVelocities, WheelAccelerations>& odometry,
-      const wpi::util::array<double, 3>& stateStdDevs,
-      const wpi::util::array<double, 3>& visionMeasurementStdDevs)
+  PoseEstimator(const Kinematics& kinematics,
+                Odometry<Kinematics, WheelPositions, WheelVelocities,
+                         WheelAccelerations>& odometry,
+                const wpi::util::array<double, 3>& stateStdDevs,
+                const wpi::util::array<double, 3>& visionMeasurementStdDevs)
       : m_odometry(odometry) {
     for (size_t i = 0; i < 3; ++i) {
       m_q[i] = stateStdDevs[i] * stateStdDevs[i];
@@ -482,7 +481,8 @@ class WPILIB_DLLEXPORT PoseEstimator {
 
   static constexpr wpi::units::second_t kBufferDuration = 1.5_s;
 
-  Odometry<WheelPositions, WheelVelocities, WheelAccelerations>& m_odometry;
+  Odometry<Kinematics, WheelPositions, WheelVelocities, WheelAccelerations>&
+      m_odometry;
 
   // Diagonal of process noise covariance matrix Q
   wpi::util::array<double, 3> m_q{wpi::util::empty_array};

--- a/wpimath/src/main/native/include/wpi/math/estimator/PoseEstimator3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/PoseEstimator3d.hpp
@@ -19,7 +19,6 @@
 #include "wpi/math/geometry/Transform3d.hpp"
 #include "wpi/math/geometry/Translation3d.hpp"
 #include "wpi/math/interpolation/TimeInterpolatableBuffer.hpp"
-#include "wpi/math/kinematics/Kinematics.hpp"
 #include "wpi/math/kinematics/Odometry3d.hpp"
 #include "wpi/math/linalg/EigenCore.hpp"
 #include "wpi/math/util/MathShared.hpp"
@@ -48,12 +47,13 @@ namespace wpi::math {
  * AddVisionMeasurement() can be called as infrequently as you want; if you
  * never call it, then this class will behave like regular encoder odometry.
  *
+ * @tparam Kinematics Kinematics type.
  * @tparam WheelPositions Wheel positions type.
  * @tparam WheelVelocities Wheel velocities type.
  * @tparam WheelAccelerations Wheel accelerations type.
  */
-template <typename WheelPositions, typename WheelVelocities,
-          typename WheelAccelerations>
+template <typename Kinematics, typename WheelPositions,
+          typename WheelVelocities, typename WheelAccelerations>
 class WPILIB_DLLEXPORT PoseEstimator3d {
  public:
   /**
@@ -73,12 +73,11 @@ class WPILIB_DLLEXPORT PoseEstimator3d {
    * in meters, and angle in radians). Increase these numbers to trust the
    * vision pose measurement less.
    */
-  PoseEstimator3d(
-      Kinematics<WheelPositions, WheelVelocities, WheelAccelerations>&
-          kinematics,
-      Odometry3d<WheelPositions, WheelVelocities, WheelAccelerations>& odometry,
-      const wpi::util::array<double, 4>& stateStdDevs,
-      const wpi::util::array<double, 4>& visionMeasurementStdDevs)
+  PoseEstimator3d(const Kinematics& kinematics,
+                  Odometry3d<Kinematics, WheelPositions, WheelVelocities,
+                             WheelAccelerations>& odometry,
+                  const wpi::util::array<double, 4>& stateStdDevs,
+                  const wpi::util::array<double, 4>& visionMeasurementStdDevs)
       : m_odometry(odometry) {
     for (size_t i = 0; i < 4; ++i) {
       m_q[i] = stateStdDevs[i] * stateStdDevs[i];
@@ -496,7 +495,8 @@ class WPILIB_DLLEXPORT PoseEstimator3d {
 
   static constexpr wpi::units::second_t kBufferDuration = 1.5_s;
 
-  Odometry3d<WheelPositions, WheelVelocities, WheelAccelerations>& m_odometry;
+  Odometry3d<Kinematics, WheelPositions, WheelVelocities, WheelAccelerations>&
+      m_odometry;
 
   // Diagonal of process noise covariance matrix Q
   wpi::util::array<double, 4> m_q{wpi::util::empty_array};

--- a/wpimath/src/main/native/include/wpi/math/estimator/SwerveDrivePoseEstimator.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/SwerveDrivePoseEstimator.hpp
@@ -33,6 +33,7 @@ namespace wpi::math {
 template <size_t NumModules>
 class SwerveDrivePoseEstimator
     : public PoseEstimator<
+          SwerveDriveKinematics<NumModules>,
           wpi::util::array<SwerveModulePosition, NumModules>,
           wpi::util::array<SwerveModuleVelocity, NumModules>,
           wpi::util::array<SwerveModuleAcceleration, NumModules>> {

--- a/wpimath/src/main/native/include/wpi/math/estimator/SwerveDrivePoseEstimator3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/SwerveDrivePoseEstimator3d.hpp
@@ -37,6 +37,7 @@ namespace wpi::math {
 template <size_t NumModules>
 class SwerveDrivePoseEstimator3d
     : public PoseEstimator3d<
+          SwerveDriveKinematics<NumModules>,
           wpi::util::array<SwerveModulePosition, NumModules>,
           wpi::util::array<SwerveModuleVelocity, NumModules>,
           wpi::util::array<SwerveModuleAcceleration, NumModules>> {

--- a/wpimath/src/main/native/include/wpi/math/kinematics/DifferentialDriveOdometry.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/DifferentialDriveOdometry.hpp
@@ -28,7 +28,8 @@ namespace wpi::math {
  * Any subsequent pose resets also require the encoders to be reset to zero.
  */
 class WPILIB_DLLEXPORT DifferentialDriveOdometry
-    : public Odometry<DifferentialDriveWheelPositions,
+    : public Odometry<DifferentialDriveKinematics,
+                      DifferentialDriveWheelPositions,
                       DifferentialDriveWheelVelocities,
                       DifferentialDriveWheelAccelerations> {
  public:
@@ -84,8 +85,5 @@ class WPILIB_DLLEXPORT DifferentialDriveOdometry
                        wpi::units::meter_t rightDistance) {
     return Odometry::Update(gyroAngle, {leftDistance, rightDistance});
   }
-
- private:
-  DifferentialDriveKinematics m_kinematicsImpl{wpi::units::meter_t{1}};
 };
 }  // namespace wpi::math

--- a/wpimath/src/main/native/include/wpi/math/kinematics/DifferentialDriveOdometry3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/DifferentialDriveOdometry3d.hpp
@@ -28,7 +28,8 @@ namespace wpi::math {
  * Any subsequent pose resets also require the encoders to be reset to zero.
  */
 class WPILIB_DLLEXPORT DifferentialDriveOdometry3d
-    : public Odometry3d<DifferentialDriveWheelPositions,
+    : public Odometry3d<DifferentialDriveKinematics,
+                        DifferentialDriveWheelPositions,
                         DifferentialDriveWheelVelocities,
                         DifferentialDriveWheelAccelerations> {
  public:
@@ -84,8 +85,5 @@ class WPILIB_DLLEXPORT DifferentialDriveOdometry3d
                        wpi::units::meter_t rightDistance) {
     return Odometry3d::Update(gyroAngle, {leftDistance, rightDistance});
   }
-
- private:
-  DifferentialDriveKinematics m_kinematicsImpl{wpi::units::meter_t{1}};
 };
 }  // namespace wpi::math

--- a/wpimath/src/main/native/include/wpi/math/kinematics/MecanumDriveOdometry.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/MecanumDriveOdometry.hpp
@@ -25,7 +25,8 @@ namespace wpi::math {
  * when using computer-vision systems.
  */
 class WPILIB_DLLEXPORT MecanumDriveOdometry
-    : public Odometry<MecanumDriveWheelPositions, MecanumDriveWheelVelocities,
+    : public Odometry<MecanumDriveKinematics, MecanumDriveWheelPositions,
+                      MecanumDriveWheelVelocities,
                       MecanumDriveWheelAccelerations> {
  public:
   /**
@@ -40,9 +41,6 @@ class WPILIB_DLLEXPORT MecanumDriveOdometry
       MecanumDriveKinematics kinematics, const Rotation2d& gyroAngle,
       const MecanumDriveWheelPositions& wheelPositions,
       const Pose2d& initialPose = Pose2d{});
-
- private:
-  MecanumDriveKinematics m_kinematicsImpl;
 };
 
 }  // namespace wpi::math

--- a/wpimath/src/main/native/include/wpi/math/kinematics/MecanumDriveOdometry3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/MecanumDriveOdometry3d.hpp
@@ -25,7 +25,8 @@ namespace wpi::math {
  * when using computer-vision systems.
  */
 class WPILIB_DLLEXPORT MecanumDriveOdometry3d
-    : public Odometry3d<MecanumDriveWheelPositions, MecanumDriveWheelVelocities,
+    : public Odometry3d<MecanumDriveKinematics, MecanumDriveWheelPositions,
+                        MecanumDriveWheelVelocities,
                         MecanumDriveWheelAccelerations> {
  public:
   /**
@@ -40,9 +41,6 @@ class WPILIB_DLLEXPORT MecanumDriveOdometry3d
       MecanumDriveKinematics kinematics, const Rotation3d& gyroAngle,
       const MecanumDriveWheelPositions& wheelPositions,
       const Pose3d& initialPose = Pose3d{});
-
- private:
-  MecanumDriveKinematics m_kinematicsImpl;
 };
 
 }  // namespace wpi::math

--- a/wpimath/src/main/native/include/wpi/math/kinematics/Odometry.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/Odometry.hpp
@@ -7,7 +7,6 @@
 #include "wpi/math/geometry/Pose2d.hpp"
 #include "wpi/math/geometry/Rotation2d.hpp"
 #include "wpi/math/geometry/Translation2d.hpp"
-#include "wpi/math/kinematics/Kinematics.hpp"
 #include "wpi/util/SymbolExports.hpp"
 
 namespace wpi::math {
@@ -22,12 +21,13 @@ namespace wpi::math {
  * path following. Furthermore, odometry can be used for latency compensation
  * when using computer-vision systems.
  *
+ * @tparam Kinematics type.
  * @tparam WheelPositions Wheel positions type.
  * @tparam WheelVelocities Wheel velocities type.
  * @tparam WheelAccelerations Wheel accelerations type.
  */
-template <typename WheelPositions, typename WheelVelocities,
-          typename WheelAccelerations>
+template <typename Kinematics, typename WheelPositions,
+          typename WheelVelocities, typename WheelAccelerations>
 class WPILIB_DLLEXPORT Odometry {
  public:
   /**
@@ -38,9 +38,7 @@ class WPILIB_DLLEXPORT Odometry {
    * @param wheelPositions The current distances measured by each wheel.
    * @param initialPose The starting position of the robot on the field.
    */
-  explicit Odometry(const Kinematics<WheelPositions, WheelVelocities,
-                                     WheelAccelerations>& kinematics,
-                    const Rotation2d& gyroAngle,
+  explicit Odometry(const Kinematics& kinematics, const Rotation2d& gyroAngle,
                     const WheelPositions& wheelPositions,
                     const Pose2d& initialPose = Pose2d{})
       : m_kinematics(kinematics),
@@ -135,8 +133,7 @@ class WPILIB_DLLEXPORT Odometry {
   }
 
  private:
-  const Kinematics<WheelPositions, WheelVelocities, WheelAccelerations>&
-      m_kinematics;
+  Kinematics m_kinematics;
   Pose2d m_pose;
 
   WheelPositions m_previousWheelPositions;

--- a/wpimath/src/main/native/include/wpi/math/kinematics/Odometry3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/Odometry3d.hpp
@@ -7,7 +7,9 @@
 #include "wpi/math/geometry/Pose3d.hpp"
 #include "wpi/math/geometry/Rotation3d.hpp"
 #include "wpi/math/geometry/Translation3d.hpp"
-#include "wpi/math/kinematics/Kinematics.hpp"
+#include "wpi/math/geometry/Twist3d.hpp"
+#include "wpi/units/angle.hpp"
+#include "wpi/units/length.hpp"
 #include "wpi/util/SymbolExports.hpp"
 
 namespace wpi::math {
@@ -22,12 +24,13 @@ namespace wpi::math {
  * path following. Furthermore, odometry can be used for latency compensation
  * when using computer-vision systems.
  *
+ * @tparam Kinematics type.
  * @tparam WheelPositions Wheel positions type.
  * @tparam WheelVelocities Wheel velocities type.
  * @tparam WheelAccelerations Wheel accelerations type.
  */
-template <typename WheelPositions, typename WheelVelocities,
-          typename WheelAccelerations>
+template <typename Kinematics, typename WheelPositions,
+          typename WheelVelocities, typename WheelAccelerations>
 class WPILIB_DLLEXPORT Odometry3d {
  public:
   /**
@@ -38,9 +41,7 @@ class WPILIB_DLLEXPORT Odometry3d {
    * @param wheelPositions The current distances measured by each wheel.
    * @param initialPose The starting position of the robot on the field.
    */
-  explicit Odometry3d(const Kinematics<WheelPositions, WheelVelocities,
-                                       WheelAccelerations>& kinematics,
-                      const Rotation3d& gyroAngle,
+  explicit Odometry3d(const Kinematics& kinematics, const Rotation3d& gyroAngle,
                       const WheelPositions& wheelPositions,
                       const Pose3d& initialPose = Pose3d{})
       : m_kinematics(kinematics),
@@ -148,8 +149,7 @@ class WPILIB_DLLEXPORT Odometry3d {
   }
 
  private:
-  const Kinematics<WheelPositions, WheelVelocities, WheelAccelerations>&
-      m_kinematics;
+  Kinematics m_kinematics;
   Pose3d m_pose;
 
   WheelPositions m_previousWheelPositions;

--- a/wpimath/src/main/native/include/wpi/math/kinematics/SwerveDriveOdometry.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/SwerveDriveOdometry.hpp
@@ -30,7 +30,8 @@ namespace wpi::math {
  */
 template <size_t NumModules>
 class SwerveDriveOdometry
-    : public Odometry<wpi::util::array<SwerveModulePosition, NumModules>,
+    : public Odometry<SwerveDriveKinematics<NumModules>,
+                      wpi::util::array<SwerveModulePosition, NumModules>,
                       wpi::util::array<SwerveModuleVelocity, NumModules>,
                       wpi::util::array<SwerveModuleAcceleration, NumModules>> {
  public:
@@ -46,14 +47,10 @@ class SwerveDriveOdometry
       SwerveDriveKinematics<NumModules> kinematics, const Rotation2d& gyroAngle,
       const wpi::util::array<SwerveModulePosition, NumModules>& modulePositions,
       const Pose2d& initialPose = Pose2d{})
-      : SwerveDriveOdometry::Odometry(m_kinematicsImpl, gyroAngle,
-                                      modulePositions, initialPose),
-        m_kinematicsImpl(kinematics) {
+      : SwerveDriveOdometry::Odometry(kinematics, gyroAngle, modulePositions,
+                                      initialPose) {
     wpi::math::MathSharedStore::ReportUsage("SwerveDriveOdometry", "");
   }
-
- private:
-  SwerveDriveKinematics<NumModules> m_kinematicsImpl;
 };
 
 extern template class EXPORT_TEMPLATE_DECLARE(WPILIB_DLLEXPORT)

--- a/wpimath/src/main/native/include/wpi/math/kinematics/SwerveDriveOdometry3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/SwerveDriveOdometry3d.hpp
@@ -31,6 +31,7 @@ namespace wpi::math {
 template <size_t NumModules>
 class SwerveDriveOdometry3d
     : public Odometry3d<
+          SwerveDriveKinematics<NumModules>,
           wpi::util::array<SwerveModulePosition, NumModules>,
           wpi::util::array<SwerveModuleVelocity, NumModules>,
           wpi::util::array<SwerveModuleAcceleration, NumModules>> {
@@ -43,25 +44,14 @@ class SwerveDriveOdometry3d
    * @param modulePositions The wheel positions reported by each module.
    * @param initialPose The starting position of the robot on the field.
    */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif  // defined(__GNUC__) && !defined(__clang__)
   SwerveDriveOdometry3d(
       SwerveDriveKinematics<NumModules> kinematics, const Rotation3d& gyroAngle,
       const wpi::util::array<SwerveModulePosition, NumModules>& modulePositions,
       const Pose3d& initialPose = Pose3d{})
-      : SwerveDriveOdometry3d::Odometry3d(m_kinematicsImpl, gyroAngle,
-                                          modulePositions, initialPose),
-        m_kinematicsImpl(kinematics) {
+      : SwerveDriveOdometry3d::Odometry3d(kinematics, gyroAngle,
+                                          modulePositions, initialPose) {
     wpi::math::MathSharedStore::ReportUsage("SwerveDriveOdometry3d", "");
   }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif  // defined(__GNUC__) && !defined(__clang__)
-
- private:
-  SwerveDriveKinematics<NumModules> m_kinematicsImpl;
 };
 
 extern template class EXPORT_TEMPLATE_DECLARE(WPILIB_DLLEXPORT)

--- a/wpimath/src/main/python/semiwrap/Odometry.yml
+++ b/wpimath/src/main/python/semiwrap/Odometry.yml
@@ -1,16 +1,19 @@
 extra_includes:
+- wpi/math/kinematics/DifferentialDriveKinematics.hpp
 - wpi/math/kinematics/DifferentialDriveWheelAccelerations.hpp
 - wpi/math/kinematics/DifferentialDriveWheelPositions.hpp
 - wpi/math/kinematics/DifferentialDriveWheelVelocities.hpp
+- wpi/math/kinematics/MecanumDriveKinematics.hpp
 - wpi/math/kinematics/MecanumDriveWheelAccelerations.hpp
 - wpi/math/kinematics/MecanumDriveWheelPositions.hpp
 - wpi/math/kinematics/MecanumDriveWheelVelocities.hpp
-- wpi/math/kinematics/SwerveModuleAcceleration.hpp
 - wpi/math/kinematics/SwerveDriveKinematics.hpp
+- wpi/math/kinematics/SwerveModuleAcceleration.hpp
 
 classes:
   wpi::math::Odometry:
     template_params:
+    - Kinematics
     - WheelPositions
     - WheelVelocities
     - WheelAccelerations
@@ -27,36 +30,42 @@ templates:
   DifferentialDriveOdometryBase:
     qualname: wpi::math::Odometry
     params:
+    - wpi::math::DifferentialDriveKinematics
     - wpi::math::DifferentialDriveWheelPositions
     - wpi::math::DifferentialDriveWheelVelocities
     - wpi::math::DifferentialDriveWheelAccelerations
   MecanumDriveOdometryBase:
     qualname: wpi::math::Odometry
     params:
+    - wpi::math::MecanumDriveKinematics
     - wpi::math::MecanumDriveWheelPositions
     - wpi::math::MecanumDriveWheelVelocities
     - wpi::math::MecanumDriveWheelAccelerations
   SwerveDrive2OdometryBase:
     qualname: wpi::math::Odometry
     params:
+    - wpi::math::SwerveDriveKinematics<2>
     - wpi::util::array<wpi::math::SwerveModulePosition,2>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,2>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,2>
   SwerveDrive3OdometryBase:
     qualname: wpi::math::Odometry
     params:
+    - wpi::math::SwerveDriveKinematics<3>
     - wpi::util::array<wpi::math::SwerveModulePosition,3>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,3>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,3>
   SwerveDrive4OdometryBase:
     qualname: wpi::math::Odometry
     params:
+    - wpi::math::SwerveDriveKinematics<4>
     - wpi::util::array<wpi::math::SwerveModulePosition,4>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,4>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,4>
   SwerveDrive6OdometryBase:
     qualname: wpi::math::Odometry
     params:
+    - wpi::math::SwerveDriveKinematics<6>
     - wpi::util::array<wpi::math::SwerveModulePosition,6>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,6>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,6>

--- a/wpimath/src/main/python/semiwrap/Odometry3d.yml
+++ b/wpimath/src/main/python/semiwrap/Odometry3d.yml
@@ -1,16 +1,19 @@
 extra_includes:
+- wpi/math/kinematics/DifferentialDriveKinematics.hpp
 - wpi/math/kinematics/DifferentialDriveWheelAccelerations.hpp
 - wpi/math/kinematics/DifferentialDriveWheelPositions.hpp
 - wpi/math/kinematics/DifferentialDriveWheelVelocities.hpp
+- wpi/math/kinematics/MecanumDriveKinematics.hpp
 - wpi/math/kinematics/MecanumDriveWheelAccelerations.hpp
 - wpi/math/kinematics/MecanumDriveWheelPositions.hpp
 - wpi/math/kinematics/MecanumDriveWheelVelocities.hpp
-- wpi/math/kinematics/SwerveModuleAcceleration.hpp
 - wpi/math/kinematics/SwerveDriveKinematics.hpp
+- wpi/math/kinematics/SwerveModuleAcceleration.hpp
 
 classes:
   wpi::math::Odometry3d:
     template_params:
+    - Kinematics
     - WheelPositions
     - WheelVelocities
     - WheelAccelerations
@@ -28,36 +31,42 @@ templates:
   DifferentialDriveOdometry3dBase:
     qualname: wpi::math::Odometry3d
     params:
+    - wpi::math::DifferentialDriveKinematics
     - wpi::math::DifferentialDriveWheelPositions
     - wpi::math::DifferentialDriveWheelVelocities
     - wpi::math::DifferentialDriveWheelAccelerations
   MecanumDriveOdometry3dBase:
     qualname: wpi::math::Odometry3d
     params:
+    - wpi::math::MecanumDriveKinematics
     - wpi::math::MecanumDriveWheelPositions
     - wpi::math::MecanumDriveWheelVelocities
     - wpi::math::MecanumDriveWheelAccelerations
   SwerveDrive2Odometry3dBase:
     qualname: wpi::math::Odometry3d
     params:
+    - wpi::math::SwerveDriveKinematics<2>
     - wpi::util::array<wpi::math::SwerveModulePosition,2>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,2>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,2>
   SwerveDrive3Odometry3dBase:
     qualname: wpi::math::Odometry3d
     params:
+    - wpi::math::SwerveDriveKinematics<3>
     - wpi::util::array<wpi::math::SwerveModulePosition,3>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,3>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,3>
   SwerveDrive4Odometry3dBase:
     qualname: wpi::math::Odometry3d
     params:
+    - wpi::math::SwerveDriveKinematics<4>
     - wpi::util::array<wpi::math::SwerveModulePosition,4>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,4>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,4>
   SwerveDrive6Odometry3dBase:
     qualname: wpi::math::Odometry3d
     params:
+    - wpi::math::SwerveDriveKinematics<6>
     - wpi::util::array<wpi::math::SwerveModulePosition,6>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,6>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,6>

--- a/wpimath/src/main/python/semiwrap/PoseEstimator.yml
+++ b/wpimath/src/main/python/semiwrap/PoseEstimator.yml
@@ -1,17 +1,20 @@
 extra_includes:
+- wpi/math/kinematics/DifferentialDriveKinematics.hpp
 - wpi/math/kinematics/DifferentialDriveWheelAccelerations.hpp
 - wpi/math/kinematics/DifferentialDriveWheelPositions.hpp
 - wpi/math/kinematics/DifferentialDriveWheelVelocities.hpp
+- wpi/math/kinematics/MecanumDriveKinematics.hpp
 - wpi/math/kinematics/MecanumDriveWheelAccelerations.hpp
 - wpi/math/kinematics/MecanumDriveWheelPositions.hpp
 - wpi/math/kinematics/MecanumDriveWheelVelocities.hpp
-- wpi/math/kinematics/SwerveModuleAcceleration.hpp
 - wpi/math/kinematics/SwerveDriveKinematics.hpp
+- wpi/math/kinematics/SwerveModuleAcceleration.hpp
 
 
 classes:
   wpi::math::PoseEstimator:
     template_params:
+    - Kinematics
     - WheelPositions
     - WheelVelocities
     - WheelAccelerations
@@ -35,36 +38,42 @@ templates:
   DifferentialDrivePoseEstimatorBase:
     qualname: wpi::math::PoseEstimator
     params:
+    - wpi::math::DifferentialDriveKinematics
     - wpi::math::DifferentialDriveWheelPositions
     - wpi::math::DifferentialDriveWheelVelocities
     - wpi::math::DifferentialDriveWheelAccelerations
   MecanumDrivePoseEstimatorBase:
     qualname: wpi::math::PoseEstimator
     params:
+    - wpi::math::MecanumDriveKinematics
     - wpi::math::MecanumDriveWheelPositions
     - wpi::math::MecanumDriveWheelVelocities
     - wpi::math::MecanumDriveWheelAccelerations
   SwerveDrive2PoseEstimatorBase:
     qualname: wpi::math::PoseEstimator
     params:
+    - wpi::math::SwerveDriveKinematics<2>
     - wpi::util::array<wpi::math::SwerveModulePosition,2>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,2>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,2>
   SwerveDrive3PoseEstimatorBase:
     qualname: wpi::math::PoseEstimator
     params:
+    - wpi::math::SwerveDriveKinematics<3>
     - wpi::util::array<wpi::math::SwerveModulePosition,3>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,3>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,3>
   SwerveDrive4PoseEstimatorBase:
     qualname: wpi::math::PoseEstimator
     params:
+    - wpi::math::SwerveDriveKinematics<4>
     - wpi::util::array<wpi::math::SwerveModulePosition,4>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,4>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,4>
   SwerveDrive6PoseEstimatorBase:
     qualname: wpi::math::PoseEstimator
     params:
+    - wpi::math::SwerveDriveKinematics<6>
     - wpi::util::array<wpi::math::SwerveModulePosition,6>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,6>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,6>

--- a/wpimath/src/main/python/semiwrap/PoseEstimator3d.yml
+++ b/wpimath/src/main/python/semiwrap/PoseEstimator3d.yml
@@ -1,16 +1,19 @@
 extra_includes:
+- wpi/math/kinematics/DifferentialDriveKinematics.hpp
 - wpi/math/kinematics/DifferentialDriveWheelAccelerations.hpp
 - wpi/math/kinematics/DifferentialDriveWheelPositions.hpp
 - wpi/math/kinematics/DifferentialDriveWheelVelocities.hpp
+- wpi/math/kinematics/MecanumDriveKinematics.hpp
 - wpi/math/kinematics/MecanumDriveWheelAccelerations.hpp
 - wpi/math/kinematics/MecanumDriveWheelPositions.hpp
 - wpi/math/kinematics/MecanumDriveWheelVelocities.hpp
-- wpi/math/kinematics/SwerveModuleAcceleration.hpp
 - wpi/math/kinematics/SwerveDriveKinematics.hpp
+- wpi/math/kinematics/SwerveModuleAcceleration.hpp
 
 classes:
   wpi::math::PoseEstimator3d:
     template_params:
+    - Kinematics
     - WheelPositions
     - WheelVelocities
     - WheelAccelerations
@@ -35,36 +38,42 @@ templates:
   DifferentialDrivePoseEstimator3dBase:
     qualname: wpi::math::PoseEstimator3d
     params:
+    - wpi::math::DifferentialDriveKinematics
     - wpi::math::DifferentialDriveWheelPositions
     - wpi::math::DifferentialDriveWheelVelocities
     - wpi::math::DifferentialDriveWheelAccelerations
   MecanumDrivePoseEstimator3dBase:
     qualname: wpi::math::PoseEstimator3d
     params:
+    - wpi::math::MecanumDriveKinematics
     - wpi::math::MecanumDriveWheelPositions
     - wpi::math::MecanumDriveWheelVelocities
     - wpi::math::MecanumDriveWheelAccelerations
   SwerveDrive2PoseEstimator3dBase:
     qualname: wpi::math::PoseEstimator3d
     params:
+    - wpi::math::SwerveDriveKinematics<2>
     - wpi::util::array<wpi::math::SwerveModulePosition,2>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,2>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,2>
   SwerveDrive3PoseEstimator3dBase:
     qualname: wpi::math::PoseEstimator3d
     params:
+    - wpi::math::SwerveDriveKinematics<3>
     - wpi::util::array<wpi::math::SwerveModulePosition,3>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,3>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,3>
   SwerveDrive4PoseEstimator3dBase:
     qualname: wpi::math::PoseEstimator3d
     params:
+    - wpi::math::SwerveDriveKinematics<4>
     - wpi::util::array<wpi::math::SwerveModulePosition,4>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,4>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,4>
   SwerveDrive6PoseEstimator3dBase:
     qualname: wpi::math::PoseEstimator3d
     params:
+    - wpi::math::SwerveDriveKinematics<6>
     - wpi::util::array<wpi::math::SwerveModulePosition,6>
     - wpi::util::array<wpi::math::SwerveModuleVelocity,6>
     - wpi::util::array<wpi::math::SwerveModuleAcceleration,6>


### PR DESCRIPTION
The derived class's kinematics object was being passed to the base class constructor before it was initialized. This was fixed by having the base class store the kinematics object instead.