### PR TITLE
[cmd3] Allow fork/await failures to be handled by user code

### DIFF
--- a/commandsv3/src/main/java/org/wpilib/command3/ConflictDetector.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/ConflictDetector.java
@@ -54,6 +54,10 @@ public final class ConflictDetector {
    */
   public static void throwIfConflicts(Collection<? extends Command> commands) {
     requireNonNullParam(commands, "commands", "ConflictDetector.throwIfConflicts");
+    if (commands.size() <= 1) {
+      // can't have conflicts with only one command
+      return;
+    }
 
     var conflicts = findAllConflicts(commands);
     if (conflicts.isEmpty()) {
@@ -85,6 +89,9 @@ public final class ConflictDetector {
     requireNonNullParam(commands, "commands", "ConflictDetector.findAllConflicts");
 
     List<Conflict> conflicts = new ArrayList<>();
+    if (commands.size() <= 1) {
+      return conflicts;
+    }
 
     int i = 0;
     for (Command command : commands) {

--- a/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
@@ -29,6 +29,7 @@ public final class Coroutine {
 
   private boolean m_cancelOnForkFailure = true;
   private ForkResultFailure m_lastForkFailure = null;
+  private boolean m_cancellationRequested = false;
 
   /**
    * Creates a new coroutine. Package-private; only the scheduler should be creating these.
@@ -82,6 +83,26 @@ public final class Coroutine {
   // before the coroutine yields itself.
   boolean isInterruptRequested() {
     return m_cancelOnForkFailure && m_lastForkFailure != null;
+  }
+
+  /**
+   * Requests early cancellation of the coroutine and the command bound to it. Any child commands
+   * will be canceled as well, as commands can never outlive their parent, but the parent command
+   * will not be canceled.
+   */
+  public void requestCancellation() {
+    requireMounted();
+
+    // Set the flag and immediately yield. The scheduler will check the flag after the yield call
+    // and cancel the command and its descendants.
+    m_cancellationRequested = true;
+    this.yield();
+  }
+
+  // package-private; setting the flag will immediately yield, so user code can never access this
+  // in a state where it returns anything other than `false`
+  boolean isCancellationRequested() {
+    return m_cancellationRequested;
   }
 
   ForkResultFailure getForkResult() {

--- a/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
@@ -47,8 +47,20 @@ public final class Coroutine {
    * defaults to {@code true}, but can be changed to allow the coroutine to continue running after a
    * fork failure.
    *
+   * <p>This setting only affects commands forked by using the coroutine methods {@code fork},
+   * {@code await}, {@code awaitAll}, or {@code awaitAny}. Commands scheduled directly with {@link
+   * Scheduler#schedule(Command)} or via inner trigger bindings will not be affected.
+   *
    * @param cancelOnForkFailure true to make the coroutine cancel itself if a child command couldn't
    *     be forked, false to allow the coroutine to continue running after a fork failure
+   *
+   * @see #fork(Command...)
+   * @see #fork(Collection)
+   * @see #await(Command)
+   * @see #awaitAll(Command...)
+   * @see #awaitAll(Collection)
+   * @see #awaitAny(Command...)
+   * @see #awaitAny(Collection)
    */
   public void setCancelOnForkFailure(boolean cancelOnForkFailure) {
     m_cancelOnForkFailure = cancelOnForkFailure;
@@ -60,6 +72,7 @@ public final class Coroutine {
    *
    * @return true if the coroutine will cancel itself if a child command couldn't be forked, false
    *     otherwise
+   * @see #setCancelOnForkFailure(boolean)
    */
   public boolean isCancelOnForkFailure() {
     return m_cancelOnForkFailure;

--- a/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
@@ -28,7 +28,7 @@ public final class Coroutine {
   private final Continuation m_backingContinuation;
 
   private boolean m_cancelOnForkFailure = true;
-  private ForkResultFailure m_lastForkFailure = null;
+  private ForkResult m_lastForkFailure = null;
   private boolean m_cancellationRequested = false;
 
   /**
@@ -89,6 +89,10 @@ public final class Coroutine {
    * Requests early cancellation of the coroutine and the command bound to it. Any child commands
    * will be canceled as well, as commands can never outlive their parent, but the parent command
    * will not be canceled.
+   *
+   * <p>Team code shouldn't need to use this; instead, use a {@code return} statement in your
+   * command's function body to exit early. This method is primarily to be used by internal APIs
+   * that don't have access to the command's function body.
    */
   public void requestCancellation() {
     requireMounted();
@@ -105,7 +109,7 @@ public final class Coroutine {
     return m_cancellationRequested;
   }
 
-  ForkResultFailure getForkResult() {
+  ForkResult getForkResult() {
     return m_lastForkFailure;
   }
 
@@ -138,22 +142,93 @@ public final class Coroutine {
     }
   }
 
-  /** The result of an attempt to fork or await commands. */
-  public sealed interface ForkResult {}
-
-  /** Commands were successfully forked. */
-  public record ForkResultSuccess() implements ForkResult {
-    // No state, so may as well use a singleton
-    private static final ForkResultSuccess INSTANCE = new ForkResultSuccess();
-  }
-
   /**
-   * At least one command was unable to be scheduled because a command with a higher priority is
-   * already running and owns at least one of the same required mechanisms.
+   * Represents the result of a fork operation that attempts to schedule multiple commands
+   * concurrently. The class provides information about the success or failure of the fork operation
+   * as well as utility methods to handle the outcome.
    *
-   * @param failed The failed scheduling attempts.
+   * <p>Instances of this class are immutable and provide methods to access the details of the
+   * forked and failed commands.
    */
-  public record ForkResultFailure(List<ScheduleResult.Failure> failed) implements ForkResult {}
+  public final class ForkResult {
+    private final List<? extends Command> m_forkedCommands;
+    private final List<? extends ScheduleResult.Failure> m_failedCommands;
+
+    // private - only the coroutine can construct these
+    private ForkResult(
+        Collection<? extends Command> forkedCommands,
+        List<? extends ScheduleResult.Failure> failedCommands) {
+      m_forkedCommands = List.copyOf(forkedCommands);
+      m_failedCommands = List.copyOf(failedCommands);
+    }
+
+    /**
+     * Checks if the fork request was successful.
+     *
+     * @return True if no commands failed to be forked, false if at least one failed.
+     */
+    public boolean successful() {
+      return m_failedCommands.isEmpty();
+    }
+
+    /**
+     * Checks if the fork request failed.
+     *
+     * @return True if at least one command failed to be forked, false if all commands were
+     *     successfully forked.
+     */
+    public boolean failed() {
+      return !successful();
+    }
+
+    /**
+     * Checks if the fork request was partially successful. A partial success is defined as at least
+     * one command being forked but at least one failing to be forked. This can happen if a child
+     * immediately schedules a grandchild with a higher priority than a later sibling that shares
+     * requirements with that grandchild.
+     *
+     * @return True if at least one command was forked but at least one failed to be forked, false
+     *     if all commands were successfully forked or none were forked.
+     */
+    public boolean partialSuccess() {
+      return !m_forkedCommands.isEmpty() && !m_failedCommands.isEmpty();
+    }
+
+    /**
+     * Waits for all forked commands to complete. Unlike a fork-then-await pattern, which will
+     * reschedule any forked commands that already completed, {@code awaitCompletion()} will only
+     * wait for the forked commands that are still running.
+     *
+     * <p>This method does nothing if no commands were successfully forked.
+     */
+    public void awaitCompletion() {
+      for (Command command : m_forkedCommands) {
+        if (m_scheduler.isRunning(command)) {
+          Coroutine.this.yield();
+        }
+      }
+    }
+
+    /**
+     * Returns the list of commands that failed to be forked. This list is read-only and cannot be
+     * modified.
+     *
+     * @return The list of failed commands.
+     */
+    public List<? extends ScheduleResult.Failure> getFailedCommands() {
+      return m_failedCommands;
+    }
+
+    /**
+     * Returns the list of commands that were successfully forked. This list is read-only and cannot
+     * be modified.
+     *
+     * @return The list of forked commands.
+     */
+    public List<? extends Command> getForkedCommands() {
+      return m_forkedCommands;
+    }
+  }
 
   /**
    * Checks that all the given commands can be forked.
@@ -161,35 +236,38 @@ public final class Coroutine {
    * @param commands The commands to check
    * @return A failure-type ForkResult if the commands can't all be scheduled, or null on success.
    */
-  private ForkResultFailure checkAllForkable(Collection<? extends Command> commands) {
+  private ForkResult checkAllForkable(Collection<? extends Command> commands) {
     // Check for user error; there's no reason to fork conflicting commands simultaneously
     // Because this is a bug in user code, throw an error instead of returning a failure result
     ConflictDetector.throwIfConflicts(commands);
 
+    var schedulable = new ArrayList<Command>();
     var unschedulable = new ArrayList<ScheduleResult.Failure>();
     for (var command : commands) {
       var result = m_scheduler.isSchedulable(command);
       if (result instanceof ScheduleResult.Failure fail) {
         unschedulable.add(fail);
+      } else {
+        schedulable.add(command);
       }
     }
 
+    var result = new ForkResult(schedulable, unschedulable);
     if (!unschedulable.isEmpty()) {
-      var failure = new ForkResultFailure(unschedulable);
       if (m_cancelOnForkFailure) {
         // Canceling on fork failure means no coroutine or user code gets to run to handle the
         // failure result
-        m_lastForkFailure = failure;
+        m_lastForkFailure = result;
         this.yield();
         // could throw an IllegalStateException, but probably shouldn't crash user code
-        return failure;
+        return result;
       } else {
         // always return the failure object if self-cancellation is disabled
-        return failure;
+        return result;
       }
     }
 
-    return null;
+    return result;
   }
 
   /**
@@ -213,15 +291,19 @@ public final class Coroutine {
    *     success result if all commands were scheduled.
    */
   private ForkResult doFork(Collection<? extends Command> commands) {
+    var successes = new ArrayList<Command>();
     var fails = new ArrayList<ScheduleResult.Failure>();
     for (var command : commands) {
       var result = m_scheduler.schedule(command);
       if (result instanceof ScheduleResult.Failure fail) {
         fails.add(fail);
+      } else {
+        successes.add(command);
       }
     }
+    ForkResult result = new ForkResult(successes, fails);
 
-    if (!fails.isEmpty()) {
+    if (!fails.isEmpty() && m_cancelOnForkFailure) {
       // At least one of the commands couldn't be scheduled due to runtime behavior that can't be
       // checked ahead of time by `checkAllForkable`.
       //
@@ -230,17 +312,12 @@ public final class Coroutine {
       // commands, which we can't restore. The two options are to either cancel the entire command
       // composition - which is the default behavior - or to allow user code to handle the failure
       // and do something with it (eg trying something else, retrying, etc).
-      var result = new ForkResultFailure(fails);
-      if (m_cancelOnForkFailure) {
-        m_lastForkFailure = result;
-        this.yield();
-        return result; // note: unreachable
-      } else {
-        return result;
-      }
+      m_lastForkFailure = result;
+      this.yield();
+      return result; // note: unreachable
     }
 
-    return ForkResultSuccess.INSTANCE;
+    return result;
   }
 
   /**
@@ -249,9 +326,9 @@ public final class Coroutine {
    *
    * <p>If any child command is unable to be scheduled per the contract of {@link
    * Scheduler#isSchedulable(Command)}, then none of the commands will be scheduled and the method
-   * call will return a {@link ForkResultFailure} containing the unschedulable commands. If the
-   * coroutine is configured to cancel on fork failure, then the coroutine will be canceled and user
-   * code will not get a chance to handle the failure result.
+   * call will return a {@link ForkResult} containing the unschedulable commands. If the coroutine
+   * is configured to cancel on fork failure, then the coroutine will be canceled and user code will
+   * not get a chance to handle the failure result.
    *
    * <p>This is a nonblocking operation. To fork and then wait for the child command to complete,
    * use {@link #await(Command)}.
@@ -263,10 +340,12 @@ public final class Coroutine {
    * Command example() {
    *   return Command.noRequirements(coroutine -> {
    *     Command child = ...;
-   *     coroutine.fork(child);
+   *     ForkResult childTask = coroutine.fork(child);
    *     // ... do more things
    *     // then sync back up with the child command
-   *     coroutine.await(child);
+   *     if (childTask.successful()) {
+   *       childTask.awaitCompletion();
+   *     }
    *   }).named("Example");
    * }
    * }</pre>
@@ -286,9 +365,9 @@ public final class Coroutine {
       requireNonNullParam(commands[i], "commands[" + i + "]", "Coroutine.fork");
     }
 
-    var failure = checkAllForkable(Arrays.asList(commands));
-    if (failure != null) {
-      return failure;
+    var forkableCheck = checkAllForkable(Arrays.asList(commands));
+    if (forkableCheck.failed()) {
+      return forkableCheck;
     }
 
     return doFork(Arrays.asList(commands));
@@ -302,18 +381,20 @@ public final class Coroutine {
    *
    * <p>If any child command is unable to be scheduled per the contract of {@link
    * Scheduler#isSchedulable(Command)}, then none of the commands will be scheduled and the method
-   * call will return a {@link ForkResultFailure} containing the unschedulable commands. If the
-   * coroutine is configured to cancel on fork failure, then the coroutine will be canceled and user
-   * code will not get a chance to handle the failure result.
+   * call will return a {@link ForkResult} containing the unschedulable commands. If the coroutine
+   * is configured to cancel on fork failure, then the coroutine will be canceled and user code will
+   * not get a chance to handle the failure result.
    *
    * <pre>{@code
    * Command example() {
    *   return Command.noRequirements(coroutine -> {
    *     Collection<Command> innerCommands = ...;
-   *     coroutine.fork(innerCommands);
+   *     ForkResult childTask = coroutine.fork(innerCommands);
    *     // ... do more things
    *     // then sync back up with the inner commands
-   *     coroutine.awaitAll(innerCommands);
+   *     if (childTask.successful()) {
+   *       childTask.awaitCompletion();
+   *     }
    *   }).named("Example");
    * }
    * }</pre>
@@ -335,9 +416,9 @@ public final class Coroutine {
    *
    * <p>If the child command is unable to be scheduled per the contract of {@link
    * Scheduler#isSchedulable(Command)}, then it will not be scheduled and the method call will
-   * return a {@link ForkResultFailure} containing the command. If the coroutine is configured to
-   * cancel on fork failure, then the coroutine will be canceled and user code will not get a chance
-   * to handle the failure result.
+   * return a {@link ForkResult} containing the command. If the coroutine is configured to cancel on
+   * fork failure, then the coroutine will be canceled and user code will not get a chance to handle
+   * the failure result.
    *
    * @param command the command to await
    * @return a result indicating whether the await was successful or if the commands could not be
@@ -351,9 +432,9 @@ public final class Coroutine {
 
     requireNonNullParam(command, "command", "Coroutine.await");
 
-    var failure = checkAllForkable(List.of(command));
-    if (failure != null) {
-      return failure;
+    var forkableCheck = checkAllForkable(List.of(command));
+    if (forkableCheck.failed()) {
+      return forkableCheck;
     }
 
     // Don't need doFork() because there's no chance of sibling conflicts
@@ -365,7 +446,7 @@ public final class Coroutine {
       this.yield();
     }
 
-    return new ForkResultSuccess();
+    return new ForkResult(List.of(command), List.of());
   }
 
   /**
@@ -374,9 +455,9 @@ public final class Coroutine {
    *
    * <p>If any child command is unable to be scheduled per the contract of {@link
    * Scheduler#isSchedulable(Command)}, then none of the commands will be scheduled and the method
-   * call will return a {@link ForkResultFailure} containing the unschedulable commands. If the
-   * coroutine is configured to cancel on fork failure, then the coroutine will be canceled and user
-   * code will not get a chance to handle the failure result.
+   * call will return a {@link ForkResult} containing the unschedulable commands. If the coroutine
+   * is configured to cancel on fork failure, then the coroutine will be canceled and user code will
+   * not get a chance to handle the failure result.
    *
    * @param commands the commands to await
    * @return a result indicating whether the await was successful or if the commands could not be
@@ -395,21 +476,21 @@ public final class Coroutine {
       i++;
     }
 
-    var failure = checkAllForkable(commands);
-    if (failure != null) {
-      return failure;
+    var forkableCheck = checkAllForkable(commands);
+    if (forkableCheck.failed()) {
+      return forkableCheck;
     }
 
     var forkResult = doFork(commands);
-    if (forkResult instanceof ForkResultFailure forkFailed) {
-      return forkFailed;
+    if (forkResult.failed()) {
+      return forkResult;
     }
 
     while (commands.stream().anyMatch(m_scheduler::isScheduledOrRunning)) {
       this.yield();
     }
 
-    return ForkResultSuccess.INSTANCE;
+    return forkResult;
   }
 
   /**
@@ -418,9 +499,9 @@ public final class Coroutine {
    *
    * <p>If any child command is unable to be scheduled per the contract of {@link
    * Scheduler#isSchedulable(Command)}, then none of the commands will be scheduled and the method
-   * call will return a {@link ForkResultFailure} containing the unschedulable commands. If the
-   * coroutine is configured to cancel on fork failure, then the coroutine will be canceled and user
-   * code will not get a chance to handle the failure result.
+   * call will return a {@link ForkResult} containing the unschedulable commands. If the coroutine
+   * is configured to cancel on fork failure, then the coroutine will be canceled and user code will
+   * not get a chance to handle the failure result.
    *
    * @param commands the commands to await
    * @return a result indicating whether the await was successful or if the commands could not be
@@ -439,9 +520,9 @@ public final class Coroutine {
    *
    * <p>If any child command is unable to be scheduled per the contract of {@link
    * Scheduler#isSchedulable(Command)}, then none of the commands will be scheduled and the method
-   * call will return a {@link ForkResultFailure} containing the unschedulable commands. If the
-   * coroutine is configured to cancel on fork failure, then the coroutine will be canceled and user
-   * code will not get a chance to handle the failure result.
+   * call will return a {@link ForkResult} containing the unschedulable commands. If the coroutine
+   * is configured to cancel on fork failure, then the coroutine will be canceled and user code will
+   * not get a chance to handle the failure result.
    *
    * @param commands the commands to await
    * @return a result indicating whether the await was successful or if the commands could not be
@@ -460,14 +541,14 @@ public final class Coroutine {
       i++;
     }
 
-    var failure = checkAllForkable(commands);
-    if (failure != null) {
-      return failure;
+    var forkableCheck = checkAllForkable(commands);
+    if (forkableCheck.failed()) {
+      return forkableCheck;
     }
 
     var forkResult = doFork(commands);
-    if (forkResult instanceof ForkResultFailure forkFailed) {
-      return forkFailed;
+    if (forkResult.failed()) {
+      return forkResult;
     }
 
     while (commands.stream().allMatch(m_scheduler::isScheduledOrRunning)) {
@@ -477,7 +558,7 @@ public final class Coroutine {
     // At least one command exited; cancel the rest.
     commands.forEach(m_scheduler::cancel);
 
-    return ForkResultSuccess.INSTANCE;
+    return forkResult;
   }
 
   /**
@@ -486,9 +567,9 @@ public final class Coroutine {
    *
    * <p>If any child command is unable to be scheduled per the contract of {@link
    * Scheduler#isSchedulable(Command)}, then none of the commands will be scheduled and the method
-   * call will return a {@link ForkResultFailure} containing the unschedulable commands. If the
-   * coroutine is configured to cancel on fork failure, then the coroutine will be canceled and user
-   * code will not get a chance to handle the failure result.
+   * call will return a {@link ForkResult} containing the unschedulable commands. If the coroutine
+   * is configured to cancel on fork failure, then the coroutine will be canceled and user code will
+   * not get a chance to handle the failure result.
    *
    * @param commands the commands to await
    * @return a result indicating whether the await was successful or if the commands could not be

--- a/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
@@ -7,6 +7,7 @@ package org.wpilib.command3;
 import static org.wpilib.units.Units.Seconds;
 import static org.wpilib.util.ErrorMessages.requireNonNullParam;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -25,6 +26,9 @@ public final class Coroutine {
   private final Scheduler m_scheduler;
   private final Continuation m_backingContinuation;
 
+  private boolean m_cancelOnForkFailure = true;
+  private ForkResultFailure m_lastForkFailure = null;
+
   /**
    * Creates a new coroutine. Package-private; only the scheduler should be creating these.
    *
@@ -36,6 +40,39 @@ public final class Coroutine {
   Coroutine(Scheduler scheduler, ContinuationScope scope, Consumer<Coroutine> callback) {
     m_scheduler = scheduler;
     m_backingContinuation = new Continuation(scope, () -> callback.accept(this));
+  }
+
+  /**
+   * Configures the coroutine to cancel itself if a child command couldn't be forked. This setting
+   * defaults to {@code true}, but can be changed to allow the coroutine to continue running after a
+   * fork failure.
+   *
+   * @param cancelOnForkFailure true to make the coroutine cancel itself if a child command couldn't
+   *     be forked, false to allow the coroutine to continue running after a fork failure
+   */
+  public void setCancelOnForkFailure(boolean cancelOnForkFailure) {
+    m_cancelOnForkFailure = cancelOnForkFailure;
+  }
+
+  /**
+   * Checks if the coroutine is currently configured to cancel itself if a child command couldn't be
+   * forked.
+   *
+   * @return true if the coroutine will cancel itself if a child command couldn't be forked, false
+   *     otherwise
+   */
+  public boolean isCancelOnForkFailure() {
+    return m_cancelOnForkFailure;
+  }
+
+  // Package-private. User code can never access this because setting the flag happens immediately
+  // before the coroutine yields itself.
+  boolean isInterruptRequested() {
+    return m_cancelOnForkFailure && m_lastForkFailure != null;
+  }
+
+  ForkResultFailure getForkResult() {
+    return m_lastForkFailure;
   }
 
   /**
@@ -67,9 +104,69 @@ public final class Coroutine {
     }
   }
 
+  /** The result of an attempt to fork or await commands. */
+  public sealed interface ForkResult {}
+
+  /** Commands were successfully forked. */
+  public record ForkResultSuccess() implements ForkResult {
+    // No state, so may as well use a singleton
+    private static final ForkResultSuccess INSTANCE = new ForkResultSuccess();
+  }
+
   /**
-   * Schedules a child command and then immediately returns. The child command will run until its
+   * At least one command was unable to be scheduled because a command with a higher priority is
+   * already running and owns at least one of the same required mechanisms.
+   *
+   * @param failed The failed scheduling attempts.
+   */
+  public record ForkResultFailure(List<Scheduler.ScheduleResult> failed) implements ForkResult {}
+
+  /**
+   * Checks that all the given commands can be forked.
+   *
+   * @param commands The commands to check
+   * @return A failure-type ForkResult if the commands can't all be scheduled, or null on success.
+   */
+  private ForkResultFailure checkAllForkable(Collection<? extends Command> commands) {
+    // Check for user error; there's no reason to fork conflicting commands simultaneously
+    // Because this is a bug in user code, throw an error instead of returning a failure result
+    ConflictDetector.throwIfConflicts(commands);
+
+    var unschedulable = new ArrayList<Scheduler.ScheduleResult>();
+    for (var command : commands) {
+      var result = m_scheduler.isSchedulable(command);
+      if (!result.successful()) {
+        unschedulable.add(result);
+      }
+    }
+
+    if (!unschedulable.isEmpty()) {
+      var failure = new ForkResultFailure(unschedulable);
+      if (m_cancelOnForkFailure) {
+        // Canceling on fork failure means no coroutine or user code gets to run to handle the
+        // failure result
+        m_lastForkFailure = failure;
+        this.yield();
+        // could throw an IllegalStateException, but probably shouldn't crash user code
+        return failure;
+      } else {
+        // always return the failure object if self-cancellation is disabled
+        return failure;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Schedules child commands and then immediately returns. The child commands will run until their
    * natural completion, the parent command exits, or the parent command cancels it.
+   *
+   * <p>If any child command is unable to be scheduled per the contract of {@link
+   * Scheduler#isSchedulable(Command)}, then none of the commands will be scheduled and the method
+   * call will return a {@link ForkResultFailure} containing the unschedulable commands. If the
+   * coroutine is configured to cancel on fork failure, then the coroutine will be canceled and user
+   * code will not get a chance to handle the failure result.
    *
    * <p>This is a nonblocking operation. To fork and then wait for the child command to complete,
    * use {@link #await(Command)}.
@@ -93,10 +190,13 @@ public final class Coroutine {
    * command will not be scheduled, and the existing command will continue to run.
    *
    * @param commands The commands to fork.
+   * @return a result indicating whether the fork was successful or if the commands could not be
+   *     forked
    * @throws IllegalStateException if called anywhere other than the coroutine's running command
    * @see #await(Command)
+   * @see #setCancelOnForkFailure(boolean)
    */
-  public void fork(Command... commands) {
+  public ForkResult fork(Command... commands) {
     requireMounted();
 
     requireNonNullParam(commands, "commands", "Coroutine.fork");
@@ -104,13 +204,17 @@ public final class Coroutine {
       requireNonNullParam(commands[i], "commands[" + i + "]", "Coroutine.fork");
     }
 
-    // Check for user error; there's no reason to fork conflicting commands simultaneously
-    ConflictDetector.throwIfConflicts(List.of(commands));
+    var failure = checkAllForkable(Arrays.asList(commands));
+    if (failure != null) {
+      return failure;
+    }
 
     // Shorthand; this is handy for user-defined compositions
     for (var command : commands) {
       m_scheduler.schedule(command);
     }
+
+    return ForkResultSuccess.INSTANCE;
   }
 
   /**
@@ -118,6 +222,12 @@ public final class Coroutine {
    * exits, or the parent command cancels it. The parent command will continue executing while the
    * forked commands run, and can resync with the forked commands using {@link
    * #awaitAll(Collection)}.
+   *
+   * <p>If any child command is unable to be scheduled per the contract of {@link
+   * Scheduler#isSchedulable(Command)}, then none of the commands will be scheduled and the method
+   * call will return a {@link ForkResultFailure} containing the unschedulable commands. If the
+   * coroutine is configured to cancel on fork failure, then the coroutine will be canceled and user
+   * code will not get a chance to handle the failure result.
    *
    * <pre>{@code
    * Command example() {
@@ -135,10 +245,13 @@ public final class Coroutine {
    * command will not be scheduled, and the existing command will continue to run.
    *
    * @param commands The commands to fork.
+   * @return a result indicating whether the fork was successful or if the commands could not be
+   *     forked
    * @throws IllegalStateException if called anywhere other than the coroutine's running command
+   * @see #setCancelOnForkFailure(boolean)
    */
-  public void fork(Collection<? extends Command> commands) {
-    fork(commands.toArray(Command[]::new));
+  public ForkResult fork(Collection<? extends Command> commands) {
+    return fork(commands.toArray(Command[]::new));
   }
 
   /**
@@ -146,14 +259,28 @@ public final class Coroutine {
    * be scheduled automatically. This is a blocking operation and will not return until the command
    * completes or has been interrupted by another command scheduled by the same parent.
    *
+   * <p>If the child command is unable to be scheduled per the contract of {@link
+   * Scheduler#isSchedulable(Command)}, then it will not be scheduled and the method call will
+   * return a {@link ForkResultFailure} containing the command. If the coroutine is configured to
+   * cancel on fork failure, then the coroutine will be canceled and user code will not get a chance
+   * to handle the failure result.
+   *
    * @param command the command to await
+   * @return a result indicating whether the await was successful or if the commands could not be
+   *     awaited
    * @throws IllegalStateException if called anywhere other than the coroutine's running command
    * @see #fork(Command...)
+   * @see #setCancelOnForkFailure(boolean)
    */
-  public void await(Command command) {
+  public ForkResult await(Command command) {
     requireMounted();
 
     requireNonNullParam(command, "command", "Coroutine.await");
+
+    var failure = checkAllForkable(List.of(command));
+    if (failure != null) {
+      return failure;
+    }
 
     m_scheduler.schedule(command);
 
@@ -162,17 +289,28 @@ public final class Coroutine {
       // There would be nothing to await
       this.yield();
     }
+
+    return new ForkResultSuccess();
   }
 
   /**
-   * Awaits completion of all given commands. If any command is not current scheduled or running, it
-   * will be scheduled.
+   * Awaits completion of all given commands. If any command is not currently scheduled or running,
+   * it will be scheduled.
+   *
+   * <p>If any child command is unable to be scheduled per the contract of {@link
+   * Scheduler#isSchedulable(Command)}, then none of the commands will be scheduled and the method
+   * call will return a {@link ForkResultFailure} containing the unschedulable commands. If the
+   * coroutine is configured to cancel on fork failure, then the coroutine will be canceled and user
+   * code will not get a chance to handle the failure result.
    *
    * @param commands the commands to await
+   * @return a result indicating whether the await was successful or if the commands could not be
+   *     awaited
    * @throws IllegalArgumentException if any of the commands conflict with each other
    * @throws IllegalStateException if called anywhere other than the coroutine's running command
+   * @see #setCancelOnForkFailure(boolean)
    */
-  public void awaitAll(Collection<? extends Command> commands) {
+  public ForkResult awaitAll(Collection<? extends Command> commands) {
     requireMounted();
 
     requireNonNullParam(commands, "commands", "Coroutine.awaitAll");
@@ -182,7 +320,10 @@ public final class Coroutine {
       i++;
     }
 
-    ConflictDetector.throwIfConflicts(commands);
+    var failure = checkAllForkable(commands);
+    if (failure != null) {
+      return failure;
+    }
 
     for (var command : commands) {
       m_scheduler.schedule(command);
@@ -191,29 +332,49 @@ public final class Coroutine {
     while (commands.stream().anyMatch(m_scheduler::isScheduledOrRunning)) {
       this.yield();
     }
+
+    return new ForkResultSuccess();
   }
 
   /**
-   * Awaits completion of all given commands. If any command is not current scheduled or running, it
-   * will be scheduled.
+   * Awaits completion of all given commands. If any command is not currently scheduled or running,
+   * it will be scheduled.
+   *
+   * <p>If any child command is unable to be scheduled per the contract of {@link
+   * Scheduler#isSchedulable(Command)}, then none of the commands will be scheduled and the method
+   * call will return a {@link ForkResultFailure} containing the unschedulable commands. If the
+   * coroutine is configured to cancel on fork failure, then the coroutine will be canceled and user
+   * code will not get a chance to handle the failure result.
    *
    * @param commands the commands to await
+   * @return a result indicating whether the await was successful or if the commands could not be
+   *     awaited
    * @throws IllegalArgumentException if any of the commands conflict with each other
    * @throws IllegalStateException if called anywhere other than the coroutine's running command
+   * @see #setCancelOnForkFailure(boolean)
    */
-  public void awaitAll(Command... commands) {
-    awaitAll(Arrays.asList(commands));
+  public ForkResult awaitAll(Command... commands) {
+    return awaitAll(Arrays.asList(commands));
   }
 
   /**
    * Awaits completion of any given commands. Any command that's not already scheduled or running
-   * will be scheduled. After any of the given commands completes, the rest will be canceled.
+   * will be scheduled. After any of the given commands complete, the rest will be canceled.
+   *
+   * <p>If any child command is unable to be scheduled per the contract of {@link
+   * Scheduler#isSchedulable(Command)}, then none of the commands will be scheduled and the method
+   * call will return a {@link ForkResultFailure} containing the unschedulable commands. If the
+   * coroutine is configured to cancel on fork failure, then the coroutine will be canceled and user
+   * code will not get a chance to handle the failure result.
    *
    * @param commands the commands to await
+   * @return a result indicating whether the await was successful or if the commands could not be
+   *     awaited
    * @throws IllegalArgumentException if any of the commands conflict with each other
    * @throws IllegalStateException if called anywhere other than the coroutine's running command
+   * @see #setCancelOnForkFailure(boolean)
    */
-  public void awaitAny(Collection<? extends Command> commands) {
+  public ForkResult awaitAny(Collection<? extends Command> commands) {
     requireMounted();
 
     requireNonNullParam(commands, "commands", "Coroutine.awaitAny");
@@ -223,7 +384,10 @@ public final class Coroutine {
       i++;
     }
 
-    ConflictDetector.throwIfConflicts(commands);
+    var failure = checkAllForkable(commands);
+    if (failure != null) {
+      return failure;
+    }
 
     // Schedule anything that's not already queued or running
     for (var command : commands) {
@@ -236,18 +400,29 @@ public final class Coroutine {
 
     // At least one command exited; cancel the rest.
     commands.forEach(m_scheduler::cancel);
+
+    return ForkResultSuccess.INSTANCE;
   }
 
   /**
    * Awaits completion of any given commands. Any command that's not already scheduled or running
    * will be scheduled. After any of the given commands completes, the rest will be canceled.
    *
+   * <p>If any child command is unable to be scheduled per the contract of {@link
+   * Scheduler#isSchedulable(Command)}, then none of the commands will be scheduled and the method
+   * call will return a {@link ForkResultFailure} containing the unschedulable commands. If the
+   * coroutine is configured to cancel on fork failure, then the coroutine will be canceled and user
+   * code will not get a chance to handle the failure result.
+   *
    * @param commands the commands to await
+   * @return a result indicating whether the await was successful or if the commands could not be
+   *     awaited
    * @throws IllegalArgumentException if any of the commands conflict with each other
    * @throws IllegalStateException if called anywhere other than the coroutine's running command
+   * @see #setCancelOnForkFailure(boolean)
    */
-  public void awaitAny(Command... commands) {
-    awaitAny(Arrays.asList(commands));
+  public ForkResult awaitAny(Command... commands) {
+    return awaitAny(Arrays.asList(commands));
   }
 
   /**

--- a/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
+import org.wpilib.command3.Scheduler.ScheduleResult;
 import org.wpilib.system.Timer;
 import org.wpilib.units.measure.Time;
 
@@ -53,7 +54,6 @@ public final class Coroutine {
    *
    * @param cancelOnForkFailure true to make the coroutine cancel itself if a child command couldn't
    *     be forked, false to allow the coroutine to continue running after a fork failure
-   *
    * @see #fork(Command...)
    * @see #fork(Collection)
    * @see #await(Command)
@@ -132,7 +132,7 @@ public final class Coroutine {
    *
    * @param failed The failed scheduling attempts.
    */
-  public record ForkResultFailure(List<Scheduler.ScheduleResult> failed) implements ForkResult {}
+  public record ForkResultFailure(List<ScheduleResult.Failure> failed) implements ForkResult {}
 
   /**
    * Checks that all the given commands can be forked.
@@ -145,11 +145,11 @@ public final class Coroutine {
     // Because this is a bug in user code, throw an error instead of returning a failure result
     ConflictDetector.throwIfConflicts(commands);
 
-    var unschedulable = new ArrayList<Scheduler.ScheduleResult>();
+    var unschedulable = new ArrayList<ScheduleResult.Failure>();
     for (var command : commands) {
       var result = m_scheduler.isSchedulable(command);
-      if (!result.successful()) {
-        unschedulable.add(result);
+      if (result instanceof ScheduleResult.Failure fail) {
+        unschedulable.add(fail);
       }
     }
 
@@ -169,6 +169,30 @@ public final class Coroutine {
     }
 
     return null;
+  }
+
+  /**
+   * Performs the actual fork operation for a collection of commands. This is used in conjuction
+   * with {@link #checkAllForkable(Collection)}
+   *
+   * @param commands The commands to fork
+   * @return A failure result if at least one of the given commands was unable to be scheduled, or a
+   *     success result if all commands were scheduled.
+   */
+  private ForkResult doFork(Collection<? extends Command> commands) {
+    var fails = new ArrayList<ScheduleResult.Failure>();
+    for (var command : commands) {
+      var result = m_scheduler.schedule(command);
+      if (result instanceof ScheduleResult.Failure fail) {
+        fails.add(fail);
+      }
+    }
+
+    if (!fails.isEmpty()) {
+      return new ForkResultFailure(fails);
+    }
+
+    return ForkResultSuccess.INSTANCE;
   }
 
   /**
@@ -222,12 +246,7 @@ public final class Coroutine {
       return failure;
     }
 
-    // Shorthand; this is handy for user-defined compositions
-    for (var command : commands) {
-      m_scheduler.schedule(command);
-    }
-
-    return ForkResultSuccess.INSTANCE;
+    return doFork(Arrays.asList(commands));
   }
 
   /**
@@ -295,6 +314,7 @@ public final class Coroutine {
       return failure;
     }
 
+    // Don't need doFork() because there's no chance of sibling conflicts
     m_scheduler.schedule(command);
 
     while (m_scheduler.isScheduledOrRunning(command)) {
@@ -338,15 +358,16 @@ public final class Coroutine {
       return failure;
     }
 
-    for (var command : commands) {
-      m_scheduler.schedule(command);
+    var forkResult = doFork(commands);
+    if (forkResult instanceof ForkResultFailure forkFailed) {
+      return forkFailed;
     }
 
     while (commands.stream().anyMatch(m_scheduler::isScheduledOrRunning)) {
       this.yield();
     }
 
-    return new ForkResultSuccess();
+    return ForkResultSuccess.INSTANCE;
   }
 
   /**
@@ -402,9 +423,9 @@ public final class Coroutine {
       return failure;
     }
 
-    // Schedule anything that's not already queued or running
-    for (var command : commands) {
-      m_scheduler.schedule(command);
+    var forkResult = doFork(commands);
+    if (forkResult instanceof ForkResultFailure forkFailed) {
+      return forkFailed;
     }
 
     while (commands.stream().allMatch(m_scheduler::isScheduledOrRunning)) {

--- a/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
@@ -172,8 +172,20 @@ public final class Coroutine {
   }
 
   /**
-   * Performs the actual fork operation for a collection of commands. This is used in conjuction
-   * with {@link #checkAllForkable(Collection)}
+   * Performs the actual fork operation for a collection of commands. This is used in conjunction
+   * with {@link #checkAllForkable(Collection)} in case a child forks a grandchild that conflicts
+   * with another entry in the set.
+   *
+   * <p>Given this setup, child1 and child2 are both forkable at the same time (no shared
+   * requirements and no conflicts with running commands), but child1 immediately forks a higher
+   * priority command than child2, which prevents child2 from being scheduled.
+   *
+   * <pre>{@code
+   * parent:
+   *   child1:
+   *     fork priority(1000, mech)
+   *   child2: priority(0, mech))
+   * }</pre>
    *
    * @param commands The commands to fork
    * @return A failure result if at least one of the given commands was unable to be scheduled, or a
@@ -189,7 +201,22 @@ public final class Coroutine {
     }
 
     if (!fails.isEmpty()) {
-      return new ForkResultFailure(fails);
+      // At least one of the commands couldn't be scheduled due to runtime behavior that can't be
+      // checked ahead of time by `checkAllForkable`.
+      //
+      // We can't roll back the partial success; the commands that successfully started will have
+      // already affected the state of the robot and may have interrupted previously running
+      // commands, which we can't restore. The two options are to either cancel the entire command
+      // composition - which is the default behavior - or to allow user code to handle the failure
+      // and do something with it (eg trying something else, retrying, etc).
+      var result = new ForkResultFailure(fails);
+      if (m_cancelOnForkFailure) {
+        m_lastForkFailure = result;
+        this.yield();
+        return result; // note: unreachable
+      } else {
+        return result;
+      }
     }
 
     return ForkResultSuccess.INSTANCE;
@@ -222,9 +249,6 @@ public final class Coroutine {
    *   }).named("Example");
    * }
    * }</pre>
-   *
-   * <p>Note: forking a command that conflicts with a higher-priority command will fail. The forked
-   * command will not be scheduled, and the existing command will continue to run.
    *
    * @param commands The commands to fork.
    * @return a result indicating whether the fork was successful or if the commands could not be
@@ -272,9 +296,6 @@ public final class Coroutine {
    *   }).named("Example");
    * }
    * }</pre>
-   *
-   * <p>Note: forking a command that conflicts with a higher-priority command will fail. The forked
-   * command will not be scheduled, and the existing command will continue to run.
    *
    * @param commands The commands to fork.
    * @return a result indicating whether the fork was successful or if the commands could not be

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -1048,12 +1048,6 @@ public final class Scheduler implements ProtobufSerializable {
    */
   @SuppressWarnings("PMD.CompareObjectsWithEquals")
   private void interruptCommandTree(Command command, Command interrupter) {
-    var childCommands =
-        m_runningCommands.values().stream()
-            .filter(state -> state.parent() == command)
-            .map(CommandState::command)
-            .toList();
-
     boolean running = isRunning(command);
     boolean scheduled = isScheduled(command);
 
@@ -1070,6 +1064,11 @@ public final class Scheduler implements ProtobufSerializable {
       emitCanceledEvent(command);
     }
 
+    var childCommands =
+        m_runningCommands.values().stream()
+            .filter(state -> state.parent() == command)
+            .map(CommandState::command)
+            .toList();
     childCommands.forEach(child -> interruptCommandTree(child, interrupter));
   }
 

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -942,13 +942,10 @@ public final class Scheduler implements ProtobufSerializable {
           }
         };
 
-    Command root = command;
-    if (!m_currentCommandAncestry.isEmpty()) {
-      root = m_currentCommandAncestry.firstElement().command();
-    }
-
-    interruptCommandTree(root, interruptor);
+    Command root = getRoot(command);
     m_currentCommandAncestry.clear();
+    emitInterruptedEvent(command, interruptor);
+    cancel(root);
     Continuation.mountContinuation(null);
   }
 
@@ -968,10 +965,7 @@ public final class Scheduler implements ProtobufSerializable {
 
     // Fetch the root command
     // (needs to be done before removing the failed command from the running set)
-    Command root = command;
-    while (getParentOf(root) != null) {
-      root = getParentOf(root);
-    }
+    final Command root = getRoot(command);
 
     // Remove it from the running set.
     m_runningCommands.remove(command);
@@ -1085,38 +1079,6 @@ public final class Scheduler implements ProtobufSerializable {
   }
 
   /**
-   * Interrupts a command and all descendants in its composition tree.
-   *
-   * @param command the root of the tree to interrupt
-   * @param interrupter the command that caused the interruption
-   */
-  @SuppressWarnings("PMD.CompareObjectsWithEquals")
-  private void interruptCommandTree(Command command, Command interrupter) {
-    boolean running = isRunning(command);
-    boolean scheduled = isScheduled(command);
-
-    m_runningCommands.remove(command);
-    m_queuedToRun.removeIf(state -> state.command() == command);
-
-    if (running || scheduled) {
-      emitInterruptedEvent(command, interrupter);
-    }
-    if (running) {
-      command.onCancel();
-    }
-    if (running || scheduled) {
-      emitCanceledEvent(command);
-    }
-
-    var childCommands =
-        m_runningCommands.values().stream()
-            .filter(state -> state.parent() == command)
-            .map(CommandState::command)
-            .toList();
-    childCommands.forEach(child -> interruptCommandTree(child, interrupter));
-  }
-
-  /**
    * Builds a coroutine object that the command will be bound to. The coroutine will be scoped to
    * this scheduler object and cannot be used by another scheduler instance.
    *
@@ -1223,6 +1185,17 @@ public final class Scheduler implements ProtobufSerializable {
   @NoDiscard
   public Collection<Command> getQueuedCommands() {
     return m_queuedToRun.stream().map(CommandState::command).toList();
+  }
+
+  private Command getRoot(Command command) {
+    Command root = command;
+    Command parent = getParentOf(command);
+    while (parent != null) {
+      root = parent;
+      parent = getParentOf(parent);
+    }
+
+    return root;
   }
 
   /**

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -848,8 +848,10 @@ public final class Scheduler implements ProtobufSerializable {
         Continuation.mountContinuation(null);
       }
 
-      if (coroutine.isDone() || coroutine.isInterruptRequested()) {
-        // Callback finished or requested interrupt - remove it from the list
+      if (coroutine.isDone()
+          || coroutine.isInterruptRequested()
+          || coroutine.isCancellationRequested()) {
+        // Callback finished or requested early termination - remove it from the list
         iterator.remove();
       }
     }

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -273,11 +273,21 @@ public final class Scheduler implements ProtobufSerializable {
    * control back to the scheduler with {@link Coroutine#yield} or risk stalling your program in an
    * unrecoverable infinite loop!
    *
+   * <p>The coroutines provided to sideloaded functions will not cancel themselves if a fork or
+   * await call fails. This allows user code the opportunity to recover from a failure. You can opt
+   * into canceling the coroutine if a fork or await call fails by calling
+   * {@link Coroutine#setCancelOnForkFailure(boolean)}.
+   *
    * @param callback the callback to sideload
    * @see #addPeriodic(Runnable)
    */
   public void sideload(Consumer<Coroutine> callback) {
     var coroutine = new Coroutine(this, m_scope, callback);
+    // Sideloaded functions shouldn't be canceled if a command can't be forked. The default behavior
+    // should allow user code the opportunity to recover from a failure. This differs from
+    // coroutines issued to commands, which should fail by default to prevent unexpected robot state
+    coroutine.setCancelOnForkFailure(false);
+
     var scope = BindingScope.createNarrowestScope(this);
     m_periodicCallbacks.add(new PeriodicCallback(scope, coroutine));
   }
@@ -797,15 +807,16 @@ public final class Scheduler implements ProtobufSerializable {
       }
 
       // Update periodic callbacks
-      callback.coroutine().mount();
+      Coroutine coroutine = callback.coroutine();
+      coroutine.mount();
       try {
-        callback.coroutine().runToYieldPoint();
+        coroutine.runToYieldPoint();
       } finally {
         Continuation.mountContinuation(null);
       }
 
-      if (callback.coroutine().isDone()) {
-        // Callback finished - remove it from the list
+      if (coroutine.isDone() || coroutine.isInterruptRequested()) {
+        // Callback finished or requested interrupt - remove it from the list
         iterator.remove();
       }
     }

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -356,6 +356,7 @@ public final class Scheduler implements ProtobufSerializable {
      */
     boolean successful();
 
+    /** Common interface for successful scheduling attempts. */
     sealed interface Successful extends ScheduleResult {
       @Override
       default boolean successful() {
@@ -363,6 +364,7 @@ public final class Scheduler implements ProtobufSerializable {
       }
     }
 
+    /** Common interface for failed scheduling attempts. */
     sealed interface Failure extends ScheduleResult {
       @Override
       default boolean successful() {

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -275,8 +275,8 @@ public final class Scheduler implements ProtobufSerializable {
    *
    * <p>The coroutines provided to sideloaded functions will not cancel themselves if a fork or
    * await call fails. This allows user code the opportunity to recover from a failure. You can opt
-   * into canceling the coroutine if a fork or await call fails by calling
-   * {@link Coroutine#setCancelOnForkFailure(boolean)}.
+   * into canceling the coroutine if a fork or await call fails by calling {@link
+   * Coroutine#setCancelOnForkFailure(boolean)}.
    *
    * @param callback the callback to sideload
    * @see #addPeriodic(Runnable)
@@ -356,12 +356,26 @@ public final class Scheduler implements ProtobufSerializable {
      */
     boolean successful();
 
+    sealed interface Successful extends ScheduleResult {
+      @Override
+      default boolean successful() {
+        return true;
+      }
+    }
+
+    sealed interface Failure extends ScheduleResult {
+      @Override
+      default boolean successful() {
+        return false;
+      }
+    }
+
     /**
      * A successful scheduling attempt.
      *
      * @param command the command that was successfully scheduled
      */
-    record Success(Command command) implements ScheduleResult {
+    record Success(Command command) implements Successful {
       /**
        * A successful scheduling attempt is always successful.
        *
@@ -378,7 +392,7 @@ public final class Scheduler implements ProtobufSerializable {
      *
      * @param command the command that was attempted to be scheduled
      */
-    record AlreadyRunning(Command command) implements ScheduleResult {
+    record AlreadyRunning(Command command) implements Successful {
       /**
        * A scheduling attempt that was redundant because the command was already running is always
        * successful.
@@ -399,7 +413,7 @@ public final class Scheduler implements ProtobufSerializable {
      * @param alreadyRunning the running command that prevented the command from being scheduled
      */
     record LowerPriorityThanRunningCommand(Command command, Command alreadyRunning)
-        implements ScheduleResult {
+        implements Failure {
       /**
        * A scheduling attempt that failed because the command was lower priority than a running
        * command with shared requirements is always unsuccessful.
@@ -420,7 +434,7 @@ public final class Scheduler implements ProtobufSerializable {
      * @param queuedCommand the queued command that prevented the command from being scheduled
      */
     record LowerPriorityThanQueuedCommand(Command command, Command queuedCommand)
-        implements ScheduleResult {
+        implements Failure {
       /**
        * A scheduling attempt that failed because the command was lower priority than a queued
        * command with shared requirements is always unsuccessful.

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -597,12 +597,28 @@ public final class Scheduler implements ProtobufSerializable {
       }
 
       var c = state.command();
-      if (c.conflictsWith(command) && maxAncestorPriority < c.priority()) {
+      if (c.conflictsWith(command) && maxAncestorPriority < effectivePriority(state)) {
         return c;
       }
     }
 
     return null;
+  }
+
+  /**
+   * Calculates the effective priority of a command, taking into account the priorities of its
+   * ancestors.
+   *
+   * @param state The command state to check
+   * @return The effective priority of the command
+   */
+  private int effectivePriority(CommandState state) {
+    int max = state.command().priority();
+    for (var parent = state.parent(); parent != null; parent = state.parent()) {
+      state = m_runningCommands.get(parent);
+      max = Math.max(max, parent.priority());
+    }
+    return max;
   }
 
   private void evictConflictingOnDeckCommands(Command command) {

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -708,9 +708,10 @@ public final class Scheduler implements ProtobufSerializable {
    */
   @SuppressWarnings("PMD.CompareObjectsWithEquals")
   public void cancel(Command command) {
-    if (command == currentCommand()) {
-      throw new IllegalArgumentException(
-          "Command `" + command.name() + "` is mounted and cannot be canceled");
+    var currentState = currentState();
+    if (currentState != null && command == currentState.command()) {
+      currentState.coroutine().requestCancellation(); // yields internally
+      return;
     }
 
     boolean running = isRunning(command);
@@ -910,7 +911,9 @@ public final class Scheduler implements ProtobufSerializable {
       }
     }
 
-    if (coroutine.isDone()) {
+    if (coroutine.isCancellationRequested()) {
+      cancel(command);
+    } else if (coroutine.isDone()) {
       handleCommandCompletion(command);
     } else if (coroutine.isInterruptRequested()) {
       handleCoroutineIRQ(coroutine, command);

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -22,6 +22,8 @@ import java.util.Stack;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.wpilib.annotation.NoDiscard;
+import org.wpilib.command3.Scheduler.ScheduleResult.LowerPriorityThanQueuedCommand;
+import org.wpilib.command3.Scheduler.ScheduleResult.LowerPriorityThanRunningCommand;
 import org.wpilib.command3.button.CommandGenericHID;
 import org.wpilib.command3.proto.SchedulerProto;
 import org.wpilib.event.EventLoop;
@@ -324,14 +326,140 @@ public final class Scheduler implements ProtobufSerializable {
         });
   }
 
-  /** Represents possible results of a command scheduling attempt. */
-  public enum ScheduleResult {
-    /** The command was successfully scheduled and added to the queue. */
-    SUCCESS,
-    /** The command is already scheduled or running. */
-    ALREADY_RUNNING,
-    /** The command is a lower priority and conflicts with a command that's already running. */
-    LOWER_PRIORITY_THAN_RUNNING_COMMAND,
+  /**
+   * Represents possible results of a command scheduling attempt. These can be used either as
+   * concrete results after a command was attempted to be scheduled, or as predictive results when
+   * checking if a command can be scheduled before committing to it.
+   */
+  public sealed interface ScheduleResult {
+    /**
+     * The command that was attempted to be scheduled.
+     *
+     * @return the command that was attempted to be scheduled
+     */
+    Command command();
+
+    /**
+     * Whether the scheduling attempt was successful.
+     *
+     * @return true if the scheduling attempt was successful, false if it failed
+     */
+    boolean successful();
+
+    /**
+     * A successful scheduling attempt.
+     *
+     * @param command the command that was successfully scheduled
+     */
+    record Success(Command command) implements ScheduleResult {
+      /**
+       * A successful scheduling attempt is always successful.
+       *
+       * @return true
+       */
+      @Override
+      public boolean successful() {
+        return true;
+      }
+    }
+
+    /**
+     * A scheduling attempt that was redundant because the command was already running.
+     *
+     * @param command the command that was attempted to be scheduled
+     */
+    record AlreadyRunning(Command command) implements ScheduleResult {
+      /**
+       * A scheduling attempt that was redundant because the command was already running is always
+       * successful.
+       *
+       * @return true
+       */
+      @Override
+      public boolean successful() {
+        return true;
+      }
+    }
+
+    /**
+     * A scheduling attempt that failed because the command was lower priority than a running
+     * command with shared requirements.
+     *
+     * @param command the command that failed to be scheduled
+     * @param alreadyRunning the running command that prevented the command from being scheduled
+     */
+    record LowerPriorityThanRunningCommand(Command command, Command alreadyRunning)
+        implements ScheduleResult {
+      /**
+       * A scheduling attempt that failed because the command was lower priority than a running
+       * command with shared requirements is always unsuccessful.
+       *
+       * @return false
+       */
+      @Override
+      public boolean successful() {
+        return false;
+      }
+    }
+
+    /**
+     * A scheduling attempt that failed because the command was lower priority than a queued command
+     * with shared requirements.
+     *
+     * @param command the command that failed to be scheduled
+     * @param queuedCommand the queued command that prevented the command from being scheduled
+     */
+    record LowerPriorityThanQueuedCommand(Command command, Command queuedCommand)
+        implements ScheduleResult {
+      /**
+       * A scheduling attempt that failed because the command was lower priority than a queued
+       * command with shared requirements is always unsuccessful.
+       *
+       * @return false
+       */
+      @Override
+      public boolean successful() {
+        return false;
+      }
+    }
+  }
+
+  /**
+   * Checks if a command is able to be scheduled. Returns of the following states:
+   *
+   * <ul>
+   *   <li>{@link ScheduleResult.AlreadyRunning} if the command is already scheduled or running.
+   *   <li>{@link ScheduleResult.Success} if the command is not already scheduled or running and
+   *       does not conflict with any other scheduled or running commands.
+   *   <li>{@link LowerPriorityThanRunningCommand} if the command has a lower priority than a
+   *       running command that shares requirements
+   *   <li>{@link LowerPriorityThanQueuedCommand} if the command has a lower priority than a queued
+   *       command that shares requirements
+   * </ul>
+   *
+   * @param command The command to check. Cannot be null.
+   * @return A schedule result indicating the schedulability of the command.
+   */
+  @NoDiscard
+  public ScheduleResult isSchedulable(Command command) {
+    ErrorMessages.requireNonNullParam(command, "command", "isSchedulable");
+
+    if (isScheduledOrRunning(command)) {
+      return new ScheduleResult.AlreadyRunning(command);
+    }
+
+    var running = m_runningCommands.values();
+    Command conflict = lowerPriorityThanConflictingCommands(command, running);
+    if (conflict != null) {
+      return new LowerPriorityThanRunningCommand(command, conflict);
+    }
+
+    conflict = lowerPriorityThanConflictingCommands(command, m_queuedToRun);
+    if (conflict != null) {
+      return new LowerPriorityThanQueuedCommand(command, conflict);
+    }
+
+    return new ScheduleResult.Success(command);
   }
 
   /**
@@ -341,6 +469,12 @@ public final class Scheduler implements ProtobufSerializable {
    *
    * <p>Does nothing if the command is already scheduled or running, or requires at least one
    * mechanism already used by a higher priority command.
+   *
+   * <p>For purposes of scheduling, a child command is considered to have a priority equal to the
+   * highest priority in its scheduling hierarchy. For example, if a parent command with priority 10
+   * schedules a child command with priority 5, the child command will be treated as having a
+   * priority of 10 and will interrupt any conflicting command with a priority of 10 or lower,
+   * rather than the usual 5.
    *
    * @param command the command to schedule
    * @return the result of the scheduling attempt. See {@link ScheduleResult} for details.
@@ -372,24 +506,9 @@ public final class Scheduler implements ProtobufSerializable {
   ScheduleResult schedule(Binding binding) {
     var command = binding.command();
 
-    if (isScheduledOrRunning(command)) {
-      return ScheduleResult.ALREADY_RUNNING;
-    }
-
-    if (lowerPriorityThanConflictingCommands(command)) {
-      return ScheduleResult.LOWER_PRIORITY_THAN_RUNNING_COMMAND;
-    }
-
-    for (var scheduledState : m_queuedToRun) {
-      if (!command.conflictsWith(scheduledState.command())) {
-        // No shared requirements, skip
-        continue;
-      }
-      if (command.isLowerPriorityThan(scheduledState.command())) {
-        // Lower priority than an already-scheduled (but not yet running) command that requires at
-        // one of the same mechanism. Ignore it.
-        return ScheduleResult.LOWER_PRIORITY_THAN_RUNNING_COMMAND;
-      }
+    var result = isSchedulable(command);
+    if (!(result instanceof ScheduleResult.Success)) {
+      return result;
     }
 
     // Track this binding so we can disable it when it's out of scope.
@@ -427,33 +546,39 @@ public final class Scheduler implements ProtobufSerializable {
       m_queuedToRun.add(state);
     }
 
-    return ScheduleResult.SUCCESS;
+    return result;
   }
 
   /**
    * Checks if a command conflicts with and is a lower priority than any running command. Used when
    * determining if the command can be scheduled.
+   *
+   * @return The conflicting command, or null if there is no conflict
    */
-  private boolean lowerPriorityThanConflictingCommands(Command command) {
+  private Command lowerPriorityThanConflictingCommands(
+      Command command, Collection<CommandState> checkAgainst) {
     Set<CommandState> ancestors = new HashSet<>();
+    // Inherit priority from ancestor commands
+    int maxAncestorPriority = command.priority();
     for (var state = currentState(); state != null; state = m_runningCommands.get(state.parent())) {
       ancestors.add(state);
+      maxAncestorPriority = Math.max(maxAncestorPriority, state.command().priority());
     }
 
     // Check for conflicts with the commands that are already running
-    for (var state : m_runningCommands.values()) {
+    for (var state : checkAgainst) {
       if (ancestors.contains(state)) {
         // Can't conflict with an ancestor command
         continue;
       }
 
       var c = state.command();
-      if (c.conflictsWith(command) && command.isLowerPriorityThan(c)) {
-        return true;
+      if (c.conflictsWith(command) && maxAncestorPriority < c.priority()) {
+        return c;
       }
     }
 
-    return false;
+    return null;
   }
 
   private void evictConflictingOnDeckCommands(Command command) {
@@ -687,6 +812,8 @@ public final class Scheduler implements ProtobufSerializable {
   }
 
   private void runCommands() {
+    // TODO: Track command roots and run the commands in each root in reverse order, but run the
+    //       roots in insertion order
     // Tick every command that hasn't been completed yet
     // Run in reverse so parent commands can resume in the same loop cycle an awaited child command
     // completes. Otherwise, parents could only resume on the next loop cycle, introducing a delay
@@ -741,15 +868,44 @@ public final class Scheduler implements ProtobufSerializable {
     }
 
     if (coroutine.isDone()) {
-      // Immediately check if the command has completed and remove any children commands.
-      // This prevents child commands from being executed one extra time in the run() loop
-      emitCompletedEvent(command);
-      m_runningCommands.remove(command);
-      removeOrphanedChildren(command);
+      handleCommandCompletion(command);
+    } else if (coroutine.isInterruptRequested()) {
+      handleCoroutineIRQ(coroutine, command);
     } else {
       // Yielded
       emitYieldedEvent(command);
     }
+  }
+
+  private void handleCommandCompletion(Command command) {
+    emitCompletedEvent(command);
+    m_runningCommands.remove(command);
+    removeOrphanedChildren(command);
+  }
+
+  private void handleCoroutineIRQ(Coroutine coroutine, Command command) {
+    // The coroutine requested to be interrupted. Cancel this command and bubble up the stack
+    // to interrupt the entire composition. Because InterruptEvent only supports a single
+    // interruptor, we attribute the interrupt to the first conflicting command.
+    var failure = coroutine.getForkResult().failed().getFirst();
+    Command interruptor =
+        switch (failure) {
+          case LowerPriorityThanRunningCommand(var _, Command conflict) -> conflict;
+          case LowerPriorityThanQueuedCommand(var _, Command conflict) -> conflict;
+          default -> {
+            // Shouldn't get here (this is a bug in WPILib code, not handling new cases).
+            // But we don't want to crash user programs, so just attribute to null.
+            yield null;
+          }
+        };
+
+    Command root = command;
+    if (!m_currentCommandAncestry.isEmpty()) {
+      root = m_currentCommandAncestry.firstElement().command();
+    }
+
+    interruptCommandTree(root, interruptor);
+    m_currentCommandAncestry.clear();
   }
 
   /**
@@ -882,6 +1038,39 @@ public final class Scheduler implements ProtobufSerializable {
         .filter(e -> e.getValue().parent() == parent)
         .toList() // copy to an intermediate list to avoid concurrent modification
         .forEach(e -> cancel(e.getKey()));
+  }
+
+  /**
+   * Interrupts a command and all descendants in its composition tree.
+   *
+   * @param command the root of the tree to interrupt
+   * @param interrupter the command that caused the interruption
+   */
+  @SuppressWarnings("PMD.CompareObjectsWithEquals")
+  private void interruptCommandTree(Command command, Command interrupter) {
+    var childCommands =
+        m_runningCommands.values().stream()
+            .filter(state -> state.parent() == command)
+            .map(CommandState::command)
+            .toList();
+
+    boolean running = isRunning(command);
+    boolean scheduled = isScheduled(command);
+
+    m_runningCommands.remove(command);
+    m_queuedToRun.removeIf(state -> state.command() == command);
+
+    if (running || scheduled) {
+      emitInterruptedEvent(command, interrupter);
+    }
+    if (running) {
+      command.onCancel();
+    }
+    if (running || scheduled) {
+      emitCanceledEvent(command);
+    }
+
+    childCommands.forEach(child -> interruptCommandTree(child, interrupter));
   }
 
   /**

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -931,6 +931,7 @@ public final class Scheduler implements ProtobufSerializable {
 
     interruptCommandTree(root, interruptor);
     m_currentCommandAncestry.clear();
+    Continuation.mountContinuation(null);
   }
 
   /**

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -973,7 +973,7 @@ public final class Scheduler implements ProtobufSerializable {
     // The coroutine requested to be interrupted. Cancel this command and bubble up the stack
     // to interrupt the entire composition. Because InterruptEvent only supports a single
     // interruptor, we attribute the interrupt to the first conflicting command.
-    var failure = coroutine.getForkResult().failed().getFirst();
+    var failure = coroutine.getForkResult().getFailedCommands().getFirst();
     Command interruptor =
         switch (failure) {
           case LowerPriorityThanRunningCommand(var _, Command conflict) -> conflict;

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -474,13 +474,50 @@ public final class Scheduler implements ProtobufSerializable {
       return new ScheduleResult.AlreadyRunning(command);
     }
 
+    Set<Command> ancestry = new HashSet<>();
+    for (var state = currentState(); state != null; state = m_runningCommands.get(state.parent())) {
+      ancestry.add(state.command());
+    }
+
+    return isSchedulableFromPriority(command, ancestry);
+  }
+
+  // similar to isSchedulable(Command), but used internally for processing bindings
+  // that may have command scopes.
+  private ScheduleResult isSchedulable(Binding binding) {
+    var command = binding.command();
+
+    if (isScheduledOrRunning(command)) {
+      return new ScheduleResult.AlreadyRunning(command);
+    }
+
+    Set<Command> ancestry = new HashSet<>();
+    if (binding.scope() instanceof BindingScope.ForCommand(Scheduler _, Command parent)) {
+      for (var state = m_runningCommands.get(parent);
+          state != null;
+          state = m_runningCommands.get(state.parent())) {
+        ancestry.add(state.command());
+      }
+    } else {
+      for (var state = currentState();
+          state != null;
+          state = m_runningCommands.get(state.parent())) {
+        ancestry.add(state.command());
+      }
+    }
+
+    return isSchedulableFromPriority(command, ancestry);
+  }
+
+  private Scheduler.ScheduleResult isSchedulableFromPriority(
+      Command command, Set<Command> ancestry) {
     var running = m_runningCommands.values();
-    Command conflict = lowerPriorityThanConflictingCommands(command, running);
+    Command conflict = lowerPriorityThanConflictingCommands(command, ancestry, running);
     if (conflict != null) {
       return new LowerPriorityThanRunningCommand(command, conflict);
     }
 
-    conflict = lowerPriorityThanConflictingCommands(command, m_queuedToRun);
+    conflict = lowerPriorityThanConflictingCommands(command, ancestry, m_queuedToRun);
     if (conflict != null) {
       return new LowerPriorityThanQueuedCommand(command, conflict);
     }
@@ -532,8 +569,12 @@ public final class Scheduler implements ProtobufSerializable {
   ScheduleResult schedule(Binding binding) {
     var command = binding.command();
 
-    var result = isSchedulable(command);
+    var result = isSchedulable(binding);
     if (!(result instanceof ScheduleResult.Success)) {
+      // We check specifically for Success, instead of `successful()`, because only a Success
+      // indicates that the command can actually go through the scheduling process. AlreadyRunning
+      // means what it says on the tin, and it would be incorrect to run the command back through
+      // the scheduling process.
       return result;
     }
 
@@ -582,18 +623,15 @@ public final class Scheduler implements ProtobufSerializable {
    * @return The conflicting command, or null if there is no conflict
    */
   private Command lowerPriorityThanConflictingCommands(
-      Command command, Collection<CommandState> checkAgainst) {
-    Set<CommandState> ancestors = new HashSet<>();
-    // Inherit priority from ancestor commands
+      Command command, Collection<Command> ancestry, Collection<CommandState> checkAgainst) {
     int maxAncestorPriority = command.priority();
-    for (var state = currentState(); state != null; state = m_runningCommands.get(state.parent())) {
-      ancestors.add(state);
-      maxAncestorPriority = Math.max(maxAncestorPriority, state.command().priority());
+    for (Command ancestor : ancestry) {
+      maxAncestorPriority = Math.max(maxAncestorPriority, ancestor.priority());
     }
 
     // Check for conflicts with the commands that are already running
     for (var state : checkAgainst) {
-      if (ancestors.contains(state)) {
+      if (ancestry.contains(state.command())) {
         // Can't conflict with an ancestor command
         continue;
       }

--- a/commandsv3/src/main/java/org/wpilib/command3/StateMachine.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/StateMachine.java
@@ -162,6 +162,8 @@ public final class StateMachine implements Command {
     outer_loop:
     while (currentState != null) {
       final var currentCommand = currentState.command();
+      // NOTE: The state machine will exit if the child command fails to be forked. This happens
+      //       if the command shares requirements with a higher-priority command.
       coroutine.fork(currentCommand);
       currentState.runEnterCallbacks();
       boolean didYield = false;

--- a/commandsv3/src/test/java/org/wpilib/command3/CommandTestBase.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/CommandTestBase.java
@@ -4,8 +4,11 @@
 
 package org.wpilib.command3;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.wpilib.system.RobotController;
@@ -44,5 +47,23 @@ class CommandTestBase {
   void resetOpmodeFetcher() {
     m_opModeId = 0;
     m_opModeName = "";
+  }
+
+  /**
+   * Asserts that any scheduler event of the given class occurred and that the given predicate
+   * returns true for the event. Does not make any assertions on the order of the event.
+   *
+   * @param eventClass the class of the event to assert
+   * @param tester a predicate that tests the event
+   * @param message the message to include in the exception if the event is not found
+   * @param <E> the type of the event to assert
+   */
+  <E extends SchedulerEvent> void assertSchedulerEvent(
+      Class<E> eventClass, Predicate<E> tester, String message) {
+    if (m_events.stream().filter(eventClass::isInstance).map(eventClass::cast).anyMatch(tester)) {
+      return;
+    }
+
+    fail(message);
   }
 }

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerCancellationTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerCancellationTests.java
@@ -6,7 +6,6 @@ package org.wpilib.command3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -100,16 +99,102 @@ class SchedulerCancellationTests extends CommandTestBase {
                   co.scheduler().cancel(commandRef.get());
                   ranAfterCancel.set(true);
                 })
-            .named("Command");
+            .named("Self-Canceling Command");
     commandRef.set(command);
     m_scheduler.schedule(command);
+    m_scheduler.run();
 
-    var error = assertThrows(IllegalArgumentException.class, () -> m_scheduler.run());
-    assertEquals("Command `Command` is mounted and cannot be canceled", error.getMessage());
-    assertFalse(ranAfterCancel.get(), "Command should have stopped after encountering an error");
+    assertFalse(ranAfterCancel.get(), "Command should have stopped after canceling itself");
+    assertSchedulerEvent(
+        SchedulerEvent.Canceled.class,
+        c -> c.command().equals(command),
+        "Command should have been canceled");
     assertFalse(
         m_scheduler.isScheduledOrRunning(command),
         "Command should have been removed from the scheduler");
+  }
+
+  @Test
+  void requestCancellation() {
+    var ranAfterCancel = new AtomicBoolean(false);
+    var command =
+        Command.noRequirements(
+                co -> {
+                  co.requestCancellation();
+                  ranAfterCancel.set(true);
+                })
+            .named("Self-Canceling Command");
+    m_scheduler.schedule(command);
+    m_scheduler.run();
+
+    assertFalse(ranAfterCancel.get(), "Command should have stopped after requesting cancellation");
+    assertSchedulerEvent(
+        SchedulerEvent.Canceled.class,
+        c -> c.command().equals(command),
+        "Command should have been canceled");
+    assertFalse(
+        m_scheduler.isScheduledOrRunning(command),
+        "Command should have been removed from the scheduler");
+  }
+
+  @Test
+  void requestCancellationBubblesDown() {
+    var child = new PriorityCommand(0);
+    var command =
+        Command.noRequirements(
+                co -> {
+                  co.fork(child);
+                  co.requestCancellation();
+                })
+            .named("Self-Canceling Command");
+    m_scheduler.schedule(command);
+    m_scheduler.run();
+
+    assertSchedulerEvent(
+        SchedulerEvent.Canceled.class,
+        c -> c.command().equals(command),
+        "Command should have been canceled");
+    assertSchedulerEvent(
+        SchedulerEvent.Canceled.class,
+        c -> c.command().equals(child),
+        "Child command should have been canceled");
+    assertFalse(
+        m_scheduler.isScheduledOrRunning(child),
+        "Child command should have been removed from the scheduler");
+  }
+
+  @Test
+  void requestCancellationDoesNotBubbleUp() {
+    var selfCanceller =
+        Command.noRequirements(Coroutine::requestCancellation).named("Self-Canceling Command");
+    var parent =
+        Command.noRequirements(
+                co -> {
+                  co.await(selfCanceller);
+                  co.park();
+                })
+            .named("Parent");
+
+    m_scheduler.schedule(parent);
+    m_scheduler.run();
+
+    assertSchedulerEvent(
+        SchedulerEvent.Canceled.class,
+        c -> c.command().equals(selfCanceller),
+        "Self-cancelling command should have been canceled");
+    assertEquals(List.of(parent), m_scheduler.getRunningCommands());
+  }
+
+  @Test
+  void requestCancellationCallsOnCancel() {
+    AtomicBoolean callbackRan = new AtomicBoolean(false);
+    var command =
+        Command.noRequirements(Coroutine::requestCancellation)
+            .whenCanceled(() -> callbackRan.set(true))
+            .named("Self-Cancelling Command");
+    m_scheduler.schedule(command);
+    m_scheduler.run();
+    assertTrue(callbackRan.get(), "OnCancel callback should have been called");
   }
 
   @Test

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
@@ -7,6 +7,7 @@ package org.wpilib.command3;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -121,6 +122,77 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
     assertFalse(
         m_scheduler.isRunning(higherPriority),
         "Higher priority command should have been interrupted");
+  }
+
+  @Test
+  void innerDefaultCommandInheritsHigherParentPriority() {
+    var mech = new DummyMechanism("Mechanism", m_scheduler);
+
+    final Command higherPriority = new PriorityCommand(200, mech);
+    final Command lowPriorityChild = new PriorityCommand(-1000, mech);
+    final Command parent =
+        Command.noRequirements(
+                coroutine -> {
+                  mech.setDefaultCommand(lowPriorityChild);
+                  coroutine.park();
+                })
+            .withPriority(1000)
+            .named("Parent");
+
+    m_scheduler.schedule(parent);
+    m_scheduler.run();
+    assertEquals(List.of(parent, lowPriorityChild), m_scheduler.getRunningCommands());
+
+    // the inner default command should inherit priority=1000 and prevent
+    // the 200-priority command from running
+    var result = m_scheduler.schedule(higherPriority);
+    var failure = assertInstanceOf(LowerPriorityThanRunningCommand.class, result);
+    assertSame(lowPriorityChild, failure.alreadyRunning());
+    assertSame(higherPriority, failure.command());
+    assertEquals(
+        List.of(parent, lowPriorityChild),
+        m_scheduler.getRunningCommands(),
+        "Parent and the inner default command should continue to run");
+  }
+
+  @Test
+  void innerTriggerCommandInheritsHigherParentPriority() {
+    var mech = new DummyMechanism("Mechanism", m_scheduler);
+
+    var higherPriority = new PriorityCommand(200, mech);
+    var lowPriorityChild = new PriorityCommand(-1000, mech);
+
+    var trigger = new Trigger(m_scheduler, () -> true);
+    var parent =
+        Command.noRequirements(
+                coroutine -> {
+                  // Because the trigger is created outside this command and before it's scheduled,
+                  // an `onTrue` or `whileTrue` binding won't fire because the signal edge happens
+                  // before the binding can be evaluated.
+                  trigger.retryWhileTrue(lowPriorityChild);
+
+                  coroutine.park();
+                })
+            .withPriority(1000)
+            .named("Parent");
+
+    m_scheduler.schedule(higherPriority);
+    m_scheduler.run();
+
+    m_scheduler.schedule(parent);
+    m_scheduler.run(); // Schedules parent, adds binding. The binding is evaluated on the next run()
+    m_scheduler.run(); // Polls the binding and schedules the child
+
+    assertEquals(
+        List.of(parent, lowPriorityChild),
+        m_scheduler.getRunningCommands(),
+        "Trigger-bound child should have inherited parent's priority");
+    assertSchedulerEvent(
+        SchedulerEvent.Interrupted.class,
+        i -> {
+          return i.interrupter().equals(lowPriorityChild) && i.command().equals(higherPriority);
+        },
+        "Higher-priority command should have been interrupted by the trigger-bound child");
   }
 
   @Test

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
@@ -14,6 +14,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.wpilib.command3.Coroutine.ForkResultFailure;
+import org.wpilib.command3.Scheduler.ScheduleResult.LowerPriorityThanRunningCommand;
 
 class SchedulerPriorityLevelTests extends CommandTestBase {
   @FunctionalInterface
@@ -153,6 +155,54 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
     }
   }
 
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("multiChildForkOperations")
+  void highPriorityGrandchildWithLowPriorityChild(NamedCoroutineForkOperation operation) {
+    /*
+     Given this setup, child1 and child2 are both forkable at the same time (no shared requirements
+     and no conflicts with running commands), but child1 forks a higher-priority command than
+     child2, which should cause child2 to fail to be scheduled
+
+     parent:
+       child1:
+         fork priority(1000, mech)
+       child2: priority(0, mech))
+    */
+
+    var mech = new DummyMechanism("Mech", m_scheduler);
+
+    PriorityCommand grandchild = new PriorityCommand(1000, mech);
+    var child1 = Command.noRequirements(co -> co.await(grandchild)).named("Child1");
+    var child2 = new PriorityCommand(0, mech);
+
+    var parent =
+        Command.noRequirements(
+                co -> {
+                  co.setCancelOnForkFailure(false);
+                  var result = operation.operation().apply(co, child1, child2);
+                  assertInstanceOf(
+                      ForkResultFailure.class, result, "Forking operation should have failed");
+
+                  var failure = (ForkResultFailure) result;
+                  var fails = failure.failed();
+                  assertEquals(1, fails.size(), "Exactly one failure was expected");
+                  assertInstanceOf(
+                      LowerPriorityThanRunningCommand.class,
+                      fails.getFirst(),
+                      "Failure should be a LowerPriorityThanRunningCommand");
+
+                  var failedCommand = fails.getFirst().command();
+                  var running =
+                      ((LowerPriorityThanRunningCommand) fails.getFirst()).alreadyRunning();
+                  assertEquals(child2, failedCommand, "Failed command should be child2");
+                  assertEquals(grandchild, running, "Running command should be grandchild");
+                })
+            .named("Parent");
+
+    m_scheduler.schedule(parent);
+    m_scheduler.run();
+  }
+
   private void assertUnschedulableSingleChildCancelsParent(CoroutineForkOperation operation) {
     final var subsystem = new DummyMechanism("Subsystem", m_scheduler);
 
@@ -231,8 +281,8 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
 
   private static void assertFailureResult(
       Coroutine.ForkResult result, List<Command> expectedFailedCommands) {
-    assertInstanceOf(Coroutine.ForkResultFailure.class, result, "Fork result should be a failure");
-    var failure = (Coroutine.ForkResultFailure) result;
+    assertInstanceOf(ForkResultFailure.class, result, "Fork result should be a failure");
+    var failure = (ForkResultFailure) result;
 
     var failedCommands = failure.failed().stream().map(Scheduler.ScheduleResult::command).toList();
     assertEquals(expectedFailedCommands, failedCommands);

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
@@ -98,6 +98,96 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
     assertFalse(m_scheduler.isRunning(first), "Old command should be canceled");
   }
 
+  @Test
+  void childInheritsHigherParentPriority() {
+    var mech = new DummyMechanism("Mechanism", m_scheduler);
+
+    var higherPriority = new PriorityCommand(200, mech);
+    var lowPriorityChild = new PriorityCommand(-1000, mech);
+    var parent =
+        Command.noRequirements(
+                coroutine -> {
+                  coroutine.await(lowPriorityChild);
+                })
+            .withPriority(1000)
+            .named("Parent");
+
+    m_scheduler.schedule(higherPriority);
+    m_scheduler.schedule(parent);
+    m_scheduler.run();
+
+    assertTrue(m_scheduler.isRunning(parent), "Parent command should be running");
+    assertTrue(m_scheduler.isRunning(lowPriorityChild), "Child command should be running");
+    assertFalse(
+        m_scheduler.isRunning(higherPriority),
+        "Higher priority command should have been interrupted");
+  }
+
+  @Test
+  void conflictingCommandsWithPriorityInheritance() {
+    var mech = new DummyMechanism("Mechanism", m_scheduler);
+
+    var child1 = new PriorityCommand(0, mech);
+    var child2 = new PriorityCommand(0, mech);
+
+    var parent1 =
+        Command.noRequirements(
+                coroutine -> {
+                  coroutine.await(child1);
+                })
+            .withPriority(2000)
+            .named("Parent1");
+
+    var parent2 =
+        Command.noRequirements(
+                coroutine -> {
+                  // child2 inherits parent2 priority (1000) and should fail to be scheduled due to
+                  // being
+                  //  a lower priority than child1 (2000, inherited from its parent)
+                  coroutine.await(child2);
+                })
+            .withPriority(1000)
+            .named("Parent2");
+
+    m_scheduler.schedule(parent1);
+    m_scheduler.schedule(parent2);
+    m_scheduler.run();
+
+    assertEquals(List.of(parent1, child1), m_scheduler.getRunningCommands());
+  }
+
+  @Test
+  void conflictingCommandsWithPriorityInheritance2() {
+    var mech = new DummyMechanism("Mechanism", m_scheduler);
+
+    var child1 = new PriorityCommand(0, mech);
+    var child2 = new PriorityCommand(0, mech);
+
+    var parent1 =
+        Command.noRequirements(
+                coroutine -> {
+                  coroutine.await(child1);
+                })
+            .withPriority(1000)
+            .named("Parent1");
+
+    var parent2 =
+        Command.noRequirements(
+                coroutine -> {
+                  // child2 inherits parent2 priority (2000) and should be scheduled due to being a
+                  // higher priority than child1 (1000, inherited from its parent)
+                  coroutine.await(child2);
+                })
+            .withPriority(2000)
+            .named("Parent2");
+
+    m_scheduler.schedule(parent1);
+    m_scheduler.schedule(parent2);
+    m_scheduler.run();
+
+    assertEquals(List.of(parent2, child2), m_scheduler.getRunningCommands());
+  }
+
   @ParameterizedTest(name = "{0}")
   @MethodSource("singleChildForkOperations")
   void lowPriorityChildCancelsParent(NamedCoroutineForkOperation operation) {

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
@@ -4,12 +4,46 @@
 
 package org.wpilib.command3;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class SchedulerPriorityLevelTests extends CommandTestBase {
+  @FunctionalInterface
+  private interface CoroutineForkOperation {
+    Coroutine.ForkResult apply(Coroutine coroutine, Command... commands);
+  }
+
+  private record NamedCoroutineForkOperation(String name, CoroutineForkOperation operation) {
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  private static Stream<NamedCoroutineForkOperation> singleChildForkOperations() {
+    return Stream.of(
+        new NamedCoroutineForkOperation("fork", Coroutine::fork),
+        new NamedCoroutineForkOperation(
+            "await", (coroutine, commands) -> coroutine.await(commands[0])),
+        new NamedCoroutineForkOperation("awaitAll", Coroutine::awaitAll),
+        new NamedCoroutineForkOperation("awaitAny", Coroutine::awaitAny));
+  }
+
+  private static Stream<NamedCoroutineForkOperation> multiChildForkOperations() {
+    return Stream.of(
+        new NamedCoroutineForkOperation("fork", Coroutine::fork),
+        new NamedCoroutineForkOperation("awaitAll", Coroutine::awaitAll),
+        new NamedCoroutineForkOperation("awaitAny", Coroutine::awaitAny));
+  }
+
   @Test
   void higherPriorityCancels() {
     final var subsystem = new DummyMechanism("Subsystem", m_scheduler);
@@ -60,5 +94,162 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
     m_scheduler.run();
     assertTrue(m_scheduler.isRunning(second), "New command should be running");
     assertFalse(m_scheduler.isRunning(first), "Old command should be canceled");
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("singleChildForkOperations")
+  void lowPriorityChildCancelsParent(NamedCoroutineForkOperation operation) {
+    assertUnschedulableSingleChildCancelsParent(operation.operation());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("singleChildForkOperations")
+  void lowPriorityChildGivesFailureObject(NamedCoroutineForkOperation operation) {
+    assertUnschedulableSingleChildReturnsFailure(operation.operation());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("multiChildForkOperations")
+  void lowPriorityChildWithSchedulableSiblingGivesFailureObject(
+      NamedCoroutineForkOperation operation) {
+    assertUnschedulableChildWithSchedulableSiblingReturnsFailure(operation.operation());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("singleChildForkOperations")
+  void lowPriorityChildCancelsEntireComposition(NamedCoroutineForkOperation operation) {
+    final var subsystem = new DummyMechanism("Subsystem", m_scheduler);
+
+    var highPriority = new PriorityCommand(512, subsystem);
+    var unschedulable = new PriorityCommand(Command.DEFAULT_PRIORITY, subsystem);
+    var grandchild = Command.noRequirements(Coroutine::park).named("Grandchild");
+    var child =
+        Command.noRequirements(
+                coroutine -> {
+                  coroutine.fork(grandchild);
+                  coroutine.park();
+                })
+            .named("Child");
+    var current =
+        Command.noRequirements(
+                coroutine -> {
+                  coroutine.fork(child);
+                  operation.operation().apply(coroutine, unschedulable);
+                })
+            .named("Current");
+    var parent = Command.noRequirements(coroutine -> coroutine.await(current)).named("Parent");
+    var grandparent =
+        Command.noRequirements(coroutine -> coroutine.await(parent)).named("Grandparent");
+
+    m_scheduler.schedule(highPriority);
+    m_scheduler.schedule(grandparent);
+    m_scheduler.run();
+
+    assertTrue(m_scheduler.isRunning(highPriority), "Higher priority command should still run");
+    for (var command : List.of(grandparent, parent, current, child, grandchild)) {
+      assertFalse(
+          m_scheduler.isScheduledOrRunning(command),
+          command.name() + " should have been canceled");
+      assertInterruptedBy(command, highPriority);
+    }
+  }
+
+  private void assertUnschedulableSingleChildCancelsParent(CoroutineForkOperation operation) {
+    final var subsystem = new DummyMechanism("Subsystem", m_scheduler);
+
+    var highPriority = new PriorityCommand(512, subsystem);
+    var defaultPriority = new PriorityCommand(Command.DEFAULT_PRIORITY, subsystem);
+    var parent =
+        Command.noRequirements(coroutine -> operation.apply(coroutine, defaultPriority))
+            .named("Parent");
+
+    m_scheduler.schedule(highPriority);
+    m_scheduler.schedule(parent);
+    m_scheduler.run();
+
+    assertFalse(m_scheduler.isRunning(parent), "Parent command should have been canceled");
+    assertSchedulerEvent(
+        SchedulerEvent.Canceled.class,
+        c -> c.command().equals(parent),
+        "Should have received a Canceled event for parent");
+    assertSchedulerEvent(
+        SchedulerEvent.Interrupted.class,
+        i -> i.command().equals(parent) && i.interrupter().equals(highPriority),
+        "Should have received an Interrupted event for parent");
+  }
+
+  private void assertUnschedulableSingleChildReturnsFailure(CoroutineForkOperation operation) {
+    final var subsystem = new DummyMechanism("Subsystem", m_scheduler);
+
+    var highPriority = new PriorityCommand(512, subsystem);
+    var defaultPriority = new PriorityCommand(Command.DEFAULT_PRIORITY, subsystem);
+
+    assertForkFailure(operation, highPriority, List.of(defaultPriority), List.of(defaultPriority));
+  }
+
+  private void assertUnschedulableChildWithSchedulableSiblingReturnsFailure(
+      CoroutineForkOperation operation) {
+    final var busySubsystem = new DummyMechanism("Busy Subsystem", m_scheduler);
+    final var idleSubsystem = new DummyMechanism("Idle Subsystem", m_scheduler);
+
+    var highPriority = new PriorityCommand(512, busySubsystem);
+    var unschedulable = new PriorityCommand(Command.DEFAULT_PRIORITY, busySubsystem);
+    var schedulable = new PriorityCommand(Command.DEFAULT_PRIORITY, idleSubsystem);
+
+    assertForkFailure(
+        operation, highPriority, List.of(unschedulable, schedulable), List.of(unschedulable));
+  }
+
+  private void assertForkFailure(
+      CoroutineForkOperation operation,
+      Command alreadyRunning,
+      List<Command> commands,
+      List<Command> expectedFailures) {
+    var parent =
+        Command.noRequirements(
+                coroutine -> {
+                  coroutine.setCancelOnForkFailure(false);
+                  var result = operation.apply(coroutine, commands.toArray(Command[]::new));
+                  assertFailureResult(result, expectedFailures);
+
+                  coroutine.park();
+                })
+            .named("Parent");
+
+    m_scheduler.schedule(alreadyRunning);
+    m_scheduler.schedule(parent);
+    m_scheduler.run();
+
+    assertTrue(m_scheduler.isRunning(parent), "Parent command should still be running");
+    assertTrue(
+        m_scheduler.isRunning(alreadyRunning), "Higher priority command should still be running");
+    for (var command : commands) {
+      assertFalse(
+          m_scheduler.isScheduledOrRunning(command),
+          command.name() + " should not have been scheduled");
+    }
+  }
+
+  private static void assertFailureResult(
+      Coroutine.ForkResult result, List<Command> expectedFailedCommands) {
+    assertInstanceOf(Coroutine.ForkResultFailure.class, result, "Fork result should be a failure");
+    var failure = (Coroutine.ForkResultFailure) result;
+
+    var failedCommands = failure.failed().stream().map(Scheduler.ScheduleResult::command).toList();
+    assertEquals(expectedFailedCommands, failedCommands);
+    assertTrue(
+        failure.failed().stream().noneMatch(Scheduler.ScheduleResult::successful),
+        "All failure results should be unsuccessful");
+  }
+
+  private void assertInterruptedBy(Command command, Command interrupter) {
+    assertSchedulerEvent(
+        SchedulerEvent.Canceled.class,
+        event -> event.command().equals(command),
+        command.name() + " should have received a Canceled event");
+    assertSchedulerEvent(
+        SchedulerEvent.Interrupted.class,
+        event -> event.command().equals(command) && event.interrupter().equals(interrupter),
+        command.name() + " should have received an Interrupted event");
   }
 }

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
@@ -15,7 +15,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.wpilib.command3.Coroutine.ForkResultFailure;
 import org.wpilib.command3.Scheduler.ScheduleResult.LowerPriorityThanRunningCommand;
 
 class SchedulerPriorityLevelTests extends CommandTestBase {
@@ -342,12 +341,10 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
         Command.noRequirements(
                 co -> {
                   co.setCancelOnForkFailure(false);
-                  var result = operation.operation().apply(co, child1, child2);
-                  assertInstanceOf(
-                      ForkResultFailure.class, result, "Forking operation should have failed");
+                  var failure = operation.operation().apply(co, child1, child2);
+                  assertTrue(failure.failed(), "Forking operation should have failed");
 
-                  var failure = (ForkResultFailure) result;
-                  var fails = failure.failed();
+                  var fails = failure.getFailedCommands();
                   assertEquals(1, fails.size(), "Exactly one failure was expected");
                   assertInstanceOf(
                       LowerPriorityThanRunningCommand.class,
@@ -444,13 +441,13 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
 
   private static void assertFailureResult(
       Coroutine.ForkResult result, List<Command> expectedFailedCommands) {
-    assertInstanceOf(ForkResultFailure.class, result, "Fork result should be a failure");
-    var failure = (ForkResultFailure) result;
+    assertTrue(result.failed(), "Fork result should be a failure");
 
-    var failedCommands = failure.failed().stream().map(Scheduler.ScheduleResult::command).toList();
+    var failedCommands =
+        result.getFailedCommands().stream().map(Scheduler.ScheduleResult::command).toList();
     assertEquals(expectedFailedCommands, failedCommands);
     assertTrue(
-        failure.failed().stream().noneMatch(Scheduler.ScheduleResult::successful),
+        result.getFailedCommands().stream().noneMatch(Scheduler.ScheduleResult::successful),
         "All failure results should be unsuccessful");
   }
 

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
@@ -142,8 +142,7 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
         Command.noRequirements(
                 coroutine -> {
                   // child2 inherits parent2 priority (1000) and should fail to be scheduled due to
-                  // being
-                  //  a lower priority than child1 (2000, inherited from its parent)
+                  // being a lower priority than child1 (2000, inherited from its parent)
                   coroutine.await(child2);
                 })
             .withPriority(1000)
@@ -238,10 +237,12 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
     m_scheduler.run();
 
     assertTrue(m_scheduler.isRunning(highPriority), "Higher priority command should still run");
+    // Only the command that failed to fork should get an interrupted event.
+    // All other commands in the composition will still be canceled, but won't be interrupted.
+    assertInterruptedBy(current, highPriority);
     for (var command : List.of(grandparent, parent, current, child, grandchild)) {
       assertFalse(
           m_scheduler.isScheduledOrRunning(command), command.name() + " should have been canceled");
-      assertInterruptedBy(command, highPriority);
     }
   }
 

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
@@ -148,8 +148,7 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
     assertTrue(m_scheduler.isRunning(highPriority), "Higher priority command should still run");
     for (var command : List.of(grandparent, parent, current, child, grandchild)) {
       assertFalse(
-          m_scheduler.isScheduledOrRunning(command),
-          command.name() + " should have been canceled");
+          m_scheduler.isScheduledOrRunning(command), command.name() + " should have been canceled");
       assertInterruptedBy(command, highPriority);
     }
   }

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerSideloadFunctionTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerSideloadFunctionTests.java
@@ -122,4 +122,27 @@ class SchedulerSideloadFunctionTests extends CommandTestBase {
     assertTrue(signal.get(), "Sideload should have run and set the signal");
     assertTrue(m_scheduler.isRunning(command), "Command should have started");
   }
+
+  @Test
+  void sideloadFailingToForkDoesNotCancel() {
+    var mech = new DummyMechanism("Mech", m_scheduler);
+    Command highPriority = new PriorityCommand(100, mech);
+    Command lowPriority = new PriorityCommand(0, mech);
+
+    AtomicBoolean reached = new AtomicBoolean(false);
+
+    m_scheduler.sideload(
+        coroutine -> {
+          var result = coroutine.fork(lowPriority);
+          reached.set(true);
+          assertTrue(
+              result instanceof Coroutine.ForkResultFailure(var fails)
+                  && fails.size() == 1
+                  && fails.getFirst().command().equals(lowPriority));
+        });
+
+    m_scheduler.schedule(highPriority);
+    m_scheduler.run();
+    assertTrue(reached.get(), "sideload function was terminated before it reached assertions");
+  }
 }

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerSideloadFunctionTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerSideloadFunctionTests.java
@@ -135,10 +135,11 @@ class SchedulerSideloadFunctionTests extends CommandTestBase {
         coroutine -> {
           var result = coroutine.fork(lowPriority);
           reached.set(true);
-          assertTrue(
-              result instanceof Coroutine.ForkResultFailure(var fails)
-                  && fails.size() == 1
-                  && fails.getFirst().command().equals(lowPriority));
+          assertTrue(result.failed(), "Fork result should be a failure");
+          var fails = result.getFailedCommands();
+          assertEquals(1, fails.size(), "Failed forks should show 1 command");
+          assertEquals(
+              lowPriority, fails.getFirst().command(), "Failed fork should be lowPriority");
         });
 
     m_scheduler.schedule(highPriority);


### PR DESCRIPTION
fork/awaitAll/awaitAny is now all or nothing - if any given command is unschedulable, none of the commands will be scheduled and a failure result object will be returned to the user code to handle

However, if the coroutine's `cancelOnForkFailure` flag is `true` (which is the default), the failure will immediately yield the coroutine and cancel the entire composition with no chance for user interaction. Interrupt events will be issued and attributed to the first conflicting command that prevented the child command(s) from being scheduled

Fixes #9205, implementing points 2 and 3 (`cancelOnForkFailure` controls which mode is used) and the addendum.