### PR TITLE
[wpimath] Add ProfiledPIDController.getNextSetpoint()

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/controller/ProfiledPIDController.java
+++ b/wpimath/src/main/java/org/wpilib/math/controller/ProfiledPIDController.java
@@ -261,6 +261,19 @@ public class ProfiledPIDController implements Sendable {
   }
 
   /**
+   * Returns the next setpoint of the ProfiledPIDController, one controller period after the current
+   * setpoint.
+   *
+   * <p>This is useful with the feedforward calculate() overloads that take a next velocity, which
+   * are more accurate for discrete systems.
+   *
+   * @return The next setpoint.
+   */
+  public TrapezoidProfile.State getNextSetpoint() {
+    return m_profile.calculate(getPeriod(), m_setpoint, m_goal);
+  }
+
+  /**
    * Returns true if the error is within the tolerance of the error.
    *
    * <p>This will return false until at least one input value has been computed.

--- a/wpimath/src/main/native/include/wpi/math/controller/ProfiledPIDController.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/ProfiledPIDController.hpp
@@ -243,6 +243,20 @@ class ProfiledPIDController
   constexpr State GetSetpoint() const { return m_setpoint; }
 
   /**
+   * Returns the next setpoint of the ProfiledPIDController, one controller
+   * period after the current setpoint.
+   *
+   * This is useful with the feedforward Calculate() overloads that take a next
+   * velocity, which are more accurate for discrete systems.
+   *
+   * @return The next setpoint.
+   */
+  constexpr State GetNextSetpoint() const {
+    return TrapezoidProfile<Distance>{m_constraints}.Calculate(
+        GetPeriod(), m_setpoint, m_goal);
+  }
+
+  /**
    * Returns true if the error is within the tolerance of the error.
    *
    * Currently this just reports on target as the actual value passes through

--- a/wpimath/src/test/java/org/wpilib/math/controller/ProfiledPIDControllerTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/controller/ProfiledPIDControllerTest.java
@@ -19,4 +19,21 @@ class ProfiledPIDControllerTest {
 
     assertEquals(0.0, controller.calculate(20), 0.05);
   }
+
+  @Test
+  void getNextSetpointTest() {
+    ProfiledPIDController controller =
+        new ProfiledPIDController(1.0, 0.0, 0.0, new TrapezoidProfile.Constraints(1.0, 1.0));
+
+    // Advance the profile one step toward the goal.
+    controller.calculate(0.0, 5.0);
+
+    TrapezoidProfile.State next = controller.getNextSetpoint();
+
+    // The next setpoint should equal the setpoint produced by the following calculate() call.
+    controller.calculate(controller.getSetpoint().position);
+
+    assertEquals(next.position, controller.getSetpoint().position, 1e-9);
+    assertEquals(next.velocity, controller.getSetpoint().velocity, 1e-9);
+  }
 }


### PR DESCRIPTION
Adds `getNextSetpoint()` to `ProfiledPIDController`, returning the setpoint one controller period after the current setpoint.

The discrete feedforward `calculate()` overloads take a next velocity and are more accurate for discrete systems, but `ProfiledPIDController` previously exposed only the current setpoint, so there was no way to get the next one. This provides it:

```java
double ff =
    feedforward.calculate(
        controller.getSetpoint().velocity, controller.getNextSetpoint().velocity);
```

Implemented in Java and C++ with a Java unit test. The C++ version uses a throwaway profile so it stays `const` and has no side effects.

Fixes #5236
