### PR TITLE
[datalog] Fix FileLogger move assignment

### DIFF
--- a/datalog/src/main/native/cpp/FileLogger.cpp
+++ b/datalog/src/main/native/cpp/FileLogger.cpp
@@ -39,32 +39,33 @@ FileLogger::FileLogger(std::string_view file,
   if (m_fileHandle == -1 || m_inotifyWatchHandle == -1) {
     return;
   }
-  m_thread = std::thread{[=, this] {
-    char buf[8000];
-    char eventBuf[sizeof(struct inotify_event) + NAME_MAX + 1];
-    lseek(m_fileHandle, 0, SEEK_END);
-    while (m_running) {
-      // A moved-from object has m_inotifyHandle == -1; poll() ignores
-      // negative fds and would return immediately, so exit instead.
-      if (m_inotifyHandle < 0) {
-        break;
-      }
-      // poll() with a timeout instead of a blocking read() so the thread
-      // periodically checks m_running and the destructor can join it even
-      // when the watched file is gone and no events ever arrive.
-      struct pollfd pfd{m_inotifyHandle, POLLIN, 0};
-      if (poll(&pfd, 1, 100) <= 0 || (pfd.revents & POLLIN) == 0) {
-        continue;
-      }
-      if (read(m_inotifyHandle, eventBuf, sizeof(eventBuf)) > 0) {
-        int bufLen = 0;
-        if ((bufLen = read(m_fileHandle, buf, sizeof(buf))) > 0) {
-          callback(std::string_view{buf, static_cast<size_t>(bufLen)});
+  m_thread =
+      std::thread{[callback = std::move(callback), fileHandle = m_fileHandle,
+                   inotifyHandle = m_inotifyHandle, running = m_running] {
+        char buf[8000];
+        char eventBuf[sizeof(struct inotify_event) + NAME_MAX + 1];
+        lseek(fileHandle, 0, SEEK_END);
+        while (running->load()) {
+          // poll() with a timeout instead of a blocking read() so the thread
+          // periodically checks m_running and the destructor can join it even
+          // when the watched file is gone and no events ever arrive.
+          struct pollfd pfd{inotifyHandle, POLLIN, 0};
+          if (poll(&pfd, 1, 100) <= 0) {
+            continue;
+          }
+          if ((pfd.revents & POLLNVAL) != 0) {
+            break;
+          }
+          if ((pfd.revents & POLLIN) != 0 &&
+              read(inotifyHandle, eventBuf, sizeof(eventBuf)) > 0) {
+            int bufLen = 0;
+            if ((bufLen = read(fileHandle, buf, sizeof(buf))) > 0) {
+              callback(std::string_view{buf, static_cast<size_t>(bufLen)});
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+          }
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      }
-    }
-  }};
+      }};
 #endif
 }
 FileLogger::FileLogger(std::string_view file, log::DataLog& log,
@@ -78,39 +79,54 @@ FileLogger::FileLogger(FileLogger&& other)
     : m_fileHandle{std::exchange(other.m_fileHandle, -1)},
       m_inotifyHandle{std::exchange(other.m_inotifyHandle, -1)},
       m_inotifyWatchHandle{std::exchange(other.m_inotifyWatchHandle, -1)},
-      m_running{true},
+      m_running{std::move(other.m_running)},
       m_thread{std::move(other.m_thread)}
 #endif
 {
 }
 FileLogger& FileLogger::operator=(FileLogger&& rhs) {
 #ifdef __linux__
-  std::swap(m_fileHandle, rhs.m_fileHandle);
-  std::swap(m_inotifyHandle, rhs.m_inotifyHandle);
-  std::swap(m_inotifyWatchHandle, rhs.m_inotifyWatchHandle);
+  if (this == &rhs) {
+    return *this;
+  }
+
+  Stop();
+  m_fileHandle = std::exchange(rhs.m_fileHandle, -1);
+  m_inotifyHandle = std::exchange(rhs.m_inotifyHandle, -1);
+  m_inotifyWatchHandle = std::exchange(rhs.m_inotifyWatchHandle, -1);
+  m_running = std::move(rhs.m_running);
   m_thread = std::move(rhs.m_thread);
 #endif
   return *this;
 }
 FileLogger::~FileLogger() {
 #ifdef __linux__
-  // Stop the reader thread first (it polls with a timeout, so the join
-  // completes quickly) so it never touches the fds after they are closed.
-  m_running = false;
+  Stop();
+#endif
+}
+
+#ifdef __linux__
+void FileLogger::Stop() {
+  if (m_running) {
+    m_running->store(false);
+  }
   if (m_thread.joinable()) {
     m_thread.join();
   }
   if (m_inotifyWatchHandle != -1) {
     inotify_rm_watch(m_inotifyHandle, m_inotifyWatchHandle);
+    m_inotifyWatchHandle = -1;
   }
   if (m_inotifyHandle != -1) {
     close(m_inotifyHandle);
+    m_inotifyHandle = -1;
   }
   if (m_fileHandle != -1) {
     close(m_fileHandle);
+    m_fileHandle = -1;
   }
-#endif
 }
+#endif
 
 std::function<void(std::string_view)> FileLogger::Buffer(
     std::function<void(std::string_view)> callback) {

--- a/datalog/src/main/native/include/wpi/datalog/FileLogger.hpp
+++ b/datalog/src/main/native/include/wpi/datalog/FileLogger.hpp
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <functional>
+#include <memory>
 #include <string_view>
 #include <thread>
 
@@ -53,10 +54,13 @@ class FileLogger {
 
  private:
 #ifdef __linux__
+  void Stop();
+
   int m_fileHandle = -1;
   int m_inotifyHandle = -1;
   int m_inotifyWatchHandle = -1;
-  std::atomic<bool> m_running{true};
+  std::shared_ptr<std::atomic<bool>> m_running =
+      std::make_shared<std::atomic<bool>>(true);
   std::thread m_thread;
 #endif
 };

--- a/datalog/src/test/native/cpp/FileLoggerTest.cpp
+++ b/datalog/src/test/native/cpp/FileLoggerTest.cpp
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <format>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -118,6 +119,33 @@ TEST_CASE("FileLoggerTest ExistingFileDeliversData", "[datalog][file-logger]") {
     }
     CHECK(gotData);
   }
+  unlink(path.c_str());
+}
+
+TEST_CASE("FileLoggerTest MoveAssignedLoggerReceivesUpdatesAndStops",
+          "[datalog][file-logger]") {
+  auto path = std::format("/tmp/wpi_filelogger_move_assign_{}", getpid());
+  unlink(path.c_str());
+  int fd = open(path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+  REQUIRE(fd != -1);
+  close(fd);
+
+  std::atomic<bool> gotData{false};
+  wpi::log::FileLogger logger;
+  logger = {path, [&gotData](std::string_view) { gotData = true; }};
+
+  // Append repeatedly so the reader thread notices regardless of when its
+  // initial lseek() runs.
+  for (int i = 0; i < 40 && !gotData; ++i) {
+    int wfd = open(path.c_str(), O_WRONLY | O_APPEND);
+    REQUIRE(wfd != -1);
+    REQUIRE(write(wfd, "hello\n", 6) != -1);
+    close(wfd);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  CHECK(gotData);
+
+  logger = {};
   unlink(path.c_str());
 }
 #endif


### PR DESCRIPTION
Fixes #8976.

This was the root cause of the `DataLogManager::Stop()` crash.  `Stop()` joins the logging thread, whose destructor stops console logging. On robot, console logging uses FileLogger; `FileLogger::operator=()` was move-assigning over a joinable `std::thread`, which triggers `std::terminate` with terminate called without an active exception. That also explains why simulator was fine: `StartConsoleLog()` only runs when `RobotBase::IsReal()` is true.

Changed FileLogger so the worker captures file descriptors instead of this, and move assignment now stops/joins any existing worker before taking ownership of another one. Added the shared cleanup helper in FileLogger, plus a Linux regression test in FileLoggerTest.