### PR TITLE
[wpimath] Cleanup of cruft in Odometry/PoseEstimator

### DIFF
--- a/robotpyExamples/examples/DifferentialDrivePoseEstimator/drivetrain.py
+++ b/robotpyExamples/examples/DifferentialDrivePoseEstimator/drivetrain.py
@@ -59,7 +59,6 @@ class Drivetrain:
         # Here we use DifferentialDrivePoseEstimator so that we can fuse odometry readings. The
         # numbers used below are robot specific, and should be tuned.
         self.pose_estimator = wpimath.DifferentialDrivePoseEstimator(
-            self.kinematics,
             self.imu.get_rotation2d(),
             self.left_encoder.get_distance(),
             self.right_encoder.get_distance(),

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/include/Drivetrain.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/include/Drivetrain.hpp
@@ -151,7 +151,6 @@ class Drivetrain {
   // Gains are for example purposes only - must be determined for your own
   // robot!
   wpi::math::DifferentialDrivePoseEstimator poseEstimator{
-      kinematics,
       imu.GetRotation2d(),
       wpi::units::meter_t{leftEncoder.GetDistance()},
       wpi::units::meter_t{rightEncoder.GetDistance()},

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/differentialdriveposeestimator/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/differentialdriveposeestimator/Drivetrain.java
@@ -79,7 +79,6 @@ public class Drivetrain {
   numbers used  below are robot specific, and should be tuned. */
   private final DifferentialDrivePoseEstimator poseEstimator =
       new DifferentialDrivePoseEstimator(
-          kinematics,
           imu.getRotation2d(),
           leftEncoder.getDistance(),
           rightEncoder.getDistance(),

--- a/wpimath/src/main/java/org/wpilib/math/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpimath/src/main/java/org/wpilib/math/estimator/DifferentialDrivePoseEstimator.java
@@ -6,7 +6,6 @@ package org.wpilib.math.estimator;
 
 import org.wpilib.math.geometry.Pose2d;
 import org.wpilib.math.geometry.Rotation2d;
-import org.wpilib.math.kinematics.DifferentialDriveKinematics;
 import org.wpilib.math.kinematics.DifferentialDriveOdometry;
 import org.wpilib.math.kinematics.DifferentialDriveWheelPositions;
 import org.wpilib.math.linalg.Matrix;
@@ -36,20 +35,15 @@ public class DifferentialDrivePoseEstimator extends PoseEstimator<DifferentialDr
    * y, and 0.01 radians for heading. The default standard deviations of the vision measurements are
    * 0.1 meters for x, 0.1 meters for y, and 0.1 radians for heading.
    *
-   * @param kinematics A correctly-configured kinematics object for your drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder in meters.
    * @param rightDistance The distance traveled by the right encoder in meters.
    * @param initialPose The starting pose estimate.
    */
   public DifferentialDrivePoseEstimator(
-      DifferentialDriveKinematics kinematics,
-      Rotation2d gyroAngle,
-      double leftDistance,
-      double rightDistance,
-      Pose2d initialPose) {
+      Rotation2d gyroAngle, double leftDistance, double rightDistance, Pose2d initialPose) {
     this(
-        kinematics,
         gyroAngle,
         leftDistance,
         rightDistance,
@@ -61,8 +55,8 @@ public class DifferentialDrivePoseEstimator extends PoseEstimator<DifferentialDr
   /**
    * Constructs a DifferentialDrivePoseEstimator.
    *
-   * @param kinematics A correctly-configured kinematics object for your drivetrain.
-   * @param gyroAngle The gyro angle of the robot.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder in meters.
    * @param rightDistance The distance traveled by the right encoder in meters.
    * @param initialPose The estimated initial pose.
@@ -74,7 +68,6 @@ public class DifferentialDrivePoseEstimator extends PoseEstimator<DifferentialDr
    *     the vision pose measurement less.
    */
   public DifferentialDrivePoseEstimator(
-      DifferentialDriveKinematics kinematics,
       Rotation2d gyroAngle,
       double leftDistance,
       double rightDistance,
@@ -82,7 +75,6 @@ public class DifferentialDrivePoseEstimator extends PoseEstimator<DifferentialDr
       Matrix<N3, N1> stateStdDevs,
       Matrix<N3, N1> visionMeasurementStdDevs) {
     super(
-        kinematics,
         new DifferentialDriveOdometry(gyroAngle, leftDistance, rightDistance, initialPose),
         stateStdDevs,
         visionMeasurementStdDevs);
@@ -94,7 +86,8 @@ public class DifferentialDrivePoseEstimator extends PoseEstimator<DifferentialDr
    * <p>The gyroscope angle does not need to be reset here on the user's robot code. The library
    * automatically takes care of offsetting the gyro angle.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftPosition The distance traveled by the left encoder in meters.
    * @param rightPosition The distance traveled by the right encoder in meters.
    * @param pose The position on the field that your robot is at.
@@ -109,7 +102,8 @@ public class DifferentialDrivePoseEstimator extends PoseEstimator<DifferentialDr
    * Updates the pose estimator with wheel encoder and gyro information. This should be called every
    * loop.
    *
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param distanceLeft The total distance travelled by the left wheel in meters.
    * @param distanceRight The total distance travelled by the right wheel in meters.
    * @return The estimated pose of the robot in meters.
@@ -123,7 +117,8 @@ public class DifferentialDrivePoseEstimator extends PoseEstimator<DifferentialDr
    * loop.
    *
    * @param currentTime Time at which this method was called, in seconds.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param distanceLeft The total distance travelled by the left wheel in meters.
    * @param distanceRight The total distance travelled by the right wheel in meters.
    * @return The estimated pose of the robot in meters.

--- a/wpimath/src/main/java/org/wpilib/math/estimator/DifferentialDrivePoseEstimator3d.java
+++ b/wpimath/src/main/java/org/wpilib/math/estimator/DifferentialDrivePoseEstimator3d.java
@@ -10,7 +10,6 @@ import org.wpilib.math.geometry.Rotation2d;
 import org.wpilib.math.geometry.Rotation3d;
 import org.wpilib.math.geometry.Translation2d;
 import org.wpilib.math.geometry.Translation3d;
-import org.wpilib.math.kinematics.DifferentialDriveKinematics;
 import org.wpilib.math.kinematics.DifferentialDriveOdometry3d;
 import org.wpilib.math.kinematics.DifferentialDriveWheelPositions;
 import org.wpilib.math.linalg.Matrix;
@@ -46,20 +45,15 @@ public class DifferentialDrivePoseEstimator3d
    * measurements are 0.1 meters for x, 0.1 meters for y, 0.1 meters for z, and 0.1 radians for
    * angle.
    *
-   * @param kinematics A correctly-configured kinematics object for your drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder in meters.
    * @param rightDistance The distance traveled by the right encoder in meters.
    * @param initialPose The starting pose estimate.
    */
   public DifferentialDrivePoseEstimator3d(
-      DifferentialDriveKinematics kinematics,
-      Rotation3d gyroAngle,
-      double leftDistance,
-      double rightDistance,
-      Pose3d initialPose) {
+      Rotation3d gyroAngle, double leftDistance, double rightDistance, Pose3d initialPose) {
     this(
-        kinematics,
         gyroAngle,
         leftDistance,
         rightDistance,
@@ -71,8 +65,8 @@ public class DifferentialDrivePoseEstimator3d
   /**
    * Constructs a DifferentialDrivePoseEstimator3d.
    *
-   * @param kinematics A correctly-configured kinematics object for your drivetrain.
-   * @param gyroAngle The gyro angle of the robot.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder in meters.
    * @param rightDistance The distance traveled by the right encoder in meters.
    * @param initialPose The estimated initial pose.
@@ -84,7 +78,6 @@ public class DifferentialDrivePoseEstimator3d
    *     the vision pose measurement less.
    */
   public DifferentialDrivePoseEstimator3d(
-      DifferentialDriveKinematics kinematics,
       Rotation3d gyroAngle,
       double leftDistance,
       double rightDistance,
@@ -92,7 +85,6 @@ public class DifferentialDrivePoseEstimator3d
       Matrix<N4, N1> stateStdDevs,
       Matrix<N4, N1> visionMeasurementStdDevs) {
     super(
-        kinematics,
         new DifferentialDriveOdometry3d(gyroAngle, leftDistance, rightDistance, initialPose),
         stateStdDevs,
         visionMeasurementStdDevs);
@@ -104,7 +96,8 @@ public class DifferentialDrivePoseEstimator3d
    * <p>The gyroscope angle does not need to be reset here on the user's robot code. The library
    * automatically takes care of offsetting the gyro angle.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftPosition The distance traveled by the left encoder in meters.
    * @param rightPosition The distance traveled by the right encoder in meters.
    * @param pose The position on the field that your robot is at.
@@ -119,7 +112,8 @@ public class DifferentialDrivePoseEstimator3d
    * Updates the pose estimator with wheel encoder and gyro information. This should be called every
    * loop.
    *
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param distanceLeft The total distance travelled by the left wheel in meters.
    * @param distanceRight The total distance travelled by the right wheel in meters.
    * @return The estimated pose of the robot in meters.
@@ -133,7 +127,8 @@ public class DifferentialDrivePoseEstimator3d
    * loop.
    *
    * @param currentTime Time at which this method was called, in seconds.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param distanceLeft The total distance travelled by the left wheel in meters.
    * @param distanceRight The total distance travelled by the right wheel in meters.
    * @return The estimated pose of the robot in meters.

--- a/wpimath/src/main/java/org/wpilib/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/org/wpilib/math/estimator/MecanumDrivePoseEstimator.java
@@ -35,7 +35,8 @@ public class MecanumDrivePoseEstimator extends PoseEstimator<MecanumDriveWheelPo
    * 0.45 meters for x, 0.45 meters for y, and 0.45 radians for heading.
    *
    * @param kinematics A correctly-configured kinematics object for your drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The distances driven by each wheel.
    * @param initialPose The starting pose estimate.
    */
@@ -75,7 +76,6 @@ public class MecanumDrivePoseEstimator extends PoseEstimator<MecanumDriveWheelPo
       Matrix<N3, N1> stateStdDevs,
       Matrix<N3, N1> visionMeasurementStdDevs) {
     super(
-        kinematics,
         new MecanumDriveOdometry(kinematics, gyroAngle, wheelPositions, initialPose),
         stateStdDevs,
         visionMeasurementStdDevs);

--- a/wpimath/src/main/java/org/wpilib/math/estimator/MecanumDrivePoseEstimator3d.java
+++ b/wpimath/src/main/java/org/wpilib/math/estimator/MecanumDrivePoseEstimator3d.java
@@ -44,7 +44,8 @@ public class MecanumDrivePoseEstimator3d extends PoseEstimator3d<MecanumDriveWhe
    * angle.
    *
    * @param kinematics A correctly-configured kinematics object for your drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The distances driven by each wheel.
    * @param initialPose The starting pose estimate.
    */
@@ -84,7 +85,6 @@ public class MecanumDrivePoseEstimator3d extends PoseEstimator3d<MecanumDriveWhe
       Matrix<N4, N1> stateStdDevs,
       Matrix<N4, N1> visionMeasurementStdDevs) {
     super(
-        kinematics,
         new MecanumDriveOdometry3d(kinematics, gyroAngle, wheelPositions, initialPose),
         stateStdDevs,
         visionMeasurementStdDevs);

--- a/wpimath/src/main/java/org/wpilib/math/estimator/PoseEstimator.java
+++ b/wpimath/src/main/java/org/wpilib/math/estimator/PoseEstimator.java
@@ -12,7 +12,6 @@ import org.wpilib.math.geometry.Rotation2d;
 import org.wpilib.math.geometry.Transform2d;
 import org.wpilib.math.geometry.Translation2d;
 import org.wpilib.math.interpolation.TimeInterpolatableBuffer;
-import org.wpilib.math.kinematics.Kinematics;
 import org.wpilib.math.kinematics.Odometry;
 import org.wpilib.math.linalg.Matrix;
 import org.wpilib.math.numbers.N1;
@@ -59,7 +58,6 @@ public class PoseEstimator<T> {
   /**
    * Constructs a PoseEstimator.
    *
-   * @param kinematics A correctly-configured kinematics object for your drivetrain.
    * @param odometry A correctly-configured odometry object for your drivetrain.
    * @param stateStdDevs Standard deviations of the pose estimate (x position in meters, y position
    *     in meters, and heading in radians). Increase these numbers to trust your state estimate
@@ -69,10 +67,7 @@ public class PoseEstimator<T> {
    *     the vision pose measurement less.
    */
   public PoseEstimator(
-      Kinematics<T, ?, ?> kinematics,
-      Odometry<T> odometry,
-      Matrix<N3, N1> stateStdDevs,
-      Matrix<N3, N1> visionMeasurementStdDevs) {
+      Odometry<T> odometry, Matrix<N3, N1> stateStdDevs, Matrix<N3, N1> visionMeasurementStdDevs) {
     m_odometry = odometry;
 
     m_poseEstimate = m_odometry.getPose();
@@ -114,10 +109,10 @@ public class PoseEstimator<T> {
   /**
    * Resets the robot's position on the field.
    *
-   * <p>The gyroscope angle does not need to be reset here on the user's robot code. The library
-   * automatically takes care of offsetting the gyro angle.
+   * <p>The gyroscope angle does not need to be reset here in the user's robot code.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The current encoder readings.
    * @param pose The position on the field that your robot is at.
    */
@@ -360,7 +355,8 @@ public class PoseEstimator<T> {
    * Updates the pose estimator with wheel encoder and gyro information. This should be called every
    * loop.
    *
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The current encoder readings.
    * @return The estimated pose of the robot in meters.
    */
@@ -373,7 +369,8 @@ public class PoseEstimator<T> {
    * loop.
    *
    * @param currentTime Time at which this method was called, in seconds.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The current encoder readings.
    * @return The estimated pose of the robot in meters.
    */

--- a/wpimath/src/main/java/org/wpilib/math/estimator/PoseEstimator3d.java
+++ b/wpimath/src/main/java/org/wpilib/math/estimator/PoseEstimator3d.java
@@ -15,7 +15,6 @@ import org.wpilib.math.geometry.Transform3d;
 import org.wpilib.math.geometry.Translation2d;
 import org.wpilib.math.geometry.Translation3d;
 import org.wpilib.math.interpolation.TimeInterpolatableBuffer;
-import org.wpilib.math.kinematics.Kinematics;
 import org.wpilib.math.kinematics.Odometry3d;
 import org.wpilib.math.linalg.Matrix;
 import org.wpilib.math.numbers.N1;
@@ -66,7 +65,6 @@ public class PoseEstimator3d<T> {
   /**
    * Constructs a PoseEstimator3d.
    *
-   * @param kinematics A correctly-configured kinematics object for your drivetrain.
    * @param odometry A correctly-configured odometry object for your drivetrain.
    * @param stateStdDevs Standard deviations of the pose estimate (x position in meters, y position
    *     in meters, z position in meters, and angle in radians). Increase these numbers to trust
@@ -76,7 +74,6 @@ public class PoseEstimator3d<T> {
    *     these numbers to trust the vision pose measurement less.
    */
   public PoseEstimator3d(
-      Kinematics<T, ?, ?> kinematics,
       Odometry3d<T> odometry,
       Matrix<N4, N1> stateStdDevs,
       Matrix<N4, N1> visionMeasurementStdDevs) {
@@ -125,10 +122,10 @@ public class PoseEstimator3d<T> {
   /**
    * Resets the robot's position on the field.
    *
-   * <p>The gyroscope angle does not need to be reset here on the user's robot code. The library
-   * automatically takes care of offsetting the gyro angle.
+   * <p>The gyroscope angle does not need to be reset here in the user's robot code.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The current encoder readings.
    * @param pose The position on the field that your robot is at.
    */
@@ -375,7 +372,8 @@ public class PoseEstimator3d<T> {
    * Updates the pose estimator with wheel encoder and gyro information. This should be called every
    * loop.
    *
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The current encoder readings.
    * @return The estimated pose of the robot in meters.
    */
@@ -388,7 +386,8 @@ public class PoseEstimator3d<T> {
    * loop.
    *
    * @param currentTime Time at which this method was called, in seconds.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The current encoder readings.
    * @return The estimated pose of the robot in meters.
    */

--- a/wpimath/src/main/java/org/wpilib/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/org/wpilib/math/estimator/SwerveDrivePoseEstimator.java
@@ -36,7 +36,8 @@ public class SwerveDrivePoseEstimator extends PoseEstimator<SwerveModulePosition
    * meters for x, 0.9 meters for y, and 0.9 radians for heading.
    *
    * @param kinematics A correctly-configured kinematics object for your drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param modulePositions The current distance measurements and rotations of the swerve modules.
    * @param initialPose The starting pose estimate.
    */
@@ -58,7 +59,8 @@ public class SwerveDrivePoseEstimator extends PoseEstimator<SwerveModulePosition
    * Constructs a SwerveDrivePoseEstimator.
    *
    * @param kinematics A correctly-configured kinematics object for your drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param modulePositions The current distance and rotation measurements of the swerve modules.
    * @param initialPose The starting pose estimate.
    * @param stateStdDevs Standard deviations of the pose estimate (x position in meters, y position
@@ -76,7 +78,6 @@ public class SwerveDrivePoseEstimator extends PoseEstimator<SwerveModulePosition
       Matrix<N3, N1> stateStdDevs,
       Matrix<N3, N1> visionMeasurementStdDevs) {
     super(
-        kinematics,
         new SwerveDriveOdometry(kinematics, gyroAngle, modulePositions, initialPose),
         stateStdDevs,
         visionMeasurementStdDevs);

--- a/wpimath/src/main/java/org/wpilib/math/estimator/SwerveDrivePoseEstimator3d.java
+++ b/wpimath/src/main/java/org/wpilib/math/estimator/SwerveDrivePoseEstimator3d.java
@@ -45,7 +45,8 @@ public class SwerveDrivePoseEstimator3d extends PoseEstimator3d<SwerveModulePosi
    * angle.
    *
    * @param kinematics A correctly-configured kinematics object for your drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param modulePositions The current distance measurements and rotations of the swerve modules.
    * @param initialPose The starting pose estimate.
    */
@@ -67,7 +68,8 @@ public class SwerveDrivePoseEstimator3d extends PoseEstimator3d<SwerveModulePosi
    * Constructs a SwerveDrivePoseEstimator3d.
    *
    * @param kinematics A correctly-configured kinematics object for your drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param modulePositions The current distance and rotation measurements of the swerve modules.
    * @param initialPose The starting pose estimate.
    * @param stateStdDevs Standard deviations of the pose estimate (x position in meters, y position
@@ -85,7 +87,6 @@ public class SwerveDrivePoseEstimator3d extends PoseEstimator3d<SwerveModulePosi
       Matrix<N4, N1> stateStdDevs,
       Matrix<N4, N1> visionMeasurementStdDevs) {
     super(
-        kinematics,
         new SwerveDriveOdometry3d(kinematics, gyroAngle, modulePositions, initialPose),
         stateStdDevs,
         visionMeasurementStdDevs);

--- a/wpimath/src/main/java/org/wpilib/math/kinematics/DifferentialDriveOdometry.java
+++ b/wpimath/src/main/java/org/wpilib/math/kinematics/DifferentialDriveOdometry.java
@@ -25,7 +25,8 @@ public class DifferentialDriveOdometry extends Odometry<DifferentialDriveWheelPo
   /**
    * Constructs a DifferentialDriveOdometry object.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder in meters.
    * @param rightDistance The distance traveled by the right encoder in meters.
    * @param initialPose The starting position of the robot on the field.
@@ -43,7 +44,8 @@ public class DifferentialDriveOdometry extends Odometry<DifferentialDriveWheelPo
   /**
    * Constructs a DifferentialDriveOdometry object.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    * @param initialPose The starting position of the robot on the field.
@@ -56,7 +58,8 @@ public class DifferentialDriveOdometry extends Odometry<DifferentialDriveWheelPo
   /**
    * Constructs a DifferentialDriveOdometry object.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder in meters.
    * @param rightDistance The distance traveled by the right encoder in meters.
    */
@@ -68,7 +71,8 @@ public class DifferentialDriveOdometry extends Odometry<DifferentialDriveWheelPo
   /**
    * Constructs a DifferentialDriveOdometry object.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    */
@@ -80,10 +84,10 @@ public class DifferentialDriveOdometry extends Odometry<DifferentialDriveWheelPo
   /**
    * Resets the robot's position on the field.
    *
-   * <p>The gyroscope angle does not need to be reset here on the user's robot code. The library
-   * automatically takes care of offsetting the gyro angle.
+   * <p>The gyroscope angle does not need to be reset here in the user's robot code.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder in meters.
    * @param rightDistance The distance traveled by the right encoder in meters.
    * @param pose The position on the field that your robot is at.
@@ -97,10 +101,10 @@ public class DifferentialDriveOdometry extends Odometry<DifferentialDriveWheelPo
   /**
    * Resets the robot's position on the field.
    *
-   * <p>The gyroscope angle does not need to be reset here on the user's robot code. The library
-   * automatically takes care of offsetting the gyro angle.
+   * <p>The gyroscope angle does not need to be reset here in the user's robot code.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    * @param pose The position on the field that your robot is at.
@@ -111,11 +115,10 @@ public class DifferentialDriveOdometry extends Odometry<DifferentialDriveWheelPo
   }
 
   /**
-   * Updates the robot position on the field using distance measurements from encoders. This method
-   * is more numerically accurate than using velocities to integrate the pose and is also
-   * advantageous for teams that are using lower CPR encoders.
+   * Updates the robot position on the field using distance measurements from encoders.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder in meters.
    * @param rightDistance The distance traveled by the right encoder in meters.
    * @return The new pose of the robot.

--- a/wpimath/src/main/java/org/wpilib/math/kinematics/DifferentialDriveOdometry3d.java
+++ b/wpimath/src/main/java/org/wpilib/math/kinematics/DifferentialDriveOdometry3d.java
@@ -34,7 +34,8 @@ public class DifferentialDriveOdometry3d extends Odometry3d<DifferentialDriveWhe
   /**
    * Constructs a DifferentialDriveOdometry3d object.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder in meters.
    * @param rightDistance The distance traveled by the right encoder in meters.
    * @param initialPose The starting position of the robot on the field.
@@ -52,7 +53,8 @@ public class DifferentialDriveOdometry3d extends Odometry3d<DifferentialDriveWhe
   /**
    * Constructs a DifferentialDriveOdometry3d object.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    * @param initialPose The starting position of the robot on the field.
@@ -89,8 +91,7 @@ public class DifferentialDriveOdometry3d extends Odometry3d<DifferentialDriveWhe
   /**
    * Resets the robot's position on the field.
    *
-   * <p>The gyroscope angle does not need to be reset here on the user's robot code. The library
-   * automatically takes care of offsetting the gyro angle.
+   * <p>The gyroscope angle does not need to be reset here in the user's robot code.
    *
    * @param gyroAngle The angle reported by the gyroscope.
    * @param leftDistance The distance traveled by the left encoder in meters.
@@ -106,8 +107,7 @@ public class DifferentialDriveOdometry3d extends Odometry3d<DifferentialDriveWhe
   /**
    * Resets the robot's position on the field.
    *
-   * <p>The gyroscope angle does not need to be reset here on the user's robot code. The library
-   * automatically takes care of offsetting the gyro angle.
+   * <p>The gyroscope angle does not need to be reset here in the user's robot code.
    *
    * @param gyroAngle The angle reported by the gyroscope.
    * @param leftDistance The distance traveled by the left encoder.
@@ -120,9 +120,7 @@ public class DifferentialDriveOdometry3d extends Odometry3d<DifferentialDriveWhe
   }
 
   /**
-   * Updates the robot position on the field using distance measurements from encoders. This method
-   * is more numerically accurate than using velocities to integrate the pose and is also
-   * advantageous for teams that are using lower CPR encoders.
+   * Updates the robot position on the field using distance measurements from encoders.
    *
    * @param gyroAngle The angle reported by the gyroscope.
    * @param leftDistance The distance traveled by the left encoder in meters.

--- a/wpimath/src/main/java/org/wpilib/math/kinematics/MecanumDriveOdometry.java
+++ b/wpimath/src/main/java/org/wpilib/math/kinematics/MecanumDriveOdometry.java
@@ -20,7 +20,8 @@ public class MecanumDriveOdometry extends Odometry<MecanumDriveWheelPositions> {
    * Constructs a MecanumDriveOdometry object.
    *
    * @param kinematics The mecanum drive kinematics for your drivetrain.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The distances driven by each wheel.
    * @param initialPose The starting position of the robot on the field.
    */
@@ -37,7 +38,8 @@ public class MecanumDriveOdometry extends Odometry<MecanumDriveWheelPositions> {
    * Constructs a MecanumDriveOdometry object with the default pose at the origin.
    *
    * @param kinematics The mecanum drive kinematics for your drivetrain.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The distances driven by each wheel.
    */
   public MecanumDriveOdometry(

--- a/wpimath/src/main/java/org/wpilib/math/kinematics/MecanumDriveOdometry3d.java
+++ b/wpimath/src/main/java/org/wpilib/math/kinematics/MecanumDriveOdometry3d.java
@@ -29,7 +29,8 @@ public class MecanumDriveOdometry3d extends Odometry3d<MecanumDriveWheelPosition
    * Constructs a MecanumDriveOdometry3d object.
    *
    * @param kinematics The mecanum drive kinematics for your drivetrain.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The distances driven by each wheel.
    * @param initialPose The starting position of the robot on the field.
    */
@@ -46,7 +47,8 @@ public class MecanumDriveOdometry3d extends Odometry3d<MecanumDriveWheelPosition
    * Constructs a MecanumDriveOdometry3d object with the default pose at the origin.
    *
    * @param kinematics The mecanum drive kinematics for your drivetrain.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The distances driven by each wheel.
    */
   public MecanumDriveOdometry3d(

--- a/wpimath/src/main/java/org/wpilib/math/kinematics/Odometry.java
+++ b/wpimath/src/main/java/org/wpilib/math/kinematics/Odometry.java
@@ -23,10 +23,7 @@ public class Odometry<T> {
   private final Kinematics<T, ?, ?> m_kinematics;
   private Pose2d m_pose;
 
-  private Rotation2d m_gyroOffset;
-
-  // Always equal to m_poseMeters.getRotation()
-  private Rotation2d m_previousAngle;
+  private Rotation2d m_previousGyroAngle;
 
   private final T m_previousWheelPositions;
 
@@ -34,7 +31,8 @@ public class Odometry<T> {
    * Constructs an Odometry object.
    *
    * @param kinematics The kinematics of the drivebase.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The current encoder readings.
    * @param initialPose The starting position of the robot on the field.
    */
@@ -42,25 +40,23 @@ public class Odometry<T> {
       Kinematics<T, ?, ?> kinematics, Rotation2d gyroAngle, T wheelPositions, Pose2d initialPose) {
     m_kinematics = kinematics;
     m_pose = initialPose;
-    m_gyroOffset = gyroAngle.unaryMinus().rotateBy(m_pose.getRotation());
-    m_previousAngle = m_pose.getRotation();
+    m_previousGyroAngle = gyroAngle;
     m_previousWheelPositions = m_kinematics.copy(wheelPositions);
   }
 
   /**
    * Resets the robot's position on the field.
    *
-   * <p>The gyroscope angle does not need to be reset here on the user's robot code. The library
-   * automatically takes care of offsetting the gyro angle.
+   * <p>The gyroscope angle does not need to be reset here in the user's robot code.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The current encoder readings.
    * @param pose The position on the field that your robot is at.
    */
   public void resetPosition(Rotation2d gyroAngle, T wheelPositions, Pose2d pose) {
     m_pose = pose;
-    m_gyroOffset = gyroAngle.unaryMinus().rotateBy(m_pose.getRotation());
-    m_previousAngle = m_pose.getRotation();
+    m_previousGyroAngle = gyroAngle;
     m_kinematics.copyInto(wheelPositions, m_previousWheelPositions);
   }
 
@@ -70,10 +66,7 @@ public class Odometry<T> {
    * @param pose The pose to reset to.
    */
   public void resetPose(Pose2d pose) {
-    m_gyroOffset =
-        m_gyroOffset.rotateBy(m_pose.getRotation().unaryMinus()).rotateBy(pose.getRotation());
     m_pose = pose;
-    m_previousAngle = m_pose.getRotation();
   }
 
   /**
@@ -91,9 +84,7 @@ public class Odometry<T> {
    * @param rotation The rotation to reset to.
    */
   public void resetRotation(Rotation2d rotation) {
-    m_gyroOffset = m_gyroOffset.rotateBy(m_pose.getRotation().unaryMinus()).rotateBy(rotation);
     m_pose = new Pose2d(m_pose.getTranslation(), rotation);
-    m_previousAngle = m_pose.getRotation();
   }
 
   /**
@@ -111,21 +102,19 @@ public class Odometry<T> {
    * that is calculated from forward kinematics, in addition to the current distance measurement at
    * each wheel.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The current encoder readings.
    * @return The new pose of the robot.
    */
   public Pose2d update(Rotation2d gyroAngle, T wheelPositions) {
-    var angle = gyroAngle.rotateBy(m_gyroOffset);
-
     var twist = m_kinematics.toTwist2d(m_previousWheelPositions, wheelPositions);
-    twist.dtheta = angle.minus(m_previousAngle).getRadians();
+    twist.dtheta = gyroAngle.minus(m_previousGyroAngle).getRadians();
 
-    var newPose = m_pose.plus(twist.exp());
+    m_pose = m_pose.plus(twist.exp());
 
     m_kinematics.copyInto(wheelPositions, m_previousWheelPositions);
-    m_previousAngle = angle;
-    m_pose = new Pose2d(newPose.getTranslation(), angle);
+    m_previousGyroAngle = gyroAngle;
 
     return m_pose;
   }

--- a/wpimath/src/main/java/org/wpilib/math/kinematics/Odometry3d.java
+++ b/wpimath/src/main/java/org/wpilib/math/kinematics/Odometry3d.java
@@ -32,14 +32,7 @@ public class Odometry3d<T> {
   private final Kinematics<T, ?, ?> m_kinematics;
   private Pose3d m_pose;
 
-  // Applying a rotation intrinsically to the measured gyro angle should cause the corrected angle
-  // to be rotated intrinsically in the same way, so the measured gyro angle must be applied
-  // intrinsically. This is equivalent to applying the offset extrinsically to the measured gyro
-  // angle.
-  private Rotation3d m_gyroOffset;
-
-  // Always equal to m_poseMeters.getRotation()
-  private Rotation3d m_previousAngle;
+  private Rotation3d m_previousGyroAngle;
 
   private final T m_previousWheelPositions;
 
@@ -47,7 +40,8 @@ public class Odometry3d<T> {
    * Constructs an Odometry3d object.
    *
    * @param kinematics The kinematics of the drivebase.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The current encoder readings.
    * @param initialPose The starting position of the robot on the field.
    */
@@ -55,29 +49,23 @@ public class Odometry3d<T> {
       Kinematics<T, ?, ?> kinematics, Rotation3d gyroAngle, T wheelPositions, Pose3d initialPose) {
     m_kinematics = kinematics;
     m_pose = initialPose;
-    // When applied extrinsically, m_gyroOffset cancels the current gyroAngle and
-    // then rotates to m_poseMeters.getRotation()
-    m_gyroOffset = gyroAngle.inverse().rotateBy(m_pose.getRotation());
-    m_previousAngle = m_pose.getRotation();
+    m_previousGyroAngle = gyroAngle;
     m_previousWheelPositions = m_kinematics.copy(wheelPositions);
   }
 
   /**
    * Resets the robot's position on the field.
    *
-   * <p>The gyroscope angle does not need to be reset here on the user's robot code. The library
-   * automatically takes care of offsetting the gyro angle.
+   * <p>The gyroscope angle does not need to be reset here in the user's robot code.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The current encoder readings.
    * @param pose The position on the field that your robot is at.
    */
   public void resetPosition(Rotation3d gyroAngle, T wheelPositions, Pose3d pose) {
     m_pose = pose;
-    // When applied extrinsically, m_gyroOffset cancels the current gyroAngle and
-    // then rotates to m_poseMeters.getRotation()
-    m_gyroOffset = gyroAngle.inverse().rotateBy(m_pose.getRotation());
-    m_previousAngle = m_pose.getRotation();
+    m_previousGyroAngle = gyroAngle;
     m_kinematics.copyInto(wheelPositions, m_previousWheelPositions);
   }
 
@@ -87,11 +75,7 @@ public class Odometry3d<T> {
    * @param pose The pose to reset to.
    */
   public void resetPose(Pose3d pose) {
-    // Cancel the previous m_pose.Rotation() and then rotate to the new angle
-    m_gyroOffset =
-        m_gyroOffset.rotateBy(m_pose.getRotation().inverse()).rotateBy(pose.getRotation());
     m_pose = pose;
-    m_previousAngle = m_pose.getRotation();
   }
 
   /**
@@ -109,10 +93,7 @@ public class Odometry3d<T> {
    * @param rotation The rotation to reset to.
    */
   public void resetRotation(Rotation3d rotation) {
-    // Cancel the previous m_pose.Rotation() and then rotate to the new angle
-    m_gyroOffset = m_gyroOffset.rotateBy(m_pose.getRotation().inverse()).rotateBy(rotation);
     m_pose = new Pose3d(m_pose.getTranslation(), rotation);
-    m_previousAngle = m_pose.getRotation();
   }
 
   /**
@@ -130,13 +111,13 @@ public class Odometry3d<T> {
    * that is calculated from forward kinematics, in addition to the current distance measurement at
    * each wheel.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param wheelPositions The current encoder readings.
    * @return The new pose of the robot.
    */
   public Pose3d update(Rotation3d gyroAngle, T wheelPositions) {
-    var angle = gyroAngle.rotateBy(m_gyroOffset);
-    var angle_difference = angle.relativeTo(m_previousAngle).toVector();
+    var angle_difference = gyroAngle.relativeTo(m_previousGyroAngle).toVector();
 
     var twist2d = m_kinematics.toTwist2d(m_previousWheelPositions, wheelPositions);
     var twist =
@@ -148,11 +129,10 @@ public class Odometry3d<T> {
             angle_difference.get(1),
             angle_difference.get(2));
 
-    var newPose = m_pose.plus(twist.exp());
+    m_pose = m_pose.plus(twist.exp());
 
     m_kinematics.copyInto(wheelPositions, m_previousWheelPositions);
-    m_previousAngle = angle;
-    m_pose = new Pose3d(newPose.getTranslation(), angle);
+    m_previousGyroAngle = gyroAngle;
 
     return m_pose;
   }

--- a/wpimath/src/main/java/org/wpilib/math/kinematics/SwerveDriveOdometry.java
+++ b/wpimath/src/main/java/org/wpilib/math/kinematics/SwerveDriveOdometry.java
@@ -23,7 +23,8 @@ public class SwerveDriveOdometry extends Odometry<SwerveModulePosition[]> {
    * Constructs a SwerveDriveOdometry object.
    *
    * @param kinematics The swerve drive kinematics for your drivetrain.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param modulePositions The wheel positions reported by each module.
    * @param initialPose The starting position of the robot on the field.
    */
@@ -43,7 +44,8 @@ public class SwerveDriveOdometry extends Odometry<SwerveModulePosition[]> {
    * Constructs a SwerveDriveOdometry object with the default pose at the origin.
    *
    * @param kinematics The swerve drive kinematics for your drivetrain.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param modulePositions The wheel positions reported by each module.
    */
   public SwerveDriveOdometry(

--- a/wpimath/src/main/java/org/wpilib/math/kinematics/SwerveDriveOdometry3d.java
+++ b/wpimath/src/main/java/org/wpilib/math/kinematics/SwerveDriveOdometry3d.java
@@ -32,7 +32,8 @@ public class SwerveDriveOdometry3d extends Odometry3d<SwerveModulePosition[]> {
    * Constructs a SwerveDriveOdometry3d object.
    *
    * @param kinematics The swerve drive kinematics for your drivetrain.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param modulePositions The wheel positions reported by each module.
    * @param initialPose The starting position of the robot on the field.
    */
@@ -52,7 +53,8 @@ public class SwerveDriveOdometry3d extends Odometry3d<SwerveModulePosition[]> {
    * Constructs a SwerveDriveOdometry3d object with the default pose at the origin.
    *
    * @param kinematics The swerve drive kinematics for your drivetrain.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to be offset to match
+   *     the robot's orientation on the field.
    * @param modulePositions The wheel positions reported by each module.
    */
   public SwerveDriveOdometry3d(

--- a/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
@@ -14,20 +14,18 @@
 using namespace wpi::math;
 
 DifferentialDrivePoseEstimator::DifferentialDrivePoseEstimator(
-    DifferentialDriveKinematics& kinematics, const Rotation2d& gyroAngle,
-    wpi::units::meter_t leftDistance, wpi::units::meter_t rightDistance,
-    const Pose2d& initialPose)
-    : DifferentialDrivePoseEstimator{
-          kinematics,  gyroAngle,          leftDistance,   rightDistance,
-          initialPose, {0.02, 0.02, 0.01}, {0.1, 0.1, 0.1}} {}
+    const Rotation2d& gyroAngle, wpi::units::meter_t leftDistance,
+    wpi::units::meter_t rightDistance, const Pose2d& initialPose)
+    : DifferentialDrivePoseEstimator{gyroAngle,          leftDistance,
+                                     rightDistance,      initialPose,
+                                     {0.02, 0.02, 0.01}, {0.1, 0.1, 0.1}} {}
 
 DifferentialDrivePoseEstimator::DifferentialDrivePoseEstimator(
-    DifferentialDriveKinematics& kinematics, const Rotation2d& gyroAngle,
-    wpi::units::meter_t leftDistance, wpi::units::meter_t rightDistance,
-    const Pose2d& initialPose, const wpi::util::array<double, 3>& stateStdDevs,
+    const Rotation2d& gyroAngle, wpi::units::meter_t leftDistance,
+    wpi::units::meter_t rightDistance, const Pose2d& initialPose,
+    const wpi::util::array<double, 3>& stateStdDevs,
     const wpi::util::array<double, 3>& visionMeasurementStdDevs)
-    : PoseEstimator(kinematics, m_odometryImpl, stateStdDevs,
-                    visionMeasurementStdDevs),
+    : PoseEstimator(m_odometryImpl, stateStdDevs, visionMeasurementStdDevs),
       m_odometryImpl{gyroAngle, leftDistance, rightDistance, initialPose} {
   ResetPose(initialPose);
 }

--- a/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator3d.cpp
+++ b/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator3d.cpp
@@ -14,21 +14,21 @@
 using namespace wpi::math;
 
 DifferentialDrivePoseEstimator3d::DifferentialDrivePoseEstimator3d(
-    DifferentialDriveKinematics& kinematics, const Rotation3d& gyroAngle,
-    wpi::units::meter_t leftDistance, wpi::units::meter_t rightDistance,
-    const Pose3d& initialPose)
-    : DifferentialDrivePoseEstimator3d{
-          kinematics,          gyroAngle,   leftDistance,
-          rightDistance,       initialPose, {0.02, 0.02, 0.02, 0.01},
-          {0.1, 0.1, 0.1, 0.1}} {}
+    const Rotation3d& gyroAngle, wpi::units::meter_t leftDistance,
+    wpi::units::meter_t rightDistance, const Pose3d& initialPose)
+    : DifferentialDrivePoseEstimator3d{gyroAngle,
+                                       leftDistance,
+                                       rightDistance,
+                                       initialPose,
+                                       {0.02, 0.02, 0.02, 0.01},
+                                       {0.1, 0.1, 0.1, 0.1}} {}
 
 DifferentialDrivePoseEstimator3d::DifferentialDrivePoseEstimator3d(
-    DifferentialDriveKinematics& kinematics, const Rotation3d& gyroAngle,
-    wpi::units::meter_t leftDistance, wpi::units::meter_t rightDistance,
-    const Pose3d& initialPose, const wpi::util::array<double, 4>& stateStdDevs,
+    const Rotation3d& gyroAngle, wpi::units::meter_t leftDistance,
+    wpi::units::meter_t rightDistance, const Pose3d& initialPose,
+    const wpi::util::array<double, 4>& stateStdDevs,
     const wpi::util::array<double, 4>& visionMeasurementStdDevs)
-    : PoseEstimator3d(kinematics, m_odometryImpl, stateStdDevs,
-                      visionMeasurementStdDevs),
+    : PoseEstimator3d(m_odometryImpl, stateStdDevs, visionMeasurementStdDevs),
       m_odometryImpl{gyroAngle, leftDistance, rightDistance, initialPose} {
   ResetPose(initialPose);
 }

--- a/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
@@ -25,8 +25,7 @@ wpi::math::MecanumDrivePoseEstimator::MecanumDrivePoseEstimator(
     const MecanumDriveWheelPositions& wheelPositions, const Pose2d& initialPose,
     const wpi::util::array<double, 3>& stateStdDevs,
     const wpi::util::array<double, 3>& visionMeasurementStdDevs)
-    : PoseEstimator(kinematics, m_odometryImpl, stateStdDevs,
-                    visionMeasurementStdDevs),
+    : PoseEstimator(m_odometryImpl, stateStdDevs, visionMeasurementStdDevs),
       m_odometryImpl(kinematics, gyroAngle, wheelPositions, initialPose) {
   ResetPose(initialPose);
 }

--- a/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator3d.cpp
+++ b/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator3d.cpp
@@ -26,8 +26,7 @@ wpi::math::MecanumDrivePoseEstimator3d::MecanumDrivePoseEstimator3d(
     const MecanumDriveWheelPositions& wheelPositions, const Pose3d& initialPose,
     const wpi::util::array<double, 4>& stateStdDevs,
     const wpi::util::array<double, 4>& visionMeasurementStdDevs)
-    : PoseEstimator3d(kinematics, m_odometryImpl, stateStdDevs,
-                      visionMeasurementStdDevs),
+    : PoseEstimator3d(m_odometryImpl, stateStdDevs, visionMeasurementStdDevs),
       m_odometryImpl(kinematics, gyroAngle, wheelPositions, initialPose) {
   ResetPose(initialPose);
 }

--- a/wpimath/src/main/native/include/wpi/math/estimator/DifferentialDrivePoseEstimator.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/DifferentialDrivePoseEstimator.hpp
@@ -48,15 +48,13 @@ class WPILIB_DLLEXPORT DifferentialDrivePoseEstimator
    * The default standard deviations of the vision measurements are
    * 0.1 meters for x, 0.1 meters for y, and 0.1 radians for heading.
    *
-   * @param kinematics A correctly-configured kinematics object for your
-   *     drivetrain.
-   * @param gyroAngle The gyro angle of the robot.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    * @param initialPose The estimated initial pose.
    */
-  DifferentialDrivePoseEstimator(DifferentialDriveKinematics& kinematics,
-                                 const Rotation2d& gyroAngle,
+  DifferentialDrivePoseEstimator(const Rotation2d& gyroAngle,
                                  wpi::units::meter_t leftDistance,
                                  wpi::units::meter_t rightDistance,
                                  const Pose2d& initialPose);
@@ -64,9 +62,8 @@ class WPILIB_DLLEXPORT DifferentialDrivePoseEstimator
   /**
    * Constructs a DifferentialDrivePoseEstimator.
    *
-   * @param kinematics A correctly-configured kinematics object for your
-   *     drivetrain.
-   * @param gyroAngle The gyro angle of the robot.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    * @param initialPose The estimated initial pose.
@@ -79,9 +76,8 @@ class WPILIB_DLLEXPORT DifferentialDrivePoseEstimator
    *     less.
    */
   DifferentialDrivePoseEstimator(
-      DifferentialDriveKinematics& kinematics, const Rotation2d& gyroAngle,
-      wpi::units::meter_t leftDistance, wpi::units::meter_t rightDistance,
-      const Pose2d& initialPose,
+      const Rotation2d& gyroAngle, wpi::units::meter_t leftDistance,
+      wpi::units::meter_t rightDistance, const Pose2d& initialPose,
       const wpi::util::array<double, 3>& stateStdDevs,
       const wpi::util::array<double, 3>& visionMeasurementStdDevs);
 

--- a/wpimath/src/main/native/include/wpi/math/estimator/DifferentialDrivePoseEstimator3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/DifferentialDrivePoseEstimator3d.hpp
@@ -53,15 +53,13 @@ class WPILIB_DLLEXPORT DifferentialDrivePoseEstimator3d
    * 0.1 meters for x, 0.1 meters for y, 0.1 meters for z, and 0.1 radians for
    * angle.
    *
-   * @param kinematics A correctly-configured kinematics object for your
-   *     drivetrain.
-   * @param gyroAngle The gyro angle of the robot.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    * @param initialPose The estimated initial pose.
    */
-  DifferentialDrivePoseEstimator3d(DifferentialDriveKinematics& kinematics,
-                                   const Rotation3d& gyroAngle,
+  DifferentialDrivePoseEstimator3d(const Rotation3d& gyroAngle,
                                    wpi::units::meter_t leftDistance,
                                    wpi::units::meter_t rightDistance,
                                    const Pose3d& initialPose);
@@ -69,9 +67,8 @@ class WPILIB_DLLEXPORT DifferentialDrivePoseEstimator3d
   /**
    * Constructs a DifferentialDrivePoseEstimator3d.
    *
-   * @param kinematics A correctly-configured kinematics object for your
-   *     drivetrain.
-   * @param gyroAngle The gyro angle of the robot.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    * @param initialPose The estimated initial pose.
@@ -84,16 +81,16 @@ class WPILIB_DLLEXPORT DifferentialDrivePoseEstimator3d
    * pose measurement less.
    */
   DifferentialDrivePoseEstimator3d(
-      DifferentialDriveKinematics& kinematics, const Rotation3d& gyroAngle,
-      wpi::units::meter_t leftDistance, wpi::units::meter_t rightDistance,
-      const Pose3d& initialPose,
+      const Rotation3d& gyroAngle, wpi::units::meter_t leftDistance,
+      wpi::units::meter_t rightDistance, const Pose3d& initialPose,
       const wpi::util::array<double, 4>& stateStdDevs,
       const wpi::util::array<double, 4>& visionMeasurementStdDevs);
 
   /**
    * Resets the robot's position on the field.
    *
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    * @param pose The estimated pose of the robot on the field.
@@ -109,7 +106,8 @@ class WPILIB_DLLEXPORT DifferentialDrivePoseEstimator3d
    * Updates the pose estimator with wheel encoder and gyro information. This
    * should be called every loop.
    *
-   * @param gyroAngle     The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param leftDistance  The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    *
@@ -125,7 +123,8 @@ class WPILIB_DLLEXPORT DifferentialDrivePoseEstimator3d
    * should be called every loop.
    *
    * @param currentTime   The time at which this method was called.
-   * @param gyroAngle     The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param leftDistance  The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    *

--- a/wpimath/src/main/native/include/wpi/math/estimator/MecanumDrivePoseEstimator.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/MecanumDrivePoseEstimator.hpp
@@ -46,7 +46,8 @@ class WPILIB_DLLEXPORT MecanumDrivePoseEstimator
    *
    * @param kinematics A correctly-configured kinematics object for your
    *     drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The distance measured by each wheel.
    * @param initialPose The starting pose estimate.
    */
@@ -60,7 +61,8 @@ class WPILIB_DLLEXPORT MecanumDrivePoseEstimator
    *
    * @param kinematics A correctly-configured kinematics object for your
    *     drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The distance measured by each wheel.
    * @param initialPose The starting pose estimate.
    * @param stateStdDevs Standard deviations of the pose estimate (x position in

--- a/wpimath/src/main/native/include/wpi/math/estimator/MecanumDrivePoseEstimator3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/MecanumDrivePoseEstimator3d.hpp
@@ -51,7 +51,8 @@ class WPILIB_DLLEXPORT MecanumDrivePoseEstimator3d
    *
    * @param kinematics A correctly-configured kinematics object for your
    *     drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The distance measured by each wheel.
    * @param initialPose The starting pose estimate.
    */
@@ -65,7 +66,8 @@ class WPILIB_DLLEXPORT MecanumDrivePoseEstimator3d
    *
    * @param kinematics A correctly-configured kinematics object for your
    *     drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The distance measured by each wheel.
    * @param initialPose The starting pose estimate.
    * @param stateStdDevs Standard deviations of the pose estimate (x position in

--- a/wpimath/src/main/native/include/wpi/math/estimator/PoseEstimator.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/PoseEstimator.hpp
@@ -57,8 +57,6 @@ class WPILIB_DLLEXPORT PoseEstimator {
    * @warning The initial pose estimate will always be the default pose,
    * regardless of the odometry's current pose.
    *
-   * @param kinematics A correctly-configured kinematics object for your
-   *     drivetrain.
    * @param odometry A correctly-configured odometry object for your drivetrain.
    * @param stateStdDevs Standard deviations of the pose estimate (x position in
    *     meters, y position in meters, and heading in radians). Increase these
@@ -68,8 +66,7 @@ class WPILIB_DLLEXPORT PoseEstimator {
    *     radians). Increase these numbers to trust the vision pose measurement
    *     less.
    */
-  PoseEstimator(const Kinematics& kinematics,
-                Odometry<Kinematics, WheelPositions, WheelVelocities,
+  PoseEstimator(Odometry<Kinematics, WheelPositions, WheelVelocities,
                          WheelAccelerations>& odometry,
                 const wpi::util::array<double, 3>& stateStdDevs,
                 const wpi::util::array<double, 3>& visionMeasurementStdDevs)
@@ -115,10 +112,11 @@ class WPILIB_DLLEXPORT PoseEstimator {
   /**
    * Resets the robot's position on the field.
    *
-   * The gyroscope angle does not need to be reset in the user's robot code.
-   * The library automatically takes care of offsetting the gyro angle.
+   * The gyroscope angle does not need to be reset here in the user's robot
+   * code.
    *
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The distances traveled by the encoders.
    * @param pose The estimated pose of the robot on the field.
    */
@@ -387,7 +385,8 @@ class WPILIB_DLLEXPORT PoseEstimator {
    * Updates the pose estimator with wheel encoder and gyro information. This
    * should be called every loop.
    *
-   * @param gyroAngle      The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The distances traveled by the encoders.
    *
    * @return The estimated pose of the robot in meters.
@@ -403,7 +402,8 @@ class WPILIB_DLLEXPORT PoseEstimator {
    * should be called every loop.
    *
    * @param currentTime   The time at which this method was called.
-   * @param gyroAngle     The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The distances traveled by the encoders.
    *
    * @return The estimated pose of the robot in meters.

--- a/wpimath/src/main/native/include/wpi/math/estimator/PoseEstimator3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/PoseEstimator3d.hpp
@@ -62,8 +62,6 @@ class WPILIB_DLLEXPORT PoseEstimator3d {
    * @warning The initial pose estimate will always be the default pose,
    * regardless of the odometry's current pose.
    *
-   * @param kinematics A correctly-configured kinematics object for your
-   *     drivetrain.
    * @param odometry A correctly-configured odometry object for your drivetrain.
    * @param stateStdDevs Standard deviations of the pose estimate (x position in
    *     meters, y position in meters, and heading in radians). Increase these
@@ -73,8 +71,7 @@ class WPILIB_DLLEXPORT PoseEstimator3d {
    * in meters, and angle in radians). Increase these numbers to trust the
    * vision pose measurement less.
    */
-  PoseEstimator3d(const Kinematics& kinematics,
-                  Odometry3d<Kinematics, WheelPositions, WheelVelocities,
+  PoseEstimator3d(Odometry3d<Kinematics, WheelPositions, WheelVelocities,
                              WheelAccelerations>& odometry,
                   const wpi::util::array<double, 4>& stateStdDevs,
                   const wpi::util::array<double, 4>& visionMeasurementStdDevs)
@@ -123,10 +120,11 @@ class WPILIB_DLLEXPORT PoseEstimator3d {
   /**
    * Resets the robot's position on the field.
    *
-   * The gyroscope angle does not need to be reset in the user's robot code.
-   * The library automatically takes care of offsetting the gyro angle.
+   * The gyroscope angle does not need to be reset here in the user's robot
+   * code.
    *
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The distances traveled by the encoders.
    * @param pose The estimated pose of the robot on the field.
    */
@@ -401,7 +399,8 @@ class WPILIB_DLLEXPORT PoseEstimator3d {
    * Updates the pose estimator with wheel encoder and gyro information. This
    * should be called every loop.
    *
-   * @param gyroAngle      The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The distances traveled by the encoders.
    *
    * @return The estimated pose of the robot in meters.
@@ -417,7 +416,8 @@ class WPILIB_DLLEXPORT PoseEstimator3d {
    * should be called every loop.
    *
    * @param currentTime   The time at which this method was called.
-   * @param gyroAngle     The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The distances traveled by the encoders.
    *
    * @return The estimated pose of the robot in meters.

--- a/wpimath/src/main/native/include/wpi/math/estimator/SwerveDrivePoseEstimator.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/SwerveDrivePoseEstimator.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include "wpi/math/estimator/PoseEstimator.hpp"
 #include "wpi/math/geometry/Pose2d.hpp"
 #include "wpi/math/geometry/Rotation2d.hpp"

--- a/wpimath/src/main/native/include/wpi/math/estimator/SwerveDrivePoseEstimator.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/SwerveDrivePoseEstimator.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+
 #include "wpi/math/estimator/PoseEstimator.hpp"
 #include "wpi/math/geometry/Pose2d.hpp"
 #include "wpi/math/geometry/Rotation2d.hpp"

--- a/wpimath/src/main/native/include/wpi/math/estimator/SwerveDrivePoseEstimator.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/SwerveDrivePoseEstimator.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <cstddef>
-
 #include "wpi/math/estimator/PoseEstimator.hpp"
 #include "wpi/math/geometry/Pose2d.hpp"
 #include "wpi/math/geometry/Rotation2d.hpp"
@@ -49,7 +47,8 @@ class SwerveDrivePoseEstimator
    *
    * @param kinematics A correctly-configured kinematics object for your
    *     drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param modulePositions The current distance and rotation measurements of
    *     the swerve modules.
    * @param initialPose The starting pose estimate.
@@ -68,7 +67,8 @@ class SwerveDrivePoseEstimator
    *
    * @param kinematics A correctly-configured kinematics object for your
    *     drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param modulePositions The current distance and rotation measurements of
    *     the swerve modules.
    * @param initialPose The starting pose estimate.
@@ -87,8 +87,8 @@ class SwerveDrivePoseEstimator
       const Pose2d& initialPose,
       const wpi::util::array<double, 3>& stateStdDevs,
       const wpi::util::array<double, 3>& visionMeasurementStdDevs)
-      : SwerveDrivePoseEstimator::PoseEstimator(
-            kinematics, m_odometryImpl, stateStdDevs, visionMeasurementStdDevs),
+      : SwerveDrivePoseEstimator::PoseEstimator(m_odometryImpl, stateStdDevs,
+                                                visionMeasurementStdDevs),
         m_odometryImpl{kinematics, gyroAngle, modulePositions, initialPose} {
     this->ResetPose(initialPose);
   }

--- a/wpimath/src/main/native/include/wpi/math/estimator/SwerveDrivePoseEstimator3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/estimator/SwerveDrivePoseEstimator3d.hpp
@@ -54,7 +54,8 @@ class SwerveDrivePoseEstimator3d
    *
    * @param kinematics A correctly-configured kinematics object for your
    *     drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param modulePositions The current distance and rotation measurements of
    *     the swerve modules.
    * @param initialPose The starting pose estimate.
@@ -74,7 +75,8 @@ class SwerveDrivePoseEstimator3d
    *
    * @param kinematics A correctly-configured kinematics object for your
    *     drivetrain.
-   * @param gyroAngle The current gyro angle.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param modulePositions The current distance and rotation measurements of
    *     the swerve modules.
    * @param initialPose The starting pose estimate.
@@ -94,7 +96,7 @@ class SwerveDrivePoseEstimator3d
       const wpi::util::array<double, 4>& stateStdDevs,
       const wpi::util::array<double, 4>& visionMeasurementStdDevs)
       : SwerveDrivePoseEstimator3d::PoseEstimator3d(
-            kinematics, m_odometryImpl, stateStdDevs, visionMeasurementStdDevs),
+            m_odometryImpl, stateStdDevs, visionMeasurementStdDevs),
         m_odometryImpl{kinematics, gyroAngle, modulePositions, initialPose} {
     this->ResetPose(initialPose);
   }

--- a/wpimath/src/main/native/include/wpi/math/kinematics/DifferentialDriveOdometry.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/DifferentialDriveOdometry.hpp
@@ -23,9 +23,6 @@ namespace wpi::math {
  * Teams can use odometry during the autonomous period for complex tasks like
  * path following. Furthermore, odometry can be used for latency compensation
  * when using computer-vision systems.
- *
- * It is important that you reset your encoders to zero before using this class.
- * Any subsequent pose resets also require the encoders to be reset to zero.
  */
 class WPILIB_DLLEXPORT DifferentialDriveOdometry
     : public Odometry<DifferentialDriveKinematics,
@@ -39,7 +36,8 @@ class WPILIB_DLLEXPORT DifferentialDriveOdometry
    * IF leftDistance and rightDistance are unspecified,
    * You NEED to reset your encoders (to zero).
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    * @param initialPose The starting position of the robot on the field.
@@ -59,7 +57,8 @@ class WPILIB_DLLEXPORT DifferentialDriveOdometry
    * code. The library automatically takes care of offsetting the gyro angle.
    *
    * @param pose The position on the field that your robot is at.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    */
@@ -71,11 +70,10 @@ class WPILIB_DLLEXPORT DifferentialDriveOdometry
 
   /**
    * Updates the robot position on the field using distance measurements from
-   * encoders. This method is more numerically accurate than using velocities to
-   * integrate the pose and is also advantageous for teams that are using lower
-   * CPR encoders.
+   * encoders.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    * @return The new pose of the robot.

--- a/wpimath/src/main/native/include/wpi/math/kinematics/DifferentialDriveOdometry3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/DifferentialDriveOdometry3d.hpp
@@ -23,9 +23,6 @@ namespace wpi::math {
  * Teams can use odometry during the autonomous period for complex tasks like
  * path following. Furthermore, odometry can be used for latency compensation
  * when using computer-vision systems.
- *
- * It is important that you reset your encoders to zero before using this class.
- * Any subsequent pose resets also require the encoders to be reset to zero.
  */
 class WPILIB_DLLEXPORT DifferentialDriveOdometry3d
     : public Odometry3d<DifferentialDriveKinematics,
@@ -39,7 +36,8 @@ class WPILIB_DLLEXPORT DifferentialDriveOdometry3d
    * IF leftDistance and rightDistance are unspecified,
    * You NEED to reset your encoders (to zero).
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    * @param initialPose The starting position of the robot on the field.
@@ -59,7 +57,8 @@ class WPILIB_DLLEXPORT DifferentialDriveOdometry3d
    * code. The library automatically takes care of offsetting the gyro angle.
    *
    * @param pose The position on the field that your robot is at.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    */
@@ -71,11 +70,10 @@ class WPILIB_DLLEXPORT DifferentialDriveOdometry3d
 
   /**
    * Updates the robot position on the field using distance measurements from
-   * encoders. This method is more numerically accurate than using velocities to
-   * integrate the pose and is also advantageous for teams that are using lower
-   * CPR encoders.
+   * encoders.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param leftDistance The distance traveled by the left encoder.
    * @param rightDistance The distance traveled by the right encoder.
    * @return The new pose of the robot.

--- a/wpimath/src/main/native/include/wpi/math/kinematics/MecanumDriveOdometry.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/MecanumDriveOdometry.hpp
@@ -33,7 +33,8 @@ class WPILIB_DLLEXPORT MecanumDriveOdometry
    * Constructs a MecanumDriveOdometry object.
    *
    * @param kinematics The mecanum drive kinematics for your drivetrain.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The current distances measured by each wheel.
    * @param initialPose The starting position of the robot on the field.
    */

--- a/wpimath/src/main/native/include/wpi/math/kinematics/MecanumDriveOdometry3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/MecanumDriveOdometry3d.hpp
@@ -33,7 +33,8 @@ class WPILIB_DLLEXPORT MecanumDriveOdometry3d
    * Constructs a MecanumDriveOdometry3d object.
    *
    * @param kinematics The mecanum drive kinematics for your drivetrain.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The current distances measured by each wheel.
    * @param initialPose The starting position of the robot on the field.
    */

--- a/wpimath/src/main/native/include/wpi/math/kinematics/Odometry.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/Odometry.hpp
@@ -34,7 +34,8 @@ class WPILIB_DLLEXPORT Odometry {
    * Constructs an Odometry object.
    *
    * @param kinematics The kinematics for your drivetrain.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The current distances measured by each wheel.
    * @param initialPose The starting position of the robot on the field.
    */
@@ -43,26 +44,24 @@ class WPILIB_DLLEXPORT Odometry {
                     const Pose2d& initialPose = Pose2d{})
       : m_kinematics(kinematics),
         m_pose(initialPose),
-        m_previousWheelPositions(wheelPositions) {
-    m_previousAngle = m_pose.Rotation();
-    m_gyroOffset = (-gyroAngle).RotateBy(m_pose.Rotation());
-  }
+        m_previousWheelPositions(wheelPositions),
+        m_previousGyroAngle(gyroAngle) {}
 
   /**
    * Resets the robot's position on the field.
    *
-   * The gyroscope angle does not need to be reset here on the user's robot
-   * code. The library automatically takes care of offsetting the gyro angle.
+   * The gyroscope angle does not need to be reset here in the user's robot
+   * code.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The current distances measured by each wheel.
    * @param pose The position on the field that your robot is at.
    */
   void ResetPosition(const Rotation2d& gyroAngle,
                      const WheelPositions& wheelPositions, const Pose2d& pose) {
     m_pose = pose;
-    m_previousAngle = pose.Rotation();
-    m_gyroOffset = (-gyroAngle).RotateBy(m_pose.Rotation());
+    m_previousGyroAngle = gyroAngle;
     m_previousWheelPositions = wheelPositions;
   }
 
@@ -71,12 +70,7 @@ class WPILIB_DLLEXPORT Odometry {
    *
    * @param pose The pose to reset to.
    */
-  void ResetPose(const Pose2d& pose) {
-    m_gyroOffset =
-        m_gyroOffset.RotateBy(-m_pose.Rotation()).RotateBy(pose.Rotation());
-    m_pose = pose;
-    m_previousAngle = pose.Rotation();
-  }
+  void ResetPose(const Pose2d& pose) { m_pose = pose; }
 
   /**
    * Resets the translation of the pose.
@@ -93,9 +87,7 @@ class WPILIB_DLLEXPORT Odometry {
    * @param rotation The rotation to reset to.
    */
   void ResetRotation(const Rotation2d& rotation) {
-    m_gyroOffset = m_gyroOffset.RotateBy(-m_pose.Rotation()).RotateBy(rotation);
     m_pose = Pose2d{m_pose.Translation(), rotation};
-    m_previousAngle = rotation;
   }
 
   /**
@@ -110,24 +102,22 @@ class WPILIB_DLLEXPORT Odometry {
    * which is used instead of the angular rate that is calculated from forward
    * kinematics, in addition to the current distance measurement at each wheel.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The current distances measured by each wheel.
    *
    * @return The new pose of the robot.
    */
   const Pose2d& Update(const Rotation2d& gyroAngle,
                        const WheelPositions& wheelPositions) {
-    auto angle = gyroAngle.RotateBy(m_gyroOffset);
-
     auto twist =
         m_kinematics.ToTwist2d(m_previousWheelPositions, wheelPositions);
-    twist.dtheta = (angle - m_previousAngle).Radians();
+    twist.dtheta = (gyroAngle - m_previousGyroAngle).Radians();
 
-    auto newPose = m_pose + twist.Exp();
+    m_pose = m_pose + twist.Exp();
 
-    m_previousAngle = angle;
     m_previousWheelPositions = wheelPositions;
-    m_pose = {newPose.Translation(), angle};
+    m_previousGyroAngle = gyroAngle;
 
     return m_pose;
   }
@@ -138,10 +128,7 @@ class WPILIB_DLLEXPORT Odometry {
 
   WheelPositions m_previousWheelPositions;
 
-  // Always equal to m_pose.Rotation()
-  Rotation2d m_previousAngle;
-
-  Rotation2d m_gyroOffset;
+  Rotation2d m_previousGyroAngle;
 };
 
 }  // namespace wpi::math

--- a/wpimath/src/main/native/include/wpi/math/kinematics/Odometry3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/Odometry3d.hpp
@@ -37,7 +37,8 @@ class WPILIB_DLLEXPORT Odometry3d {
    * Constructs an Odometry3d object.
    *
    * @param kinematics The kinematics for your drivetrain.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The current distances measured by each wheel.
    * @param initialPose The starting position of the robot on the field.
    */
@@ -46,30 +47,24 @@ class WPILIB_DLLEXPORT Odometry3d {
                       const Pose3d& initialPose = Pose3d{})
       : m_kinematics(kinematics),
         m_pose(initialPose),
-        m_previousWheelPositions(wheelPositions) {
-    m_previousAngle = m_pose.Rotation();
-    // When applied extrinsically, m_gyroOffset cancels the
-    // current gyroAngle and then rotates to m_pose.Rotation()
-    m_gyroOffset = gyroAngle.Inverse().RotateBy(m_pose.Rotation());
-  }
+        m_previousWheelPositions(wheelPositions),
+        m_previousGyroAngle(gyroAngle) {}
 
   /**
    * Resets the robot's position on the field.
    *
-   * The gyroscope angle does not need to be reset here on the user's robot
-   * code. The library automatically takes care of offsetting the gyro angle.
+   * The gyroscope angle does not need to be reset here in the user's robot
+   * code.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The current distances measured by each wheel.
    * @param pose The position on the field that your robot is at.
    */
   void ResetPosition(const Rotation3d& gyroAngle,
                      const WheelPositions& wheelPositions, const Pose3d& pose) {
     m_pose = pose;
-    m_previousAngle = pose.Rotation();
-    // When applied extrinsically, m_gyroOffset cancels the
-    // current gyroAngle and then rotates to m_pose.Rotation()
-    m_gyroOffset = gyroAngle.Inverse().RotateBy(m_pose.Rotation());
+    m_previousGyroAngle = gyroAngle;
     m_previousWheelPositions = wheelPositions;
   }
 
@@ -78,13 +73,7 @@ class WPILIB_DLLEXPORT Odometry3d {
    *
    * @param pose The pose to reset to.
    */
-  void ResetPose(const Pose3d& pose) {
-    // Cancel the previous m_pose.Rotation() and then rotate to the new angle
-    m_gyroOffset = m_gyroOffset.RotateBy(m_pose.Rotation().Inverse())
-                       .RotateBy(pose.Rotation());
-    m_pose = pose;
-    m_previousAngle = pose.Rotation();
-  }
+  void ResetPose(const Pose3d& pose) { m_pose = pose; }
 
   /**
    * Resets the translation of the pose.
@@ -101,11 +90,7 @@ class WPILIB_DLLEXPORT Odometry3d {
    * @param rotation The rotation to reset to.
    */
   void ResetRotation(const Rotation3d& rotation) {
-    // Cancel the previous m_pose.Rotation() and then rotate to the new angle
-    m_gyroOffset =
-        m_gyroOffset.RotateBy(m_pose.Rotation().Inverse()).RotateBy(rotation);
     m_pose = Pose3d{m_pose.Translation(), rotation};
-    m_previousAngle = rotation;
   }
 
   /**
@@ -120,15 +105,16 @@ class WPILIB_DLLEXPORT Odometry3d {
    * which is used instead of the angular rate that is calculated from forward
    * kinematics, in addition to the current distance measurement at each wheel.
    *
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param wheelPositions The current distances measured by each wheel.
    *
    * @return The new pose of the robot.
    */
   const Pose3d& Update(const Rotation3d& gyroAngle,
                        const WheelPositions& wheelPositions) {
-    auto angle = gyroAngle.RotateBy(m_gyroOffset);
-    auto angle_difference = angle.RelativeTo(m_previousAngle).ToVector();
+    auto angle_difference =
+        gyroAngle.RelativeTo(m_previousGyroAngle).ToVector();
 
     auto twist2d =
         m_kinematics.ToTwist2d(m_previousWheelPositions, wheelPositions);
@@ -139,11 +125,10 @@ class WPILIB_DLLEXPORT Odometry3d {
                   wpi::units::radian_t{angle_difference(1)},
                   wpi::units::radian_t{angle_difference(2)}};
 
-    auto newPose = m_pose + twist.Exp();
+    m_pose = m_pose + twist.Exp();
 
     m_previousWheelPositions = wheelPositions;
-    m_previousAngle = angle;
-    m_pose = {newPose.Translation(), angle};
+    m_previousGyroAngle = gyroAngle;
 
     return m_pose;
   }
@@ -154,14 +139,7 @@ class WPILIB_DLLEXPORT Odometry3d {
 
   WheelPositions m_previousWheelPositions;
 
-  // Always equal to m_pose.Rotation()
-  Rotation3d m_previousAngle;
-
-  // Applying a rotation intrinsically to the measured gyro angle should cause
-  // the corrected angle to be rotated intrinsically in the same way, so the
-  // measured gyro angle must be applied intrinsically. This is equivalent to
-  // applying the offset extrinsically to the measured gyro angle.
-  Rotation3d m_gyroOffset;
+  Rotation3d m_previousGyroAngle;
 };
 
 }  // namespace wpi::math

--- a/wpimath/src/main/native/include/wpi/math/kinematics/SwerveDriveOdometry.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/SwerveDriveOdometry.hpp
@@ -39,7 +39,8 @@ class SwerveDriveOdometry
    * Constructs a SwerveDriveOdometry object.
    *
    * @param kinematics The swerve drive kinematics for your drivetrain.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param modulePositions The wheel positions reported by each module.
    * @param initialPose The starting position of the robot on the field.
    */

--- a/wpimath/src/main/native/include/wpi/math/kinematics/SwerveDriveOdometry3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/kinematics/SwerveDriveOdometry3d.hpp
@@ -40,7 +40,8 @@ class SwerveDriveOdometry3d
    * Constructs a SwerveDriveOdometry3d object.
    *
    * @param kinematics The swerve drive kinematics for your drivetrain.
-   * @param gyroAngle The angle reported by the gyroscope.
+   * @param gyroAngle The angle reported by the gyroscope. This does not need to
+   * be offset to match the robot's orientation on the field.
    * @param modulePositions The wheel positions reported by each module.
    * @param initialPose The starting position of the robot on the field.
    */

--- a/wpimath/src/main/python/semiwrap/DifferentialDrivePoseEstimator.yml
+++ b/wpimath/src/main/python/semiwrap/DifferentialDrivePoseEstimator.yml
@@ -37,8 +37,8 @@ classes:
     methods:
       DifferentialDrivePoseEstimator:
         overloads:
-          DifferentialDriveKinematics&, const Rotation2d&, wpi::units::meter_t, wpi::units::meter_t, const Pose2d&:
-          ? DifferentialDriveKinematics&, const Rotation2d&, wpi::units::meter_t, wpi::units::meter_t, const Pose2d&, const wpi::util::array<double, 3>&, const wpi::util::array<double, 3>&
+          const Rotation2d&, wpi::units::meter_t, wpi::units::meter_t, const Pose2d&:
+          ? const Rotation2d&, wpi::units::meter_t, wpi::units::meter_t, const Pose2d&, const wpi::util::array<double, 3>&, const wpi::util::array<double, 3>&
           :
       ResetPosition:
       Update:

--- a/wpimath/src/main/python/semiwrap/DifferentialDrivePoseEstimator3d.yml
+++ b/wpimath/src/main/python/semiwrap/DifferentialDrivePoseEstimator3d.yml
@@ -4,8 +4,8 @@ classes:
     methods:
       DifferentialDrivePoseEstimator3d:
         overloads:
-          DifferentialDriveKinematics&, const Rotation3d&, wpi::units::meter_t, wpi::units::meter_t, const Pose3d&:
-          ? DifferentialDriveKinematics&, const Rotation3d&, wpi::units::meter_t, wpi::units::meter_t, const Pose3d&, const wpi::util::array<double, 4>&, const wpi::util::array<double, 4>&
+          const Rotation3d&, wpi::units::meter_t, wpi::units::meter_t, const Pose3d&:
+          ? const Rotation3d&, wpi::units::meter_t, wpi::units::meter_t, const Pose3d&, const wpi::util::array<double, 4>&, const wpi::util::array<double, 4>&
           :
       ResetPosition:
       Update:

--- a/wpimath/src/test/java/org/wpilib/math/estimator/DifferentialDrivePoseEstimator3dTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/estimator/DifferentialDrivePoseEstimator3dTest.java
@@ -225,8 +225,6 @@ class DifferentialDrivePoseEstimator3dTest {
     // is that all measurements affect the estimated pose. The alternative result is that only one
     // vision measurement affects the outcome. If that were the case, after 1000 measurements, the
     // estimated pose would converge to that measurement.
-    var kinematics = new DifferentialDriveKinematics(1);
-
     var estimator =
         new DifferentialDrivePoseEstimator3d(
             Rotation3d.kZero,
@@ -271,7 +269,6 @@ class DifferentialDrivePoseEstimator3dTest {
 
   @Test
   void testDiscardsStaleVisionMeasurements() {
-    var kinematics = new DifferentialDriveKinematics(1);
     var estimator =
         new DifferentialDrivePoseEstimator3d(
             Rotation3d.kZero,
@@ -324,7 +321,6 @@ class DifferentialDrivePoseEstimator3dTest {
 
   @Test
   void testSampleAt() {
-    var kinematics = new DifferentialDriveKinematics(1);
     var estimator =
         new DifferentialDrivePoseEstimator3d(
             Rotation3d.kZero,
@@ -373,7 +369,6 @@ class DifferentialDrivePoseEstimator3dTest {
 
   @Test
   void testReset() {
-    var kinematics = new DifferentialDriveKinematics(1);
     var estimator =
         new DifferentialDrivePoseEstimator3d(
             Rotation3d.kZero,

--- a/wpimath/src/test/java/org/wpilib/math/estimator/DifferentialDrivePoseEstimator3dTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/estimator/DifferentialDrivePoseEstimator3dTest.java
@@ -38,7 +38,6 @@ class DifferentialDrivePoseEstimator3dTest {
 
     var estimator =
         new DifferentialDrivePoseEstimator3d(
-            kinematics,
             Rotation3d.kZero,
             0,
             0,
@@ -75,7 +74,6 @@ class DifferentialDrivePoseEstimator3dTest {
 
     var estimator =
         new DifferentialDrivePoseEstimator3d(
-            kinematics,
             Rotation3d.kZero,
             0,
             0,
@@ -231,7 +229,6 @@ class DifferentialDrivePoseEstimator3dTest {
 
     var estimator =
         new DifferentialDrivePoseEstimator3d(
-            kinematics,
             Rotation3d.kZero,
             0,
             0,
@@ -277,7 +274,6 @@ class DifferentialDrivePoseEstimator3dTest {
     var kinematics = new DifferentialDriveKinematics(1);
     var estimator =
         new DifferentialDrivePoseEstimator3d(
-            kinematics,
             Rotation3d.kZero,
             0,
             0,
@@ -331,7 +327,6 @@ class DifferentialDrivePoseEstimator3dTest {
     var kinematics = new DifferentialDriveKinematics(1);
     var estimator =
         new DifferentialDrivePoseEstimator3d(
-            kinematics,
             Rotation3d.kZero,
             0,
             0,
@@ -381,7 +376,6 @@ class DifferentialDrivePoseEstimator3dTest {
     var kinematics = new DifferentialDriveKinematics(1);
     var estimator =
         new DifferentialDrivePoseEstimator3d(
-            kinematics,
             Rotation3d.kZero,
             0,
             0,

--- a/wpimath/src/test/java/org/wpilib/math/estimator/DifferentialDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/estimator/DifferentialDrivePoseEstimatorTest.java
@@ -216,8 +216,6 @@ class DifferentialDrivePoseEstimatorTest {
     // is that all measurements affect the estimated pose. The alternative result is that only one
     // vision measurement affects the outcome. If that were the case, after 1000 measurements, the
     // estimated pose would converge to that measurement.
-    var kinematics = new DifferentialDriveKinematics(1);
-
     var estimator =
         new DifferentialDrivePoseEstimator(
             Rotation2d.kZero,
@@ -262,7 +260,6 @@ class DifferentialDrivePoseEstimatorTest {
 
   @Test
   void testDiscardsStaleVisionMeasurements() {
-    var kinematics = new DifferentialDriveKinematics(1);
     var estimator =
         new DifferentialDrivePoseEstimator(
             Rotation2d.kZero,
@@ -298,7 +295,6 @@ class DifferentialDrivePoseEstimatorTest {
 
   @Test
   void testSampleAt() {
-    var kinematics = new DifferentialDriveKinematics(1);
     var estimator =
         new DifferentialDrivePoseEstimator(
             Rotation2d.kZero,
@@ -347,7 +343,6 @@ class DifferentialDrivePoseEstimatorTest {
 
   @Test
   void testReset() {
-    var kinematics = new DifferentialDriveKinematics(1);
     var estimator =
         new DifferentialDrivePoseEstimator(
             Rotation2d.kZero,

--- a/wpimath/src/test/java/org/wpilib/math/estimator/DifferentialDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/estimator/DifferentialDrivePoseEstimatorTest.java
@@ -35,7 +35,6 @@ class DifferentialDrivePoseEstimatorTest {
 
     var estimator =
         new DifferentialDrivePoseEstimator(
-            kinematics,
             Rotation2d.kZero,
             0,
             0,
@@ -72,7 +71,6 @@ class DifferentialDrivePoseEstimatorTest {
 
     var estimator =
         new DifferentialDrivePoseEstimator(
-            kinematics,
             Rotation2d.kZero,
             0,
             0,
@@ -222,7 +220,6 @@ class DifferentialDrivePoseEstimatorTest {
 
     var estimator =
         new DifferentialDrivePoseEstimator(
-            kinematics,
             Rotation2d.kZero,
             0,
             0,
@@ -268,7 +265,6 @@ class DifferentialDrivePoseEstimatorTest {
     var kinematics = new DifferentialDriveKinematics(1);
     var estimator =
         new DifferentialDrivePoseEstimator(
-            kinematics,
             Rotation2d.kZero,
             0,
             0,
@@ -305,7 +301,6 @@ class DifferentialDrivePoseEstimatorTest {
     var kinematics = new DifferentialDriveKinematics(1);
     var estimator =
         new DifferentialDrivePoseEstimator(
-            kinematics,
             Rotation2d.kZero,
             0,
             0,
@@ -355,7 +350,6 @@ class DifferentialDrivePoseEstimatorTest {
     var kinematics = new DifferentialDriveKinematics(1);
     var estimator =
         new DifferentialDrivePoseEstimator(
-            kinematics,
             Rotation2d.kZero,
             0,
             0,

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/DifferentialDriveOdometry3dTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/DifferentialDriveOdometry3dTest.java
@@ -28,10 +28,10 @@ class DifferentialDriveOdometry3dTest {
             new Pose3d(1, 2, 0, new Rotation3d(0, 0, Units.degreesToRadians(45))));
     var pose = odometry.getPose();
     assertAll(
-        () -> assertEquals(pose.getX(), 1.0, kEpsilon),
-        () -> assertEquals(pose.getY(), 2.0, kEpsilon),
-        () -> assertEquals(pose.getZ(), 0.0, kEpsilon),
-        () -> assertEquals(pose.getRotation().toRotation2d().getDegrees(), 45.0, kEpsilon));
+        () -> assertEquals(1.0, pose.getX(), kEpsilon),
+        () -> assertEquals(2.0, pose.getY(), kEpsilon),
+        () -> assertEquals(0.0, pose.getZ(), kEpsilon),
+        () -> assertEquals(45.0, pose.getRotation().toRotation2d().getDegrees(), kEpsilon));
   }
 
   @Test
@@ -41,10 +41,10 @@ class DifferentialDriveOdometry3dTest {
         m_odometry.update(new Rotation3d(0, 0, Units.degreesToRadians(135.0)), 0.0, 5 * Math.PI);
 
     assertAll(
-        () -> assertEquals(pose.getX(), 5.0, kEpsilon),
-        () -> assertEquals(pose.getY(), 5.0, kEpsilon),
-        () -> assertEquals(pose.getZ(), 0.0, kEpsilon),
-        () -> assertEquals(pose.getRotation().toRotation2d().getDegrees(), 90.0, kEpsilon));
+        () -> assertEquals(5.0, pose.getX(), kEpsilon),
+        () -> assertEquals(5.0, pose.getY(), kEpsilon),
+        () -> assertEquals(0.0, pose.getZ(), kEpsilon),
+        () -> assertEquals(90.0, pose.getRotation().toRotation2d().getDegrees(), kEpsilon));
   }
 
   @Test
@@ -57,11 +57,11 @@ class DifferentialDriveOdometry3dTest {
     var pose = m_odometry.update(new Rotation3d(0, Units.degreesToRadians(10), 0), 0, 0);
 
     assertAll(
-        () -> assertEquals(pose.getX(), 0.0, kEpsilon),
-        () -> assertEquals(pose.getY(), 0.0, kEpsilon),
-        () -> assertEquals(pose.getZ(), 0.0, kEpsilon),
-        () -> assertEquals(pose.getRotation().getX(), Units.degreesToRadians(0), kEpsilon),
-        () -> assertEquals(pose.getRotation().getY(), Units.degreesToRadians(5), kEpsilon),
-        () -> assertEquals(pose.getRotation().getZ(), Units.degreesToRadians(90), kEpsilon));
+        () -> assertEquals(0.0, pose.getX(), kEpsilon),
+        () -> assertEquals(0.0, pose.getY(), kEpsilon),
+        () -> assertEquals(0.0, pose.getZ(), kEpsilon),
+        () -> assertEquals(Units.degreesToRadians(0), pose.getRotation().getX(), kEpsilon),
+        () -> assertEquals(Units.degreesToRadians(5), pose.getRotation().getY(), kEpsilon),
+        () -> assertEquals(Units.degreesToRadians(90), pose.getRotation().getZ(), kEpsilon));
   }
 }

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/DifferentialDriveOdometryTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/DifferentialDriveOdometryTest.java
@@ -22,8 +22,8 @@ class DifferentialDriveOdometryTest {
     var pose = m_odometry.update(Rotation2d.fromDegrees(135.0), 0.0, 5 * Math.PI);
 
     assertAll(
-        () -> assertEquals(pose.getX(), 5.0, kEpsilon),
-        () -> assertEquals(pose.getY(), 5.0, kEpsilon),
-        () -> assertEquals(pose.getRotation().getDegrees(), 90.0, kEpsilon));
+        () -> assertEquals(5.0, pose.getX(), kEpsilon),
+        () -> assertEquals(5.0, pose.getY(), kEpsilon),
+        () -> assertEquals(90.0, pose.getRotation().getDegrees(), kEpsilon));
   }
 }

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/MecanumDriveOdometry3dTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/MecanumDriveOdometry3dTest.java
@@ -44,10 +44,10 @@ class MecanumDriveOdometry3dTest {
             new Pose3d(1, 2, 0, new Rotation3d(0, 0, Units.degreesToRadians(45))));
     var pose = odometry.getPose();
     assertAll(
-        () -> assertEquals(pose.getX(), 1.0, 1e-9),
-        () -> assertEquals(pose.getY(), 2.0, 1e-9),
-        () -> assertEquals(pose.getZ(), 0.0, 1e-9),
-        () -> assertEquals(pose.getRotation().toRotation2d().getDegrees(), 45.0, 1e-9));
+        () -> assertEquals(1.0, pose.getX(), 1e-9),
+        () -> assertEquals(2.0, pose.getY(), 1e-9),
+        () -> assertEquals(0.0, pose.getZ(), 1e-9),
+        () -> assertEquals(45.0, pose.getRotation().toRotation2d().getDegrees(), 1e-9));
   }
 
   @Test
@@ -60,10 +60,10 @@ class MecanumDriveOdometry3dTest {
     var secondPose = m_odometry.update(Rotation3d.kZero, wheelPositions);
 
     assertAll(
-        () -> assertEquals(secondPose.getX(), 0.0, 0.01),
-        () -> assertEquals(secondPose.getY(), 0.0, 0.01),
-        () -> assertEquals(secondPose.getZ(), 0.0, 0.01),
-        () -> assertEquals(secondPose.getRotation().toRotation2d().getDegrees(), 0.0, 0.01));
+        () -> assertEquals(0.0, secondPose.getX(), 0.01),
+        () -> assertEquals(0.0, secondPose.getY(), 0.01),
+        () -> assertEquals(0.0, secondPose.getZ(), 0.01),
+        () -> assertEquals(0.0, secondPose.getRotation().toRotation2d().getDegrees(), 0.01));
   }
 
   @Test
@@ -301,11 +301,11 @@ class MecanumDriveOdometry3dTest {
     var pose = m_odometry.update(new Rotation3d(0, Units.degreesToRadians(10), 0), wheelPositions);
 
     assertAll(
-        () -> assertEquals(pose.getX(), 0.0, 1e-9),
-        () -> assertEquals(pose.getY(), 0.0, 1e-9),
-        () -> assertEquals(pose.getZ(), 0.0, 1e-9),
-        () -> assertEquals(pose.getRotation().getX(), Units.degreesToRadians(0), 1e-9),
-        () -> assertEquals(pose.getRotation().getY(), Units.degreesToRadians(5), 1e-9),
-        () -> assertEquals(pose.getRotation().getZ(), Units.degreesToRadians(90), 1e-9));
+        () -> assertEquals(0.0, pose.getX(), 1e-9),
+        () -> assertEquals(0.0, pose.getY(), 1e-9),
+        () -> assertEquals(0.0, pose.getZ(), 1e-9),
+        () -> assertEquals(Units.degreesToRadians(0), pose.getRotation().getX(), 1e-9),
+        () -> assertEquals(Units.degreesToRadians(5), pose.getRotation().getY(), 1e-9),
+        () -> assertEquals(Units.degreesToRadians(90), pose.getRotation().getZ(), 1e-9));
   }
 }

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/MecanumDriveOdometryTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/MecanumDriveOdometryTest.java
@@ -40,9 +40,9 @@ class MecanumDriveOdometryTest {
     var secondPose = m_odometry.update(Rotation2d.kZero, wheelPositions);
 
     assertAll(
-        () -> assertEquals(secondPose.getX(), 0.0, 0.01),
-        () -> assertEquals(secondPose.getY(), 0.0, 0.01),
-        () -> assertEquals(secondPose.getRotation().getDegrees(), 0.0, 0.01));
+        () -> assertEquals(0.0, secondPose.getX(), 0.01),
+        () -> assertEquals(0.0, secondPose.getY(), 0.01),
+        () -> assertEquals(0.0, secondPose.getRotation().getDegrees(), 0.01));
   }
 
   @Test

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/SwerveDriveOdometry3dTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/SwerveDriveOdometry3dTest.java
@@ -45,10 +45,10 @@ class SwerveDriveOdometry3dTest {
             new Pose3d(1, 2, 0, new Rotation3d(0, 0, Units.degreesToRadians(45))));
     var pose = odometry.getPose();
     assertAll(
-        () -> assertEquals(pose.getX(), 1.0, 1e-9),
-        () -> assertEquals(pose.getY(), 2.0, 1e-9),
-        () -> assertEquals(pose.getZ(), 0.0, 1e-9),
-        () -> assertEquals(pose.getRotation().toRotation2d().getDegrees(), 45.0, 1e-9));
+        () -> assertEquals(1.0, pose.getX(), 1e-9),
+        () -> assertEquals(2.0, pose.getY(), 1e-9),
+        () -> assertEquals(0.0, pose.getZ(), 1e-9),
+        () -> assertEquals(45.0, pose.getRotation().toRotation2d().getDegrees(), 1e-9));
   }
 
   @Test
@@ -314,11 +314,11 @@ class SwerveDriveOdometry3dTest {
     var pose = m_odometry.update(new Rotation3d(0, Units.degreesToRadians(10), 0), modulePositions);
 
     assertAll(
-        () -> assertEquals(pose.getX(), 0.0, 1e-9),
-        () -> assertEquals(pose.getY(), 0.0, 1e-9),
-        () -> assertEquals(pose.getZ(), 0.0, 1e-9),
-        () -> assertEquals(pose.getRotation().getX(), Units.degreesToRadians(0), 1e-9),
-        () -> assertEquals(pose.getRotation().getY(), Units.degreesToRadians(5), 1e-9),
-        () -> assertEquals(pose.getRotation().getZ(), Units.degreesToRadians(90), 1e-9));
+        () -> assertEquals(0.0, pose.getX(), 1e-9),
+        () -> assertEquals(0.0, pose.getY(), 1e-9),
+        () -> assertEquals(0.0, pose.getZ(), 1e-9),
+        () -> assertEquals(Units.degreesToRadians(0), pose.getRotation().getX(), 1e-9),
+        () -> assertEquals(Units.degreesToRadians(5), pose.getRotation().getY(), 1e-9),
+        () -> assertEquals(Units.degreesToRadians(90), pose.getRotation().getZ(), 1e-9));
   }
 }

--- a/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimator3dTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimator3dTest.cpp
@@ -256,8 +256,6 @@ TEST(DifferentialDrivePoseEstimator3dTest, SimultaneousVisionMeasurements) {
   // The alternative result is that only one vision measurement affects the
   // outcome. If that were the case, after 1000 measurements, the estimated
   // pose would converge to that measurement.
-  wpi::math::DifferentialDriveKinematics kinematics{1.0_m};
-
   wpi::math::DifferentialDrivePoseEstimator3d estimator{
       wpi::math::Rotation3d{},
       0_m,
@@ -316,8 +314,6 @@ TEST(DifferentialDrivePoseEstimator3dTest, SimultaneousVisionMeasurements) {
 }
 
 TEST(DifferentialDrivePoseEstimator3dTest, TestDiscardStaleVisionMeasurements) {
-  wpi::math::DifferentialDriveKinematics kinematics{1_m};
-
   wpi::math::DifferentialDrivePoseEstimator3d estimator{
       wpi::math::Rotation3d{},
       0_m,
@@ -354,7 +350,6 @@ TEST(DifferentialDrivePoseEstimator3dTest, TestDiscardStaleVisionMeasurements) {
 }
 
 TEST(DifferentialDrivePoseEstimator3dTest, TestSampleAt) {
-  wpi::math::DifferentialDriveKinematics kinematics{1_m};
   wpi::math::DifferentialDrivePoseEstimator3d estimator{wpi::math::Rotation3d{},
                                                         0_m,
                                                         0_m,
@@ -430,7 +425,6 @@ TEST(DifferentialDrivePoseEstimator3dTest, TestSampleAt) {
 }
 
 TEST(DifferentialDrivePoseEstimator3dTest, TestReset) {
-  wpi::math::DifferentialDriveKinematics kinematics{1_m};
   wpi::math::DifferentialDrivePoseEstimator3d estimator{
       wpi::math::Rotation3d{},
       0_m,

--- a/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimator3dTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimator3dTest.cpp
@@ -175,7 +175,6 @@ TEST(DifferentialDrivePoseEstimator3dTest, Accuracy) {
   wpi::math::DifferentialDriveKinematics kinematics{1.0_m};
 
   wpi::math::DifferentialDrivePoseEstimator3d estimator{
-      kinematics,
       wpi::math::Rotation3d{},
       0_m,
       0_m,
@@ -208,7 +207,6 @@ TEST(DifferentialDrivePoseEstimator3dTest, BadInitialPose) {
   wpi::math::DifferentialDriveKinematics kinematics{1.0_m};
 
   wpi::math::DifferentialDrivePoseEstimator3d estimator{
-      kinematics,
       wpi::math::Rotation3d{},
       0_m,
       0_m,
@@ -261,7 +259,6 @@ TEST(DifferentialDrivePoseEstimator3dTest, SimultaneousVisionMeasurements) {
   wpi::math::DifferentialDriveKinematics kinematics{1.0_m};
 
   wpi::math::DifferentialDrivePoseEstimator3d estimator{
-      kinematics,
       wpi::math::Rotation3d{},
       0_m,
       0_m,
@@ -322,7 +319,6 @@ TEST(DifferentialDrivePoseEstimator3dTest, TestDiscardStaleVisionMeasurements) {
   wpi::math::DifferentialDriveKinematics kinematics{1_m};
 
   wpi::math::DifferentialDrivePoseEstimator3d estimator{
-      kinematics,
       wpi::math::Rotation3d{},
       0_m,
       0_m,
@@ -359,8 +355,7 @@ TEST(DifferentialDrivePoseEstimator3dTest, TestDiscardStaleVisionMeasurements) {
 
 TEST(DifferentialDrivePoseEstimator3dTest, TestSampleAt) {
   wpi::math::DifferentialDriveKinematics kinematics{1_m};
-  wpi::math::DifferentialDrivePoseEstimator3d estimator{kinematics,
-                                                        wpi::math::Rotation3d{},
+  wpi::math::DifferentialDrivePoseEstimator3d estimator{wpi::math::Rotation3d{},
                                                         0_m,
                                                         0_m,
                                                         wpi::math::Pose3d{},
@@ -437,7 +432,6 @@ TEST(DifferentialDrivePoseEstimator3dTest, TestSampleAt) {
 TEST(DifferentialDrivePoseEstimator3dTest, TestReset) {
   wpi::math::DifferentialDriveKinematics kinematics{1_m};
   wpi::math::DifferentialDrivePoseEstimator3d estimator{
-      kinematics,
       wpi::math::Rotation3d{},
       0_m,
       0_m,

--- a/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
@@ -296,8 +296,8 @@ TEST(DifferentialDrivePoseEstimatorTest, TestDiscardStaleVisionMeasurements) {
   wpi::math::DifferentialDriveKinematics kinematics{1_m};
 
   wpi::math::DifferentialDrivePoseEstimator estimator{
-      kinematics,      wpi::math::Rotation2d{}, 0_m, 0_m, wpi::math::Pose2d{},
-      {0.1, 0.1, 0.1}, {0.45, 0.45, 0.45}};
+      wpi::math::Rotation2d{}, 0_m, 0_m, wpi::math::Pose2d{}, {0.1, 0.1, 0.1},
+      {0.45, 0.45, 0.45}};
 
   // Add enough measurements to fill up the buffer
   for (auto time = 0_s; time < 4_s; time += 20_ms) {
@@ -324,8 +324,8 @@ TEST(DifferentialDrivePoseEstimatorTest, TestDiscardStaleVisionMeasurements) {
 TEST(DifferentialDrivePoseEstimatorTest, TestSampleAt) {
   wpi::math::DifferentialDriveKinematics kinematics{1_m};
   wpi::math::DifferentialDrivePoseEstimator estimator{
-      kinematics,      wpi::math::Rotation2d{}, 0_m, 0_m, wpi::math::Pose2d{},
-      {1.0, 1.0, 1.0}, {1.0, 1.0, 1.0}};
+      wpi::math::Rotation2d{}, 0_m, 0_m, wpi::math::Pose2d{}, {1.0, 1.0, 1.0},
+      {1.0, 1.0, 1.0}};
 
   // Returns empty when null
   EXPECT_EQ(std::nullopt, estimator.SampleAt(1_s));

--- a/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
@@ -165,8 +165,7 @@ void testFollowTrajectory(
 TEST(DifferentialDrivePoseEstimatorTest, Accuracy) {
   wpi::math::DifferentialDriveKinematics kinematics{1.0_m};
 
-  wpi::math::DifferentialDrivePoseEstimator estimator{kinematics,
-                                                      wpi::math::Rotation2d{},
+  wpi::math::DifferentialDrivePoseEstimator estimator{wpi::math::Rotation2d{},
                                                       0_m,
                                                       0_m,
                                                       wpi::math::Pose2d{},
@@ -197,8 +196,7 @@ TEST(DifferentialDrivePoseEstimatorTest, Accuracy) {
 TEST(DifferentialDrivePoseEstimatorTest, BadInitialPose) {
   wpi::math::DifferentialDriveKinematics kinematics{1.0_m};
 
-  wpi::math::DifferentialDrivePoseEstimator estimator{kinematics,
-                                                      wpi::math::Rotation2d{},
+  wpi::math::DifferentialDrivePoseEstimator estimator{wpi::math::Rotation2d{},
                                                       0_m,
                                                       0_m,
                                                       wpi::math::Pose2d{},
@@ -248,7 +246,6 @@ TEST(DifferentialDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
   wpi::math::DifferentialDriveKinematics kinematics{1.0_m};
 
   wpi::math::DifferentialDrivePoseEstimator estimator{
-      kinematics,
       wpi::math::Rotation2d{},
       0_m,
       0_m,
@@ -395,7 +392,6 @@ TEST(DifferentialDrivePoseEstimatorTest, TestSampleAt) {
 TEST(DifferentialDrivePoseEstimatorTest, TestReset) {
   wpi::math::DifferentialDriveKinematics kinematics{1_m};
   wpi::math::DifferentialDrivePoseEstimator estimator{
-      kinematics,
       wpi::math::Rotation2d{},
       0_m,
       0_m,

--- a/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
@@ -243,8 +243,6 @@ TEST(DifferentialDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
   // The alternative result is that only one vision measurement affects the
   // outcome. If that were the case, after 1000 measurements, the estimated
   // pose would converge to that measurement.
-  wpi::math::DifferentialDriveKinematics kinematics{1.0_m};
-
   wpi::math::DifferentialDrivePoseEstimator estimator{
       wpi::math::Rotation2d{},
       0_m,

--- a/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
@@ -291,8 +291,6 @@ TEST(DifferentialDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
 }
 
 TEST(DifferentialDrivePoseEstimatorTest, TestDiscardStaleVisionMeasurements) {
-  wpi::math::DifferentialDriveKinematics kinematics{1_m};
-
   wpi::math::DifferentialDrivePoseEstimator estimator{
       wpi::math::Rotation2d{}, 0_m, 0_m, wpi::math::Pose2d{}, {0.1, 0.1, 0.1},
       {0.45, 0.45, 0.45}};
@@ -320,7 +318,6 @@ TEST(DifferentialDrivePoseEstimatorTest, TestDiscardStaleVisionMeasurements) {
 }
 
 TEST(DifferentialDrivePoseEstimatorTest, TestSampleAt) {
-  wpi::math::DifferentialDriveKinematics kinematics{1_m};
   wpi::math::DifferentialDrivePoseEstimator estimator{
       wpi::math::Rotation2d{}, 0_m, 0_m, wpi::math::Pose2d{}, {1.0, 1.0, 1.0},
       {1.0, 1.0, 1.0}};
@@ -388,7 +385,6 @@ TEST(DifferentialDrivePoseEstimatorTest, TestSampleAt) {
 }
 
 TEST(DifferentialDrivePoseEstimatorTest, TestReset) {
-  wpi::math::DifferentialDriveKinematics kinematics{1_m};
   wpi::math::DifferentialDrivePoseEstimator estimator{
       wpi::math::Rotation2d{},
       0_m,


### PR DESCRIPTION
Cleans up a bunch of cruft in Odometry & PoseEstimator.

- Remove an unused `kinematics` parameter in the `PoseEstimator` constructor
- Remove an unnecessary `kinematics` parameter in the `DifferentialDrivePoseEstimator` constructor
- Clean up code in `Odometry` to remove an unnecessary gyro offset variable
  - This preserves behavior as the gyro offset mathematically canceled out
- Clean up various code comments
- Fix backwards parameters in some of the Java odometry unit tests