### PR TITLE
[bazel] Move cscore examples to packages, make runnable

### DIFF
--- a/cscore/BUILD.bazel
+++ b/cscore/BUILD.bazel
@@ -257,28 +257,6 @@ java_binary(
     ],
 )
 
-[wpilib_cc_library(
-    name = example + "-examples",
-    srcs = glob([
-        "examples/" + example + "/*.cpp",
-    ]),
-    tags = [
-        "wpi-example",
-    ],
-    deps = [
-        "//cscore",
-        "//wpigui",
-        "@bzlmodrio-opencv//libraries/cpp/opencv",
-    ],
-) for example in [
-    "enum_usb",
-    "httpcvstream",
-    "settings",
-    "usbcvstream",
-    "usbstream",
-    "usbviewer",
-]]
-
 package_default_jni_project(
     name = "cscore",
     maven_artifact_name = "cscore-cpp",

--- a/cscore/examples/enum_usb/BUILD.bazel
+++ b/cscore/examples/enum_usb/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 
-wpilib_cc_library(
+cc_binary(
     name = "enum_usb",
     srcs = glob(["*.cpp"]),
     tags = [

--- a/cscore/examples/enum_usb/BUILD.bazel
+++ b/cscore/examples/enum_usb/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library")
+
+wpilib_cc_library(
+    name = "enum_usb",
+    srcs = glob(["*.cpp"]),
+    tags = [
+        "wpi-example",
+    ],
+    deps = [
+        "//cscore",
+        "//wpiutil",
+    ],
+)

--- a/cscore/examples/httpcvstream/BUILD.bazel
+++ b/cscore/examples/httpcvstream/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library")
+
+wpilib_cc_library(
+    name = "httpcvstream",
+    srcs = glob(["*.cpp"]),
+    tags = [
+        "wpi-example",
+    ],
+    deps = [
+        "//cscore",
+        "//wpiutil",
+        "@bzlmodrio-opencv//libraries/cpp/opencv",
+    ],
+)

--- a/cscore/examples/httpcvstream/BUILD.bazel
+++ b/cscore/examples/httpcvstream/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 
-wpilib_cc_library(
+cc_binary(
     name = "httpcvstream",
     srcs = glob(["*.cpp"]),
     tags = [

--- a/cscore/examples/settings/BUILD.bazel
+++ b/cscore/examples/settings/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 
-wpilib_cc_library(
+cc_binary(
     name = "settings",
     srcs = glob(["*.cpp"]),
     tags = [

--- a/cscore/examples/settings/BUILD.bazel
+++ b/cscore/examples/settings/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library")
+
+wpilib_cc_library(
+    name = "settings",
+    srcs = glob(["*.cpp"]),
+    tags = [
+        "wpi-example",
+    ],
+    deps = [
+        "//cscore",
+        "//wpiutil",
+    ],
+)

--- a/cscore/examples/usbcvstream/BUILD.bazel
+++ b/cscore/examples/usbcvstream/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 
-wpilib_cc_library(
+cc_binary(
     name = "usbcvstream",
     srcs = glob(["*.cpp"]),
     tags = [

--- a/cscore/examples/usbcvstream/BUILD.bazel
+++ b/cscore/examples/usbcvstream/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library")
+
+wpilib_cc_library(
+    name = "usbcvstream",
+    srcs = glob(["*.cpp"]),
+    tags = [
+        "wpi-example",
+    ],
+    deps = [
+        "//cscore",
+        "//wpiutil",
+        "@bzlmodrio-opencv//libraries/cpp/opencv",
+    ],
+)

--- a/cscore/examples/usbstream/BUILD.bazel
+++ b/cscore/examples/usbstream/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library")
+
+wpilib_cc_library(
+    name = "usbstream",
+    srcs = glob(["*.cpp"]),
+    tags = [
+        "wpi-example",
+    ],
+    deps = [
+        "//cscore",
+        "//wpiutil",
+    ],
+)

--- a/cscore/examples/usbstream/BUILD.bazel
+++ b/cscore/examples/usbstream/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 
-wpilib_cc_library(
+cc_binary(
     name = "usbstream",
     srcs = glob(["*.cpp"]),
     tags = [

--- a/cscore/examples/usbviewer/BUILD.bazel
+++ b/cscore/examples/usbviewer/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library")
+
+wpilib_cc_library(
+    name = "usbviewer",
+    srcs = glob(["*.cpp"]),
+    tags = [
+        "wpi-example",
+    ],
+    deps = [
+        "//cscore",
+        "//wpigui",
+        "@bzlmodrio-opencv//libraries/cpp/opencv",
+    ],
+)

--- a/cscore/examples/usbviewer/BUILD.bazel
+++ b/cscore/examples/usbviewer/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//shared/bazel/rules:cc_rules.bzl", "wpilib_cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 
-wpilib_cc_library(
+cc_binary(
     name = "usbviewer",
     srcs = glob(["*.cpp"]),
     tags = [


### PR DESCRIPTION
This removes wpigui from the dependency graph where it's unneeded in cscore.