### PR TITLE
[wpimath] Use "reference" instead of "setpoint" in feedforward docs

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/controller/ArmFeedforward.java
+++ b/wpimath/src/main/java/org/wpilib/math/controller/ArmFeedforward.java
@@ -175,13 +175,13 @@ public class ArmFeedforward implements ProtobufSerializable, StructSerializable 
   }
 
   /**
-   * Calculates the feedforward from the gains and velocity setpoint assuming continuous control
+   * Calculates the feedforward from the gains and velocity reference assuming continuous control
    * (acceleration is assumed to be zero).
    *
-   * @param position The position setpoint in radians. This angle should be measured from the
+   * @param position The position reference in radians. This angle should be measured from the
    *     horizontal (i.e. if the provided angle is 0, the arm should be parallel with the floor). If
    *     your encoder does not follow this convention, an offset should be added.
-   * @param velocity The velocity setpoint in radians per second.
+   * @param velocity The velocity reference in radians per second.
    * @return The computed feedforward.
    */
   public double calculate(double position, double velocity) {
@@ -189,13 +189,13 @@ public class ArmFeedforward implements ProtobufSerializable, StructSerializable 
   }
 
   /**
-   * Calculates the feedforward from the gains and setpoints assuming continuous control.
+   * Calculates the feedforward from the gains and references assuming continuous control.
    *
    * @param currentAngle The current angle in radians. This angle should be measured from the
    *     horizontal (i.e. if the provided angle is 0, the arm should be parallel to the floor). If
    *     your encoder does not follow this convention, an offset should be added.
-   * @param currentVelocity The current velocity setpoint in radians per second.
-   * @param nextVelocity The next velocity setpoint in radians per second.
+   * @param currentVelocity The current velocity reference in radians per second.
+   * @param nextVelocity The next velocity reference in radians per second.
    * @return The computed feedforward in volts.
    */
   public double calculate(double currentAngle, double currentVelocity, double nextVelocity) {

--- a/wpimath/src/main/java/org/wpilib/math/controller/DifferentialDriveFeedforward.java
+++ b/wpimath/src/main/java/org/wpilib/math/controller/DifferentialDriveFeedforward.java
@@ -63,7 +63,7 @@ public class DifferentialDriveFeedforward implements ProtobufSerializable, Struc
   }
 
   /**
-   * Calculates the differential drive feedforward inputs given velocity setpoints.
+   * Calculates the differential drive feedforward inputs given velocity references.
    *
    * @param currentLeftVelocity The current left velocity of the differential drive in
    *     meters/second.

--- a/wpimath/src/main/java/org/wpilib/math/controller/ElevatorFeedforward.java
+++ b/wpimath/src/main/java/org/wpilib/math/controller/ElevatorFeedforward.java
@@ -167,10 +167,10 @@ public class ElevatorFeedforward implements ProtobufSerializable, StructSerializ
   }
 
   /**
-   * Calculates the feedforward from the gains and velocity setpoint assuming continuous control
+   * Calculates the feedforward from the gains and velocity reference assuming continuous control
    * (acceleration is assumed to be zero).
    *
-   * @param velocity The velocity setpoint in meters per second.
+   * @param velocity The velocity reference in meters per second.
    * @return The computed feedforward.
    */
   public double calculate(double velocity) {
@@ -178,12 +178,12 @@ public class ElevatorFeedforward implements ProtobufSerializable, StructSerializ
   }
 
   /**
-   * Calculates the feedforward from the gains and setpoints assuming discrete control.
+   * Calculates the feedforward from the gains and references assuming discrete control.
    *
    * <p>Note this method is inaccurate when the velocity crosses 0.
    *
-   * @param currentVelocity The current velocity setpoint in meters per second.
-   * @param nextVelocity The next velocity setpoint in meters per second.
+   * @param currentVelocity The current velocity reference in meters per second.
+   * @param nextVelocity The next velocity reference in meters per second.
    * @return The computed feedforward.
    */
   public double calculate(double currentVelocity, double nextVelocity) {

--- a/wpimath/src/main/java/org/wpilib/math/controller/SimpleMotorFeedforward.java
+++ b/wpimath/src/main/java/org/wpilib/math/controller/SimpleMotorFeedforward.java
@@ -150,10 +150,10 @@ public class SimpleMotorFeedforward implements ProtobufSerializable, StructSeria
   }
 
   /**
-   * Calculates the feedforward from the gains and velocity setpoint assuming continuous control
+   * Calculates the feedforward from the gains and velocity reference assuming continuous control
    * (acceleration is assumed to be zero).
    *
-   * @param velocity The velocity setpoint.
+   * @param velocity The velocity reference.
    * @return The computed feedforward.
    */
   public double calculate(double velocity) {
@@ -161,12 +161,12 @@ public class SimpleMotorFeedforward implements ProtobufSerializable, StructSeria
   }
 
   /**
-   * Calculates the feedforward from the gains and setpoints assuming discrete control.
+   * Calculates the feedforward from the gains and references assuming discrete control.
    *
    * <p>Note this method is inaccurate when the velocity crosses 0.
    *
-   * @param currentVelocity The current velocity setpoint.
-   * @param nextVelocity The next velocity setpoint.
+   * @param currentVelocity The current velocity reference.
+   * @param nextVelocity The next velocity reference.
    * @return The computed feedforward.
    */
   public double calculate(double currentVelocity, double nextVelocity) {

--- a/wpimath/src/main/native/include/wpi/math/controller/ArmFeedforward.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/ArmFeedforward.hpp
@@ -70,7 +70,7 @@ class WPILIB_DLLEXPORT ArmFeedforward {
   }
 
   /**
-   * Calculates the feedforward from the gains and setpoint assuming discrete
+   * Calculates the feedforward from the gains and reference assuming discrete
    * control. Use this method when the velocity does not change.
    *
    * @param currentAngle The current angle. This angle should be measured from
@@ -88,7 +88,7 @@ class WPILIB_DLLEXPORT ArmFeedforward {
   }
 
   /**
-   * Calculates the feedforward from the gains and setpoints assuming discrete
+   * Calculates the feedforward from the gains and references assuming discrete
    * control.
    *
    * @param currentAngle The current angle. This angle should be measured from

--- a/wpimath/src/main/native/include/wpi/math/controller/DifferentialDriveFeedforward.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/DifferentialDriveFeedforward.hpp
@@ -74,7 +74,7 @@ class WPILIB_DLLEXPORT DifferentialDriveFeedforward {
 
   /**
    * Calculates the differential drive feedforward inputs given velocity
-   * setpoints.
+   * references.
    *
    * @param currentLeftVelocity The current left velocity of the differential
    * drive in meters/second.

--- a/wpimath/src/main/native/include/wpi/math/controller/ElevatorFeedforward.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/ElevatorFeedforward.hpp
@@ -71,10 +71,10 @@ class ElevatorFeedforward {
   }
 
   /**
-   * Calculates the feedforward from the gains and setpoint assuming discrete
-   * control. Use this method when the setpoint does not change.
+   * Calculates the feedforward from the gains and reference assuming discrete
+   * control. Use this method when the reference does not change.
    *
-   * @param currentVelocity The velocity setpoint.
+   * @param currentVelocity The velocity reference.
    * @return The computed feedforward, in volts.
    */
   constexpr wpi::units::volt_t Calculate(
@@ -83,13 +83,13 @@ class ElevatorFeedforward {
   }
 
   /**
-   * Calculates the feedforward from the gains and setpoints assuming discrete
+   * Calculates the feedforward from the gains and references assuming discrete
    * control.
    *
    * <p>Note this method is inaccurate when the velocity crosses 0.
    *
-   * @param currentVelocity The current velocity setpoint.
-   * @param nextVelocity    The next velocity setpoint.
+   * @param currentVelocity The current velocity reference.
+   * @param nextVelocity    The next velocity reference.
    * @return The computed feedforward, in volts.
    */
   constexpr wpi::units::volt_t Calculate(

--- a/wpimath/src/main/native/include/wpi/math/controller/SimpleMotorFeedforward.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/SimpleMotorFeedforward.hpp
@@ -72,11 +72,11 @@ class SimpleMotorFeedforward {
   }
 
   /**
-   * Calculates the feedforward from the gains and velocity setpoint assuming
-   * discrete control. Use this method when the velocity setpoint does not
+   * Calculates the feedforward from the gains and velocity reference assuming
+   * discrete control. Use this method when the velocity reference does not
    * change.
    *
-   * @param velocity The velocity setpoint.
+   * @param velocity The velocity reference.
    * @return The computed feedforward, in volts.
    */
   constexpr wpi::units::volt_t Calculate(
@@ -85,13 +85,13 @@ class SimpleMotorFeedforward {
   }
 
   /**
-   * Calculates the feedforward from the gains and setpoints assuming discrete
+   * Calculates the feedforward from the gains and references assuming discrete
    * control.
    *
    * <p>Note this method is inaccurate when the velocity crosses 0.
    *
-   * @param currentVelocity The current velocity setpoint.
-   * @param nextVelocity    The next velocity setpoint.
+   * @param currentVelocity The current velocity reference.
+   * @param nextVelocity    The next velocity reference.
    * @return The computed feedforward, in volts.
    */
   constexpr wpi::units::volt_t Calculate(


### PR DESCRIPTION
The feedforward classes document their velocity/position inputs as "setpoints", but the desired state that a feedforward tracks is a "reference" in control-theory terms. This updates the Java and C++ documentation to use the correct term.

Docs only, no behavior change.

Fixes #6749