### PR TITLE
[examples] Eliminate extraneous MotorSafety API usage

### DIFF
--- a/robotpyExamples/examples/GettingStarted/robot.py
+++ b/robotpyExamples/examples/GettingStarted/robot.py
@@ -38,7 +38,7 @@ class MyRobot(wpilib.TimedRobot):
             # Drive forwards half velocity, make sure to turn input squaring off
             self.robot_drive.arcade_drive(0.5, 0, square_inputs=False)
         else:
-            self.robot_drive.stop_motor()  # Stop robot
+            self.robot_drive.arcade_drive(0, 0)  # Stop robot
 
     def teleop_init(self):
         """This function is called once each time the robot enters teleoperated mode."""

--- a/robotpyExamples/examples/RapidReactCommandBot/subsystems/drive.py
+++ b/robotpyExamples/examples/RapidReactCommandBot/subsystems/drive.py
@@ -117,7 +117,7 @@ class Drive(Subsystem):
                 )
                 >= distance
             )
-            .finally_do(lambda interrupted: self.drive.stop_motor())
+            .finally_do(lambda interrupted: self.drive.arcade_drive(0, 0))
         )
 
     def turn_to_angle_command(self, angle_deg: float) -> Command:

--- a/robotpyExamples/examples/RapidReactCommandBot/subsystems/intake.py
+++ b/robotpyExamples/examples/RapidReactCommandBot/subsystems/intake.py
@@ -37,7 +37,7 @@ class Intake(Subsystem):
         """Returns a command that turns off and retracts the intake."""
         return self.run_once(
             lambda: (
-                self.motor.disable(),
+                self.motor.set_throttle(0.0),
                 self.pistons.set(wpilib.DoubleSolenoid.Value.REVERSE),
             )
         ).with_name("Retract")

--- a/robotpyExamples/examples/RapidReactCommandBot/subsystems/shooter.py
+++ b/robotpyExamples/examples/RapidReactCommandBot/subsystems/shooter.py
@@ -36,8 +36,8 @@ class Shooter(Subsystem):
         self.set_default_command(
             self.run_once(
                 lambda: (
-                    self.shooter_motor.disable(),
-                    self.feeder_motor.disable(),
+                    self.shooter_motor.set_throttle(0.0),
+                    self.feeder_motor.set_throttle(0.0),
                 )
             )
             .and_then(self.run(lambda: None))

--- a/robotpyExamples/examples/SysId/subsystems/shooter.py
+++ b/robotpyExamples/examples/SysId/subsystems/shooter.py
@@ -98,8 +98,8 @@ class Shooter(Subsystem):
             self.feeder_motor.set_throttle(ShooterConstants.FEEDER_VELOCITY)
 
         def _stop_motors(interrupted: bool) -> None:
-            self.shooter_motor.stop_motor()
-            self.feeder_motor.stop_motor()
+            self.shooter_motor.set_throttle(0.0)
+            self.feeder_motor.set_throttle(0.0)
 
         return self.run(_run_shooter).finally_do(_stop_motors).with_name("runShooter")
 

--- a/robotpyExamples/snippets/EventLoop/robot.py
+++ b/robotpyExamples/snippets/EventLoop/robot.py
@@ -42,14 +42,14 @@ class MyRobot(wpilib.TimedRobot):
         intake_button.and_(is_ball_at_kicker_event.negate()).if_high(
             # and there is not a ball at the kicker
             # activate the intake
-            lambda: self.intake.set(0.5)
+            lambda: self.intake.set_throttle(0.5)
         )
 
         # if the thumb button is not held
         intake_button.negate().or_(is_ball_at_kicker_event).if_high(
             # or there is a ball in the kicker
             # stop the intake
-            self.intake.stop_motor
+            lambda: self.intake.set_throttle(0.0)
         )
 
         shoot_trigger = wpilib.BooleanEvent(self.loop, self.joystick.get_trigger)
@@ -66,7 +66,7 @@ class MyRobot(wpilib.TimedRobot):
         )
 
         # if not, stop
