### PR TITLE
[wpiutil] Revert "Synchronization: shard signal objects (#8971)"

### DIFF
--- a/wpiutil/src/main/native/cpp/Synchronization.cpp
+++ b/wpiutil/src/main/native/cpp/Synchronization.cpp
@@ -5,9 +5,8 @@
 #include "wpi/util/Synchronization.hpp"
 
 #include <algorithm>
-#include <array>
 #include <atomic>
-#include <chrono>
+#include <cstring>
 #include <mutex>
 
 #include "wpi/util/DenseMap.hpp"
@@ -32,69 +31,22 @@ static std::atomic_int gActive{0};
 
 namespace {
 
-constexpr size_t STATE_SHARD_COUNT = 32;
-
-class SignalWaiter {
- public:
-  void Notify() {
-    {
-      std::scoped_lock lock{m_mutex};
-      m_notified = true;
-    }
-    m_cv.notify_all();
-  }
-
-  void Wait() {
-    std::unique_lock lock{m_mutex};
-    m_cv.wait(lock, [&] { return m_notified; });
-    m_notified = false;
-  }
-
-  bool WaitUntil(std::chrono::steady_clock::time_point timeoutTime) {
-    std::unique_lock lock{m_mutex};
-    if (!m_cv.wait_until(lock, timeoutTime, [&] { return m_notified; })) {
-      return true;
-    }
-    m_notified = false;
-    return false;
-  }
-
- private:
-  wpi::util::mutex m_mutex;
-  wpi::util::condition_variable m_cv;
-  bool m_notified{false};
-};
-
 struct State {
   int signaled{0};
-  int maxCount{0};
   bool autoReset{false};
-  wpi::util::SmallVector<SignalWaiter*, 2> waiters;
+  wpi::util::SmallVector<wpi::util::condition_variable*, 2> waiters;
 };
-
-struct StateShard {
-  wpi::util::mutex mutex;
-  wpi::util::DenseMap<WPI_Handle, State> states;
-};
-
-size_t GetStateShardIndex(WPI_Handle handle) {
-  auto value = static_cast<uint32_t>(handle);
-  value ^= value >> 16;
-  value *= 0x7feb352dU;
-  value ^= value >> 15;
-  return value % STATE_SHARD_COUNT;
-}
 
 struct HandleManager {
   ~HandleManager() {
     gActive.fetch_add(INT_MIN / 2);
 
     // wake up all waiters
-    for (auto& shard : stateShards) {
-      std::scoped_lock lock{shard.mutex};
-      for (auto&& [handle, state] : shard.states) {
+    {
+      std::scoped_lock lock{mutex};
+      for (auto&& [handle, state] : states) {
         for (auto&& waiter : state.waiters) {
-          waiter->Notify();
+          waiter->notify_all();
         }
       }
     }
@@ -115,54 +67,11 @@ struct HandleManager {
     }
 #endif
   }
-  StateShard& GetStateShard(WPI_Handle handle) {
-    return stateShards[GetStateShardIndex(handle)];
-  }
-
-  wpi::util::mutex idsMutex;
+  wpi::util::mutex mutex;
   wpi::util::UidVector<int, 8> eventIds;
   wpi::util::UidVector<int, 8> semaphoreIds;
-  std::array<StateShard, STATE_SHARD_COUNT> stateShards;
+  wpi::util::DenseMap<WPI_Handle, State> states;
 };
-
-using StateShardIndices = wpi::util::SmallVector<size_t, 8>;
-using StateShardLocks =
-    wpi::util::SmallVector<std::unique_lock<wpi::util::mutex>, 8>;
-
-StateShardIndices GetStateShardIndices(std::span<const WPI_Handle> handles) {
-  StateShardIndices indices;
-  for (auto handle : handles) {
-    indices.emplace_back(GetStateShardIndex(handle));
-  }
-
-  std::sort(indices.begin(), indices.end());
-
-  StateShardIndices uniqueIndices;
-  for (auto index : indices) {
-    if (uniqueIndices.empty() || uniqueIndices.back() != index) {
-      uniqueIndices.emplace_back(index);
-    }
-  }
-  return uniqueIndices;
-}
-
-StateShardLocks LockStateShards(HandleManager& manager,
-                                const StateShardIndices& shardIndices) {
-  StateShardLocks locks;
-  for (auto index : shardIndices) {
-    locks.emplace_back(manager.stateShards[index].mutex);
-  }
-  return locks;
-}
-
-State* FindState(HandleManager& manager, WPI_Handle handle) {
-  auto& shard = manager.GetStateShard(handle);
-  auto it = shard.states.find(handle);
-  if (it == shard.states.end()) {
-    return nullptr;
-  }
-  return &it->second;
-}
 
 class ManagerGuard {
  public:
@@ -194,18 +103,13 @@ WPI_EventHandle wpi::util::MakeEvent(bool manualReset, bool initialState) {
     return {};
   }
   auto& manager = guard.GetManager();
+  std::scoped_lock lock{manager.mutex};
 
-  size_t index;
-  {
-    std::scoped_lock lock{manager.idsMutex};
-    index = manager.eventIds.emplace_back(0);
-  }
+  auto index = manager.eventIds.emplace_back(0);
   WPI_EventHandle handle = (HANDLE_TYPE_EVENT << 24) | (index & 0xffffff);
 
   // configure state data
-  auto& shard = manager.GetStateShard(handle);
-  std::scoped_lock lock{shard.mutex};
-  auto& state = shard.states[handle];
+  auto& state = manager.states[handle];
   state.signaled = initialState ? 1 : 0;
   state.autoReset = !manualReset;
   return handle;
@@ -223,7 +127,7 @@ void wpi::util::DestroyEvent(WPI_EventHandle handle) {
     return;
   }
   auto& manager = guard.GetManager();
-  std::scoped_lock lock{manager.idsMutex};
+  std::scoped_lock lock{manager.mutex};
   manager.eventIds.erase(handle & 0xffffff);
 }
 
@@ -250,20 +154,14 @@ WPI_SemaphoreHandle wpi::util::MakeSemaphore(int initialCount,
     return {};
   }
   auto& manager = guard.GetManager();
+  std::scoped_lock lock{manager.mutex};
 
-  size_t index;
-  {
-    std::scoped_lock lock{manager.idsMutex};
-    index = manager.semaphoreIds.emplace_back(maximumCount);
-  }
+  auto index = manager.semaphoreIds.emplace_back(maximumCount);
   WPI_EventHandle handle = (HANDLE_TYPE_SEMAPHORE << 24) | (index & 0xffffff);
 
   // configure state data
-  auto& shard = manager.GetStateShard(handle);
-  std::scoped_lock lock{shard.mutex};
-  auto& state = shard.states[handle];
+  auto& state = manager.states[handle];
   state.signaled = initialCount;
-  state.maxCount = maximumCount;
   state.autoReset = true;
 
   return handle;
@@ -281,7 +179,7 @@ void wpi::util::DestroySemaphore(WPI_SemaphoreHandle handle) {
     return;
   }
   auto& manager = guard.GetManager();
-  std::scoped_lock lock{manager.idsMutex};
+  std::scoped_lock lock{manager.mutex};
   manager.semaphoreIds.erase(handle & 0xffffff);
 }
 
@@ -293,28 +191,29 @@ bool wpi::util::ReleaseSemaphore(WPI_SemaphoreHandle handle, int releaseCount,
   if (releaseCount <= 0) {
     return false;
   }
+  int index = handle & 0xffffff;
 
   ManagerGuard guard;
   if (!guard) {
     return true;
   }
   auto& manager = guard.GetManager();
-  auto& shard = manager.GetStateShard(handle);
-  std::scoped_lock lock{shard.mutex};
-  auto it = shard.states.find(handle);
-  if (it == shard.states.end()) {
+  std::scoped_lock lock{manager.mutex};
+  auto it = manager.states.find(handle);
+  if (it == manager.states.end()) {
     return false;
   }
   auto& state = it->second;
+  int maxCount = manager.semaphoreIds[index];
   if (prevCount) {
     *prevCount = state.signaled;
   }
-  if ((state.maxCount - state.signaled) < releaseCount) {
+  if ((maxCount - state.signaled) < releaseCount) {
     return false;
   }
   state.signaled += releaseCount;
   for (auto& waiter : state.waiters) {
-    waiter->Notify();
+    waiter->notify_all();
   }
   return true;
 }
@@ -350,35 +249,30 @@ std::span<WPI_Handle> wpi::util::WaitForObjects(
     return {};
   }
   auto& manager = guard.GetManager();
-  auto shardIndices = GetStateShardIndices(handles);
-  auto locks = LockStateShards(manager, shardIndices);
-  SignalWaiter waiter;
+  std::unique_lock lock{manager.mutex};
+  wpi::util::condition_variable cv;
   bool addedWaiters = false;
   bool timedOutVal = false;
   size_t count = 0;
-  const auto timeoutTime =
-      std::chrono::steady_clock::now() +
-      std::chrono::ceil<std::chrono::steady_clock::duration>(
-          std::chrono::duration<double>{timeout});
 
   for (;;) {
-    count = 0;
     for (auto handle : handles) {
-      auto state = FindState(manager, handle);
-      if (!state) {
+      auto it = manager.states.find(handle);
+      if (it == manager.states.end()) {
         if (count < signaled.size()) {
           // treat a non-existent handle as signaled, but set the error bit
           signaled[count++] = handle | 0x80000000ul;
         }
       } else {
-        if (state->signaled > 0) {
+        auto& state = it->second;
+        if (state.signaled > 0) {
           if (count < signaled.size()) {
             signaled[count++] = handle;
           }
-          if (state->autoReset) {
-            --state->signaled;
-            if (state->signaled < 0) {
-              state->signaled = 0;
+          if (state.autoReset) {
+            --state.signaled;
+            if (state.signaled < 0) {
+              state.signaled = 0;
             }
           }
         }
@@ -397,10 +291,8 @@ std::span<WPI_Handle> wpi::util::WaitForObjects(
     if (!addedWaiters) {
       addedWaiters = true;
       for (auto handle : handles) {
-        auto state = FindState(manager, handle);
-        if (state) {
-          state->waiters.emplace_back(&waiter);
-        }
+        auto& state = manager.states[handle];
+        state.waiters.emplace_back(&cv);
       }
     }
 
@@ -411,15 +303,14 @@ std::span<WPI_Handle> wpi::util::WaitForObjects(
       break;
     }
 
-    locks.clear();
     if (timeout < 0) {
-      waiter.Wait();
-    } else if (waiter.WaitUntil(timeoutTime)) {
-      timedOutVal = true;
-    }
-    locks = LockStateShards(manager, shardIndices);
-    if (timedOutVal) {
-      break;
+      cv.wait(lock);
+    } else {
+      auto timeoutTime = std::chrono::steady_clock::now() +
+                         std::chrono::duration<double>(timeout);
+      if (cv.wait_until(lock, timeoutTime) == std::cv_status::timeout) {
+        timedOutVal = true;
+      }
     }
 
     if (gActive.load(std::memory_order_acquire) < 0) {
@@ -432,13 +323,10 @@ std::span<WPI_Handle> wpi::util::WaitForObjects(
 
   if (addedWaiters) {
     for (auto handle : handles) {
-      auto state = FindState(manager, handle);
-      if (state) {
-        auto it =
-            std::find(state->waiters.begin(), state->waiters.end(), &waiter);
-        if (it != state->waiters.end()) {
-          state->waiters.erase(it);
-        }
+      auto& state = manager.states[handle];
+      auto it = std::find(state.waiters.begin(), state.waiters.end(), &cv);
+      if (it != state.waiters.end()) {
+        state.waiters.erase(it);
       }
     }
   }
@@ -457,9 +345,8 @@ void wpi::util::CreateSignalObject(WPI_Handle handle, bool manualReset,
     return;
   }
   auto& manager = guard.GetManager();
-  auto& shard = manager.GetStateShard(handle);
-  std::scoped_lock lock{shard.mutex};
-  auto& state = shard.states[handle];
+  std::scoped_lock lock{manager.mutex};
+  auto& state = manager.states[handle];
   state.signaled = initialState ? 1 : 0;
   state.autoReset = !manualReset;
 }
@@ -470,16 +357,19 @@ void wpi::util::SetSignalObject(WPI_Handle handle) {
     return;
   }
   auto& manager = guard.GetManager();
-  auto& shard = manager.GetStateShard(handle);
-  std::scoped_lock lock{shard.mutex};
-  auto it = shard.states.find(handle);
-  if (it == shard.states.end()) {
+  std::scoped_lock lock{manager.mutex};
+  auto it = manager.states.find(handle);
+  if (it == manager.states.end()) {
     return;
   }
   auto& state = it->second;
   state.signaled = 1;
   for (auto& waiter : state.waiters) {
-    waiter->Notify();
+    waiter->notify_all();
+    if (state.autoReset) {
+      // expect the first waiter to reset it
+      break;
+    }
   }
 }
 
@@ -489,10 +379,9 @@ void wpi::util::ResetSignalObject(WPI_Handle handle) {
     return;
   }
   auto& manager = guard.GetManager();
-  auto& shard = manager.GetStateShard(handle);
-  std::scoped_lock lock{shard.mutex};
-  auto it = shard.states.find(handle);
-  if (it != shard.states.end()) {
+  std::scoped_lock lock{manager.mutex};
+  auto it = manager.states.find(handle);
+  if (it != manager.states.end()) {
     it->second.signaled = 0;
   }
 }
@@ -503,16 +392,15 @@ void wpi::util::DestroySignalObject(WPI_Handle handle) {
     return;
   }
   auto& manager = guard.GetManager();
-  auto& shard = manager.GetStateShard(handle);
-  std::scoped_lock lock{shard.mutex};
+  std::scoped_lock lock{manager.mutex};
 
-  auto it = shard.states.find(handle);
-  if (it != shard.states.end()) {
+  auto it = manager.states.find(handle);
+  if (it != manager.states.end()) {
     // wake up any waiters
     for (auto& waiter : it->second.waiters) {
-      waiter->Notify();
+      waiter->notify_all();
     }
-    shard.states.erase(it);
+    manager.states.erase(it);
   }
 }
 

--- a/wpiutil/src/test/native/cpp/SynchronizationTest.cpp
+++ b/wpiutil/src/test/native/cpp/SynchronizationTest.cpp
@@ -4,9 +4,7 @@
 
 #include "wpi/util/Synchronization.hpp"
 
-#include <array>
 #include <thread>
-#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -56,58 +54,4 @@ TEST(EventTest, WaitMultiple) {
       wpi::util::WaitForObjects({event1, event2}, signaled, 0, &timedOut);
   ASSERT_EQ(timedOut, true);
   ASSERT_EQ(result2.size(), 0u);
-}
-
-TEST(SemaphoreTest, ReleaseHonorsMaximumCount) {
-  auto semaphore = wpi::util::MakeSemaphore(0, 2);
-
-  int prevCount = -1;
-  ASSERT_TRUE(wpi::util::ReleaseSemaphore(semaphore, 1, &prevCount));
-  EXPECT_EQ(prevCount, 0);
-  ASSERT_TRUE(wpi::util::ReleaseSemaphore(semaphore, 1, &prevCount));
-  EXPECT_EQ(prevCount, 1);
-  ASSERT_FALSE(wpi::util::ReleaseSemaphore(semaphore, 1, &prevCount));
-  EXPECT_EQ(prevCount, 2);
-
-  bool timedOut = true;
-  ASSERT_TRUE(wpi::util::WaitForObject(semaphore, 0, &timedOut));
-  EXPECT_FALSE(timedOut);
-  ASSERT_TRUE(wpi::util::WaitForObject(semaphore, 0, &timedOut));
-  EXPECT_FALSE(timedOut);
-  ASSERT_FALSE(wpi::util::WaitForObject(semaphore, 0, &timedOut));
-  EXPECT_TRUE(timedOut);
-
-  wpi::util::DestroySemaphore(semaphore);
-}
-
-TEST(SignalObjectTest, ConcurrentSetDifferentHandles) {
-  constexpr int HANDLE_COUNT = 64;
-  constexpr int SET_COUNT = 100;
-
-  std::array<WPI_Handle, HANDLE_COUNT> handles;
-  for (int i = 0; i < HANDLE_COUNT; ++i) {
-    handles[i] = (wpi::util::HANDLE_TYPE_USER_BASE << 24) | i;
-    wpi::util::CreateSignalObject(handles[i], true, false);
-  }
-
-  std::vector<std::thread> threads;
-  threads.reserve(HANDLE_COUNT);
-  for (auto handle : handles) {
-    threads.emplace_back([=] {
-      for (int i = 0; i < SET_COUNT; ++i) {
-        wpi::util::SetSignalObject(handle);
-      }
-    });
-  }
-
-  for (auto& thread : threads) {
-    thread.join();
-  }
-
-  for (auto handle : handles) {
-    bool timedOut = true;
-    ASSERT_TRUE(wpi::util::WaitForObject(handle, 0, &timedOut));
-    ASSERT_FALSE(timedOut);
-    wpi::util::DestroySignalObject(handle);
-  }
 }


### PR DESCRIPTION
This reverts commit 0fc749686da0ed8052f513fbf558789d2381719d.

It appears this may be causing frequent random test failures.