### PR TITLE
[wpilib] Timer: Use integer microseconds internally

### DIFF
--- a/wpilibc/src/main/native/cpp/system/Timer.cpp
+++ b/wpilibc/src/main/native/cpp/system/Timer.cpp
@@ -4,6 +4,8 @@
 
 #include "wpi/system/Timer.hpp"
 
+#include <stdint.h>
+
 #include <chrono>
 #include <thread>
 
@@ -30,26 +32,43 @@ wpi::units::second_t GetSystemTime() {
 
 using namespace wpi;
 
+namespace {
+
+std::chrono::microseconds GetTimestampMicroseconds() {
+  return std::chrono::microseconds{
+      static_cast<int64_t>(wpi::RobotController::GetTime())};
+}
+
+}  // namespace
+
 Timer::Timer() {
   Reset();
 }
 
 wpi::units::second_t Timer::Get() const {
+  return wpi::units::microsecond_t{GetMicroseconds()};
+}
+
+double Timer::GetMicroseconds() const {
   if (m_running) {
-    return (GetTimestamp() - m_startTime) + m_accumulatedTime;
+    return static_cast<double>(
+               (GetTimestampMicroseconds() - m_startTime).count()) -
+           m_startTimeRemainderUs + m_accumulatedTimeUs;
   } else {
-    return m_accumulatedTime;
+    return m_accumulatedTimeUs;
   }
 }
 
 void Timer::Reset() {
-  m_accumulatedTime = 0_s;
-  m_startTime = GetTimestamp();
+  m_accumulatedTimeUs = 0.0;
+  m_startTime = GetTimestampMicroseconds();
+  m_startTimeRemainderUs = 0.0;
 }
 
 void Timer::Start() {
   if (!m_running) {
-    m_startTime = GetTimestamp();
+    m_startTime = GetTimestampMicroseconds();
+    m_startTimeRemainderUs = 0.0;
     m_running = true;
   }
 }
@@ -64,19 +83,24 @@ void Timer::Restart() {
 
 void Timer::Stop() {
   if (m_running) {
-    m_accumulatedTime = Get();
+    m_accumulatedTimeUs = GetMicroseconds();
     m_running = false;
   }
 }
 
 bool Timer::HasElapsed(wpi::units::second_t period) const {
-  return Get() >= period;
+  return GetMicroseconds() >= wpi::units::microsecond_t{period}.value();
 }
 
 bool Timer::AdvanceIfElapsed(wpi::units::second_t period) {
-  if (Get() >= period) {
+  double periodUs = wpi::units::microsecond_t{period}.value();
+
+  if (GetMicroseconds() >= periodUs) {
     // Advance the start time by the period.
-    m_startTime += period;
+    double advanceUs = m_startTimeRemainderUs + periodUs;
+    auto wholeUs = static_cast<int64_t>(advanceUs);
+    m_startTime += std::chrono::microseconds{wholeUs};
+    m_startTimeRemainderUs = advanceUs - wholeUs;
     // Don't set it to the current time... we want to avoid drift.
     return true;
   } else {
@@ -95,13 +119,12 @@ Timer Timer::CreateStarted() {
 }
 
 wpi::units::second_t Timer::GetTimestamp() {
-  return wpi::units::second_t{wpi::RobotController::GetTime() * 1.0e-6};
+  return GetTimestampMicroseconds();
 }
 
 wpi::units::second_t Timer::GetMonotonicTimestamp() {
-  // Monotonic timestamp is in microseconds
-  return wpi::units::second_t{wpi::RobotController::GetMonotonicTime() *
-                              1.0e-6};
+  return std::chrono::microseconds{
+      static_cast<int64_t>(wpi::RobotController::GetMonotonicTime())};
 }
 
 wpi::units::second_t Timer::GetMatchTime() {

--- a/wpilibc/src/main/native/include/wpi/system/Timer.hpp
+++ b/wpilibc/src/main/native/include/wpi/system/Timer.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <chrono>
+
 #include "wpi/units/time.hpp"
 
 namespace wpi {
@@ -182,8 +184,11 @@ class Timer {
   static wpi::units::second_t GetMatchTime();
 
  private:
-  wpi::units::second_t m_startTime = 0_s;
-  wpi::units::second_t m_accumulatedTime = 0_s;
+  double GetMicroseconds() const;
+
+  std::chrono::microseconds m_startTime{0};
+  double m_startTimeRemainderUs = 0.0;
+  double m_accumulatedTimeUs = 0.0;
   bool m_running = false;
 };
 

--- a/wpilibc/src/test/native/cpp/TimerTest.cpp
+++ b/wpilibc/src/test/native/cpp/TimerTest.cpp
@@ -4,17 +4,35 @@
 
 #include "wpi/system/Timer.hpp"
 
+#include <stdint.h>
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "wpi/simulation/SimHooks.hpp"
+#include "wpi/system/RobotController.hpp"
 
 using namespace wpi;
 
 namespace {
+uint64_t mockTime = 0;
+
+class ScopedMockTimeSource {
+ public:
+  ScopedMockTimeSource() {
+    RobotController::SetTimeSource([] { return mockTime; });
+  }
+
+  ~ScopedMockTimeSource() {
+    RobotController::SetTimeSource(
+        [] { return RobotController::GetMonotonicTime(); });
+  }
+};
+
 class TimerTest {
  public:
   TimerTest() {
+    mockTime = 0;
     wpi::sim::PauseTiming();
     wpi::sim::RestartTiming();
   }
@@ -76,6 +94,23 @@ TEST_CASE_METHOD(TimerTest, "TimerTest Reset", "[wpilibc]") {
   CHECK(timer.Get() == 0_ms);
 }
 
+TEST_CASE_METHOD(TimerTest, "TimerTest ResetWithLargeTimestamp", "[wpilibc]") {
+  ScopedMockTimeSource timeSource;
+  mockTime = 1'000'002;
+
+  Timer timer;
+  timer.Start();
+
+  mockTime += 500'000;
+  CHECK(timer.Get() == 500_ms);
+
+  timer.Reset();
+  CHECK(timer.Get() == 0_s);
+
+  mockTime += 500'000;
+  CHECK(timer.Get() == 500_ms);
+}
+
 TEST_CASE_METHOD(TimerTest, "TimerTest HasElapsed", "[wpilibc]") {
   Timer timer;
 
@@ -116,6 +151,47 @@ TEST_CASE_METHOD(TimerTest, "TimerTest AdvanceIfElapsed", "[wpilibc]") {
   CHECK(timer.AdvanceIfElapsed(400_ms));
   CHECK(timer.AdvanceIfElapsed(400_ms));
   CHECK_FALSE(timer.AdvanceIfElapsed(400_ms));
+}
+
+TEST_CASE_METHOD(TimerTest,
+                 "TimerTest AdvanceIfElapsedPreservesFractionalPeriod",
+                 "[wpilibc]") {
+  ScopedMockTimeSource timeSource;
+  mockTime = 0;
+
+  Timer timer;
+  timer.Start();
+
+  auto period = wpi::units::second_t{1.0 / 60.0};
+
+  for (uint64_t i = 1; i <= 60; ++i) {
+    mockTime = (i * 1'000'000 + 59) / 60 + 100;
+
+    CHECK(timer.AdvanceIfElapsed(period));
+    CHECK_FALSE(timer.AdvanceIfElapsed(period));
+  }
+
+  CHECK_THAT(timer.Get().value(), Catch::Matchers::WithinAbs(100e-6, 1e-12));
+}
+
+TEST_CASE_METHOD(TimerTest,
+                 "TimerTest AdvanceIfElapsedProgressesWithSubMicrosecondPeriod",
+                 "[wpilibc]") {
+  ScopedMockTimeSource timeSource;
+  mockTime = 0;
+
+  Timer timer;
+  timer.Start();
+
+  mockTime = 1;
+  auto period = wpi::units::microsecond_t{0.1};
+
+  for (int i = 0; i < 10; ++i) {
+    CHECK(timer.AdvanceIfElapsed(period));
+  }
+
+  CHECK_FALSE(timer.AdvanceIfElapsed(period));
+  CHECK_THAT(timer.Get().value(), Catch::Matchers::WithinAbs(0.0, 1e-12));
 }
 
 TEST_CASE_METHOD(TimerTest, "TimerTest GetMonotonicTimestamp", "[wpilibc]") {

--- a/wpilibc/src/test/python/hardware/led/test_led_pattern.py
+++ b/wpilibc/src/test/python/hardware/led/test_led_pattern.py
@@ -25,7 +25,7 @@ def lerp_rgb(a: Color, b: Color, t: float) -> Color8Bit:
 def restore_time_source():
     RobotController.set_time_source(lambda: 0)
     yield
-    RobotController.set_time_source(RobotController.get_time)
+    RobotController.set_time_source(RobotController.get_monotonic_time)
 
 
 def test_apply_to_buffer_direct():

--- a/wpilibc/src/test/python/system/test_timer.py
+++ b/wpilibc/src/test/python/system/test_timer.py
@@ -1,0 +1,187 @@
+# Copyright (c) FIRST and other WPILib contributors.
+# Open Source Software; you can modify and/or share it under the terms of
+# the WPILib BSD license file in the root directory of this project.
+
+import pytest
+
+from wpilib import RobotController, Timer
+from wpilib.simulation import (
+    is_timing_paused,
+    pause_timing,
+    restart_timing,
+    resume_timing,
+    step_timing,
+)
+
+
+@pytest.fixture(autouse=True)
+def timing_setup():
+    RobotController.set_time_source(RobotController.get_monotonic_time)
+    pause_timing()
+    restart_timing()
+    yield
+    RobotController.set_time_source(RobotController.get_monotonic_time)
+    resume_timing()
+
+
+def test_start_stop():
+    timer = Timer()
+
+    # Verify timer is initialized as stopped
+    assert timer.get() == 0.0
+    assert not timer.is_running()
+    step_timing(0.5)
+    assert timer.get() == 0.0
+    assert not timer.is_running()
+
+    # Verify timer increments after it's started
+    timer.start()
+    step_timing(0.5)
+    assert timer.get() == pytest.approx(0.5)
+    assert timer.is_running()
+
+    # Verify timer stops incrementing after it's stopped
+    timer.stop()
+    step_timing(0.5)
+    assert timer.get() == pytest.approx(0.5)
+    assert not timer.is_running()
+
+
+def test_reset():
+    timer = Timer()
+    timer.start()
+
+    # Advance timer to 500 ms
+    assert timer.get() == 0.0
+    step_timing(0.5)
+    assert timer.get() == pytest.approx(0.5)
+
+    # Verify timer reports 0 ms after reset
+    timer.reset()
+    assert timer.get() == 0.0
+
+    # Verify timer continues incrementing
+    step_timing(0.5)
+    assert timer.get() == pytest.approx(0.5)
+
+    # Verify timer doesn't start incrementing after reset if it was stopped
+    timer.stop()
+    timer.reset()
+    step_timing(0.5)
+    assert timer.get() == 0.0
+
+
+def test_reset_with_large_timestamp():
+    mock_time = 1_000_002
+    RobotController.set_time_source(lambda: mock_time)
+
+    timer = Timer()
+    timer.start()
+
+    mock_time += 500_000
+    assert timer.get() == pytest.approx(0.5)
+
+    timer.reset()
+    assert timer.get() == 0.0
+
+    mock_time += 500_000
+    assert timer.get() == pytest.approx(0.5)
+
+
+def test_has_elapsed():
+    timer = Timer()
+
+    # Verify 0 ms has elapsed since timer hasn't started
+    assert timer.has_elapsed(0.0)
+
+    # Verify timer doesn't report elapsed time when stopped
+    step_timing(0.5)
+    assert not timer.has_elapsed(0.4)
+
+    timer.start()
+
+    # Verify timer reports >= 400 ms has elapsed after multiple calls
+    step_timing(0.5)
+    assert timer.has_elapsed(0.4)
+    assert timer.has_elapsed(0.4)
+
+
+def test_advance_if_elapsed():
+    timer = Timer()
+
+    # Verify 0 ms has elapsed since timer hasn't started
+    assert timer.advance_if_elapsed(0.0)
+
+    # Verify timer doesn't report elapsed time when stopped
+    step_timing(0.5)
+    assert not timer.advance_if_elapsed(0.4)
+
+    timer.start()
+
+    # Verify timer reports >= 400 ms has elapsed for only first call
+    step_timing(0.5)
+    assert timer.advance_if_elapsed(0.4)
+    assert not timer.advance_if_elapsed(0.4)
+
+    # Verify timer reports >= 400 ms has elapsed for two calls
+    step_timing(1.0)
+    assert timer.advance_if_elapsed(0.4)
+    assert timer.advance_if_elapsed(0.4)
+    assert not timer.advance_if_elapsed(0.4)
+
+
+def test_advance_if_elapsed_preserves_fractional_period():
+    mock_time = {"value": 0}
+    RobotController.set_time_source(lambda: mock_time["value"])
+
+    timer = Timer()
+    timer.start()
+
+    period = 1.0 / 60.0
+
+    for i in range(1, 61):
+        mock_time["value"] = (i * 1_000_000 + 59) // 60 + 100
+
+        assert timer.advance_if_elapsed(period)
+        assert not timer.advance_if_elapsed(period)
+
+    assert timer.get() == pytest.approx(100e-6, abs=1e-12)
+
+
+def test_advance_if_elapsed_progresses_with_sub_microsecond_period():
+    mock_time = {"value": 0}
+    RobotController.set_time_source(lambda: mock_time["value"])
+
+    timer = Timer()
+    timer.start()
+
+    mock_time["value"] = 1
+    period = 0.1e-6
+
+    for _ in range(10):
+        assert timer.advance_if_elapsed(period)
+
+    assert not timer.advance_if_elapsed(period)
+    assert timer.get() == pytest.approx(0.0, abs=1e-12)
+
+
+def test_get_monotonic_timestamp():
+    start = Timer.get_monotonic_timestamp()
+    step_timing(0.5)
+    end = Timer.get_monotonic_timestamp()
+    assert end == pytest.approx(start + 0.5)
+
+
+def test_restart_timing_preserves_paused_clock():
+    assert is_timing_paused()
+
+    step_timing(0.5)
+    before_restart = Timer.get_monotonic_timestamp()
+
+    restart_timing()
+
+    assert is_timing_paused()
+    assert Timer.get_monotonic_timestamp() == pytest.approx(before_restart)
+
+    step_timing(0.5)
+    assert Timer.get_monotonic_timestamp() == pytest.approx(before_restart + 0.5)

--- a/wpilibj/src/main/java/org/wpilib/system/Timer.java
+++ b/wpilibj/src/main/java/org/wpilib/system/Timer.java
@@ -83,8 +83,9 @@ public class Timer {
     }
   }
 
-  private double m_startTime;
-  private double m_accumulatedTime;
+  private long m_startTimeUs;
+  private double m_startTimeRemainderUs;
+  private double m_accumulatedTimeUs;
   private boolean m_running;
 
   /**
@@ -114,8 +115,16 @@ public class Timer {
     return timer;
   }
 
-  private double getMsClock() {
-    return RobotController.getTime() / 1000.0;
+  private long getUsClock() {
+    return RobotController.getTime();
+  }
+
+  private double getMicroseconds() {
+    if (m_running) {
+      return getUsClock() - m_startTimeUs - m_startTimeRemainderUs + m_accumulatedTimeUs;
+    } else {
+      return m_accumulatedTimeUs;
+    }
   }
 
   /**
@@ -126,11 +135,7 @@ public class Timer {
    * @return Current time value for this timer in seconds
    */
   public double get() {
-    if (m_running) {
-      return m_accumulatedTime + (getMsClock() - m_startTime) / 1000.0;
-    } else {
-      return m_accumulatedTime;
-    }
+    return getMicroseconds() / 1000000.0;
   }
 
   /**
@@ -139,8 +144,9 @@ public class Timer {
    * <p>Make the timer startTime the current time so new requests will be relative now.
    */
   public final void reset() {
-    m_accumulatedTime = 0;
-    m_startTime = getMsClock();
+    m_accumulatedTimeUs = 0.0;
+    m_startTimeUs = getUsClock();
+    m_startTimeRemainderUs = 0.0;
   }
 
   /**
@@ -150,7 +156,8 @@ public class Timer {
    */
   public void start() {
     if (!m_running) {
-      m_startTime = getMsClock();
+      m_startTimeUs = getUsClock();
+      m_startTimeRemainderUs = 0.0;
       m_running = true;
     }
   }
@@ -174,8 +181,10 @@ public class Timer {
    * clock.
    */
   public void stop() {
-    m_accumulatedTime = get();
-    m_running = false;
+    if (m_running) {
+      m_accumulatedTimeUs = getMicroseconds();
+      m_running = false;
+    }
   }
 
   /**
@@ -195,7 +204,7 @@ public class Timer {
    * @return Whether the period has passed.
    */
   public boolean hasElapsed(double seconds) {
-    return get() >= seconds;
+    return getMicroseconds() >= seconds * 1e6;
   }
 
   /**
@@ -207,10 +216,15 @@ public class Timer {
    * @return Whether the period has passed.
    */
   public boolean advanceIfElapsed(double seconds) {
-    if (get() >= seconds) {
+    double periodUs = seconds * 1e6;
+
+    if (getMicroseconds() >= periodUs) {
       // Advance the start time by the period.
       // Don't set it to the current time... we want to avoid drift.
-      m_startTime += seconds * 1000;
+      double advanceUs = m_startTimeRemainderUs + periodUs;
+      long wholeUs = (long) advanceUs;
+      m_startTimeUs += wholeUs;
+      m_startTimeRemainderUs = advanceUs - wholeUs;
       return true;
     } else {
       return false;

--- a/wpilibj/src/test/java/org/wpilib/system/TimerTest.java
+++ b/wpilibj/src/test/java/org/wpilib/system/TimerTest.java
@@ -16,6 +16,8 @@ import org.wpilib.hardware.hal.HAL;
 import org.wpilib.simulation.SimHooks;
 
 class TimerTest {
+  private long m_mockTime;
+
   @BeforeEach
   void setup() {
     HAL.initialize();
@@ -25,6 +27,7 @@ class TimerTest {
 
   @AfterEach
   void cleanup() {
+    RobotController.setTimeSource(RobotController::getMonotonicTime);
     SimHooks.resumeTiming();
   }
 
@@ -88,6 +91,25 @@ class TimerTest {
 
   @Test
   @ResourceLock("timing")
+  void resetWithLargeTimestampTest() {
+    RobotController.setTimeSource(() -> m_mockTime);
+    m_mockTime = 1_000_002;
+
+    var timer = new Timer();
+    timer.start();
+
+    m_mockTime += 500_000;
+    assertEquals(timer.get(), 0.5);
+
+    timer.reset();
+    assertEquals(timer.get(), 0.0);
+
+    m_mockTime += 500_000;
+    assertEquals(timer.get(), 0.5);
+  }
+
+  @Test
+  @ResourceLock("timing")
   void hasElapsedTest() {
     var timer = new Timer();
 
@@ -130,6 +152,46 @@ class TimerTest {
     assertTrue(timer.advanceIfElapsed(0.4));
     assertTrue(timer.advanceIfElapsed(0.4));
     assertFalse(timer.advanceIfElapsed(0.4));
+  }
+
+  @Test
+  @ResourceLock("timing")
+  void advanceIfElapsedPreservesFractionalPeriodTest() {
+    RobotController.setTimeSource(() -> m_mockTime);
+    m_mockTime = 0;
+
+    var timer = new Timer();
+    timer.start();
+
+    double period = 1.0 / 60.0;
+
+    for (long i = 1; i <= 60; ++i) {
+      m_mockTime = (i * 1_000_000 + 59) / 60 + 100;
+
+      assertTrue(timer.advanceIfElapsed(period));
+      assertFalse(timer.advanceIfElapsed(period));
+    }
+
+    assertEquals(timer.get(), 100e-6, 1e-12);
+  }
+
+  @Test
+  @ResourceLock("timing")
+  void advanceIfElapsedProgressesWithSubMicrosecondPeriodTest() {
+    RobotController.setTimeSource(() -> m_mockTime);
+
+    var timer = new Timer();
+    timer.start();
+
+    m_mockTime = 1;
+    double period = 0.1e-6;
+
+    for (int i = 0; i < 10; ++i) {
+      assertTrue(timer.advanceIfElapsed(period));
+    }
+
+    assertFalse(timer.advanceIfElapsed(period));
+    assertEquals(timer.get(), 0.0, 1e-12);
   }
 
   @Test


### PR DESCRIPTION
This avoids unnecessary rounding errors in internal calculations.