### PR TITLE
[wpimath] Note that gain setters are for online tuning

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/controller/ArmFeedforward.java
+++ b/wpimath/src/main/java/org/wpilib/math/controller/ArmFeedforward.java
@@ -96,6 +96,10 @@ public class ArmFeedforward implements ProtobufSerializable, StructSerializable 
   /**
    * Sets the static gain.
    *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
+   *
    * @param ks The static gain in volts.
    */
   public void setKs(double ks) {
@@ -104,6 +108,10 @@ public class ArmFeedforward implements ProtobufSerializable, StructSerializable 
 
   /**
    * Sets the gravity gain.
+   *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
    *
    * @param kg The gravity gain in volts.
    */
@@ -114,6 +122,10 @@ public class ArmFeedforward implements ProtobufSerializable, StructSerializable 
   /**
    * Sets the velocity gain.
    *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
+   *
    * @param kv The velocity gain in V/(rad/s).
    */
   public void setKv(double kv) {
@@ -122,6 +134,10 @@ public class ArmFeedforward implements ProtobufSerializable, StructSerializable 
 
   /**
    * Sets the acceleration gain.
+   *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
    *
    * @param ka The acceleration gain in V/(rad/s²).
    */

--- a/wpimath/src/main/java/org/wpilib/math/controller/ArmFeedforward.java
+++ b/wpimath/src/main/java/org/wpilib/math/controller/ArmFeedforward.java
@@ -96,9 +96,8 @@ public class ArmFeedforward implements ProtobufSerializable, StructSerializable 
   /**
    * Sets the static gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
-   * assumed constant, so gain scheduling means the system was not correctly
-   * modeled.
+   * <p>This setter is intended for online tuning only. Feedforward gains are assumed constant, so
+   * gain scheduling means the system was not correctly modeled.
    *
    * @param ks The static gain in volts.
    */
@@ -109,9 +108,8 @@ public class ArmFeedforward implements ProtobufSerializable, StructSerializable 
   /**
    * Sets the gravity gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
-   * assumed constant, so gain scheduling means the system was not correctly
-   * modeled.
+   * <p>This setter is intended for online tuning only. Feedforward gains are assumed constant, so
+   * gain scheduling means the system was not correctly modeled.
    *
    * @param kg The gravity gain in volts.
    */
@@ -122,9 +120,8 @@ public class ArmFeedforward implements ProtobufSerializable, StructSerializable 
   /**
    * Sets the velocity gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
-   * assumed constant, so gain scheduling means the system was not correctly
-   * modeled.
+   * <p>This setter is intended for online tuning only. Feedforward gains are assumed constant, so
+   * gain scheduling means the system was not correctly modeled.
    *
    * @param kv The velocity gain in V/(rad/s).
    */
@@ -135,9 +132,8 @@ public class ArmFeedforward implements ProtobufSerializable, StructSerializable 
   /**
    * Sets the acceleration gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
-   * assumed constant, so gain scheduling means the system was not correctly
-   * modeled.
+   * <p>This setter is intended for online tuning only. Feedforward gains are assumed constant, so
+   * gain scheduling means the system was not correctly modeled.
    *
    * @param ka The acceleration gain in V/(rad/s²).
    */

--- a/wpimath/src/main/java/org/wpilib/math/controller/ElevatorFeedforward.java
+++ b/wpimath/src/main/java/org/wpilib/math/controller/ElevatorFeedforward.java
@@ -88,9 +88,8 @@ public class ElevatorFeedforward implements ProtobufSerializable, StructSerializ
   /**
    * Sets the static gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
-   * assumed constant, so gain scheduling means the system was not correctly
-   * modeled.
+   * <p>This setter is intended for online tuning only. Feedforward gains are assumed constant, so
+   * gain scheduling means the system was not correctly modeled.
    *
    * @param ks The static gain in volts.
    */
@@ -101,9 +100,8 @@ public class ElevatorFeedforward implements ProtobufSerializable, StructSerializ
   /**
    * Sets the gravity gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
-   * assumed constant, so gain scheduling means the system was not correctly
-   * modeled.
+   * <p>This setter is intended for online tuning only. Feedforward gains are assumed constant, so
+   * gain scheduling means the system was not correctly modeled.
    *
    * @param kg The gravity gain in volts.
    */
@@ -114,9 +112,8 @@ public class ElevatorFeedforward implements ProtobufSerializable, StructSerializ
   /**
    * Sets the velocity gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
-   * assumed constant, so gain scheduling means the system was not correctly
-   * modeled.
+   * <p>This setter is intended for online tuning only. Feedforward gains are assumed constant, so
+   * gain scheduling means the system was not correctly modeled.
    *
    * @param kv The velocity gain in V/(m/s).
    */
@@ -127,9 +124,8 @@ public class ElevatorFeedforward implements ProtobufSerializable, StructSerializ
   /**
    * Sets the acceleration gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
-   * assumed constant, so gain scheduling means the system was not correctly
-   * modeled.
+   * <p>This setter is intended for online tuning only. Feedforward gains are assumed constant, so
+   * gain scheduling means the system was not correctly modeled.
    *
    * @param ka The acceleration gain in V/(m/s²).
    */

--- a/wpimath/src/main/java/org/wpilib/math/controller/ElevatorFeedforward.java
+++ b/wpimath/src/main/java/org/wpilib/math/controller/ElevatorFeedforward.java
@@ -88,6 +88,10 @@ public class ElevatorFeedforward implements ProtobufSerializable, StructSerializ
   /**
    * Sets the static gain.
    *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
+   *
    * @param ks The static gain in volts.
    */
   public void setKs(double ks) {
@@ -96,6 +100,10 @@ public class ElevatorFeedforward implements ProtobufSerializable, StructSerializ
 
   /**
    * Sets the gravity gain.
+   *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
    *
    * @param kg The gravity gain in volts.
    */
@@ -106,6 +114,10 @@ public class ElevatorFeedforward implements ProtobufSerializable, StructSerializ
   /**
    * Sets the velocity gain.
    *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
+   *
    * @param kv The velocity gain in V/(m/s).
    */
   public void setKv(double kv) {
@@ -114,6 +126,10 @@ public class ElevatorFeedforward implements ProtobufSerializable, StructSerializ
 
   /**
    * Sets the acceleration gain.
+   *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
    *
    * @param ka The acceleration gain in V/(m/s²).
    */

--- a/wpimath/src/main/java/org/wpilib/math/controller/PIDController.java
+++ b/wpimath/src/main/java/org/wpilib/math/controller/PIDController.java
@@ -123,6 +123,8 @@ public class PIDController implements Sendable, AutoCloseable {
    *
    * <p>Set the proportional, integral, and differential coefficients.
    *
+   * <p>This setter is intended for online tuning.
+   *
    * @param kp The proportional coefficient.
    * @param ki The integral coefficient.
    * @param kd The derivative coefficient.
@@ -136,6 +138,8 @@ public class PIDController implements Sendable, AutoCloseable {
   /**
    * Sets the Proportional coefficient of the PID controller gain.
    *
+   * <p>This setter is intended for online tuning.
+   *
    * @param kp The proportional coefficient. Must be &gt;= 0.
    */
   public void setP(double kp) {
@@ -145,6 +149,8 @@ public class PIDController implements Sendable, AutoCloseable {
   /**
    * Sets the Integral coefficient of the PID controller gain.
    *
+   * <p>This setter is intended for online tuning.
+   *
    * @param ki The integral coefficient. Must be &gt;= 0.
    */
   public void setI(double ki) {
@@ -153,6 +159,8 @@ public class PIDController implements Sendable, AutoCloseable {
 
   /**
    * Sets the Differential coefficient of the PID controller gain.
+   *
+   * <p>This setter is intended for online tuning.
    *
    * @param kd The differential coefficient. Must be &gt;= 0.
    */

--- a/wpimath/src/main/java/org/wpilib/math/controller/ProfiledPIDController.java
+++ b/wpimath/src/main/java/org/wpilib/math/controller/ProfiledPIDController.java
@@ -73,6 +73,8 @@ public class ProfiledPIDController implements Sendable {
    *
    * <p>Sets the proportional, integral, and differential coefficients.
    *
+   * <p>This setter is intended for online tuning.
+   *
    * @param Kp The proportional coefficient. Must be &gt;= 0.
    * @param Ki The integral coefficient. Must be &gt;= 0.
    * @param Kd The differential coefficient. Must be &gt;= 0.
@@ -84,6 +86,8 @@ public class ProfiledPIDController implements Sendable {
   /**
    * Sets the proportional coefficient of the PID controller gain.
    *
+   * <p>This setter is intended for online tuning.
+   *
    * @param Kp The proportional coefficient. Must be &gt;= 0.
    */
   public void setP(double Kp) {
@@ -93,6 +97,8 @@ public class ProfiledPIDController implements Sendable {
   /**
    * Sets the integral coefficient of the PID controller gain.
    *
+   * <p>This setter is intended for online tuning.
+   *
    * @param Ki The integral coefficient. Must be &gt;= 0.
    */
   public void setI(double Ki) {
@@ -101,6 +107,8 @@ public class ProfiledPIDController implements Sendable {
 
   /**
    * Sets the differential coefficient of the PID controller gain.
+   *
+   * <p>This setter is intended for online tuning.
    *
    * @param Kd The differential coefficient. Must be &gt;= 0.
    */

--- a/wpimath/src/main/java/org/wpilib/math/controller/SimpleMotorFeedforward.java
+++ b/wpimath/src/main/java/org/wpilib/math/controller/SimpleMotorFeedforward.java
@@ -85,9 +85,8 @@ public class SimpleMotorFeedforward implements ProtobufSerializable, StructSeria
   /**
    * Sets the static gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
-   * assumed constant, so gain scheduling means the system was not correctly
-   * modeled.
+   * <p>This setter is intended for online tuning only. Feedforward gains are assumed constant, so
+   * gain scheduling means the system was not correctly modeled.
    *
    * @param ks The static gain in volts.
    */
@@ -98,9 +97,8 @@ public class SimpleMotorFeedforward implements ProtobufSerializable, StructSeria
   /**
    * Sets the velocity gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
-   * assumed constant, so gain scheduling means the system was not correctly
-   * modeled.
+   * <p>This setter is intended for online tuning only. Feedforward gains are assumed constant, so
+   * gain scheduling means the system was not correctly modeled.
    *
    * @param kv The velocity gain in V/(units/s).
    */
@@ -111,9 +109,8 @@ public class SimpleMotorFeedforward implements ProtobufSerializable, StructSeria
   /**
    * Sets the acceleration gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
-   * assumed constant, so gain scheduling means the system was not correctly
-   * modeled.
+   * <p>This setter is intended for online tuning only. Feedforward gains are assumed constant, so
+   * gain scheduling means the system was not correctly modeled.
    *
    * @param ka The acceleration gain in V/(units/s²).
    */

--- a/wpimath/src/main/java/org/wpilib/math/controller/SimpleMotorFeedforward.java
+++ b/wpimath/src/main/java/org/wpilib/math/controller/SimpleMotorFeedforward.java
@@ -85,6 +85,10 @@ public class SimpleMotorFeedforward implements ProtobufSerializable, StructSeria
   /**
    * Sets the static gain.
    *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
+   *
    * @param ks The static gain in volts.
    */
   public void setKs(double ks) {
@@ -94,6 +98,10 @@ public class SimpleMotorFeedforward implements ProtobufSerializable, StructSeria
   /**
    * Sets the velocity gain.
    *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
+   *
    * @param kv The velocity gain in V/(units/s).
    */
   public void setKv(double kv) {
@@ -102,6 +110,10 @@ public class SimpleMotorFeedforward implements ProtobufSerializable, StructSeria
 
   /**
    * Sets the acceleration gain.
+   *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
    *
    * @param ka The acceleration gain in V/(units/s²).
    */

--- a/wpimath/src/main/native/include/wpi/math/controller/ArmFeedforward.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/ArmFeedforward.hpp
@@ -205,12 +205,20 @@ class WPILIB_DLLEXPORT ArmFeedforward {
   /**
    * Sets the static gain.
    *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
+   *
    * @param kS The static gain.
    */
   constexpr void SetKs(wpi::units::volt_t kS) { this->kS = kS; }
 
   /**
    * Sets the gravity gain.
+   *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
    *
    * @param kG The gravity gain.
    */
@@ -219,12 +227,20 @@ class WPILIB_DLLEXPORT ArmFeedforward {
   /**
    * Sets the velocity gain.
    *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
+   *
    * @param kV The velocity gain.
    */
   constexpr void SetKv(wpi::units::unit_t<kv_unit> kV) { this->kV = kV; }
 
   /**
    * Sets the acceleration gain.
+   *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
    *
    * @param kA The acceleration gain.
    */

--- a/wpimath/src/main/native/include/wpi/math/controller/ArmFeedforward.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/ArmFeedforward.hpp
@@ -205,7 +205,7 @@ class WPILIB_DLLEXPORT ArmFeedforward {
   /**
    * Sets the static gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * This setter is intended for online tuning only. Feedforward gains are
    * assumed constant, so gain scheduling means the system was not correctly
    * modeled.
    *
@@ -216,7 +216,7 @@ class WPILIB_DLLEXPORT ArmFeedforward {
   /**
    * Sets the gravity gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * This setter is intended for online tuning only. Feedforward gains are
    * assumed constant, so gain scheduling means the system was not correctly
    * modeled.
    *
@@ -227,7 +227,7 @@ class WPILIB_DLLEXPORT ArmFeedforward {
   /**
    * Sets the velocity gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * This setter is intended for online tuning only. Feedforward gains are
    * assumed constant, so gain scheduling means the system was not correctly
    * modeled.
    *
@@ -238,7 +238,7 @@ class WPILIB_DLLEXPORT ArmFeedforward {
   /**
    * Sets the acceleration gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * This setter is intended for online tuning only. Feedforward gains are
    * assumed constant, so gain scheduling means the system was not correctly
    * modeled.
    *

--- a/wpimath/src/main/native/include/wpi/math/controller/ElevatorFeedforward.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/ElevatorFeedforward.hpp
@@ -185,12 +185,20 @@ class ElevatorFeedforward {
   /**
    * Sets the static gain.
    *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
+   *
    * @param kS The static gain.
    */
   constexpr void SetKs(wpi::units::volt_t kS) { this->kS = kS; }
 
   /**
    * Sets the gravity gain.
+   *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
    *
    * @param kG The gravity gain.
    */
@@ -199,12 +207,20 @@ class ElevatorFeedforward {
   /**
    * Sets the velocity gain.
    *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
+   *
    * @param kV The velocity gain.
    */
   constexpr void SetKv(wpi::units::unit_t<kv_unit> kV) { this->kV = kV; }
 
   /**
    * Sets the acceleration gain.
+   *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
    *
    * @param kA The acceleration gain.
    */

--- a/wpimath/src/main/native/include/wpi/math/controller/ElevatorFeedforward.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/ElevatorFeedforward.hpp
@@ -86,7 +86,7 @@ class ElevatorFeedforward {
    * Calculates the feedforward from the gains and setpoints assuming discrete
    * control.
    *
-   * <p>Note this method is inaccurate when the velocity crosses 0.
+   * Note this method is inaccurate when the velocity crosses 0.
    *
    * @param currentVelocity The current velocity setpoint.
    * @param nextVelocity    The next velocity setpoint.
@@ -185,7 +185,7 @@ class ElevatorFeedforward {
   /**
    * Sets the static gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * This setter is intended for online tuning only. Feedforward gains are
    * assumed constant, so gain scheduling means the system was not correctly
    * modeled.
    *
@@ -196,7 +196,7 @@ class ElevatorFeedforward {
   /**
    * Sets the gravity gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * This setter is intended for online tuning only. Feedforward gains are
    * assumed constant, so gain scheduling means the system was not correctly
    * modeled.
    *
@@ -207,7 +207,7 @@ class ElevatorFeedforward {
   /**
    * Sets the velocity gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * This setter is intended for online tuning only. Feedforward gains are
    * assumed constant, so gain scheduling means the system was not correctly
    * modeled.
    *
@@ -218,7 +218,7 @@ class ElevatorFeedforward {
   /**
    * Sets the acceleration gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * This setter is intended for online tuning only. Feedforward gains are
    * assumed constant, so gain scheduling means the system was not correctly
    * modeled.
    *

--- a/wpimath/src/main/native/include/wpi/math/controller/PIDController.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/PIDController.hpp
@@ -92,7 +92,7 @@ class WPILIB_DLLEXPORT PIDController
    *
    * Sets the proportional, integral, and differential coefficients.
    *
-   * <p>This setter is intended for online tuning.
+   * This setter is intended for online tuning.
    *
    * @param Kp The proportional coefficient. Must be >= 0.
    * @param Ki The integral coefficient. Must be >= 0.
@@ -107,7 +107,7 @@ class WPILIB_DLLEXPORT PIDController
   /**
    * Sets the proportional coefficient of the PID controller gain.
    *
-   * <p>This setter is intended for online tuning.
+   * This setter is intended for online tuning.
    *
    * @param Kp The proportional coefficient. Must be >= 0.
    */
@@ -116,7 +116,7 @@ class WPILIB_DLLEXPORT PIDController
   /**
    * Sets the integral coefficient of the PID controller gain.
    *
-   * <p>This setter is intended for online tuning.
+   * This setter is intended for online tuning.
    *
    * @param Ki The integral coefficient. Must be >= 0.
    */
@@ -125,7 +125,7 @@ class WPILIB_DLLEXPORT PIDController
   /**
    * Sets the differential coefficient of the PID controller gain.
    *
-   * <p>This setter is intended for online tuning.
+   * This setter is intended for online tuning.
    *
    * @param Kd The differential coefficient. Must be >= 0.
    */

--- a/wpimath/src/main/native/include/wpi/math/controller/PIDController.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/PIDController.hpp
@@ -92,6 +92,8 @@ class WPILIB_DLLEXPORT PIDController
    *
    * Sets the proportional, integral, and differential coefficients.
    *
+   * <p>This setter is intended for online tuning.
+   *
    * @param Kp The proportional coefficient. Must be >= 0.
    * @param Ki The integral coefficient. Must be >= 0.
    * @param Kd The differential coefficient. Must be >= 0.
@@ -105,6 +107,8 @@ class WPILIB_DLLEXPORT PIDController
   /**
    * Sets the proportional coefficient of the PID controller gain.
    *
+   * <p>This setter is intended for online tuning.
+   *
    * @param Kp The proportional coefficient. Must be >= 0.
    */
   constexpr void SetP(double Kp) { m_Kp = Kp; }
@@ -112,12 +116,16 @@ class WPILIB_DLLEXPORT PIDController
   /**
    * Sets the integral coefficient of the PID controller gain.
    *
+   * <p>This setter is intended for online tuning.
+   *
    * @param Ki The integral coefficient. Must be >= 0.
    */
   constexpr void SetI(double Ki) { m_Ki = Ki; }
 
   /**
    * Sets the differential coefficient of the PID controller gain.
+   *
+   * <p>This setter is intended for online tuning.
    *
    * @param Kd The differential coefficient. Must be >= 0.
    */

--- a/wpimath/src/main/native/include/wpi/math/controller/ProfiledPIDController.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/ProfiledPIDController.hpp
@@ -86,6 +86,8 @@ class ProfiledPIDController
    *
    * Sets the proportional, integral, and differential coefficients.
    *
+   * <p>This setter is intended for online tuning.
+   *
    * @param Kp The proportional coefficient. Must be >= 0.
    * @param Ki The integral coefficient. Must be >= 0.
    * @param Kd The differential coefficient. Must be >= 0.
@@ -97,6 +99,8 @@ class ProfiledPIDController
   /**
    * Sets the proportional coefficient of the PID controller gain.
    *
+   * <p>This setter is intended for online tuning.
+   *
    * @param Kp The proportional coefficient. Must be >= 0.
    */
   constexpr void SetP(double Kp) { m_controller.SetP(Kp); }
@@ -104,12 +108,16 @@ class ProfiledPIDController
   /**
    * Sets the integral coefficient of the PID controller gain.
    *
+   * <p>This setter is intended for online tuning.
+   *
    * @param Ki The integral coefficient. Must be >= 0.
    */
   constexpr void SetI(double Ki) { m_controller.SetI(Ki); }
 
   /**
    * Sets the differential coefficient of the PID controller gain.
+   *
+   * <p>This setter is intended for online tuning.
    *
    * @param Kd The differential coefficient. Must be >= 0.
    */

--- a/wpimath/src/main/native/include/wpi/math/controller/ProfiledPIDController.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/ProfiledPIDController.hpp
@@ -86,7 +86,7 @@ class ProfiledPIDController
    *
    * Sets the proportional, integral, and differential coefficients.
    *
-   * <p>This setter is intended for online tuning.
+   * This setter is intended for online tuning.
    *
    * @param Kp The proportional coefficient. Must be >= 0.
    * @param Ki The integral coefficient. Must be >= 0.
@@ -99,7 +99,7 @@ class ProfiledPIDController
   /**
    * Sets the proportional coefficient of the PID controller gain.
    *
-   * <p>This setter is intended for online tuning.
+   * This setter is intended for online tuning.
    *
    * @param Kp The proportional coefficient. Must be >= 0.
    */
@@ -108,7 +108,7 @@ class ProfiledPIDController
   /**
    * Sets the integral coefficient of the PID controller gain.
    *
-   * <p>This setter is intended for online tuning.
+   * This setter is intended for online tuning.
    *
    * @param Ki The integral coefficient. Must be >= 0.
    */
@@ -117,7 +117,7 @@ class ProfiledPIDController
   /**
    * Sets the differential coefficient of the PID controller gain.
    *
-   * <p>This setter is intended for online tuning.
+   * This setter is intended for online tuning.
    *
    * @param Kd The differential coefficient. Must be >= 0.
    */

--- a/wpimath/src/main/native/include/wpi/math/controller/SimpleMotorFeedforward.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/SimpleMotorFeedforward.hpp
@@ -188,6 +188,10 @@ class SimpleMotorFeedforward {
   /**
    * Sets the static gain.
    *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
+   *
    * @param kS The static gain.
    */
   constexpr void SetKs(wpi::units::volt_t kS) { this->kS = kS; }
@@ -195,12 +199,20 @@ class SimpleMotorFeedforward {
   /**
    * Sets the velocity gain.
    *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
+   *
    * @param kV The velocity gain.
    */
   constexpr void SetKv(wpi::units::unit_t<kv_unit> kV) { this->kV = kV; }
 
   /**
    * Sets the acceleration gain.
+   *
+   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * assumed constant, so gain scheduling means the system was not correctly
+   * modeled.
    *
    * @param kA The acceleration gain.
    */

--- a/wpimath/src/main/native/include/wpi/math/controller/SimpleMotorFeedforward.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/SimpleMotorFeedforward.hpp
@@ -88,7 +88,7 @@ class SimpleMotorFeedforward {
    * Calculates the feedforward from the gains and setpoints assuming discrete
    * control.
    *
-   * <p>Note this method is inaccurate when the velocity crosses 0.
+   * Note this method is inaccurate when the velocity crosses 0.
    *
    * @param currentVelocity The current velocity setpoint.
    * @param nextVelocity    The next velocity setpoint.
@@ -188,7 +188,7 @@ class SimpleMotorFeedforward {
   /**
    * Sets the static gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * This setter is intended for online tuning only. Feedforward gains are
    * assumed constant, so gain scheduling means the system was not correctly
    * modeled.
    *
@@ -199,7 +199,7 @@ class SimpleMotorFeedforward {
   /**
    * Sets the velocity gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * This setter is intended for online tuning only. Feedforward gains are
    * assumed constant, so gain scheduling means the system was not correctly
    * modeled.
    *
@@ -210,7 +210,7 @@ class SimpleMotorFeedforward {
   /**
    * Sets the acceleration gain.
    *
-   * <p>This setter is intended for online tuning only. Feedforward gains are
+   * This setter is intended for online tuning only. Feedforward gains are
    * assumed constant, so gain scheduling means the system was not correctly
    * modeled.
    *


### PR DESCRIPTION
Adds a short note to the PID and feedforward gain setters (setP/setI/setD/setPID and setKs/setKv/setKa/setKg) clarifying that they are intended for online tuning.

For the feedforward setters, the note also states that the gains are assumed constant, so using them for gain scheduling means the system was not modeled correctly, per the issue.

Applied consistently to Java and C++. Docs only, no behavior change. Happy to adjust the wording.

Fixes #7787