### PR TITLE
[wpiutil] Alert: Allow default constructed invalid value in C++

### DIFF
--- a/wpiutil/src/main/native/include/wpi/util/Alert.hpp
+++ b/wpiutil/src/main/native/include/wpi/util/Alert.hpp
@@ -22,6 +22,10 @@ namespace detail {
 // the C++ Alert API.
 void CloseAlertHandle(Alert& alert);
 
+// Used by process-lifetime alerts that must not call back into the Alert
+// backend during static destruction.
+void ReleaseAlertHandle(Alert& alert);
+
 }  // namespace detail
 
 /**
@@ -72,6 +76,13 @@ class Alert {
      */
     LOW = WPI_ALERT_LOW,
   };
+
+  /**
+   * Creates an invalid alert.
+   *
+   * The alert can be assigned a valid Alert later.
+   */
+  Alert() = default;
 
   /**
    * Creates a new alert in the default group - "Alerts".
@@ -136,6 +147,7 @@ class Alert {
 
  private:
   friend void detail::CloseAlertHandle(Alert& alert);
+  friend void detail::ReleaseAlertHandle(Alert& alert);
 
   Handle<WPI_AlertHandle, WPI_DestroyAlert> m_handle;
 };
@@ -144,6 +156,10 @@ namespace detail {
 
 inline void CloseAlertHandle(Alert& alert) {
   alert.m_handle = WPI_INVALID_HANDLE;
+}
+
+inline void ReleaseAlertHandle(Alert& alert) {
+  alert.m_handle.Release();
 }
 
 }  // namespace detail

--- a/wpiutil/src/main/native/include/wpi/util/Handle.hpp
+++ b/wpiutil/src/main/native/include/wpi/util/Handle.hpp
@@ -45,6 +45,17 @@ class Handle {
     return *this;
   }
 
+  /**
+   * Releases ownership of the handle without freeing it.
+   *
+   * @return The released handle.
+   */
+  CType Release() {
+    CType handle = m_handle;
+    m_handle = static_cast<CType>(CInvalid);
+    return handle;
+  }
+
   ~Handle() {
     if constexpr (std::invocable<decltype(FreeFunction), CType>) {
       if (m_handle != static_cast<CType>(CInvalid)) {

--- a/wpiutil/src/main/python/semiwrap/Alert.yml
+++ b/wpiutil/src/main/python/semiwrap/Alert.yml
@@ -7,6 +7,10 @@ functions:
     overloads:
       Alert&:
         ignore: true
+  ReleaseAlertHandle:
+    overloads:
+      Alert&:
+        ignore: true
 
 classes:
   wpi::util::Alert:
@@ -15,6 +19,8 @@ classes:
     methods:
       Alert:
         overloads:
+          "":
+            ignore: true
           std::string_view, std::string_view, Level:
             cpp_code: |
               [](std::string_view id, std::string_view text,

--- a/wpiutil/src/test/native/cpp/AlertTest.cpp
+++ b/wpiutil/src/test/native/cpp/AlertTest.cpp
@@ -217,6 +217,20 @@ TEST_F(AlertTest, CppWrapperDuplicateIsInvalid) {
   EXPECT_EQ(WPI_GetNumAlerts(), 1);
 }
 
+TEST_F(AlertTest, CppWrapperDefaultConstructsInvalid) {
+  Alert alert;
+
+  EXPECT_FALSE(alert);
+  EXPECT_FALSE(alert.Get());
+  EXPECT_EQ(alert.GetText(), "");
+  EXPECT_EQ(WPI_GetNumAlerts(), 0);
+
+  alert = Alert{"id", "text", Alert::Level::LOW};
+  EXPECT_TRUE(alert);
+  EXPECT_EQ(WPI_GetNumAlerts(), 1);
+  EXPECT_EQ(alert.GetText(), "text");
+}
+
 TEST_F(AlertTest, CApiDuplicateRulesAndPartialListing) {
   WPI_AlertHandle first = CreateAlert("group", "id", "one", WPI_ALERT_MEDIUM);
   WPI_AlertHandle second = CreateAlert("group", "id", "two", WPI_ALERT_LOW);
@@ -421,4 +435,24 @@ TEST_F(AlertTest, CustomBackendDispatchesAllOperations) {
   EXPECT_TRUE(gBackendState.reset);
   WPI_DestroyAlert(handle);
   EXPECT_EQ(gBackendState.destroyedHandle, handle);
+}
+
+TEST_F(AlertTest, CppWrapperReleaseDoesNotDestroyHandle) {
+  gBackendState = BackendState{};
+  WPI_SetAlertBackend(&kTestBackend);
+
+  {
+    Alert alert{"backendGroup", "backendId", "backendText",
+                Alert::Level::MEDIUM};
+    EXPECT_TRUE(alert);
+    WPI_AlertHandle handle = gBackendState.createdHandle;
+
+    wpi::util::detail::ReleaseAlertHandle(alert);
+
+    EXPECT_FALSE(alert);
+    EXPECT_EQ(gBackendState.destroyedHandle, WPI_INVALID_HANDLE);
+    EXPECT_EQ(handle, gBackendState.createdHandle);
+  }
+
+  EXPECT_EQ(gBackendState.destroyedHandle, WPI_INVALID_HANDLE);
 }


### PR DESCRIPTION
Also provide path for Handle to release its stored value.