### PR TITLE
[wpilib] DSDisplay.AddData: Display key as well as value

### DIFF
--- a/wpilibc/src/main/native/cpp/driverstation/DSGamepadChooser.cpp
+++ b/wpilibc/src/main/native/cpp/driverstation/DSGamepadChooser.cpp
@@ -4,6 +4,7 @@
 
 #include "wpi/driverstation/DSGamepadChooser.hpp"
 
+#include <atomic>
 #include <cctype>
 #include <cmath>
 #include <cstdint>
@@ -21,6 +22,8 @@
 #include "wpi/driverstation/Gamepad.hpp"
 
 using namespace wpi;
+
+static std::atomic_int instances;
 
 static std::string FormatDouble(double value) {
   std::ostringstream stream;
@@ -67,7 +70,10 @@ void DSGamepadChooser::GamepadSelectable::SelectNext() {
 DSGamepadChooser::DSGamepadChooser(int port)
     : DSGamepadChooser{DriverStation::GetGamepad(port)} {}
 
-DSGamepadChooser::DSGamepadChooser(Gamepad& gamepad) : m_gamepad{&gamepad} {}
+DSGamepadChooser::DSGamepadChooser(Gamepad& gamepad)
+    : m_gamepad{&gamepad},
+      m_captionPrefix{"DSGamepadChooser/" + std::to_string(instances++) + "/"} {
+}
 
 Gamepad& DSGamepadChooser::GetGamepad() {
   return *m_gamepad;
@@ -184,8 +190,8 @@ void DSGamepadChooser::Update() {
 
   for (size_t i = 0; i < m_selectables.size(); i++) {
     const GamepadSelectable& displaySelectable = *m_selectables[i];
-    DriverStationDisplay::AddData(
-        displaySelectable.GetName(),
+    DriverStationDisplay::AddKeyedLine(
+        m_captionPrefix + std::string{displaySelectable.GetName()},
         FormatDisplayLine(displaySelectable,
                           i == static_cast<size_t>(m_selectedSelectable)));
   }
@@ -266,7 +272,9 @@ int DSGamepadChooser::Wrap(int value, int size) {
 std::string DSGamepadChooser::FormatDisplayLine(
     const GamepadSelectable& selectable, bool selected) {
   if (selected) {
-    return "> " + std::string{selectable.GetSelected()} + " <";
+    return "> " + std::string{selectable.GetName()} + " : " +
+           std::string{selectable.GetSelected()} + " <";
   }
-  return "  " + std::string{selectable.GetSelected()};
+  return "  " + std::string{selectable.GetName()} + " : " +
+         std::string{selectable.GetSelected()};
 }

--- a/wpilibc/src/main/native/cpp/driverstation/DSGamepadChooser.cpp
+++ b/wpilibc/src/main/native/cpp/driverstation/DSGamepadChooser.cpp
@@ -4,7 +4,6 @@
 
 #include "wpi/driverstation/DSGamepadChooser.hpp"
 
-#include <atomic>
 #include <cctype>
 #include <cmath>
 #include <cstdint>
@@ -22,8 +21,6 @@
 #include "wpi/driverstation/Gamepad.hpp"
 
 using namespace wpi;
-
-static std::atomic_int instances;
 
 static std::string FormatDouble(double value) {
   std::ostringstream stream;
@@ -70,10 +67,7 @@ void DSGamepadChooser::GamepadSelectable::SelectNext() {
 DSGamepadChooser::DSGamepadChooser(int port)
     : DSGamepadChooser{DriverStation::GetGamepad(port)} {}
 
-DSGamepadChooser::DSGamepadChooser(Gamepad& gamepad)
-    : m_gamepad{&gamepad},
-      m_captionPrefix{"DSGamepadChooser/" + std::to_string(instances++) + "/"} {
-}
+DSGamepadChooser::DSGamepadChooser(Gamepad& gamepad) : m_gamepad{&gamepad} {}
 
 Gamepad& DSGamepadChooser::GetGamepad() {
   return *m_gamepad;
@@ -191,7 +185,7 @@ void DSGamepadChooser::Update() {
   for (size_t i = 0; i < m_selectables.size(); i++) {
     const GamepadSelectable& displaySelectable = *m_selectables[i];
     DriverStationDisplay::AddData(
-        m_captionPrefix + std::string{displaySelectable.GetName()},
+        displaySelectable.GetName(),
         FormatDisplayLine(displaySelectable,
                           i == static_cast<size_t>(m_selectedSelectable)));
   }
@@ -272,9 +266,7 @@ int DSGamepadChooser::Wrap(int value, int size) {
 std::string DSGamepadChooser::FormatDisplayLine(
     const GamepadSelectable& selectable, bool selected) {
   if (selected) {
-    return "> " + std::string{selectable.GetName()} + " : " +
-           std::string{selectable.GetSelected()} + " <";
+    return "> " + std::string{selectable.GetSelected()} + " <";
   }
-  return "  " + std::string{selectable.GetName()} + " : " +
-         std::string{selectable.GetSelected()};
+  return "  " + std::string{selectable.GetSelected()};
 }

--- a/wpilibc/src/main/native/cpp/driverstation/DriverStationDisplay.cpp
+++ b/wpilibc/src/main/native/cpp/driverstation/DriverStationDisplay.cpp
@@ -6,6 +6,7 @@
 
 #include <cctype>
 #include <cstdint>
+#include <format>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -59,46 +60,54 @@ void DriverStationDisplay::SetMode(Mode mode) {
   }
 }
 
-void DriverStationDisplay::AddData(std::string_view caption,
-                                   std::string_view line) {
+static bool IsBlank(std::string_view s) {
+  for (char ch : s) {
+    if (!std::isspace(static_cast<unsigned char>(ch))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void DriverStationDisplay::AddKeyedLine(std::string_view key,
+                                        std::string_view line) {
   auto& storage = GetDisplayStorage();
   std::scoped_lock lock(storage.mutex);
   if (storage.rawMode) {
     return;
   }
 
-  bool hasCaption = false;
-  for (char ch : caption) {
-    if (!std::isspace(static_cast<unsigned char>(ch))) {
-      hasCaption = true;
-      break;
-    }
-  }
-  if (!hasCaption) {
+  if (IsBlank(key)) {
     storage.lines.emplace_back(line);
     return;
   }
 
-  std::string text{caption};
-  text += " : ";
-  text += line;
-
   uint32_t lineNum;
-  auto it = storage.lineMap.find(caption);
+  auto it = storage.lineMap.find(key);
   if (it == storage.lineMap.end()) {
     lineNum = storage.lines.size();
-    storage.lineMap[caption] = lineNum;
-    storage.lines.emplace_back(std::move(text));
+    storage.lineMap[key] = lineNum;
+    storage.lines.emplace_back(line);
   } else {
     lineNum = it->second;
     if (lineNum < storage.lines.size()) {
-      storage.lines[lineNum] = std::move(text);
+      storage.lines[lineNum] = line;
     }
   }
 }
 
+void DriverStationDisplay::AddData(std::string_view caption,
+                                   std::string_view line) {
+  if (IsBlank(caption)) {
+    AddKeyedLine(caption, line);
+    return;
+  }
+
+  AddKeyedLine(caption, std::format("{} : {}", caption, line));
+}
+
 void DriverStationDisplay::AddLine(std::string_view line) {
-  AddData({}, line);
+  AddKeyedLine({}, line);
 }
 
 void DriverStationDisplay::UpdateLines() {

--- a/wpilibc/src/main/native/cpp/driverstation/DriverStationDisplay.cpp
+++ b/wpilibc/src/main/native/cpp/driverstation/DriverStationDisplay.cpp
@@ -79,16 +79,20 @@ void DriverStationDisplay::AddData(std::string_view caption,
     return;
   }
 
+  std::string text{caption};
+  text += " : ";
+  text += line;
+
   uint32_t lineNum;
   auto it = storage.lineMap.find(caption);
   if (it == storage.lineMap.end()) {
     lineNum = storage.lines.size();
     storage.lineMap[caption] = lineNum;
-    storage.lines.emplace_back(line);
+    storage.lines.emplace_back(std::move(text));
   } else {
     lineNum = it->second;
     if (lineNum < storage.lines.size()) {
-      storage.lines[lineNum] = line;
+      storage.lines[lineNum] = std::move(text);
     }
   }
 }

--- a/wpilibc/src/main/native/include/wpi/driverstation/DSGamepadChooser.hpp
+++ b/wpilibc/src/main/native/include/wpi/driverstation/DSGamepadChooser.hpp
@@ -227,6 +227,7 @@ class DSGamepadChooser {
   Gamepad* m_gamepad;
   std::vector<std::unique_ptr<GamepadSelectable>> m_selectables;
   std::unordered_map<std::string, GamepadSelectable*> m_selectableMap;
+  std::string m_captionPrefix;
   int m_selectedSelectable = 0;
 };
 

--- a/wpilibc/src/main/native/include/wpi/driverstation/DSGamepadChooser.hpp
+++ b/wpilibc/src/main/native/include/wpi/driverstation/DSGamepadChooser.hpp
@@ -227,7 +227,6 @@ class DSGamepadChooser {
   Gamepad* m_gamepad;
   std::vector<std::unique_ptr<GamepadSelectable>> m_selectables;
   std::unordered_map<std::string, GamepadSelectable*> m_selectableMap;
-  std::string m_captionPrefix;
   int m_selectedSelectable = 0;
 };
 

--- a/wpilibc/src/main/native/include/wpi/driverstation/DriverStationDisplay.hpp
+++ b/wpilibc/src/main/native/include/wpi/driverstation/DriverStationDisplay.hpp
@@ -36,13 +36,26 @@ class DriverStationDisplay final {
   static void SetMode(Mode mode);
 
   /**
+   * Adds display data in line mode, keyed by an identifier that is not
+   * displayed.
+   *
+   * Repeated calls with the same key before UpdateLines() replace the
+   * previous line. The key is used only to identify the line for
+   * replacement and is not displayed. Empty or whitespace-only keys always
+   * append a new line.
+   *
+   * @param key Line key.
+   * @param line Line contents.
+   */
+  static void AddKeyedLine(std::string_view key, std::string_view line);
+
+  /**
    * Adds display data in line mode.
    *
    * Repeated calls with the same caption before UpdateLines() replace the
-   * previous line. The caption is used to identify the line and is
-   * displayed before the line contents, separated by " : ". Empty or
-   * whitespace-only captions always append a new line and are not
-   * displayed.
+   * previous line. The caption is displayed before the line contents,
+   * separated by " : ". Empty or whitespace-only captions always append a
+   * new line and are not displayed.
    *
    * @param caption Line caption.
    * @param line Line contents.
@@ -52,8 +65,8 @@ class DriverStationDisplay final {
   /**
    * Adds an uncaptioned display line in line mode.
    *
-   * This is equivalent to calling AddData() with an empty caption, which always
-   * appends a new line.
+   * This is equivalent to calling AddKeyedLine() with an empty key, which
+   * always appends a new line.
    *
    * @param line Line contents.
    */

--- a/wpilibc/src/main/native/include/wpi/driverstation/DriverStationDisplay.hpp
+++ b/wpilibc/src/main/native/include/wpi/driverstation/DriverStationDisplay.hpp
@@ -39,8 +39,10 @@ class DriverStationDisplay final {
    * Adds display data in line mode.
    *
    * Repeated calls with the same caption before UpdateLines() replace the
-   * previous line. The caption is used to identify the line and is not
-   * displayed. Empty or whitespace-only captions always append a new line.
+   * previous line. The caption is used to identify the line and is
+   * displayed before the line contents, separated by " : ". Empty or
+   * whitespace-only captions always append a new line and are not
+   * displayed.
    *
    * @param caption Line caption.
    * @param line Line contents.

--- a/wpilibc/src/main/python/semiwrap/DriverStationDisplay.yml
+++ b/wpilibc/src/main/python/semiwrap/DriverStationDisplay.yml
@@ -9,3 +9,4 @@ classes:
       UpdateLines:
       WriteRawAnsi:
       ClearRaw:
+      AddKeyedLine:

--- a/wpilibj/src/main/java/org/wpilib/driverstation/DSGamepadChooser.java
+++ b/wpilibj/src/main/java/org/wpilib/driverstation/DSGamepadChooser.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A set of selectable options controlled by a {@link Gamepad}.
@@ -21,12 +20,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  * buttons change the selected option in the active selectable.
  */
 public class DSGamepadChooser {
-  private static final AtomicInteger s_instances = new AtomicInteger();
-
   private final Gamepad m_gamepad;
   private final List<GamepadSelectable> m_selectables = new ArrayList<>();
   private final Map<String, GamepadSelectable> m_selectableMap = new LinkedHashMap<>();
-  private final String m_captionPrefix;
   private int m_selectedSelectable;
 
   /**
@@ -45,7 +41,6 @@ public class DSGamepadChooser {
    */
   public DSGamepadChooser(Gamepad gamepad) {
     m_gamepad = requireNonNullParam(gamepad, "gamepad", "DSGamepadChooser");
-    m_captionPrefix = "DSGamepadChooser/" + s_instances.getAndIncrement() + "/";
   }
 
   /**
@@ -183,7 +178,7 @@ public class DSGamepadChooser {
     for (int i = 0; i < m_selectables.size(); i++) {
       GamepadSelectable displaySelectable = m_selectables.get(i);
       DriverStationDisplay.addData(
-          m_captionPrefix + displaySelectable.getName(),
+          displaySelectable.getName(),
           formatDisplayLine(displaySelectable, i == m_selectedSelectable));
     }
   }
@@ -271,9 +266,9 @@ public class DSGamepadChooser {
 
   private static String formatDisplayLine(GamepadSelectable selectable, boolean selected) {
     if (selected) {
-      return "> " + selectable.getName() + " : " + selectable.getSelected() + " <";
+      return "> " + selectable.getSelected() + " <";
     }
-    return "  " + selectable.getName() + " : " + selectable.getSelected();
+    return "  " + selectable.getSelected();
   }
 
   /** A single named set of selectable options. */

--- a/wpilibj/src/main/java/org/wpilib/driverstation/DSGamepadChooser.java
+++ b/wpilibj/src/main/java/org/wpilib/driverstation/DSGamepadChooser.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A set of selectable options controlled by a {@link Gamepad}.
@@ -20,9 +21,12 @@ import java.util.Map;
  * buttons change the selected option in the active selectable.
  */
 public class DSGamepadChooser {
+  private static final AtomicInteger s_instances = new AtomicInteger();
+
   private final Gamepad m_gamepad;
   private final List<GamepadSelectable> m_selectables = new ArrayList<>();
   private final Map<String, GamepadSelectable> m_selectableMap = new LinkedHashMap<>();
+  private final String m_captionPrefix;
   private int m_selectedSelectable;
 
   /**
@@ -41,6 +45,7 @@ public class DSGamepadChooser {
    */
   public DSGamepadChooser(Gamepad gamepad) {
     m_gamepad = requireNonNullParam(gamepad, "gamepad", "DSGamepadChooser");
+    m_captionPrefix = "DSGamepadChooser/" + s_instances.getAndIncrement() + "/";
   }
 
   /**
@@ -177,8 +182,8 @@ public class DSGamepadChooser {
 
     for (int i = 0; i < m_selectables.size(); i++) {
       GamepadSelectable displaySelectable = m_selectables.get(i);
-      DriverStationDisplay.addData(
-          displaySelectable.getName(),
+      DriverStationDisplay.addKeyedLine(
+          m_captionPrefix + displaySelectable.getName(),
           formatDisplayLine(displaySelectable, i == m_selectedSelectable));
     }
   }
@@ -266,9 +271,9 @@ public class DSGamepadChooser {
 
   private static String formatDisplayLine(GamepadSelectable selectable, boolean selected) {
     if (selected) {
-      return "> " + selectable.getSelected() + " <";
+      return "> " + selectable.getName() + " : " + selectable.getSelected() + " <";
     }
-    return "  " + selectable.getSelected();
+    return "  " + selectable.getName() + " : " + selectable.getSelected();
   }
 
   /** A single named set of selectable options. */

--- a/wpilibj/src/main/java/org/wpilib/driverstation/DriverStationDisplay.java
+++ b/wpilibj/src/main/java/org/wpilib/driverstation/DriverStationDisplay.java
@@ -68,6 +68,25 @@ public final class DriverStationDisplay {
   }
 
   /**
+   * Adds display data in line mode, keyed by an identifier that is not displayed.
+   *
+   * <p>Repeated calls with the same key before {@link #updateLines()} replace the previous line.
+   * The key is used only to identify the line for replacement and is not displayed. Empty or
+   * whitespace-only keys always append a new line.
+   *
+   * @param key Line key.
+   * @param line Line contents.
+   */
+  public static void addKeyedLine(String key, String line) {
+    m_displayLock.lock();
+    try {
+      addKeyedLineUnderLock(key, line);
+    } finally {
+      m_displayLock.unlock();
+    }
+  }
+
+  /**
    * Adds display data in line mode.
    *
    * <p>Repeated calls with the same caption before {@link #updateLines()} replace the previous
@@ -79,11 +98,14 @@ public final class DriverStationDisplay {
    * @param line Line contents.
    */
   public static void addData(String caption, String line) {
-    m_displayLock.lock();
-    try {
-      addDataUnderLock(caption, line);
-    } finally {
-      m_displayLock.unlock();
+    String captionText = nonNull(caption);
+    String lineText = nonNull(line);
+
+    if (captionText.isBlank()) {
+      addKeyedLine(captionText, lineText);
+    }
+    else {
+      addKeyedLine(captionText, captionText + " : " + lineText);
     }
   }
 
@@ -120,40 +142,38 @@ public final class DriverStationDisplay {
     addData(caption, String.format(format, args));
   }
 
-  private static void addDataUnderLock(String caption, String line) {
+  private static void addKeyedLineUnderLock(String key, String line) {
     if (rawMode) {
       return;
     }
 
-    String captionText = nonNull(caption);
+    String keyText = nonNull(key);
     String lineText = nonNull(line);
 
-    if (captionText.isBlank()) {
+    if (keyText.isBlank()) {
       lines.add(lineText);
       return;
     }
 
-    String text = captionText + " : " + lineText;
-
-    Integer lineNum = lineMap.get(captionText);
+    Integer lineNum = lineMap.get(keyText);
     if (lineNum == null) {
-      lineMap.put(captionText, lines.size());
-      lines.add(text);
+      lineMap.put(keyText, lines.size());
+      lines.add(lineText);
     } else if (lineNum < lines.size()) {
-      lines.set(lineNum, text);
+      lines.set(lineNum, lineText);
     }
   }
 
   /**
    * Adds an uncaptioned display line in line mode.
    *
-   * <p>This is equivalent to calling {@link #addData(String, String)} with an empty caption, which
-   * always appends a new line.
+   * <p>This is equivalent to calling {@link #addKeyedLine(String, String)} with an empty key,
+   * which always appends a new line.
    *
    * @param line Line contents.
    */
   public static void addLine(String line) {
-    addData("", line);
+    addKeyedLine("", line);
   }
 
   /**

--- a/wpilibj/src/main/java/org/wpilib/driverstation/DriverStationDisplay.java
+++ b/wpilibj/src/main/java/org/wpilib/driverstation/DriverStationDisplay.java
@@ -103,8 +103,7 @@ public final class DriverStationDisplay {
 
     if (captionText.isBlank()) {
       addKeyedLine(captionText, lineText);
-    }
-    else {
+    } else {
       addKeyedLine(captionText, captionText + " : " + lineText);
     }
   }
@@ -167,8 +166,8 @@ public final class DriverStationDisplay {
   /**
    * Adds an uncaptioned display line in line mode.
    *
-   * <p>This is equivalent to calling {@link #addKeyedLine(String, String)} with an empty key,
-   * which always appends a new line.
+   * <p>This is equivalent to calling {@link #addKeyedLine(String, String)} with an empty key, which
+   * always appends a new line.
    *
    * @param line Line contents.
    */

--- a/wpilibj/src/main/java/org/wpilib/driverstation/DriverStationDisplay.java
+++ b/wpilibj/src/main/java/org/wpilib/driverstation/DriverStationDisplay.java
@@ -71,8 +71,9 @@ public final class DriverStationDisplay {
    * Adds display data in line mode.
    *
    * <p>Repeated calls with the same caption before {@link #updateLines()} replace the previous
-   * line. The caption is used to identify the line and is not displayed. Empty or whitespace-only
-   * captions always append a new line.
+   * line. The caption is used to identify the line and is displayed before the line contents,
+   * separated by " : ". Empty or whitespace-only captions always append a new line and are not
+   * displayed.
    *
    * @param caption Line caption.
    * @param line Line contents.
@@ -90,8 +91,9 @@ public final class DriverStationDisplay {
    * Adds display data in line mode.
    *
    * <p>Repeated calls with the same caption before {@link #updateLines()} replace the previous
-   * line. The caption is used to identify the line and is not displayed. Empty or whitespace-only
-   * captions always append a new line.
+   * line. The caption is used to identify the line and is displayed before the line contents,
+   * separated by " : ". Empty or whitespace-only captions always append a new line and are not
+   * displayed.
    *
    * <p>The value is converted to text with {@link String#valueOf(Object)}.
    *
@@ -106,8 +108,9 @@ public final class DriverStationDisplay {
    * Adds formatted display data in line mode.
    *
    * <p>Repeated calls with the same caption before {@link #updateLines()} replace the previous
-   * line. The caption is used to identify the line and is not displayed. Empty or whitespace-only
-   * captions always append a new line.
+   * line. The caption is used to identify the line and is displayed before the line contents,
+   * separated by " : ". Empty or whitespace-only captions always append a new line and are not
+   * displayed.
    *
    * @param caption Line caption.
    * @param format Format string.
@@ -130,12 +133,14 @@ public final class DriverStationDisplay {
       return;
     }
 
+    String text = captionText + " : " + lineText;
+
     Integer lineNum = lineMap.get(captionText);
     if (lineNum == null) {
       lineMap.put(captionText, lines.size());
-      lines.add(lineText);
+      lines.add(text);
     } else if (lineNum < lines.size()) {
-      lines.set(lineNum, lineText);
+      lines.set(lineNum, text);
     }
   }
 


### PR DESCRIPTION
AddData (for the driver station) was added to be a convenience for FTC teams that are required to use only the driver station during matches and so can't use full dashboards.  

However, due to a misunderstanding it didn't work in the same way.   This PR changes it to work like FTC teams are used to.   

In FTC, the way it works AddData("yaw reading", imu.getYaw()); would print yaw reading : 90.0 which seems very user helpful.   Not displaying the caption means people will have to write code like : AddData("yaw reading", "yaw reading : " + imu.getYaw()); which feels very repetitive

DSGamepadChooser had to be changed as well because it depended on the caption only being a key and not being displayed.