### PR TITLE
Add Matrix.pseudoInverse()

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/linalg/Matrix.java
+++ b/wpimath/src/main/java/org/wpilib/math/linalg/Matrix.java
@@ -341,6 +341,18 @@ public class Matrix<R extends Num, C extends Num>
   }
 
   /**
+   * Returns the Moore-Penrose pseudoinverse of this matrix.
+   *
+   * <p>Unlike {@link #inv()}, the pseudoinverse is defined for rectangular and singular matrices.
+   * The result has the transposed dimensions of this matrix.
+   *
+   * @return The pseudoinverse of this matrix.
+   */
+  public final Matrix<C, R> pseudoInverse() {
+    return new Matrix<>(this.m_storage.pseudoInverse());
+  }
+
+  /**
    * Returns the solution x to the equation Ax = b, where A is "this" matrix.
    *
    * <p>The matrix equation could also be written as x = A<sup>-1</sup>b. Where the pseudo inverse

--- a/wpimath/src/test/java/org/wpilib/math/linalg/MatrixTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/linalg/MatrixTest.java
@@ -86,6 +86,26 @@ class MatrixTest {
   }
 
   @Test
+  void testPseudoInverse() {
+    Matrix<N2, N3> mat = MatBuilder.fill(Nat.N2(), Nat.N3(), 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+
+    Matrix<N3, N2> pseudoInverse = mat.pseudoInverse();
+
+    assertTrue(mat.isEqual(mat.times(pseudoInverse).times(mat), 1E-9));
+    assertTrue(pseudoInverse.isEqual(pseudoInverse.times(mat).times(pseudoInverse), 1E-9));
+  }
+
+  @Test
+  void testSingularMatrixPseudoInverse() {
+    Matrix<N2, N2> mat = MatBuilder.fill(Nat.N2(), Nat.N2(), 1.0, 2.0, 2.0, 4.0);
+
+    Matrix<N2, N2> pseudoInverse = mat.pseudoInverse();
+
+    assertTrue(mat.isEqual(mat.times(pseudoInverse).times(mat), 1E-9));
+    assertTrue(pseudoInverse.isEqual(pseudoInverse.times(mat).times(pseudoInverse), 1E-9));
+  }
+
+  @Test
   void testUninvertableMatrix() {
     var singularMatrix = MatBuilder.fill(Nat.N2(), Nat.N2(), 2.0, 1.0, 2.0, 1.0);
 

--- a/wpimath/src/test/java/org/wpilib/math/linalg/MatrixTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/linalg/MatrixTest.java
@@ -90,9 +90,13 @@ class MatrixTest {
     Matrix<N2, N3> mat = MatBuilder.fill(Nat.N2(), Nat.N3(), 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
 
     Matrix<N3, N2> pseudoInverse = mat.pseudoInverse();
+    Matrix<N2, N2> columnProjection = mat.times(pseudoInverse);
+    Matrix<N3, N3> rowProjection = pseudoInverse.times(mat);
 
-    assertTrue(mat.isEqual(mat.times(pseudoInverse).times(mat), 1E-9));
-    assertTrue(pseudoInverse.isEqual(pseudoInverse.times(mat).times(pseudoInverse), 1E-9));
+    assertTrue(mat.isEqual(columnProjection.times(mat), 1E-9));
+    assertTrue(pseudoInverse.isEqual(rowProjection.times(pseudoInverse), 1E-9));
+    assertTrue(columnProjection.isEqual(columnProjection.transpose(), 1E-9));
+    assertTrue(rowProjection.isEqual(rowProjection.transpose(), 1E-9));
   }
 
   @Test
@@ -100,9 +104,13 @@ class MatrixTest {
     Matrix<N2, N2> mat = MatBuilder.fill(Nat.N2(), Nat.N2(), 1.0, 2.0, 2.0, 4.0);
 
     Matrix<N2, N2> pseudoInverse = mat.pseudoInverse();
+    Matrix<N2, N2> columnProjection = mat.times(pseudoInverse);
+    Matrix<N2, N2> rowProjection = pseudoInverse.times(mat);
 
-    assertTrue(mat.isEqual(mat.times(pseudoInverse).times(mat), 1E-9));
-    assertTrue(pseudoInverse.isEqual(pseudoInverse.times(mat).times(pseudoInverse), 1E-9));
+    assertTrue(mat.isEqual(columnProjection.times(mat), 1E-9));
+    assertTrue(pseudoInverse.isEqual(rowProjection.times(pseudoInverse), 1E-9));
+    assertTrue(columnProjection.isEqual(columnProjection.transpose(), 1E-9));
+    assertTrue(rowProjection.isEqual(rowProjection.transpose(), 1E-9));
   }
 
   @Test


### PR DESCRIPTION
## What changed
- adds a shape-safe Java `Matrix.pseudoInverse()` wrapper returning `Matrix<C, R>`
- documents rectangular and singular-matrix behavior
- tests rectangular and rank-deficient inputs against all four Moore-Penrose identities

## Why
Calling EJML through `getStorage()` discards WPILib's compile-time matrix dimensions. This keeps the operation inside the typed API and makes the transposed output shape explicit.

## Impact
This is additive and does not change existing matrix behavior.

## Checks
- `:wpimath:spotlessApply`
- `:wpimath:compileJava` and `:wpimath:compileTestJava`
- the hosted matrix tests passed on the previous commit; the expanded four-identity assertions are now running in hosted CI
- the unrelated native build path is not locally available because the current macOS C++ toolchain cannot locate standard-library headers; hosted CI provides the canonical native checks

Closes #9212