### PR TITLE
[ci] Optimize Gradle host builds

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -147,6 +147,11 @@ jobs:
           distribution: 'temurin'
           java-version: 25
           architecture: ${{ matrix.architecture }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          validate-wrappers: false
+
       - name: Import Developer ID Certificate
         uses: wpilibsuite/import-signing-certificate@v3
         with:
@@ -161,6 +166,7 @@ jobs:
         if: |
           matrix.artifact-name == 'macOS' && (github.repository == 'wpilibsuite/allwpilib' &&
           (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
+
       - name: Set release environment variable
         run: echo "EXTRA_GRADLE_ARGS=-PreleaseMode" >> $GITHUB_ENV
         shell: bash
@@ -196,6 +202,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 26
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          validate-wrappers: false
       - name: Set release environment variable
         run: echo "EXTRA_GRADLE_ARGS=-PreleaseMode" >> $GITHUB_ENV
         if: startsWith(github.ref, 'refs/tags/v')
@@ -321,6 +331,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 25
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          validate-wrappers: false
       - name: Combine
         if: |
           github.repository == 'wpilibsuite/allwpilib' &&

--- a/.github/workflows/sentinel-build.yml
+++ b/.github/workflows/sentinel-build.yml
@@ -121,6 +121,11 @@ jobs:
           distribution: 'temurin'
           java-version: 25
           architecture: ${{ matrix.architecture }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-disabled: true
+          validate-wrappers: false
       - name: Import Developer ID Certificate
         uses: wpilibsuite/import-signing-certificate@v3
         with:


### PR DESCRIPTION
This uses [`gradle/actions/setup-gradle`](https://github.com/gradle/actions/tree/main#the-setup-gradle-action) to (hopefully) speed up our non-containerised Gradle CI builds and slightly improve the DX of debugging builds. In particular:

- On Windows, the Gradle user home is moved to the faster `D:\` drive with more disk space.
- Downloads of external dependencies are cached in the GitHub Actions cache.
- Build Scan links are automatically captured in job summaries.

Linux container builds are left untouched, as the Gradle user home isn't persisted outside the container for this action to do anything. We disable the builtin wrapper validation for these actions as these jobs all depend on a separate validation job.