### PR TITLE
[cmake] Only pull in datalog if it's needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,9 @@ set(DATALOG_DEP_REPLACE "find_dependency(datalog)")
 
 add_subdirectory(wpiutil)
 
-add_subdirectory(datalog)
+if (WPILIB_WITH_NTCORE OR WPILIB_WITH_GUI OR WPILIB_WITH_WPILIB)
+    add_subdirectory(datalog)
+endif()
 
 if(WPILIB_WITH_NTCORE)
     set(NTCORE_DEP_REPLACE "find_dependency(ntcore)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,11 +247,11 @@ endif()
 set(FILENAME_DEP_REPLACE "get_filename_component(SELF_DIR \"$\{CMAKE_CURRENT_LIST_FILE\}\" PATH)")
 set(SELF_DIR "$\{SELF_DIR\}")
 set(WPIUTIL_DEP_REPLACE "find_dependency(wpiutil)")
-set(DATALOG_DEP_REPLACE "find_dependency(datalog)")
 
 add_subdirectory(wpiutil)
 
 if(WPILIB_WITH_NTCORE OR WPILIB_WITH_GUI OR WPILIB_WITH_WPILIB)
+    set(DATALOG_DEP_REPLACE "find_dependency(datalog)")
     add_subdirectory(datalog)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,7 @@ set(DATALOG_DEP_REPLACE "find_dependency(datalog)")
 
 add_subdirectory(wpiutil)
 
-if (WPILIB_WITH_NTCORE OR WPILIB_WITH_GUI OR WPILIB_WITH_WPILIB)
+if(WPILIB_WITH_NTCORE OR WPILIB_WITH_GUI OR WPILIB_WITH_WPILIB)
     add_subdirectory(datalog)
 endif()
 


### PR DESCRIPTION
ntcore, GUI, and wpilibc are the only cases where this is needed. If
none of those are enabled, don't use it

Signed-off-by: crueter <crueter@eden-emu.dev>
