### PR TITLE
[wpilib] Document rumble motor mapping in RumbleType

### DIFF
--- a/wpilibc/src/main/native/include/wpi/driverstation/GenericHID.hpp
+++ b/wpilibc/src/main/native/include/wpi/driverstation/GenericHID.hpp
@@ -35,13 +35,15 @@ class GenericHID final : public HIDDevice {
    * Represents a rumble output on the Joystick.
    */
   enum class RumbleType {
-    /// Left rumble motor.
+    /// Left rumble motor. On most controllers, this is the low-frequency
+    /// motor.
     LEFT_RUMBLE,
-    /// Right rumble motor.
+    /// Right rumble motor. On most controllers, this is the high-frequency
+    /// motor.
     RIGHT_RUMBLE,
-    /// Left trigger rumble motor.
+    /// Left trigger rumble motor, on controllers that have one.
     LEFT_TRIGGER_RUMBLE,
-    /// Right trigger rumble motor.
+    /// Right trigger rumble motor, on controllers that have one.
     RIGHT_TRIGGER_RUMBLE,
   };
 

--- a/wpilibj/src/main/java/org/wpilib/driverstation/GenericHID.java
+++ b/wpilibj/src/main/java/org/wpilib/driverstation/GenericHID.java
@@ -23,13 +23,13 @@ import org.wpilib.math.util.Pair;
 public final class GenericHID implements HIDDevice {
   /** Represents a rumble output on the Joystick. */
   public enum RumbleType {
-    /** Left rumble motor. */
+    /** Left rumble motor. On most controllers, this is the low-frequency motor. */
     LEFT_RUMBLE,
-    /** Right rumble motor. */
+    /** Right rumble motor. On most controllers, this is the high-frequency motor. */
     RIGHT_RUMBLE,
-    /** Left trigger rumble motor. */
+    /** Left trigger rumble motor, on controllers that have one. */
     LEFT_TRIGGER_RUMBLE,
-    /** Right trigger rumble motor. */
+    /** Right trigger rumble motor, on controllers that have one. */
     RIGHT_TRIGGER_RUMBLE,
   }
 


### PR DESCRIPTION
Documents what the RumbleType values map to physically: the left rumble is typically the low-frequency motor and the right rumble the high-frequency motor, with the trigger rumbles only present on controllers that have trigger motors.

Worded as "on most controllers" since the exact mapping is best documented for Xbox-style controllers and may vary by device.

Applied to Java and C++. Docs only, no behavior change.

Fixes #7094