### PR TITLE
[wpimath] Document that transforms are intrinsic

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/geometry/Transform2d.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/Transform2d.java
@@ -17,7 +17,13 @@ import org.wpilib.units.measure.Distance;
 import org.wpilib.util.protobuf.ProtobufSerializable;
 import org.wpilib.util.struct.StructSerializable;
 
-/** Represents a transformation for a Pose2d in the pose's frame. */
+/**
+ * Represents a transformation for a Pose2d in the pose's frame.
+ *
+ * <p>Transforms are applied intrinsically, i.e. relative to the pose's own frame
+ * rather than the global frame. This is in contrast to the rotation classes,
+ * which apply rotations extrinsically.
+ */
 public final class Transform2d implements ProtobufSerializable, StructSerializable {
   /**
    * A preallocated Transform2d representing no transformation.

--- a/wpimath/src/main/java/org/wpilib/math/geometry/Transform2d.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/Transform2d.java
@@ -20,9 +20,8 @@ import org.wpilib.util.struct.StructSerializable;
 /**
  * Represents a transformation for a Pose2d in the pose's frame.
  *
- * <p>Transforms are applied intrinsically, i.e. relative to the pose's own frame
- * rather than the global frame. This is in contrast to the rotation classes,
- * which apply rotations extrinsically.
+ * <p>Transforms are applied intrinsically, i.e. relative to the pose's own frame rather than the
+ * global frame. This is in contrast to the rotation classes, which apply rotations extrinsically.
  */
 public final class Transform2d implements ProtobufSerializable, StructSerializable {
   /**

--- a/wpimath/src/main/java/org/wpilib/math/geometry/Transform3d.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/Transform3d.java
@@ -21,6 +21,10 @@ import org.wpilib.util.struct.StructSerializable;
 /**
  * Represents a transformation for a Pose3d in the pose's frame. Translation is applied before
  * rotation. (The translation is applied in the pose's original frame, not the transformed frame.)
+ *
+ * <p>Transforms are applied intrinsically, i.e. relative to the pose's own frame
+ * rather than the global frame. This is in contrast to the rotation classes,
+ * which apply rotations extrinsically.
  */
 public final class Transform3d implements ProtobufSerializable, StructSerializable {
   /**

--- a/wpimath/src/main/java/org/wpilib/math/geometry/Transform3d.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/Transform3d.java
@@ -22,9 +22,8 @@ import org.wpilib.util.struct.StructSerializable;
  * Represents a transformation for a Pose3d in the pose's frame. Translation is applied before
  * rotation. (The translation is applied in the pose's original frame, not the transformed frame.)
  *
- * <p>Transforms are applied intrinsically, i.e. relative to the pose's own frame
- * rather than the global frame. This is in contrast to the rotation classes,
- * which apply rotations extrinsically.
+ * <p>Transforms are applied intrinsically, i.e. relative to the pose's own frame rather than the
+ * global frame. This is in contrast to the rotation classes, which apply rotations extrinsically.
  */
 public final class Transform3d implements ProtobufSerializable, StructSerializable {
   /**

--- a/wpimath/src/main/native/include/wpi/math/geometry/Transform2d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Transform2d.hpp
@@ -24,9 +24,9 @@ struct Twist2d;
 /**
  * Represents a transformation for a Pose2d in the pose's frame.
  *
- * <p>Transforms are applied intrinsically, i.e. relative to the pose's own
- * frame rather than the global frame. This is in contrast to the rotation
- * classes, which apply rotations extrinsically.
+ * Transforms are applied intrinsically, i.e. relative to the pose's own frame
+ * rather than the global frame. This is in contrast to the rotation classes,
+ * which apply rotations extrinsically.
  */
 class WPILIB_DLLEXPORT Transform2d final {
  public:

--- a/wpimath/src/main/native/include/wpi/math/geometry/Transform2d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Transform2d.hpp
@@ -23,6 +23,10 @@ struct Twist2d;
 
 /**
  * Represents a transformation for a Pose2d in the pose's frame.
+ *
+ * <p>Transforms are applied intrinsically, i.e. relative to the pose's own
+ * frame rather than the global frame. This is in contrast to the rotation
+ * classes, which apply rotations extrinsically.
  */
 class WPILIB_DLLEXPORT Transform2d final {
  public:

--- a/wpimath/src/main/native/include/wpi/math/geometry/Transform3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Transform3d.hpp
@@ -28,9 +28,9 @@ struct Twist3d;
  * applied before rotation. (The translation is applied in the pose's original
  * frame, not the transformed frame.)
  *
- * <p>Transforms are applied intrinsically, i.e. relative to the pose's own
- * frame rather than the global frame. This is in contrast to the rotation
- * classes, which apply rotations extrinsically.
+ * Transforms are applied intrinsically, i.e. relative to the pose's own frame
+ * rather than the global frame. This is in contrast to the rotation classes,
+ * which apply rotations extrinsically.
  */
 class WPILIB_DLLEXPORT Transform3d final {
  public:

--- a/wpimath/src/main/native/include/wpi/math/geometry/Transform3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Transform3d.hpp
@@ -27,6 +27,10 @@ struct Twist3d;
  * Represents a transformation for a Pose3d in the pose's frame. Translation is
  * applied before rotation. (The translation is applied in the pose's original
  * frame, not the transformed frame.)
+ *
+ * <p>Transforms are applied intrinsically, i.e. relative to the pose's own
+ * frame rather than the global frame. This is in contrast to the rotation
+ * classes, which apply rotations extrinsically.
  */
 class WPILIB_DLLEXPORT Transform3d final {
  public:

--- a/wpimath/src/main/native/include/wpi/math/geometry/Transform3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Transform3d.hpp
@@ -91,7 +91,7 @@ class WPILIB_DLLEXPORT Transform3d final {
 
   /**
    * Constructs a 3D transform from a 2D transform in the X-Y plane.
-   **
+   *
    * @param transform The 2D transform.
    * @see Rotation3d(Rotation2d)
    * @see Translation3d(Translation2d)


### PR DESCRIPTION
Documents in the Transform2d and Transform3d class docs that transforms are applied intrinsically (relative to the pose's own frame), in contrast to the rotation classes, which apply rotations extrinsically.

This matches the existing internal comments (e.g. Pose3d notes that "we define transforms as being applied intrinsically" and Rotation3d.rotateBy applies rotations extrinsically).

Also fixes a stray `**` in a Transform3d doc comment while in the same file.

Docs only, no behavior change.

Fixes #6561