### PR TITLE
[hal] Adjust IO count error message

### DIFF
--- a/hal/src/main/native/sim/AddressableLED.cpp
+++ b/hal/src/main/native/sim/AddressableLED.cpp
@@ -28,7 +28,7 @@ HAL_AddressableLEDHandle HAL_InitializeAddressableLED(
   if (channel < 0 || channel >= kNumAddressableLEDs) {
     *status = MakeErrorIndexOutOfRange(HAL_RESOURCE_OUT_OF_RANGE,
                                        "Invalid Index for AddressableLED", 0,
-                                       kNumAddressableLEDs, channel);
+                                       kNumAddressableLEDs - 1, channel);
     return HAL_INVALID_HANDLE;
   }
 

--- a/hal/src/main/native/sim/AnalogInput.cpp
+++ b/hal/src/main/native/sim/AnalogInput.cpp
@@ -23,7 +23,7 @@ HAL_AnalogInputHandle HAL_InitializeAnalogInputPort(
   if (channel < 0 || channel >= kNumAnalogInputs) {
     *status = MakeErrorIndexOutOfRange(HAL_RESOURCE_OUT_OF_RANGE,
                                        "Invalid Index for Analog Input", 0,
-                                       kNumAnalogInputs, channel);
+                                       kNumAnalogInputs - 1, channel);
     return HAL_INVALID_HANDLE;
   }
 

--- a/hal/src/main/native/sim/DIO.cpp
+++ b/hal/src/main/native/sim/DIO.cpp
@@ -40,7 +40,7 @@ HAL_DigitalHandle HAL_InitializeDIOPort(int32_t channel, HAL_Bool input,
   if (channel < 0 || channel >= kNumDigitalChannels) {
     *status = MakeErrorIndexOutOfRange(HAL_RESOURCE_OUT_OF_RANGE,
                                        "Invalid Index for DIO", 0,
-                                       kNumDigitalChannels, channel);
+                                       kNumDigitalChannels - 1, channel);
     return HAL_INVALID_HANDLE;
   }
 

--- a/hal/src/main/native/sim/PWM.cpp
+++ b/hal/src/main/native/sim/PWM.cpp
@@ -27,7 +27,7 @@ HAL_DigitalHandle HAL_InitializePWMPort(int32_t channel,
   if (channel < 0 || channel >= kNumPWMChannels) {
     *status = MakeErrorIndexOutOfRange(HAL_RESOURCE_OUT_OF_RANGE,
                                        "Invalid Index for PWM", 0,
-                                       kNumPWMChannels, channel);
+                                       kNumPWMChannels - 1, channel);
     return HAL_INVALID_HANDLE;
   }
 

--- a/hal/src/main/native/systemcore/AddressableLED.cpp
+++ b/hal/src/main/native/systemcore/AddressableLED.cpp
@@ -80,7 +80,7 @@ HAL_AddressableLEDHandle HAL_InitializeAddressableLED(
   if (channel < 0 || channel >= kNumSmartIo) {
     *status = MakeErrorIndexOutOfRange(HAL_RESOURCE_OUT_OF_RANGE,
                                        "Invalid Index for AddressableLED", 0,
-                                       kNumSmartIo, channel);
+                                       kNumSmartIo - 1, channel);
     return HAL_INVALID_HANDLE;
   }
 

--- a/hal/src/main/native/systemcore/AnalogInput.cpp
+++ b/hal/src/main/native/systemcore/AnalogInput.cpp
@@ -30,7 +30,7 @@ HAL_AnalogInputHandle HAL_InitializeAnalogInputPort(
   if (channel < 0 || channel >= kNumSmartIo) {
     *status = MakeErrorIndexOutOfRange(HAL_RESOURCE_OUT_OF_RANGE,
                                        "Invalid Index for Analog", 0,
-                                       kNumSmartIo, channel);
+                                       kNumSmartIo - 1, channel);
     return HAL_INVALID_HANDLE;
   }
 

--- a/hal/src/main/native/systemcore/Counter.cpp
+++ b/hal/src/main/native/systemcore/Counter.cpp
@@ -28,7 +28,7 @@ HAL_CounterHandle HAL_InitializeCounter(int channel, HAL_Bool risingEdge,
   if (channel == INVALID_HANDLE_INDEX || channel >= kNumSmartIo) {
     *status = MakeErrorIndexOutOfRange(HAL_RESOURCE_OUT_OF_RANGE,
                                        "Invalid Index for Counter", 0,
-                                       kNumSmartIo, channel);
+                                       kNumSmartIo - 1, channel);
     return HAL_INVALID_HANDLE;
   }
 

