### PR TITLE
[wpical] Make calibrate more robust

### DIFF
--- a/README-CMake.md
+++ b/README-CMake.md
@@ -36,6 +36,8 @@ OpenCV needs to be findable by CMake. On systems like the Jetson, this is instal
 
 To build GUI apps (`WPILIB_WITH_GUI`), SDL3 needs to be findable by CMake.
 
+To build wpical (`WPILIB_WITH_WPICAL`), libsuitesparse-dev and libceres-dev are required.
+
 ## Build Options
 
 The following build options are available:
@@ -54,6 +56,8 @@ The following build options are available:
   * This option will build simulation modules.
 * `WPILIB_WITH_TESTS` (ON Default)
   * This option will build C++ unit tests. These can be run via `ctest -C <config>`, where `<config>` is the build configuration, e.g. `Debug` or `Release`.
+* `WPILIB_WITH_WPICAL` (OFF Default)
+  * This option will build wpical.
 * `WPILIB_WITH_WPILIB` (ON Default)
   * This option will build the HAL and wpilibc during the build. The HAL is the simulation HAL, unless the external HAL options are used. The CMake build has no capability to build for Systemcore.
 * `WPILIB_WITH_WPIMATH` (ON Default)

--- a/tools/wpical/src/main/native/cpp/fieldcalibration.cpp
+++ b/tools/wpical/src/main/native/cpp/fieldcalibration.cpp
@@ -4,6 +4,7 @@
 
 #include "fieldcalibration.hpp"
 
+#include <cmath>
 #include <filesystem>
 #include <functional>
 #include <map>
@@ -88,6 +89,16 @@ class PoseGraphError {
 };
 
 const double tagSizeMeters = 0.1651;
+
+static bool IsCameraModelValid(const wpical::CameraModel& cameraModel) {
+  return std::isfinite(cameraModel.avgReprojectionError) &&
+         cameraModel.avgReprojectionError >= 0.0 &&
+         cameraModel.intrinsicMatrix.allFinite() &&
+         cameraModel.distortionCoefficients.allFinite() &&
+         cameraModel.intrinsicMatrix(0, 0) > 0.0 &&
+         cameraModel.intrinsicMatrix(1, 1) > 0.0 &&
+         std::abs(cameraModel.intrinsicMatrix(2, 2) - 1.0) < 1e-9;
+}
 
 inline Eigen::Matrix4d EstimateTagPose(std::span<double, 8> tagCorners,
                                        const wpical::CameraModel& cameraModel,
@@ -306,6 +317,11 @@ std::optional<wpi::fields::Field> wpical::calibrate(
   // Silence OpenCV logging
   cv::utils::logging::setLogLevel(
       cv::utils::logging::LogLevel::LOG_LEVEL_SILENT);
+
+  // Reject the default/sentinel model before OpenCV tries to solve tag poses.
+  if (!IsCameraModelValid(cameraModel)) {
+    return std::nullopt;
+  }
 
   bool pinnedTagFound = false;
   // Check if pinned tag is in ideal layout


### PR DESCRIPTION
We were seeing occasional test failures due to a default CameraModel object being passed in and expecting OpenCV to reject it during pose solving.  Now calibrate() rejects that sentinel model deterministically.

Also add README-CMake note about required dependencies to build wpical.