### PR TITLE
[bazel] Suppress cached test results in CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -87,6 +87,7 @@ build:remote_user --remote_download_toplevel
 common:ci --color=yes
 build:ci --remote_download_minimal
 build:ci --progress_report_interval=60 --show_progress_rate_limit=60
+test:ci --test_summary=short_uncached
 
 build --build_metadata=REPO_URL=https://github.com/wpilibsuite/allwpilib.git
 


### PR DESCRIPTION
[Bazel 8.6.0] introduced the `--test_summary=short_uncached` and `--test_summary=detailed_uncached` options to suppress reporting of cached test results.

i.e. these lines:

    //:requirements.test                                            (cached) PASSED in 10.0s
    //apriltag:apriltag-cpp-test                                    (cached) PASSED in 0.1s
    //apriltag:python_tests                                         (cached) PASSED in 1.8s

[Bazel 8.6.0]: https://github.com/bazelbuild/bazel/releases/tag/8.6.0