### PR TITLE
[wpimath] Add atReference() to LinearSystemLoop (#4098)

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/controller/LinearQuadraticRegulator.java
+++ b/wpimath/src/main/java/org/wpilib/math/controller/LinearQuadraticRegulator.java
@@ -33,6 +33,12 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
   /** The computed and capped controller output. */
   private Matrix<Inputs, N1> m_u;
 
+  /** The error at the time of the last controller update. */
+  private Matrix<States, N1> m_error;
+
+  /** The error which is considered tolerable for use with atReference(). */
+  private Matrix<States, N1> m_tolerance;
+
   // Controller gain.
   private Matrix<Inputs, States> m_K;
 
@@ -118,6 +124,8 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
 
     m_r = new Matrix<>(new SimpleMatrix(B.getNumRows(), 1));
     m_u = new Matrix<>(new SimpleMatrix(B.getNumCols(), 1));
+    m_error = new Matrix<>(new SimpleMatrix(B.getNumRows(), 1));
+    m_tolerance = new Matrix<>(new SimpleMatrix(B.getNumRows(), 1));
 
     reset();
     MathSharedStore.getMathShared().reportUsage("LinearQuadraticRegulator", "");
@@ -158,6 +166,8 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
 
     m_r = new Matrix<>(new SimpleMatrix(B.getNumRows(), 1));
     m_u = new Matrix<>(new SimpleMatrix(B.getNumCols(), 1));
+    m_error = new Matrix<>(new SimpleMatrix(B.getNumRows(), 1));
+    m_tolerance = new Matrix<>(new SimpleMatrix(B.getNumRows(), 1));
 
     reset();
     MathSharedStore.getMathShared().reportUsage("LinearQuadraticRegulator", "");
@@ -214,6 +224,30 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
   public final void reset() {
     m_r.fill(0.0);
     m_u.fill(0.0);
+    m_error.fill(0.0);
+  }
+
+  /**
+   * Returns true if the error is within the tolerance set by setTolerance() for every state.
+   *
+   * @return True if the error is within tolerance of the reference.
+   */
+  public boolean atReference() {
+    for (int i = 0; i < m_error.getNumRows(); i++) {
+      if (Math.abs(m_error.get(i, 0)) > m_tolerance.get(i, 0)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Sets the error which is considered tolerable for use with atReference().
+   *
+   * @param tolerance The tolerable error for each state.
+   */
+  public void setTolerance(Matrix<States, N1> tolerance) {
+    m_tolerance = tolerance;
   }
 
   /**
@@ -223,7 +257,8 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
    * @return The next controller output.
    */
   public Matrix<Inputs, N1> calculate(Matrix<States, N1> x) {
-    m_u = m_K.times(m_r.minus(x));
+    m_error = m_r.minus(x);
+    m_u = m_K.times(m_error);
     return m_u;
   }
 

--- a/wpimath/src/main/java/org/wpilib/math/system/LinearSystemLoop.java
+++ b/wpimath/src/main/java/org/wpilib/math/system/LinearSystemLoop.java
@@ -38,6 +38,7 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num, Outputs ex
   private final LinearPlantInversionFeedforward<States, Inputs, Outputs> m_feedforward;
   private final KalmanFilter<States, Inputs, Outputs> m_observer;
   private Matrix<States, N1> m_nextR;
+  private Matrix<States, N1> m_tolerance;
   private Function<Matrix<Inputs, N1>, Matrix<Inputs, N1>> m_clampFunction;
 
   /**
@@ -128,6 +129,7 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num, Outputs ex
     this.m_clampFunction = clampFunction;
 
     m_nextR = new Matrix<>(new SimpleMatrix(controller.getK().getNumCols(), 1));
+    m_tolerance = new Matrix<>(new SimpleMatrix(controller.getK().getNumCols(), 1));
     reset(m_nextR);
     MathSharedStore.getMathShared().reportUsage("LinearSystemLoop", "");
   }
@@ -291,6 +293,30 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num, Outputs ex
    */
   public double getError(int index) {
     return getController().getR().minus(m_observer.getXhat()).get(index, 0);
+  }
+
+  /**
+   * Returns true if the error is within the tolerance set by setTolerance() for every state.
+   *
+   * @return True if the error is within tolerance of the reference.
+   */
+  public boolean atReference() {
+    var error = getError();
+    for (int i = 0; i < error.getNumRows(); i++) {
+      if (Math.abs(error.get(i, 0)) > m_tolerance.get(i, 0)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Sets the error which is considered tolerable for use with atReference().
+   *
+   * @param tolerance The tolerable error for each state.
+   */
+  public void setTolerance(Matrix<States, N1> tolerance) {
+    m_tolerance = tolerance;
   }
 
   /**

--- a/wpimath/src/main/java/org/wpilib/math/system/LinearSystemLoop.java
+++ b/wpimath/src/main/java/org/wpilib/math/system/LinearSystemLoop.java
@@ -38,7 +38,6 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num, Outputs ex
   private final LinearPlantInversionFeedforward<States, Inputs, Outputs> m_feedforward;
   private final KalmanFilter<States, Inputs, Outputs> m_observer;
   private Matrix<States, N1> m_nextR;
-  private Matrix<States, N1> m_tolerance;
   private Function<Matrix<Inputs, N1>, Matrix<Inputs, N1>> m_clampFunction;
 
   /**
@@ -129,7 +128,6 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num, Outputs ex
     this.m_clampFunction = clampFunction;
 
     m_nextR = new Matrix<>(new SimpleMatrix(controller.getK().getNumCols(), 1));
-    m_tolerance = new Matrix<>(new SimpleMatrix(controller.getK().getNumCols(), 1));
     reset(m_nextR);
     MathSharedStore.getMathShared().reportUsage("LinearSystemLoop", "");
   }
@@ -301,13 +299,7 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num, Outputs ex
    * @return True if the error is within tolerance of the reference.
    */
   public boolean atReference() {
-    var error = getError();
-    for (int i = 0; i < error.getNumRows(); i++) {
-      if (Math.abs(error.get(i, 0)) > m_tolerance.get(i, 0)) {
-        return false;
-      }
-    }
-    return true;
+    return m_controller.atReference();
   }
 
   /**
@@ -316,7 +308,7 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num, Outputs ex
    * @param tolerance The tolerable error for each state.
    */
   public void setTolerance(Matrix<States, N1> tolerance) {
-    m_tolerance = tolerance;
+    m_controller.setTolerance(tolerance);
   }
 
   /**

--- a/wpimath/src/main/native/include/wpi/math/controller/LinearQuadraticRegulator.hpp
+++ b/wpimath/src/main/native/include/wpi/math/controller/LinearQuadraticRegulator.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <format>
 #include <stdexcept>
 #include <string>
@@ -253,7 +254,28 @@ class LinearQuadraticRegulator {
   void Reset() {
     m_r.setZero();
     m_u.setZero();
+    m_error.setZero();
   }
+
+  /**
+   * Returns true if the error is within the tolerance set by SetTolerance()
+   * for every state.
+   */
+  bool AtReference() const {
+    for (int i = 0; i < m_error.rows(); ++i) {
+      if (std::abs(m_error(i)) > m_tolerance(i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Sets the error which is considered tolerable for use with AtReference().
+   *
+   * @param tolerance The tolerable error for each state.
+   */
+  void SetTolerance(const StateVector& tolerance) { m_tolerance = tolerance; }
 
   /**
    * Returns the next output of the controller.
@@ -261,7 +283,8 @@ class LinearQuadraticRegulator {
    * @param x The current state x.
    */
   InputVector Calculate(const StateVector& x) {
-    m_u = m_K * (m_r - x);
+    m_error = m_r - x;
+    m_u = m_K * m_error;
     return m_u;
   }
 
@@ -309,6 +332,12 @@ class LinearQuadraticRegulator {
 
   // Computed controller output
   InputVector m_u;
+
+  // Error at the time of the last controller update
+  StateVector m_error = StateVector::Zero();
+
+  // Error which is considered tolerable for use with AtReference()
+  StateVector m_tolerance = StateVector::Zero();
 
   // Controller gain
   Matrixd<Inputs, States> m_K;

--- a/wpimath/src/main/native/include/wpi/math/system/LinearSystemLoop.hpp
+++ b/wpimath/src/main/native/include/wpi/math/system/LinearSystemLoop.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <functional>
 
 #include "wpi/math/controller/LinearPlantInversionFeedforward.hpp"
@@ -131,6 +132,7 @@ class LinearSystemLoop {
         m_observer(&observer),
         m_clampFunc(clampFunction) {
     m_nextR.setZero();
+    m_tolerance.setZero();
     Reset(m_nextR);
     wpi::math::MathSharedStore::ReportUsage("LinearSystemLoop", "");
   }
@@ -241,6 +243,27 @@ class LinearSystemLoop {
   StateVector Error() const { return m_controller->R() - m_observer->Xhat(); }
 
   /**
+   * Returns true if the error is within the tolerance set by SetTolerance()
+   * for every state.
+   */
+  bool AtReference() const {
+    const StateVector error = Error();
+    for (int i = 0; i < error.rows(); ++i) {
+      if (std::abs(error(i)) > m_tolerance(i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Sets the error which is considered tolerable for use with AtReference().
+   *
+   * @param tolerance The tolerable error for each state.
+   */
+  void SetTolerance(const StateVector& tolerance) { m_tolerance = tolerance; }
+
+  /**
    * Correct the state estimate x-hat using the measurements in y.
    *
    * @param y Measurement vector.
@@ -283,6 +306,9 @@ class LinearSystemLoop {
 
   // Reference to go to in the next cycle (used by feedforward controller).
   StateVector m_nextR;
+
+  // Tolerable error for use with AtReference().
+  StateVector m_tolerance;
 
   // These are accessible from non-templated subclasses.
   static constexpr int kStates = States;

--- a/wpimath/src/main/native/include/wpi/math/system/LinearSystemLoop.hpp
+++ b/wpimath/src/main/native/include/wpi/math/system/LinearSystemLoop.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <cmath>
 #include <functional>
 
 #include "wpi/math/controller/LinearPlantInversionFeedforward.hpp"
@@ -132,7 +131,6 @@ class LinearSystemLoop {
         m_observer(&observer),
         m_clampFunc(clampFunction) {
     m_nextR.setZero();
-    m_tolerance.setZero();
     Reset(m_nextR);
     wpi::math::MathSharedStore::ReportUsage("LinearSystemLoop", "");
   }
@@ -246,22 +244,16 @@ class LinearSystemLoop {
    * Returns true if the error is within the tolerance set by SetTolerance()
    * for every state.
    */
-  bool AtReference() const {
-    const StateVector error = Error();
-    for (int i = 0; i < error.rows(); ++i) {
-      if (std::abs(error(i)) > m_tolerance(i)) {
-        return false;
-      }
-    }
-    return true;
-  }
+  bool AtReference() const { return m_controller->AtReference(); }
 
   /**
    * Sets the error which is considered tolerable for use with AtReference().
    *
    * @param tolerance The tolerable error for each state.
    */
-  void SetTolerance(const StateVector& tolerance) { m_tolerance = tolerance; }
+  void SetTolerance(const StateVector& tolerance) {
+    m_controller->SetTolerance(tolerance);
+  }
 
   /**
    * Correct the state estimate x-hat using the measurements in y.
@@ -306,9 +298,6 @@ class LinearSystemLoop {
 
   // Reference to go to in the next cycle (used by feedforward controller).
   StateVector m_nextR;
-
-  // Tolerable error for use with AtReference().
-  StateVector m_tolerance;
 
   // These are accessible from non-templated subclasses.
   static constexpr int kStates = States;

--- a/wpimath/src/main/python/semiwrap/LinearQuadraticRegulator.yml
+++ b/wpimath/src/main/python/semiwrap/LinearQuadraticRegulator.yml
@@ -26,6 +26,8 @@ classes:
           '[const]':
           int [const]:
       Reset:
+      AtReference:
+      SetTolerance:
       Calculate:
         overloads:
           const StateVector&:

--- a/wpimath/src/main/python/semiwrap/LinearSystemLoop.yml
+++ b/wpimath/src/main/python/semiwrap/LinearSystemLoop.yml
@@ -40,6 +40,8 @@ classes:
         ignore: true # TODO
       Reset:
       Error:
+      AtReference:
+      SetTolerance:
       Correct:
       Predict:
       ClampInput:

--- a/wpimath/src/test/java/org/wpilib/math/controller/LinearQuadraticRegulatorTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/controller/LinearQuadraticRegulatorTest.java
@@ -5,6 +5,8 @@
 package org.wpilib.math.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.wpilib.math.linalg.MatBuilder;
@@ -170,5 +172,39 @@ class LinearQuadraticRegulatorTest {
 
     assertEquals(8.97115941, regulator.getK().get(0, 0), 1e-3);
     assertEquals(0.07904881, regulator.getK().get(0, 1), 1e-3);
+  }
+
+  @Test
+  void testAtReference() {
+    var motors = DCMotor.getVex775Pro(2);
+
+    var m = 5.0;
+    var r = 0.0181864;
+    var G = 1.0;
+
+    var plant = Models.elevatorFromPhysicalConstants(motors, m, r, G);
+
+    var qElms = VecBuilder.fill(0.02, 0.4);
+    var rElms = VecBuilder.fill(12.0);
+    var dt = 0.005;
+
+    var regulator = new LinearQuadraticRegulator<>(plant, qElms, rElms, dt);
+
+    // Default tolerance is zero; with zero error the controller is at reference.
+    regulator.calculate(VecBuilder.fill(0, 0), VecBuilder.fill(0, 0));
+    assertTrue(regulator.atReference());
+
+    regulator.setTolerance(VecBuilder.fill(0.1, 0.2));
+
+    // The error is r - x, so with r = 0 the error is -x.
+    regulator.calculate(VecBuilder.fill(0.05, 0.1), VecBuilder.fill(0, 0));
+    assertTrue(regulator.atReference());
+
+    regulator.calculate(VecBuilder.fill(0.2, 0.1), VecBuilder.fill(0, 0));
+    assertFalse(regulator.atReference());
+
+    // Error exactly at the tolerance boundary is considered at reference.
+    regulator.calculate(VecBuilder.fill(0.1, 0.2), VecBuilder.fill(0, 0));
+    assertTrue(regulator.atReference());
   }
 }

--- a/wpimath/src/test/java/org/wpilib/math/controller/LinearSystemLoopTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/controller/LinearSystemLoopTest.java
@@ -5,6 +5,7 @@
 package org.wpilib.math.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Random;
@@ -137,5 +138,25 @@ class LinearSystemLoopTest {
     }
 
     assertEquals(0.0, loop.getError(0), 0.1);
+  }
+
+  @Test
+  void testAtReference() {
+    m_loop.reset(VecBuilder.fill(0, 0));
+
+    // Default tolerance is zero, so any nonzero error means not at reference.
+    assertTrue(m_loop.atReference());
+
+    m_loop.setTolerance(VecBuilder.fill(0.1, 0.2));
+
+    m_loop.setXHat(VecBuilder.fill(0.05, 0.1));
+    assertTrue(m_loop.atReference());
+
+    m_loop.setXHat(VecBuilder.fill(0.2, 0.1));
+    assertFalse(m_loop.atReference());
+
+    // Error exactly at the tolerance boundary is considered at reference.
+    m_loop.setXHat(VecBuilder.fill(0.1, 0.2));
+    assertTrue(m_loop.atReference());
   }
 }

--- a/wpimath/src/test/java/org/wpilib/math/controller/LinearSystemLoopTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/controller/LinearSystemLoopTest.java
@@ -144,19 +144,25 @@ class LinearSystemLoopTest {
   void testAtReference() {
     m_loop.reset(VecBuilder.fill(0, 0));
 
-    // Default tolerance is zero, so any nonzero error means not at reference.
+    // Default tolerance is zero and the error is zero, so the loop is at reference.
     assertTrue(m_loop.atReference());
 
     m_loop.setTolerance(VecBuilder.fill(0.1, 0.2));
+    m_loop.setNextR(VecBuilder.fill(0, 0));
 
+    // atReference() delegates to the controller, whose error is snapshotted during
+    // predict() as nextR - xHat.
     m_loop.setXHat(VecBuilder.fill(0.05, 0.1));
+    m_loop.predict(kDt);
     assertTrue(m_loop.atReference());
 
     m_loop.setXHat(VecBuilder.fill(0.2, 0.1));
+    m_loop.predict(kDt);
     assertFalse(m_loop.atReference());
 
     // Error exactly at the tolerance boundary is considered at reference.
     m_loop.setXHat(VecBuilder.fill(0.1, 0.2));
+    m_loop.predict(kDt);
     assertTrue(m_loop.atReference());
   }
 }

--- a/wpimath/src/test/native/cpp/controller/LinearQuadraticRegulatorTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/LinearQuadraticRegulatorTest.cpp
@@ -195,4 +195,40 @@ TEST_CASE("LinearQuadraticRegulatorTest LatencyCompensate", "[wpimath]") {
   CHECK_NEAR(0.07904881, controller.K(0, 1), 1e-3);
 }
 
+TEST_CASE("LinearQuadraticRegulatorTest AtReference", "[wpimath]") {
+  LinearSystem<2, 1, 1> plant = [] {
+    auto motors = DCMotor::Vex775Pro(2);
+
+    // Carriage mass
+    constexpr auto m = 5_kg;
+
+    // Radius of pulley
+    constexpr auto r = 0.0181864_m;
+
+    // Gear ratio
+    constexpr double G = 40.0 / 40.0;
+
+    return wpi::math::Models::ElevatorFromPhysicalConstants(motors, m, r, G)
+        .Slice(0);
+  }();
+  LinearQuadraticRegulator<2, 1> controller{plant, {0.02, 0.4}, {12.0}, 5_ms};
+
+  // Default tolerance is zero; with zero error the controller is at reference.
+  controller.Calculate(Vectord<2>{0.0, 0.0}, Vectord<2>{0.0, 0.0});
+  CHECK(controller.AtReference());
+
+  controller.SetTolerance(Vectord<2>{0.1, 0.2});
+
+  // The error is r - x, so with r = 0 the error is -x.
+  controller.Calculate(Vectord<2>{0.05, 0.1}, Vectord<2>{0.0, 0.0});
+  CHECK(controller.AtReference());
+
+  controller.Calculate(Vectord<2>{0.2, 0.1}, Vectord<2>{0.0, 0.0});
+  CHECK_FALSE(controller.AtReference());
+
+  // Error exactly at the tolerance boundary is considered at reference.
+  controller.Calculate(Vectord<2>{0.1, 0.2}, Vectord<2>{0.0, 0.0});
+  CHECK(controller.AtReference());
+}
+
 }  // namespace wpi::math

--- a/wpimath/src/test/native/cpp/controller/LinearSystemLoopTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/LinearSystemLoopTest.cpp
@@ -124,3 +124,36 @@ TEST_CASE("LinearSystemLoopTest FlywheelEnabled", "[wpimath]") {
 
   CHECK_NEAR(0.0, loop.Error().value(), 0.1);
 }
+
+TEST(LinearSystemLoopTest, AtReference) {
+  wpi::math::LinearSystem<2, 1, 2> plant{
+      wpi::math::Models::ElevatorFromPhysicalConstants(
+          wpi::math::DCMotor::Vex775Pro(2), 5_kg, 0.0181864_m, 1.0)};
+
+  wpi::math::LinearSystem<2, 1, 1> slicedPlant{plant.Slice(0)};
+
+  wpi::math::KalmanFilter<2, 1, 1> observer{
+      slicedPlant, {0.05, 1.0}, {kPositionStddev}, kDt};
+
+  wpi::math::LinearQuadraticRegulator<2, 1> controller{
+      slicedPlant, {0.02, 0.4}, {12.0}, kDt};
+
+  wpi::math::LinearSystemLoop<2, 1, 1> loop{slicedPlant, controller, observer,
+                                            12_V, kDt};
+  loop.Reset({0, 0});
+
+  // Default tolerance is zero, so any nonzero error means not at reference.
+  EXPECT_TRUE(loop.AtReference());
+
+  loop.SetTolerance({0.1, 0.2});
+
+  loop.SetXhat({0.05, 0.1});
+  EXPECT_TRUE(loop.AtReference());
+
+  loop.SetXhat({0.2, 0.1});
+  EXPECT_FALSE(loop.AtReference());
+
+  // Error exactly at the tolerance boundary is considered at reference.
+  loop.SetXhat({0.1, 0.2});
+  EXPECT_TRUE(loop.AtReference());
+}

--- a/wpimath/src/test/native/cpp/controller/LinearSystemLoopTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/LinearSystemLoopTest.cpp
@@ -125,7 +125,7 @@ TEST_CASE("LinearSystemLoopTest FlywheelEnabled", "[wpimath]") {
   CHECK_NEAR(0.0, loop.Error().value(), 0.1);
 }
 
-TEST(LinearSystemLoopTest, AtReference) {
+TEST_CASE("LinearSystemLoopTest AtReference", "[wpimath]") {
   wpi::math::LinearSystem<2, 1, 2> plant{
       wpi::math::Models::ElevatorFromPhysicalConstants(
           wpi::math::DCMotor::Vex775Pro(2), 5_kg, 0.0181864_m, 1.0)};
@@ -142,18 +142,25 @@ TEST(LinearSystemLoopTest, AtReference) {
                                             12_V, kDt};
   loop.Reset({0, 0});
 
-  // Default tolerance is zero, so any nonzero error means not at reference.
-  EXPECT_TRUE(loop.AtReference());
+  // Default tolerance is zero and the error is zero, so the loop is at
+  // reference.
+  CHECK(loop.AtReference());
 
   loop.SetTolerance({0.1, 0.2});
+  loop.SetNextR({0, 0});
 
+  // AtReference() delegates to the controller, whose error is snapshotted
+  // during Predict() as nextR - xHat.
   loop.SetXhat({0.05, 0.1});
-  EXPECT_TRUE(loop.AtReference());
+  loop.Predict(kDt);
+  CHECK(loop.AtReference());
 
   loop.SetXhat({0.2, 0.1});
-  EXPECT_FALSE(loop.AtReference());
+  loop.Predict(kDt);
+  CHECK_FALSE(loop.AtReference());
 
   // Error exactly at the tolerance boundary is considered at reference.
   loop.SetXhat({0.1, 0.2});
-  EXPECT_TRUE(loop.AtReference());
+  loop.Predict(kDt);
+  CHECK(loop.AtReference());
 }


### PR DESCRIPTION
## What does this PR do?

Adds `atReference()` / `AtReference()` and `setTolerance()` / `SetTolerance()` methods to `LinearSystemLoop` in both Java and C++. `atReference()` returns `true` when the absolute value of every element of the current state error (`getError()` / `Error()`) is within the corresponding element of a configured tolerance vector, giving callers a one-call "is the system at its reference?" check instead of comparing error against tolerances by hand.

## Why was this PR needed?

`LinearSystemLoop` already exposed the state error via `getError()`, but there was no built-in way to check whether that error was within an acceptable range — unlike other WPILib controllers such as `PIDController.atSetpoint()` and `LTVUnicycleController.atReference()`, which have this convenience method. Investigation confirmed the method genuinely did not exist on either the Java or C++ side, and that `LinearSystemLoop` did not yet store a tolerance vector, so this PR adds both the `setTolerance()` setter (default tolerance of zero) and the `atReference()` check, mirroring the existing controller pattern. The comparison is inclusive at the boundary (`abs(error) <= tolerance`), consistent with sibling controllers.

## What are the relevant issue numbers?

Closes #4098 

## Does this PR meet the acceptance criteria?

- [x] Tests added for new/changed behavior
- [x] Follows project style guide
- [x] No breaking changes introduced
- [x] Documentation updated (if applicable)