### PR TITLE
[wpimath] Reuse shared generation parsing for wpimath combined generator

### DIFF
--- a/shared/generation.py
+++ b/shared/generation.py
@@ -4,17 +4,17 @@
 import argparse
 import subprocess
 import sys
-from enum import Enum, auto
+from enum import Flag, auto
 from pathlib import Path
 
 
-class GeneratorTypes(Enum):
+class GeneratorTypes(Flag):
     QUICKBUF = auto()
     NANOPB = auto()
 
 
 def make_arg_parser(
-    subproject_root: Path, repo_root: Path, *args
+    subproject_root: Path, repo_root: Path, types: GeneratorTypes = None
 ) -> argparse.ArgumentParser:
     """Creates an ArgumentParser configured for QuickBuffers or nanopb generation.
 
@@ -32,14 +32,14 @@ def make_arg_parser(
         default=subproject_root / "src/generated",
         type=Path,
     )
-    if GeneratorTypes.QUICKBUF in args or GeneratorTypes.NANOPB in args:
+    if GeneratorTypes.QUICKBUF in types or GeneratorTypes.NANOPB in types:
         parser.add_argument(
             "--proto_directory",
             help="Optional. If set, will use this directory to glob for protobuf files",
             default=subproject_root / "src/main/proto",
             type=Path,
         )
-    if GeneratorTypes.QUICKBUF in args:
+    if GeneratorTypes.QUICKBUF in types:
         parser.add_argument(
             "--protoc",
             help="Protoc executable command",
@@ -49,7 +49,7 @@ def make_arg_parser(
             "--quickbuf_plugin",
             help="Optional if you use protoc-quickbuf as protoc. Path to the quickbuf protoc plugin.",
         )
-    if GeneratorTypes.NANOPB in args:
+    if GeneratorTypes.NANOPB in types:
         parser.add_argument(
             "--nanopb",
             help="Nanopb generator command",

--- a/shared/generation.py
+++ b/shared/generation.py
@@ -22,6 +22,7 @@ def make_arg_parser(
     Keyword arguments:
     subproject_root -- Path to the subproject root. Determines default output and proto directories.
     repo_root -- Path to the repo root. Used to find the nanopb generator.
+    types -- Flagset of all the types of generators arguments are neede for.
 
     Returns:
     The ArgumentParser with the necessary arguments.

--- a/shared/generation.py
+++ b/shared/generation.py
@@ -9,12 +9,13 @@ from pathlib import Path
 
 
 class GeneratorTypes(Flag):
+    NONE = 0
     QUICKBUF = auto()
     NANOPB = auto()
 
 
 def make_arg_parser(
-    subproject_root: Path, repo_root: Path, types: GeneratorTypes = None
+    subproject_root: Path, repo_root: Path, types: GeneratorTypes = GeneratorTypes.NONE
 ) -> argparse.ArgumentParser:
     """Creates an ArgumentParser configured for QuickBuffers or nanopb generation.
 

--- a/shared/generation.py
+++ b/shared/generation.py
@@ -10,12 +10,13 @@ from pathlib import Path
 
 
 class GeneratorTypes(Flag):
+    NONE = 0
     QUICKBUF = auto()
     NANOPB = auto()
 
 
 def make_arg_parser(
-    subproject_root: Path, repo_root: Path, types: GeneratorTypes = None
+    subproject_root: Path, repo_root: Path, types: GeneratorTypes = GeneratorTypes.NONE
 ) -> argparse.ArgumentParser:
     """Creates an ArgumentParser configured for QuickBuffers or nanopb generation.
 

--- a/shared/generation.py
+++ b/shared/generation.py
@@ -5,17 +5,17 @@ import argparse
 import subprocess
 import sys
 from collections.abc import Sequence
-from enum import Enum, auto
+from enum import Flag, auto
 from pathlib import Path
 
 
-class GeneratorTypes(Enum):
+class GeneratorTypes(Flag):
     QUICKBUF = auto()
     NANOPB = auto()
 
 
 def make_arg_parser(
-    subproject_root: Path, repo_root: Path, *args
+    subproject_root: Path, repo_root: Path, types: GeneratorTypes = None
 ) -> argparse.ArgumentParser:
     """Creates an ArgumentParser configured for QuickBuffers or nanopb generation.
 
@@ -33,14 +33,14 @@ def make_arg_parser(
         default=subproject_root / "src/generated",
         type=Path,
     )
-    if GeneratorTypes.QUICKBUF in args or GeneratorTypes.NANOPB in args:
+    if GeneratorTypes.QUICKBUF in types or GeneratorTypes.NANOPB in types:
         parser.add_argument(
             "--proto_directory",
             help="Optional. If set, will use this directory to glob for protobuf files",
             default=subproject_root / "src/main/proto",
             type=Path,
         )
