### PR TITLE
[wpilib] Add Timer.createStarted() convenience factory

### DIFF
--- a/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
@@ -288,8 +288,7 @@ public final class Coroutine {
 
     requireNonNullParam(duration, "duration", "Coroutine.wait");
 
-    var timer = new Timer();
-    timer.start();
+    var timer = Timer.createStarted();
     while (!timer.hasElapsed(duration.in(Seconds))) {
       this.yield();
     }
@@ -389,8 +388,7 @@ public final class Coroutine {
     requireNonNullParam(condition, "condition", "Coroutine.waitUntil");
     requireNonNullParam(timeout, "timeout", "Coroutine.waitUntil");
 
-    Timer timer = new Timer();
-    timer.start();
+    var timer = Timer.createStarted();
 
     while (!condition.getAsBoolean()) {
       if (timer.hasElapsed(timeout)) {

--- a/wpilibc/src/main/native/cpp/system/Timer.cpp
+++ b/wpilibc/src/main/native/cpp/system/Timer.cpp
@@ -88,6 +88,12 @@ bool Timer::IsRunning() const {
   return m_running;
 }
 
+Timer Timer::CreateStarted() {
+  Timer timer;
+  timer.Start();
+  return timer;
+}
+
 wpi::units::second_t Timer::GetTimestamp() {
   return wpi::units::second_t{wpi::RobotController::GetTime() * 1.0e-6};
 }

--- a/wpilibc/src/main/native/include/wpi/system/Timer.hpp
+++ b/wpilibc/src/main/native/include/wpi/system/Timer.hpp
@@ -40,7 +40,8 @@ class Timer {
    * Create a new timer object.
    *
    * Create a new timer object and reset the time to zero. The timer is
-   * initially not running and must be started.
+   * initially not running and must be started. Consider using
+   * CreateStarted() if the timer is used immediately after creation.
    */
   Timer();
 
@@ -127,6 +128,19 @@ class Timer {
    * @return true if running.
    */
   bool IsRunning() const;
+
+  /**
+   * Creates a new timer that begins started.
+   *
+   * <p>This is equivalent to
+   * <pre>{@code
+   *   wpi::Timer timer;
+   *   timer.Start();
+   * }
+   *
+   * @return A new started timer.
+   */
+  static wpi::Timer CreateStarted();
 
   /**
    * Return the clock time in seconds. By default, the time is the time returned

--- a/wpilibc/src/main/native/include/wpi/system/Timer.hpp
+++ b/wpilibc/src/main/native/include/wpi/system/Timer.hpp
@@ -133,10 +133,10 @@ class Timer {
    * Creates a new timer that begins started.
    *
    * <p>This is equivalent to
-   * <pre>{@code
+   * <pre>
    *   wpi::Timer timer;
    *   timer.Start();
-   * }
+   * </pre>
    *
    * @return A new started timer.
    */

--- a/wpilibc/src/main/python/semiwrap/Timer.yml
+++ b/wpilibc/src/main/python/semiwrap/Timer.yml
@@ -5,6 +5,7 @@ classes:
   wpi::Timer:
     methods:
       Timer:
+      CreateStarted:
       Get:
       Reset:
       Start:

--- a/wpilibc/src/test/native/cpp/TimerTest.cpp
+++ b/wpilibc/src/test/native/cpp/TimerTest.cpp
@@ -47,6 +47,11 @@ TEST_CASE_METHOD(TimerTest, "TimerTest StartStop", "[wpilibc]") {
   CHECK_FALSE(timer.IsRunning());
 }
 
+TEST_CASE_METHOD(TimerTest, "TimerTest CreateStarted", "[wpilibc]") {
+  Timer timer = Timer::CreateStarted();
+  CHECK(timer.IsRunning());
+}
+
 TEST_CASE_METHOD(TimerTest, "TimerTest Reset", "[wpilibc]") {
   Timer timer;
   timer.Start();

--- a/wpilibj/src/main/java/org/wpilib/system/Timer.java
+++ b/wpilibj/src/main/java/org/wpilib/system/Timer.java
@@ -87,9 +87,31 @@ public class Timer {
   private double m_accumulatedTime;
   private boolean m_running;
 
-  /** Timer constructor. */
+  /**
+   * Creates a new timer. The timer is initially not running and must be started with {@link
+   * #start()} to start measuring time. Consider using {@link #createStarted()} instead if the timer
+   * will be used immediately after creation.
+   */
   public Timer() {
     reset();
+  }
+
+  /**
+   * Creates a new timer that begins started.
+   *
+   * <p>This is equivalent to
+   *
+   * {@snippet lang="java":
+   *  Timer timer = new Timer();
+   *  timer.start();
+   * }
+   *
+   * @return A new started timer.
+   */
+  public static Timer createStarted() {
+    var timer = new Timer();
+    timer.start();
+    return timer;
   }
 
   private double getMsClock() {

--- a/wpilibj/src/test/java/org/wpilib/system/TimerTest.java
+++ b/wpilibj/src/test/java/org/wpilib/system/TimerTest.java
@@ -55,6 +55,13 @@ class TimerTest {
 
   @Test
   @ResourceLock("timing")
+  void createStarted() {
+    var timer = Timer.createStarted();
+    assertTrue(timer.isRunning(), "Timer from createStarted() should be running");
+  }
+
+  @Test
+  @ResourceLock("timing")
   void resetTest() {
     var timer = new Timer();
     timer.start();


### PR DESCRIPTION
Make it one method call to create a timer that can immediately start being used, instead of splitting across separate method calls.

Closes #9217