-        shoot_trigger.negate().if_high(self.shooter.stop_motor)
+        shoot_trigger.negate().if_high(lambda: self.shooter.set_throttle(0.0))
 
         at_target_velocity = wpilib.BooleanEvent(
             self.loop, self.controller.at_setpoint
@@ -81,7 +81,7 @@ class MyRobot(wpilib.TimedRobot):
         # when we stop being at the target velocity, it means the ball was shot
         at_target_velocity.falling().if_high(
             # so stop the kicker
-            self.kicker.stop_motor
+            lambda: self.kicker.set_throttle(0.0)
         )
 
     def robot_periodic(self) -> None:

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/cpp/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/cpp/Drivetrain.cpp
@@ -10,6 +10,7 @@
 #include "wpi/math/util/ComputerVisionUtil.hpp"
 #include "wpi/smartdashboard/SmartDashboard.hpp"
 #include "wpi/system/RobotController.hpp"
+#include "wpi/system/Timer.hpp"
 
 Drivetrain::Drivetrain() {
   leftLeader.AddFollower(leftFollower);

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Drive.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Drive.cpp
@@ -57,7 +57,7 @@ wpi::cmd::CommandPtr Drive::DriveDistanceCommand(wpi::units::meter_t distance,
                    wpi::units::meter_t(rightEncoder.GetDistance())) >= distance;
       })
       // Stop the drive when the command ends
