### PR TITLE
[wpical] Fix double linking to OpenCV

### DIFF
--- a/tools/wpical/build.gradle
+++ b/tools/wpical/build.gradle
@@ -20,9 +20,9 @@ ext {
     nativeName = 'wpical'
     useCpp = true
     nativeTestSuiteName = "${nativeName}Catch2Test"
-    sharedCvConfigs = [
+    sharedCvConfigs = []
+    staticCvConfigs = [ (nativeName): [],
         (nativeTestSuiteName): []]
-    staticCvConfigs = []
 }
 
 apply from: "${rootDir}/shared/resources.gradle"
@@ -170,7 +170,6 @@ model {
                 lib project: ':thirdparty:imgui_suite', library: 'imguiSuite', linkage: 'static'
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
                 nativeUtils.useRequiredLibrary(it, 'ceres')
-                nativeUtils.useRequiredLibrary(it, 'opencv_static')
                 project.addLibSdlGpuDependency(it)
                 it.cppCompiler.define 'OPENCV_DISABLE_EIGEN_TENSOR_SUPPORT'
                 it.cppCompiler.define 'GLOG_USE_GLOG_EXPORT'
@@ -221,7 +220,6 @@ model {
                 lib project: ':thirdparty:imgui_suite', library: 'imguiSuite', linkage: 'static'
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
                 nativeUtils.useRequiredLibrary(it, 'ceres')
-                nativeUtils.useRequiredLibrary(it, 'opencv_static')
                 project.addLibSdlGpuDependency(it)
                 it.cppCompiler.define 'OPENCV_DISABLE_EIGEN_TENSOR_SUPPORT'
                 it.cppCompiler.define('PROJECT_ROOT_PATH', testResources)


### PR DESCRIPTION
The test binaries were included in `sharedCvConfigs`, causing opencv.gradle to link the tests to the shared OpenCV libraries, while all wpical binaries also linked to opencv_static manually. This removes the manual links and moves all the binaries into `staticCvConfigs` instead.