-    if GeneratorTypes.QUICKBUF in args:
+    if GeneratorTypes.QUICKBUF in types:
         parser.add_argument(
             "--protoc",
             help="Protoc executable command",
@@ -50,7 +50,7 @@ def make_arg_parser(
             "--quickbuf_plugin",
             help="Optional if you use protoc-quickbuf as protoc. Path to the quickbuf protoc plugin.",
         )
-    if GeneratorTypes.NANOPB in args:
+    if GeneratorTypes.NANOPB in types:
         parser.add_argument(
             "--nanopb",
             help="Nanopb generator command",

--- a/shared/generation.py
+++ b/shared/generation.py
@@ -23,6 +23,7 @@ def make_arg_parser(
     Keyword arguments:
     subproject_root -- Path to the subproject root. Determines default output and proto directories.
     repo_root -- Path to the repo root. Used to find the nanopb generator.
+    types -- Flagset of all the types of generators arguments are neede for.
 
     Returns:
     The ArgumentParser with the necessary arguments.

--- a/wpimath/generate.bzl
+++ b/wpimath/generate.bzl
@@ -10,14 +10,14 @@ def __generate_wpimath_impl(ctx):
     args.add("--proto_directory", "wpimath/src/main/proto")
     args.add("--protoc", ctx.executable._protoc)
     args.add("--quickbuf_plugin", ctx.executable._quickbuf)
-    args.add("--nanopb_generator", ctx.executable._nanopb_generator)
+    args.add("--nanopb", ctx.executable._nanopb)
 
     ctx.actions.run(
         inputs = ctx.attr._templates.files.to_list() + ctx.attr.proto_files.files.to_list(),
         outputs = [output_dir],
         executable = ctx.executable._tool,
         arguments = [args],
-        tools = [ctx.executable._protoc, ctx.executable._nanopb_generator, ctx.executable._quickbuf],
+        tools = [ctx.executable._protoc, ctx.executable._nanopb, ctx.executable._quickbuf],
     )
 
     return [DefaultInfo(files = depset([output_dir]))]
@@ -29,7 +29,7 @@ generate_wpimath = rule(
             allow_files = True,
             default = Label("//wpimath:proto_files"),
         ),
-        "_nanopb_generator": attr.label(
+        "_nanopb": attr.label(
             default = Label("//wpiutil:nanopb_generator"),
             cfg = "exec",
             executable = True,

--- a/wpimath/generate_wpimath.py
+++ b/wpimath/generate_wpimath.py
@@ -1,7 +1,11 @@
-import argparse
 import sys
 from pathlib import Path
 
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
+
+from shared.generation import GeneratorTypes, add_jinja_args, make_arg_parser
 from wpimath.generate_nanopb import generate_nanopb
 from wpimath.generate_numbers import generate_numbers
 from wpimath.generate_quickbuf import generate_quickbuf
@@ -11,45 +15,15 @@ def main(argv):
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated",
-        type=Path,
+    parser = make_arg_parser(
+        dirname, dirname.parent, GeneratorTypes.NANOPB | GeneratorTypes.QUICKBUF
     )
-    parser.add_argument(
-        "--template_root",
-        help="Optional. If set, will use this directory as the root for the jinja templates",
-        default=dirname / "src/generate",
-        type=Path,
-    )
-    parser.add_argument(
-        "--proto_directory",
-        help="Optional. If set, will use this directory to glob for protobuf files",
-        default=dirname / "src/main/proto",
-        type=Path,
-    )
-    parser.add_argument(
-        "--protoc",
-        help="Protoc executable command",
-        default="protoc",
-    )
-    parser.add_argument(
-        "--nanopb_generator",
-        help="Path to the quickbuf protoc plugin",
-        required=True,
-    )
-    parser.add_argument(
-        "--quickbuf_plugin",
-        help="Path to the quickbuf protoc plugin",
-        required=True,
-    )
+    add_jinja_args(parser, dirname, None)
     args = parser.parse_args(argv)
 
     generate_numbers(args.output_directory, args.template_root)
     generate_nanopb(
-        args.nanopb_generator,
+        args.nanopb,
         args.output_directory / "main/native/cpp",
         args.proto_directory,
     )

--- a/wpimath/generate_wpimath.py
+++ b/wpimath/generate_wpimath.py
@@ -1,55 +1,29 @@
-import argparse
 import sys
 from pathlib import Path
+
+# When invoked directly, Python puts the script directory on sys.path.
+# Add the repo root so absolute package imports still work.
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
 
 from wpimath.generate_nanopb import generate_nanopb
 from wpimath.generate_numbers import generate_numbers
 from wpimath.generate_quickbuf import generate_quickbuf
+from shared.generation import GeneratorTypes, make_arg_parser, add_jinja_args
 
 
 def main(argv):
     script_path = Path(__file__).resolve()
     dirname = script_path.parent
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--output_directory",
-        help="Optional. If set, will output the generated files to this directory, otherwise it will use a path relative to the script",
-        default=dirname / "src/generated",
-        type=Path,
+    parser = make_arg_parser(
+        dirname, dirname.parent, GeneratorTypes.NANOPB | GeneratorTypes.QUICKBUF
     )
-    parser.add_argument(
-        "--template_root",
-        help="Optional. If set, will use this directory as the root for the jinja templates",
-        default=dirname / "src/generate",
-        type=Path,
-    )
-    parser.add_argument(
-        "--proto_directory",
-        help="Optional. If set, will use this directory to glob for protobuf files",
-        default=dirname / "src/main/proto",
-        type=Path,
-    )
-    parser.add_argument(
-        "--protoc",
-        help="Protoc executable command",
-        default="protoc",
-    )
-    parser.add_argument(
-        "--nanopb_generator",
-        help="Path to the quickbuf protoc plugin",
-        required=True,
-    )
-    parser.add_argument(
-        "--quickbuf_plugin",
-        help="Path to the quickbuf protoc plugin",
-        required=True,
-    )
+    add_jinja_args(parser, dirname, None)
     args = parser.parse_args(argv)
 
     generate_numbers(args.output_directory, args.template_root)
     generate_nanopb(
-        args.nanopb_generator,
+        args.nanopb,
         args.output_directory / "main/native/cpp",
         args.proto_directory,
     )


### PR DESCRIPTION
In #9071, the individual generation scripts were updated, but the combined generator script for wpimath was not. This updates the shared script to also reuse the shared parsing logic, and converts `GeneratorTypes` to a flag so that they may be combined in a single parameter.