### PR TITLE
[datalog] Fix FileLogger deadlock

### DIFF
--- a/datalog/src/main/native/cpp/FileLogger.cpp
+++ b/datalog/src/main/native/cpp/FileLogger.cpp
@@ -35,34 +35,35 @@ FileLogger::FileLogger(std::string_view file,
   // never generate events (and a file created later won't be picked up).
   // Don't spawn a thread in that case; without a watch, a reader blocked in
   // read() can never be woken up and the destructor would deadlock.
-  if (m_fileHandle != -1 && m_inotifyWatchHandle != -1) {
-    m_thread = std::thread{[=, this] {
-      char buf[8000];
-      char eventBuf[sizeof(struct inotify_event) + NAME_MAX + 1];
-      lseek(m_fileHandle, 0, SEEK_END);
-      while (m_running) {
-        // A moved-from object has m_inotifyHandle == -1; poll() ignores
-        // negative fds and would return immediately, so exit instead.
-        if (m_inotifyHandle < 0) {
-          break;
-        }
-        // poll() with a timeout instead of a blocking read() so the thread
-        // periodically checks m_running and the destructor can join it even
-        // when the watched file is gone and no events ever arrive.
-        struct pollfd pfd{m_inotifyHandle, POLLIN, 0};
-        if (poll(&pfd, 1, 100) <= 0 || (pfd.revents & POLLIN) == 0) {
-          continue;
-        }
-        if (read(m_inotifyHandle, eventBuf, sizeof(eventBuf)) > 0) {
-          int bufLen = 0;
-          if ((bufLen = read(m_fileHandle, buf, sizeof(buf))) > 0) {
-            callback(std::string_view{buf, static_cast<size_t>(bufLen)});
-          }
-          std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        }
-      }
-    }};
+  if (m_fileHandle == -1 || m_inotifyWatchHandle == -1) {
+    return;
   }
+  m_thread = std::thread{[=, this] {
+    char buf[8000];
+    char eventBuf[sizeof(struct inotify_event) + NAME_MAX + 1];
+    lseek(m_fileHandle, 0, SEEK_END);
+    while (m_running) {
+      // A moved-from object has m_inotifyHandle == -1; poll() ignores
+      // negative fds and would return immediately, so exit instead.
+      if (m_inotifyHandle < 0) {
+        break;
+      }
+      // poll() with a timeout instead of a blocking read() so the thread
+      // periodically checks m_running and the destructor can join it even
+      // when the watched file is gone and no events ever arrive.
+      struct pollfd pfd{m_inotifyHandle, POLLIN, 0};
+      if (poll(&pfd, 1, 100) <= 0 || (pfd.revents & POLLIN) == 0) {
+        continue;
+      }
+      if (read(m_inotifyHandle, eventBuf, sizeof(eventBuf)) > 0) {
+        int bufLen = 0;
+        if ((bufLen = read(m_fileHandle, buf, sizeof(buf))) > 0) {
+          callback(std::string_view{buf, static_cast<size_t>(bufLen)});
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+    }
+  }};
 #endif
 }
 FileLogger::FileLogger(std::string_view file, log::DataLog& log,

--- a/datalog/src/main/native/cpp/FileLogger.cpp
+++ b/datalog/src/main/native/cpp/FileLogger.cpp
@@ -12,6 +12,7 @@
 #endif
 
 #include <chrono>
+#include <format>
 #include <string>
 #include <string_view>
 #include <thread>

--- a/datalog/src/main/native/cpp/FileLogger.cpp
+++ b/datalog/src/main/native/cpp/FileLogger.cpp
@@ -6,6 +6,7 @@
 
 #ifdef __linux__
 #include <fcntl.h>
+#include <poll.h>
 #include <sys/inotify.h>
 #include <unistd.h>
 #endif
@@ -26,21 +27,43 @@ FileLogger::FileLogger(std::string_view file,
     : m_fileHandle{open(file.data(), O_RDONLY)},
       m_inotifyHandle{inotify_init()},
       m_inotifyWatchHandle{
-          inotify_add_watch(m_inotifyHandle, file.data(), IN_MODIFY)},
-      m_thread{[=, this] {
-        char buf[8000];
-        char eventBuf[sizeof(struct inotify_event) + NAME_MAX + 1];
-        lseek(m_fileHandle, 0, SEEK_END);
-        while (read(m_inotifyHandle, eventBuf, sizeof(eventBuf)) > 0) {
+          inotify_add_watch(m_inotifyHandle, file.data(), IN_MODIFY)}
+#endif
+{
+#ifdef __linux__
+  // inotify watches the file's inode, so a file that does not exist yet will
+  // never generate events (and a file created later won't be picked up).
+  // Don't spawn a thread in that case; without a watch, a reader blocked in
+  // read() can never be woken up and the destructor would deadlock.
+  if (m_fileHandle != -1 && m_inotifyWatchHandle != -1) {
+    m_thread = std::thread{[=, this] {
+      char buf[8000];
+      char eventBuf[sizeof(struct inotify_event) + NAME_MAX + 1];
+      lseek(m_fileHandle, 0, SEEK_END);
+      while (m_running) {
+        // A moved-from object has m_inotifyHandle == -1; poll() ignores
+        // negative fds and would return immediately, so exit instead.
+        if (m_inotifyHandle < 0) {
+          break;
+        }
+        // poll() with a timeout instead of a blocking read() so the thread
+        // periodically checks m_running and the destructor can join it even
+        // when the watched file is gone and no events ever arrive.
+        struct pollfd pfd{m_inotifyHandle, POLLIN, 0};
+        if (poll(&pfd, 1, 100) <= 0 || (pfd.revents & POLLIN) == 0) {
+          continue;
+        }
+        if (read(m_inotifyHandle, eventBuf, sizeof(eventBuf)) > 0) {
           int bufLen = 0;
           if ((bufLen = read(m_fileHandle, buf, sizeof(buf))) > 0) {
             callback(std::string_view{buf, static_cast<size_t>(bufLen)});
           }
           std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
-      }}
+      }
+    }};
+  }
 #endif
-{
 }
 FileLogger::FileLogger(std::string_view file, log::DataLog& log,
                        std::string_view key)
@@ -53,6 +76,7 @@ FileLogger::FileLogger(FileLogger&& other)
     : m_fileHandle{std::exchange(other.m_fileHandle, -1)},
       m_inotifyHandle{std::exchange(other.m_inotifyHandle, -1)},
       m_inotifyWatchHandle{std::exchange(other.m_inotifyWatchHandle, -1)},
+      m_running{true},
       m_thread{std::move(other.m_thread)}
 #endif
 {
@@ -68,6 +92,12 @@ FileLogger& FileLogger::operator=(FileLogger&& rhs) {
 }
 FileLogger::~FileLogger() {
 #ifdef __linux__
+  // Stop the reader thread first (it polls with a timeout, so the join
+  // completes quickly) so it never touches the fds after they are closed.
+  m_running = false;
+  if (m_thread.joinable()) {
+    m_thread.join();
+  }
   if (m_inotifyWatchHandle != -1) {
     inotify_rm_watch(m_inotifyHandle, m_inotifyWatchHandle);
   }
@@ -76,9 +106,6 @@ FileLogger::~FileLogger() {
   }
   if (m_fileHandle != -1) {
     close(m_fileHandle);
-  }
-  if (m_thread.joinable()) {
-    m_thread.join();
   }
 #endif
 }

--- a/datalog/src/main/native/include/wpi/datalog/FileLogger.hpp
+++ b/datalog/src/main/native/include/wpi/datalog/FileLogger.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <string_view>
 #include <thread>
@@ -55,6 +56,7 @@ class FileLogger {
   int m_fileHandle = -1;
   int m_inotifyHandle = -1;
   int m_inotifyWatchHandle = -1;
+  std::atomic<bool> m_running{true};
   std::thread m_thread;
 #endif
 };

--- a/datalog/src/test/native/cpp/FileLoggerTest.cpp
+++ b/datalog/src/test/native/cpp/FileLoggerTest.cpp
@@ -4,11 +4,19 @@
 
 #include "wpi/datalog/FileLogger.hpp"
 
+#include <atomic>
+#include <chrono>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 #include <catch2/catch_test_macros.hpp>
+
+#ifdef __linux__
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 TEST_CASE("FileLoggerTest BufferSingleLine", "[datalog][file-logger]") {
   std::vector<std::string> buf;
@@ -58,3 +66,58 @@ TEST_CASE("FileLoggerTest BufferMultipleMultiLinePartials",
   CHECK("part 1part 2" == buf[0]);
   CHECK("part 3part 4" == buf[1]);
 }
+
+#ifdef __linux__
+TEST_CASE("FileLoggerTest MissingFileDoesNotDeadlock",
+          "[datalog][file-logger]") {
+  // Constructing a FileLogger for a nonexistent path used to spawn a reader
+  // thread that blocked forever in read() (no watch was ever added, so no
+  // event could wake it), and the destructor's join() then deadlocked.
+  // Regression test: the destructor must return promptly.
+  auto path = "/tmp/wpi_filelogger_missing_" + std::to_string(getpid());
+  unlink(path.c_str());
+
+  std::atomic<bool> done{false};
+  std::thread t{[&] {
+    {
+      wpi::log::FileLogger logger{path, [](std::string_view) {}};
+      // Let the reader thread block in read() before destruction; otherwise
+      // the destructor's close() races ahead and the old deadlock never fires.
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    done = true;
+  }};
+  t.detach();
+
+  for (int i = 0; i < 100 && !done; ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  CHECK(done);
+}
+
+TEST_CASE("FileLoggerTest ExistingFileDeliversData", "[datalog][file-logger]") {
+  auto path = "/tmp/wpi_filelogger_existing_" + std::to_string(getpid());
+  unlink(path.c_str());
+  int fd = open(path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+  REQUIRE(fd != -1);
+  close(fd);
+
+  std::atomic<bool> gotData{false};
+  {
+    wpi::log::FileLogger logger{
+        path, [&gotData](std::string_view) { gotData = true; }};
+
+    // Append repeatedly so the reader thread notices regardless of when its
+    // initial lseek() runs.
+    for (int i = 0; i < 40 && !gotData; ++i) {
+      int wfd = open(path.c_str(), O_WRONLY | O_APPEND);
+      REQUIRE(wfd != -1);
+      write(wfd, "hello\n", 6);
+      close(wfd);
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    CHECK(gotData);
+  }
+  unlink(path.c_str());
+}
+#endif

--- a/datalog/src/test/native/cpp/FileLoggerTest.cpp
+++ b/datalog/src/test/native/cpp/FileLoggerTest.cpp
@@ -112,7 +112,7 @@ TEST_CASE("FileLoggerTest ExistingFileDeliversData", "[datalog][file-logger]") {
     for (int i = 0; i < 40 && !gotData; ++i) {
       int wfd = open(path.c_str(), O_WRONLY | O_APPEND);
       REQUIRE(wfd != -1);
-      (void)write(wfd, "hello\n", 6);
+      REQUIRE(write(wfd, "hello\n", 6) != -1);
       close(wfd);
       std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }

--- a/datalog/src/test/native/cpp/FileLoggerTest.cpp
+++ b/datalog/src/test/native/cpp/FileLoggerTest.cpp
@@ -74,7 +74,7 @@ TEST_CASE("FileLoggerTest MissingFileDoesNotDeadlock",
   // thread that blocked forever in read() (no watch was ever added, so no
   // event could wake it), and the destructor's join() then deadlocked.
   // Regression test: the destructor must return promptly.
-  auto path = "/tmp/wpi_filelogger_missing_" + std::to_string(getpid());
+  auto path = std::format("/tmp/wpi_filelogger_missing_{}", getpid());
   unlink(path.c_str());
 
   std::atomic<bool> done{false};
@@ -96,7 +96,7 @@ TEST_CASE("FileLoggerTest MissingFileDoesNotDeadlock",
 }
 
 TEST_CASE("FileLoggerTest ExistingFileDeliversData", "[datalog][file-logger]") {
-  auto path = "/tmp/wpi_filelogger_existing_" + std::to_string(getpid());
+  auto path = std::format("/tmp/wpi_filelogger_existing_{}", getpid());
   unlink(path.c_str());
   int fd = open(path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
   REQUIRE(fd != -1);

--- a/datalog/src/test/native/cpp/FileLoggerTest.cpp
+++ b/datalog/src/test/native/cpp/FileLoggerTest.cpp
@@ -112,7 +112,7 @@ TEST_CASE("FileLoggerTest ExistingFileDeliversData", "[datalog][file-logger]") {
     for (int i = 0; i < 40 && !gotData; ++i) {
       int wfd = open(path.c_str(), O_WRONLY | O_APPEND);
       REQUIRE(wfd != -1);
-      write(wfd, "hello\n", 6);
+      (void)write(wfd, "hello\n", 6);
       close(wfd);
       std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }


### PR DESCRIPTION
When a FileLogger is constructed on a non-existent path, it'll hang. When this happens, the destructor can never actually destruct. This fixes the issue by polling to see if the file exists, and adds a regression test.
