### PR TITLE
[bazel] Ignore git and Gradle build dirs

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,5 @@
+.git
+build
 build_cmake
 build-cmake
 

--- a/.bazelignore
+++ b/.bazelignore
@@ -1,4 +1,5 @@
 .git
+.gradle
 build
 build_cmake
 build-cmake


### PR DESCRIPTION
This (best effort) prevents `.git` from being symlinked into the execroot, which can cause git integration in some IDEs to behave weirdly when they see it via the `bazel-allwpilib` convenience symlink.

Also tell Bazel to ignore Gradle's build dir -- nothing useful for the Bazel build should ever appear there.