### PR TITLE
[wpimath] Fix adaptive RKDP advancing time by wrong step size

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/system/NumericalIntegration.java
+++ b/wpimath/src/main/java/org/wpilib/math/system/NumericalIntegration.java
@@ -223,6 +223,7 @@ public final class NumericalIntegration {
 
     Matrix<States, N1> newX;
     double truncationError;
+    double hUsed;
 
     double dtElapsed = 0.0;
     double h = dt;
@@ -232,6 +233,10 @@ public final class NumericalIntegration {
       do {
         // Only allow us to advance up to the dt remaining
         h = Math.min(h, dt - dtElapsed);
+
+        // Record the step size actually used for this attempt, since h is
+        // overwritten below with the proposal for the next step.
+        hUsed = h;
 
         var k1 = f.apply(x, u);
         var k2 = f.apply(x.plus(k1.times(A[0][0]).times(h)), u);
@@ -291,7 +296,7 @@ public final class NumericalIntegration {
         }
       } while (truncationError > maxError);
 
-      dtElapsed += h;
+      dtElapsed += hUsed;
       x = newX;
     }
 
@@ -350,6 +355,7 @@ public final class NumericalIntegration {
 
     Matrix<Rows, Cols> newY;
     double truncationError;
+    double hUsed;
 
     double dtElapsed = 0.0;
     double h = dt;
@@ -359,6 +365,7 @@ public final class NumericalIntegration {
       do {
         // Only allow us to advance up to the dt remaining
         h = Math.min(h, dt - dtElapsed);
+        hUsed = h;
 
         var k1 = f.apply(t, y);
         var k2 = f.apply(t + h * c[0], y.plus(k1.times(A[0][0]).times(h)));
@@ -418,7 +425,7 @@ public final class NumericalIntegration {
         }
       } while (truncationError > maxError);
 
-      dtElapsed += h;
+      dtElapsed += hUsed;
       y = newY;
     }
 

--- a/wpimath/src/main/native/include/wpi/math/system/NumericalIntegration.hpp
+++ b/wpimath/src/main/native/include/wpi/math/system/NumericalIntegration.hpp
@@ -109,6 +109,7 @@ T RKDP(F&& f, T x, U u, wpi::units::second_t dt, double maxError = 1e-6) {
 
   T newX;
   double truncationError;
+  double hUsed;
 
   double dtElapsed = 0.0;
   double h = dt.value();
@@ -118,6 +119,7 @@ T RKDP(F&& f, T x, U u, wpi::units::second_t dt, double maxError = 1e-6) {
     do {
       // Only allow us to advance up to the dt remaining
       h = (std::min)(h, dt.value() - dtElapsed);
+      hUsed = h;
 
       // clang-format off
       T k1 = f(x, u);
@@ -147,7 +149,7 @@ T RKDP(F&& f, T x, U u, wpi::units::second_t dt, double maxError = 1e-6) {
       }
     } while (truncationError > maxError);
 
-    dtElapsed += h;
+    dtElapsed += hUsed;
     x = newX;
   }
 
@@ -196,6 +198,7 @@ T RKDP(F&& f, wpi::units::second_t t, T y, wpi::units::second_t dt,
 
   T newY;
   double truncationError;
+  double hUsed;
 
   double dtElapsed = 0.0;
   double h = dt.value();
@@ -205,6 +208,7 @@ T RKDP(F&& f, wpi::units::second_t t, T y, wpi::units::second_t dt,
     do {
       // Only allow us to advance up to the dt remaining
       h = std::min(h, dt.value() - dtElapsed);
+      hUsed = h;
 
       // clang-format off
       T k1 = f(t, y);
@@ -230,7 +234,7 @@ T RKDP(F&& f, wpi::units::second_t t, T y, wpi::units::second_t dt,
       h *= 0.9 * std::pow(maxError / truncationError, 1.0 / 5.0);
     } while (truncationError > maxError);
 
-    dtElapsed += h;
+    dtElapsed += hUsed;
     y = newY;
   }
 


### PR DESCRIPTION
## Summary

`NumericalIntegration`'s adaptive Dormand–Prince integrator (`RKDP`)
advanced elapsed time by the wrong step size.

After the inner accept/reject loop, the code did `dtElapsed += h`. But
`h` is reassigned at the end of every loop iteration to the proposed
step size for the *next* attempt (either `dt - dtElapsed` when the error
is zero, or scaled by `0.9 * (maxError / truncationError)^(1/5)`). So on
an accepted step, `dtElapsed` advanced by the *next* proposed step
rather than the step actually taken — while the state (`x` / `y`) only
advanced by the real step. The two fall out of sync, and the integrator
under- or over-integrates across `dt`.

## Fix

Capture the step size actually used (`hUsed`) immediately after it is
clamped to the remaining time, before `h` is overwritten, and advance
`dtElapsed += hUsed`.

Applied consistently to both `RKDP` overloads — `(x, u)` and `(t, y)` —
in both Java and C++ to keep the implementations in sync.

## Changes

- `wpimath/.../system/NumericalIntegration.java` — both `rkdp` overloads
- `wpimath/.../system/NumericalIntegration.hpp` — both `RKDP` overloads

Minimal change: adds a local `hUsed`, records it after the clamp, and
uses it for the `dtElapsed` advance. No behavior change to the RK4
methods or the tableau.