--- a/hal/src/main/native/systemcore/DIO.cpp
+++ b/hal/src/main/native/systemcore/DIO.cpp
@@ -31,7 +31,7 @@ HAL_DigitalHandle HAL_InitializeDIOPort(int32_t channel, HAL_Bool input,
 
   if (channel < 0 || channel >= kNumSmartIo) {
     *status = MakeErrorIndexOutOfRange(HAL_RESOURCE_OUT_OF_RANGE,
-                                       "Invalid Index for DIO", 0, 
+                                       "Invalid Index for DIO", 0,
                                        kNumSmartIo - 1, channel);
     return HAL_INVALID_HANDLE;
   }

--- a/hal/src/main/native/systemcore/DIO.cpp
+++ b/hal/src/main/native/systemcore/DIO.cpp
@@ -31,7 +31,7 @@ HAL_DigitalHandle HAL_InitializeDIOPort(int32_t channel, HAL_Bool input,
 
   if (channel < 0 || channel >= kNumSmartIo) {
     *status = MakeErrorIndexOutOfRange(HAL_RESOURCE_OUT_OF_RANGE,
-                                       "Invalid Index for DIO", 0, kNumSmartIo,
+                                       "Invalid Index for DIO", 0, kNumSmartIo - 1,
                                        channel);
     return HAL_INVALID_HANDLE;
   }

--- a/hal/src/main/native/systemcore/DIO.cpp
+++ b/hal/src/main/native/systemcore/DIO.cpp
@@ -31,8 +31,8 @@ HAL_DigitalHandle HAL_InitializeDIOPort(int32_t channel, HAL_Bool input,
 
   if (channel < 0 || channel >= kNumSmartIo) {
     *status = MakeErrorIndexOutOfRange(HAL_RESOURCE_OUT_OF_RANGE,
-                                       "Invalid Index for DIO", 0, kNumSmartIo - 1,
-                                       channel);
+                                       "Invalid Index for DIO", 0, 
+                                       kNumSmartIo - 1, channel);
     return HAL_INVALID_HANDLE;
   }
 

--- a/hal/src/main/native/systemcore/DutyCycle.cpp
+++ b/hal/src/main/native/systemcore/DutyCycle.cpp
@@ -30,7 +30,7 @@ HAL_DutyCycleHandle HAL_InitializeDutyCycle(int32_t channel,
   if (channel < 0 || channel >= kNumSmartIo) {
     *status = MakeErrorIndexOutOfRange(HAL_RESOURCE_OUT_OF_RANGE,
                                        "Invalid Index for DutyCycle", 0,
-                                       kNumSmartIo, channel);
+                                       kNumSmartIo - 1, channel);
     return HAL_INVALID_HANDLE;
   }
 

--- a/hal/src/main/native/systemcore/PWM.cpp
+++ b/hal/src/main/native/systemcore/PWM.cpp
@@ -32,8 +32,8 @@ HAL_DigitalHandle HAL_InitializePWMPort(int32_t channel,
 
   if (channel < 0 || channel >= kNumSmartIo) {
     *status = MakeErrorIndexOutOfRange(HAL_RESOURCE_OUT_OF_RANGE,
-                                       "Invalid Index for PWM", 0, kNumSmartIo - 1,
-                                       channel);
+                                       "Invalid Index for PWM", 0, 
+                                       kNumSmartIo - 1, channel);
     return HAL_INVALID_HANDLE;
   }
 

--- a/hal/src/main/native/systemcore/PWM.cpp
+++ b/hal/src/main/native/systemcore/PWM.cpp
@@ -32,7 +32,7 @@ HAL_DigitalHandle HAL_InitializePWMPort(int32_t channel,
 
   if (channel < 0 || channel >= kNumSmartIo) {
     *status = MakeErrorIndexOutOfRange(HAL_RESOURCE_OUT_OF_RANGE,
-                                       "Invalid Index for PWM", 0, 
+                                       "Invalid Index for PWM", 0,
                                        kNumSmartIo - 1, channel);
     return HAL_INVALID_HANDLE;
   }

--- a/hal/src/main/native/systemcore/PWM.cpp
+++ b/hal/src/main/native/systemcore/PWM.cpp
@@ -32,7 +32,7 @@ HAL_DigitalHandle HAL_InitializePWMPort(int32_t channel,
 
   if (channel < 0 || channel >= kNumSmartIo) {
     *status = MakeErrorIndexOutOfRange(HAL_RESOURCE_OUT_OF_RANGE,
-                                       "Invalid Index for PWM", 0, kNumSmartIo,
+                                       "Invalid Index for PWM", 0, kNumSmartIo - 1,
                                        channel);
     return HAL_INVALID_HANDLE;
   }


### PR DESCRIPTION
0 indexed IO should report count - 1 in error messages. This results in a more intuitive error message (e.g. "Minimum: 0 Maximum: 5 Requested: 6" instead of "Minimum: 0 Maximum: 6 Requested: 6")

Addresses https://github.com/wpilibsuite/SystemcoreTesting/issues/52