-      .FinallyDo([this](bool interrupted) { drive.StopMotor(); });
+      .FinallyDo([this](bool interrupted) { drive.ArcadeDrive(0.0, 0.0); });
 }
 
 wpi::cmd::CommandPtr Drive::TurnToAngleCommand(wpi::units::degree_t angle) {

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Intake.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Intake.cpp
@@ -12,7 +12,7 @@ wpi::cmd::CommandPtr Intake::IntakeCommand() {
 
 wpi::cmd::CommandPtr Intake::RetractCommand() {
   return RunOnce([this] {
-           motor.Disable();
+           motor.SetThrottle(0.0);
            piston.Set(wpi::DoubleSolenoid::REVERSE);
          })
       .WithName("Retract");

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Shooter.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Shooter.cpp
@@ -12,8 +12,8 @@ Shooter::Shooter() {
       ShooterConstants::kEncoderDistancePerPulse);
 
   SetDefaultCommand(RunOnce([this] {
-                      shooterMotor.Disable();
-                      feederMotor.Disable();
+                      shooterMotor.SetThrottle(0.0);
+                      feederMotor.SetThrottle(0.0);
                     })
                         .AndThen(Run([] {}))
                         .WithName("Idle"));

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Storage.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/cpp/subsystems/Storage.cpp
@@ -5,8 +5,10 @@
 #include "subsystems/Storage.hpp"
 
 Storage::Storage() {
-  SetDefaultCommand(
-      RunOnce([this] { motor.Disable(); }).AndThen([] {}).WithName("Idle"));
+  SetDefaultCommand(RunOnce([this] {
+                      motor.SetThrottle(0.0);
+                    }).AndThen([] {
+                      }).WithName("Idle"));
 }
 
 wpi::cmd::CommandPtr Storage::RunCommand() {

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/gettingstarted/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/gettingstarted/Robot.java
@@ -49,7 +49,7 @@ public class Robot extends TimedRobot {
       // Drive forwards half velocity, make sure to turn input squaring off
       robotDrive.arcadeDrive(0.5, 0.0, false);
     } else {
-      robotDrive.stopMotor(); // stop robot
+      robotDrive.arcadeDrive(0.0, 0.0, false); // stop robot
     }
   }
 

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotcmdv3/mechanisms/DriveMechanism.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotcmdv3/mechanisms/DriveMechanism.java
@@ -98,7 +98,7 @@ public class DriveMechanism implements Mechanism {
           }
 
           // Finally, stop
-          drive.stopMotor();
+          drive.tankDrive(0, 0);
         })
         .named("Drive Distance[" + distance + "@" + speed + "]");
   }

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Drive.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Drive.java
@@ -117,7 +117,7 @@ public class Drive extends SubsystemBase {
         // End command when we've traveled the specified distance
         .until(() -> Math.max(leftEncoder.getDistance(), rightEncoder.getDistance()) >= distance)
         // Stop the drive when the command ends
-        .finallyDo(interrupted -> drive.stopMotor());
+        .finallyDo(interrupted -> drive.arcadeDrive(0, 0));
   }
 
   /**

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Intake.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Intake.java
@@ -37,7 +37,7 @@ public class Intake extends SubsystemBase {
   public Command retractCommand() {
     return runOnce(
             () -> {
-              motor.disable();
+              motor.setThrottle(0.0);
               pistons.set(DoubleSolenoid.Value.REVERSE);
             })
         .withName("Retract");

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Shooter.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Shooter.java
@@ -38,8 +38,8 @@ public class Shooter extends SubsystemBase {
     setDefaultCommand(
         runOnce(
                 () -> {
-                  shooterMotor.disable();
-                  feederMotor.disable();
+                  shooterMotor.setThrottle(0.0);
+                  feederMotor.setThrottle(0.0);
                 })
             .andThen(run(() -> {}))
             .withName("Idle"));

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Storage.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rapidreactcommandbot/subsystems/Storage.java
@@ -28,7 +28,7 @@ public class Storage extends SubsystemBase {
   /** Create a new Storage subsystem. */
   public Storage() {
     // Set default command to turn off the storage motor and then idle
-    setDefaultCommand(runOnce(motor::disable).andThen(run(() -> {})).withName("Idle"));
+    setDefaultCommand(runOnce(() -> motor.setThrottle(0)).andThen(run(() -> {})).withName("Idle"));
   }
 
   /** Returns a command that runs the storage motor indefinitely. */

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rebuiltcmdv3/mechanisms/IntakeRoller.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rebuiltcmdv3/mechanisms/IntakeRoller.java
@@ -23,7 +23,7 @@ public class IntakeRoller implements Mechanism {
    * @return Command to stop the roller
    */
   public Command stop() {
-    return runRepeatedly(motor::stopMotor).named("Intake.Roller.Stop");
+    return runRepeatedly(() -> motor.setThrottle(0.0)).named("Intake.Roller.Stop");
   }
 
   @Override

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rebuiltcmdv3/mechanisms/IntakeWrist.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rebuiltcmdv3/mechanisms/IntakeWrist.java
@@ -20,7 +20,7 @@ public class IntakeWrist implements Mechanism {
       new ExampleSmartMotorController(IntakeConstants.WRIST_MOTOR_ID);
 
   public Command stop() {
-    return runRepeatedly(motor::stopMotor).named("Intake.Wrist.Stop");
+    return runRepeatedly(() -> motor.setThrottle(0.0)).named("Intake.Wrist.Stop");
   }
 
   @Override

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/rebuiltcmdv3/mechanisms/SwerveModule.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/rebuiltcmdv3/mechanisms/SwerveModule.java
@@ -40,8 +40,8 @@ public final class SwerveModule {
 
   /** Stops the module by turning off the drive and turn motors. */
   public void stop() {
-    driveMotor.stopMotor();
-    turnMotor.stopMotor();
+    driveMotor.setThrottle(0.0);
+    turnMotor.setThrottle(0.0);
   }
 
   /**

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/subsystems/Shooter.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/subsystems/Shooter.java
@@ -83,8 +83,8 @@ public class Shooter extends SubsystemBase {
         })
         .finallyDo(
             () -> {
-              shooterMotor.stopMotor();
-              feederMotor.stopMotor();
+              shooterMotor.setVoltage(0.0);
+              feederMotor.setVoltage(0.0);
             })
         .withName("runShooter");
   }

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/xrptimed/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/xrptimed/Robot.java
@@ -50,7 +50,7 @@ public class Robot extends TimedRobot {
       // Drive forwards half speed, make sure to turn input squaring off
       robotDrive.arcadeDrive(0.5, 0.0, false);
     } else {
-      robotDrive.stopMotor(); // stop robot
+      robotDrive.arcadeDrive(0.0, 0.0, false); // stop robot
     }
   }
 

--- a/wpilibjExamples/src/main/java/org/wpilib/snippets/eventloop/Robot.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/snippets/eventloop/Robot.java
@@ -50,7 +50,7 @@ public class Robot extends TimedRobot {
         // or there is a ball in the kicker
         .or(isBallAtKicker)
         // stop the intake
-        .ifHigh(intake::stopMotor);
+        .ifHigh(() -> intake.setThrottle(0.0));
 
     BooleanEvent shootTrigger = new BooleanEvent(loop, joystick::getTrigger);
 
@@ -65,7 +65,7 @@ public class Robot extends TimedRobot {
         });
 
     // if not, stop
-    shootTrigger.negate().ifHigh(shooter::stopMotor);
+    shootTrigger.negate().ifHigh(() -> shooter.setThrottle(0.0));
 
     BooleanEvent atTargetVelocity =
         new BooleanEvent(loop, controller::atSetpoint)
@@ -79,7 +79,7 @@ public class Robot extends TimedRobot {
     atTargetVelocity
         .falling()
         // so stop the kicker
-        .ifHigh(kicker::stopMotor);
+        .ifHigh(() -> kicker.setThrottle(0.0));
   }
 
   @Override


### PR DESCRIPTION
There are many instances where disable() or stopMotor() is used where setThrottle() or arcadeDrive() will do, and is more consistent with the rest of the example code.