### PR TITLE
[copybara] Use robotpy-bot commit author identity

### DIFF
--- a/copy.bara.sky
+++ b/copy.bara.sky
@@ -296,7 +296,7 @@ def define_allwpilib_to_mostrobotpy():
         ),
         destination_files = destination_files,
         origin_files = origin_files,
-        authoring = authoring.pass_thru("Default email <default@default.com>"),
+        authoring = authoring.pass_thru("robotpy-bot <61093798+robotpy-bot@users.noreply.github.com>"),
         transformations = transformations,
     )
 


### PR DESCRIPTION
Using @robotpy-bot as the git commit author should make the copybara commits easily identifiable in mostrobotpy in the GitHub UI.