### PR TITLE
[build] Update to native-utils 2027.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ If you have installed the WPILib Toolchain to a directory other than the default
 ./gradlew build -PtoolChainPath=some/path/to/wpilib/toolchain/bin
 ```
 
+Linux desktop builds use `gcc-14` and `g++-14` by default. To use Gradle's default Linux toolchain discovery instead, pass `-PuseDefaultLinuxGcc` or set `WPILIB_USE_DEFAULT_LINUX_GCC=1`.
+
 ### Formatting/linting
 
 Once a PR has been submitted, formatting can be run in CI by commenting `/format` on the PR. A new commit will be pushed with the formatting changes.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ mockito-core = { module = "org.mockito:mockito-core", version = "4.1.0" }
 # Note that these are also Gradle plugins and cannot be used with the plugin specification
 # due to their presence on the classpath without version information.
 wpilib-gradle-vscode = { module = "org.wpilib:gradle-cpp-vscode", version = "2027.0.0" }
-wpilib-native-utils = { module = "org.wpilib:native-utils", version = "2027.12.0" }
+wpilib-native-utils = { module = "org.wpilib:native-utils", version = "2027.13.0" }
 
 [bundles]
 ejml = ["ejml-java9module"]
@@ -50,6 +50,6 @@ wpilib-gradle-jni = { id = "org.wpilib.GradleJni", version = "2027.0.0" }
 # Note: these plugins can't be used. Their JARs are on the classpath for buildSrc,
 # which doesn't retain version information.
 # wpilib-gradle-vscode = { id = "org.wpilib.GradleVsCode", version = "2027.0.0" }
-# wpilib-native-utils = { id = "org.wpilib.NativeUtils", version = "2027.11.0" }
+# wpilib-native-utils = { id = "org.wpilib.NativeUtils", version = "2027.13.0" }
 wpilib-repositories = { id = "org.wpilib.WPILibRepositoriesPlugin", version = "2027.0.0" }
 wpilib-versioning = { id = "org.wpilib.WPILibVersioningPlugin", version = "2027.0.1" }

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -29,14 +29,6 @@ nativeUtils {
     }
 }
 
-if (project.hasProperty('onlylinuxarm64')) {
-    nativeUtils.crossCompilers.getByName(org.wpilib.toolchain.NativePlatforms.linuxarm64).optional = false
-}
-
-if (project.hasProperty('onlylinuxsystemcore')) {
-    nativeUtils.crossCompilers.getByName(org.wpilib.toolchain.NativePlatforms.systemcore).optional = false
-}
-
 nativeUtils.wpi.addWarnings()
 nativeUtils.wpi.addWarningsAsErrors()
 

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -1,5 +1,19 @@
 nativeUtils.skipInstallPdb = project.hasProperty('buildServer')
 
+def isBuildFlagEnabled = { propertyName, environmentName ->
+    if (project.hasProperty(propertyName)) {
+        def propertyValue = project.findProperty(propertyName)
+        return propertyValue == null || propertyValue.toString().isBlank() || propertyValue.toString().toBoolean()
+    }
+
+    def environmentValue = System.getenv(environmentName)
+    return environmentValue != null && !environmentValue.isBlank() && environmentValue.toBoolean()
+}
+
+if (isBuildFlagEnabled('useDefaultLinuxGcc', 'WPILIB_USE_DEFAULT_LINUX_GCC')) {
+    nativeUtils.requireVersionedLinuxGcc = false
+}
+
 if (project.hasProperty('ciDebugOnly')) {
     toolchainsPlugin.registerReleaseBuildType = false
 }


### PR DESCRIPTION
This changes Linux desktop builds to use g++-14 by default for ABI compatibility reasons with dependencies. Changing back to using Gradle's default Linux toolchain discovery can be done with either a gradlew flag (`-PuseDefaultLinuxGcc`) or via setting an environment variable (`WPILIB_USE_DEFAULT_LINUX_GCC=1`).