### PR TITLE
[wpimath] Add ChassisAccelerations serialization tests

### DIFF
--- a/wpimath/src/test/java/org/wpilib/math/kinematics/proto/ChassisAccelerationsProtoTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/proto/ChassisAccelerationsProtoTest.java
@@ -1,0 +1,27 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.math.kinematics.proto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.wpilib.math.kinematics.ChassisAccelerations;
+import org.wpilib.math.kinematics.proto.detail.ProtobufChassisAccelerations;
+
+class ChassisAccelerationsProtoTest {
+  private static final ChassisAccelerations DATA =
+      new ChassisAccelerations(2.29, 2.2, 0.3504);
+
+  @Test
+  void testRoundtrip() {
+    ProtobufChassisAccelerations proto = ChassisAccelerations.proto.createMessage();
+    ChassisAccelerations.proto.pack(proto, DATA);
+
+    ChassisAccelerations data = ChassisAccelerations.proto.unpack(proto);
+    assertEquals(DATA.ax, data.ax);
+    assertEquals(DATA.ay, data.ay);
+    assertEquals(DATA.alpha, data.alpha);
+  }
+}

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/proto/ChassisAccelerationsProtoTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/proto/ChassisAccelerationsProtoTest.java
@@ -11,8 +11,7 @@ import org.wpilib.math.kinematics.ChassisAccelerations;
 import org.wpilib.math.kinematics.proto.detail.ProtobufChassisAccelerations;
 
 class ChassisAccelerationsProtoTest {
-  private static final ChassisAccelerations DATA =
-      new ChassisAccelerations(2.29, 2.2, 0.3504);
+  private static final ChassisAccelerations DATA = new ChassisAccelerations(2.29, 2.2, 0.3504);
 
   @Test
   void testRoundtrip() {

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/proto/DifferentialDriveWheelAccelerationsProtoTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/proto/DifferentialDriveWheelAccelerationsProtoTest.java
@@ -1,0 +1,28 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.math.kinematics.proto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.wpilib.math.kinematics.DifferentialDriveWheelAccelerations;
+import org.wpilib.math.kinematics.proto.detail.ProtobufDifferentialDriveWheelAccelerations;
+
+class DifferentialDriveWheelAccelerationsProtoTest {
+  private static final DifferentialDriveWheelAccelerations DATA =
+      new DifferentialDriveWheelAccelerations(1.74, 35.04);
+
+  @Test
+  void testRoundtrip() {
+    ProtobufDifferentialDriveWheelAccelerations proto =
+        DifferentialDriveWheelAccelerations.proto.createMessage();
+    DifferentialDriveWheelAccelerations.proto.pack(proto, DATA);
+
+    DifferentialDriveWheelAccelerations data =
+        DifferentialDriveWheelAccelerations.proto.unpack(proto);
+    assertEquals(DATA.left, data.left);
+    assertEquals(DATA.right, data.right);
+  }
+}

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/proto/MecanumDriveWheelAccelerationsProtoTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/proto/MecanumDriveWheelAccelerationsProtoTest.java
@@ -1,0 +1,29 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.math.kinematics.proto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.wpilib.math.kinematics.MecanumDriveWheelAccelerations;
+import org.wpilib.math.kinematics.proto.detail.ProtobufMecanumDriveWheelAccelerations;
+
+class MecanumDriveWheelAccelerationsProtoTest {
+  private static final MecanumDriveWheelAccelerations DATA =
+      new MecanumDriveWheelAccelerations(2.29, 17.4, 4.4, 0.229);
+
+  @Test
+  void testRoundtrip() {
+    ProtobufMecanumDriveWheelAccelerations proto =
+        MecanumDriveWheelAccelerations.proto.createMessage();
+    MecanumDriveWheelAccelerations.proto.pack(proto, DATA);
+
+    MecanumDriveWheelAccelerations data = MecanumDriveWheelAccelerations.proto.unpack(proto);
+    assertEquals(DATA.frontLeft, data.frontLeft);
+    assertEquals(DATA.frontRight, data.frontRight);
+    assertEquals(DATA.rearLeft, data.rearLeft);
+    assertEquals(DATA.rearRight, data.rearRight);
+  }
+}

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/proto/SwerveModuleAccelerationProtoTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/proto/SwerveModuleAccelerationProtoTest.java
@@ -1,0 +1,27 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.math.kinematics.proto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.wpilib.math.geometry.Rotation2d;
+import org.wpilib.math.kinematics.SwerveModuleAcceleration;
+import org.wpilib.math.kinematics.proto.detail.ProtobufSwerveModuleAcceleration;
+
+class SwerveModuleAccelerationProtoTest {
+  private static final SwerveModuleAcceleration DATA =
+      new SwerveModuleAcceleration(22.9, new Rotation2d(3.3));
+
+  @Test
+  void testRoundtrip() {
+    ProtobufSwerveModuleAcceleration proto = SwerveModuleAcceleration.proto.createMessage();
+    SwerveModuleAcceleration.proto.pack(proto, DATA);
+
+    SwerveModuleAcceleration data = SwerveModuleAcceleration.proto.unpack(proto);
+    assertEquals(DATA.acceleration, data.acceleration);
+    assertEquals(DATA.angle, data.angle);
+  }
+}

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/struct/ChassisAccelerationsStructTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/struct/ChassisAccelerationsStructTest.java
@@ -1,0 +1,30 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.math.kinematics.struct;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.junit.jupiter.api.Test;
+import org.wpilib.math.kinematics.ChassisAccelerations;
+
+class ChassisAccelerationsStructTest {
+  private static final ChassisAccelerations DATA =
+      new ChassisAccelerations(2.29, 2.2, 0.3504);
+
+  @Test
+  void testRoundtrip() {
+    ByteBuffer buffer = ByteBuffer.allocate(ChassisAccelerations.struct.getSize());
+    buffer.order(ByteOrder.LITTLE_ENDIAN);
+    ChassisAccelerations.struct.pack(buffer, DATA);
+    buffer.rewind();
+
+    ChassisAccelerations data = ChassisAccelerations.struct.unpack(buffer);
+    assertEquals(DATA.ax, data.ax);
+    assertEquals(DATA.ay, data.ay);
+    assertEquals(DATA.alpha, data.alpha);
+  }
+}

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/struct/ChassisAccelerationsStructTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/struct/ChassisAccelerationsStructTest.java
@@ -12,8 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.wpilib.math.kinematics.ChassisAccelerations;
 
 class ChassisAccelerationsStructTest {
-  private static final ChassisAccelerations DATA =
-      new ChassisAccelerations(2.29, 2.2, 0.3504);
+  private static final ChassisAccelerations DATA = new ChassisAccelerations(2.29, 2.2, 0.3504);
 
   @Test
   void testRoundtrip() {

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/struct/DifferentialDriveWheelAccelerationsStructTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/struct/DifferentialDriveWheelAccelerationsStructTest.java
@@ -1,0 +1,30 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.math.kinematics.struct;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.junit.jupiter.api.Test;
+import org.wpilib.math.kinematics.DifferentialDriveWheelAccelerations;
+
+class DifferentialDriveWheelAccelerationsStructTest {
+  private static final DifferentialDriveWheelAccelerations DATA =
+      new DifferentialDriveWheelAccelerations(1.74, 35.04);
+
+  @Test
+  void testRoundtrip() {
+    ByteBuffer buffer = ByteBuffer.allocate(DifferentialDriveWheelAccelerations.struct.getSize());
+    buffer.order(ByteOrder.LITTLE_ENDIAN);
+    DifferentialDriveWheelAccelerations.struct.pack(buffer, DATA);
+    buffer.rewind();
+
+    DifferentialDriveWheelAccelerations data =
+        DifferentialDriveWheelAccelerations.struct.unpack(buffer);
+    assertEquals(DATA.left, data.left);
+    assertEquals(DATA.right, data.right);
+  }
+}

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/struct/MecanumDriveWheelAccelerationsStructTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/struct/MecanumDriveWheelAccelerationsStructTest.java
@@ -1,0 +1,31 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.math.kinematics.struct;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.junit.jupiter.api.Test;
+import org.wpilib.math.kinematics.MecanumDriveWheelAccelerations;
+
+class MecanumDriveWheelAccelerationsStructTest {
+  private static final MecanumDriveWheelAccelerations DATA =
+      new MecanumDriveWheelAccelerations(2.29, 17.4, 4.4, 0.229);
+
+  @Test
+  void testRoundtrip() {
+    ByteBuffer buffer = ByteBuffer.allocate(MecanumDriveWheelAccelerations.struct.getSize());
+    buffer.order(ByteOrder.LITTLE_ENDIAN);
+    MecanumDriveWheelAccelerations.struct.pack(buffer, DATA);
+    buffer.rewind();
+
+    MecanumDriveWheelAccelerations data = MecanumDriveWheelAccelerations.struct.unpack(buffer);
+    assertEquals(DATA.frontLeft, data.frontLeft);
+    assertEquals(DATA.frontRight, data.frontRight);
+    assertEquals(DATA.rearLeft, data.rearLeft);
+    assertEquals(DATA.rearRight, data.rearRight);
+  }
+}

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/struct/SwerveModuleAccelerationStructTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/struct/SwerveModuleAccelerationStructTest.java
@@ -1,0 +1,30 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.math.kinematics.struct;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.junit.jupiter.api.Test;
+import org.wpilib.math.geometry.Rotation2d;
+import org.wpilib.math.kinematics.SwerveModuleAcceleration;
+
+class SwerveModuleAccelerationStructTest {
+  private static final SwerveModuleAcceleration DATA =
+      new SwerveModuleAcceleration(22.9, new Rotation2d(3.3));
+
+  @Test
+  void testRoundtrip() {
+    ByteBuffer buffer = ByteBuffer.allocate(SwerveModuleAcceleration.struct.getSize());
+    buffer.order(ByteOrder.LITTLE_ENDIAN);
+    SwerveModuleAcceleration.struct.pack(buffer, DATA);
+    buffer.rewind();
+
+    SwerveModuleAcceleration data = SwerveModuleAcceleration.struct.unpack(buffer);
+    assertEquals(DATA.acceleration, data.acceleration);
+    assertEquals(DATA.angle, data.angle);
+  }
+}

--- a/wpimath/src/test/native/cpp/kinematics/proto/ChassisAccelerationsProtoTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/proto/ChassisAccelerationsProtoTest.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "wpi/math/kinematics/ChassisAccelerations.hpp"
+#include "wpi/util/SmallVector.hpp"
+
+using namespace wpi::math;
+
+namespace {
+
+const ChassisAccelerations kExpectedData =
+    ChassisAccelerations{2.29_mps_sq, 2.2_mps_sq, 0.3504_rad_per_s_sq};
+}  // namespace
+
+TEST_CASE("ChassisAccelerationsProtoTest Roundtrip", "[wpimath]") {
+  wpi::util::ProtobufMessage<decltype(kExpectedData)> message;
+  wpi::util::SmallVector<uint8_t, 64> buf;
+
+  REQUIRE(message.Pack(buf, kExpectedData));
+  auto unpacked_data = message.Unpack(buf);
+  REQUIRE(unpacked_data.has_value());
+
+  CHECK(kExpectedData.ax.value() == unpacked_data->ax.value());
+  CHECK(kExpectedData.ay.value() == unpacked_data->ay.value());
+  CHECK(kExpectedData.alpha.value() == unpacked_data->alpha.value());
+}

--- a/wpimath/src/test/native/cpp/kinematics/proto/DifferentialDriveWheelAccelerationsProtoTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/proto/DifferentialDriveWheelAccelerationsProtoTest.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "wpi/math/kinematics/DifferentialDriveWheelAccelerations.hpp"
+#include "wpi/util/SmallVector.hpp"
+
+using namespace wpi::math;
+
+namespace {
+
+const DifferentialDriveWheelAccelerations kExpectedData =
+    DifferentialDriveWheelAccelerations{1.74_mps_sq, 35.04_mps_sq};
+}  // namespace
+
+TEST_CASE("DifferentialDriveWheelAccelerationsProtoTest Roundtrip",
+          "[wpimath]") {
+  wpi::util::ProtobufMessage<decltype(kExpectedData)> message;
+  wpi::util::SmallVector<uint8_t, 64> buf;
+
+  REQUIRE(message.Pack(buf, kExpectedData));
+  auto unpacked_data = message.Unpack(buf);
+  REQUIRE(unpacked_data.has_value());
+
+  CHECK(kExpectedData.left.value() == unpacked_data->left.value());
+  CHECK(kExpectedData.right.value() == unpacked_data->right.value());
+}

--- a/wpimath/src/test/native/cpp/kinematics/proto/MecanumDriveWheelAccelerationsProtoTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/proto/MecanumDriveWheelAccelerationsProtoTest.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "wpi/math/kinematics/MecanumDriveWheelAccelerations.hpp"
+#include "wpi/util/SmallVector.hpp"
+
+using namespace wpi::math;
+
+namespace {
+
+const MecanumDriveWheelAccelerations kExpectedData =
+    MecanumDriveWheelAccelerations{2.29_mps_sq, 17.4_mps_sq, 4.4_mps_sq,
+                                   0.229_mps_sq};
+}  // namespace
+
+TEST_CASE("MecanumDriveWheelAccelerationsProtoTest Roundtrip", "[wpimath]") {
+  wpi::util::ProtobufMessage<decltype(kExpectedData)> message;
+  wpi::util::SmallVector<uint8_t, 64> buf;
+
+  REQUIRE(message.Pack(buf, kExpectedData));
+  auto unpacked_data = message.Unpack(buf);
+  REQUIRE(unpacked_data.has_value());
+
+  CHECK(kExpectedData.frontLeft.value() == unpacked_data->frontLeft.value());
+  CHECK(kExpectedData.frontRight.value() == unpacked_data->frontRight.value());
+  CHECK(kExpectedData.rearLeft.value() == unpacked_data->rearLeft.value());
+  CHECK(kExpectedData.rearRight.value() == unpacked_data->rearRight.value());
+}

--- a/wpimath/src/test/native/cpp/kinematics/proto/SwerveModuleAccelerationProtoTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/proto/SwerveModuleAccelerationProtoTest.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "wpi/math/kinematics/SwerveModuleAcceleration.hpp"
+#include "wpi/util/SmallVector.hpp"
+
+using namespace wpi::math;
+
+namespace {
+
+const SwerveModuleAcceleration kExpectedData =
+    SwerveModuleAcceleration{22.9_mps_sq, Rotation2d{3.3_rad}};
+}  // namespace
+
+TEST_CASE("SwerveModuleAccelerationProtoTest Roundtrip", "[wpimath]") {
+  wpi::util::ProtobufMessage<decltype(kExpectedData)> message;
+  wpi::util::SmallVector<uint8_t, 64> buf;
+
+  REQUIRE(message.Pack(buf, kExpectedData));
+  auto unpacked_data = message.Unpack(buf);
+  REQUIRE(unpacked_data.has_value());
+
+  CHECK(kExpectedData.acceleration.value() ==
+        unpacked_data->acceleration.value());
+  CHECK(kExpectedData.angle == unpacked_data->angle);
+}

--- a/wpimath/src/test/native/cpp/kinematics/struct/ChassisAccelerationsStructTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/struct/ChassisAccelerationsStructTest.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "wpi/math/kinematics/ChassisAccelerations.hpp"
+
+using namespace wpi::math;
+
+namespace {
+
+using StructType = wpi::util::Struct<wpi::math::ChassisAccelerations>;
+const ChassisAccelerations kExpectedData{
+    ChassisAccelerations{2.29_mps_sq, 2.2_mps_sq, 0.3504_rad_per_s_sq}};
+}  // namespace
+
+TEST_CASE("ChassisAccelerationsStructTest Roundtrip", "[wpimath]") {
+  uint8_t buffer[StructType::GetSize()];
+  std::memset(buffer, 0, StructType::GetSize());
+  StructType::Pack(buffer, kExpectedData);
+
+  ChassisAccelerations unpacked_data = StructType::Unpack(buffer);
+
+  CHECK(kExpectedData.ax.value() == unpacked_data.ax.value());
+  CHECK(kExpectedData.ay.value() == unpacked_data.ay.value());
+  CHECK(kExpectedData.alpha.value() == unpacked_data.alpha.value());
+}

--- a/wpimath/src/test/native/cpp/kinematics/struct/DifferentialDriveWheelAccelerationsStructTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/struct/DifferentialDriveWheelAccelerationsStructTest.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "wpi/math/kinematics/DifferentialDriveWheelAccelerations.hpp"
+
+using namespace wpi::math;
+
+namespace {
+
+using StructType =
+    wpi::util::Struct<wpi::math::DifferentialDriveWheelAccelerations>;
+const DifferentialDriveWheelAccelerations kExpectedData{
+    DifferentialDriveWheelAccelerations{1.74_mps_sq, 35.04_mps_sq}};
+}  // namespace
+
+TEST_CASE("DifferentialDriveWheelAccelerationsStructTest Roundtrip",
+          "[wpimath]") {
+  uint8_t buffer[StructType::GetSize()];
+  std::memset(buffer, 0, StructType::GetSize());
+  StructType::Pack(buffer, kExpectedData);
+
+  DifferentialDriveWheelAccelerations unpacked_data =
+      StructType::Unpack(buffer);
+
+  CHECK(kExpectedData.left.value() == unpacked_data.left.value());
+  CHECK(kExpectedData.right.value() == unpacked_data.right.value());
+}

--- a/wpimath/src/test/native/cpp/kinematics/struct/MecanumDriveWheelAccelerationsStructTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/struct/MecanumDriveWheelAccelerationsStructTest.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "wpi/math/kinematics/MecanumDriveWheelAccelerations.hpp"
+
+using namespace wpi::math;
+
+namespace {
+
+using StructType = wpi::util::Struct<wpi::math::MecanumDriveWheelAccelerations>;
+const MecanumDriveWheelAccelerations kExpectedData{
+    MecanumDriveWheelAccelerations{2.29_mps_sq, 17.4_mps_sq, 4.4_mps_sq,
+                                   0.229_mps_sq}};
+}  // namespace
+
+TEST_CASE("MecanumDriveWheelAccelerationsStructTest Roundtrip", "[wpimath]") {
+  uint8_t buffer[StructType::GetSize()];
+  std::memset(buffer, 0, StructType::GetSize());
+  StructType::Pack(buffer, kExpectedData);
+
+  MecanumDriveWheelAccelerations unpacked_data = StructType::Unpack(buffer);
+
+  CHECK(kExpectedData.frontLeft.value() == unpacked_data.frontLeft.value());
+  CHECK(kExpectedData.frontRight.value() == unpacked_data.frontRight.value());
+  CHECK(kExpectedData.rearLeft.value() == unpacked_data.rearLeft.value());
+  CHECK(kExpectedData.rearRight.value() == unpacked_data.rearRight.value());
+}

--- a/wpimath/src/test/native/cpp/kinematics/struct/SwerveModuleAccelerationStructTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/struct/SwerveModuleAccelerationStructTest.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "wpi/math/kinematics/SwerveModuleAcceleration.hpp"
+
+using namespace wpi::math;
+
+namespace {
+
+using StructType = wpi::util::Struct<wpi::math::SwerveModuleAcceleration>;
+const SwerveModuleAcceleration kExpectedData{
+    SwerveModuleAcceleration{22.9_mps_sq, Rotation2d{3.3_rad}}};
+}  // namespace
+
+TEST_CASE("SwerveModuleAccelerationStructTest Roundtrip", "[wpimath]") {
+  uint8_t buffer[StructType::GetSize()];
+  std::memset(buffer, 0, StructType::GetSize());
+  StructType::Pack(buffer, kExpectedData);
+
+  SwerveModuleAcceleration unpacked_data = StructType::Unpack(buffer);
+
+  CHECK(kExpectedData.acceleration.value() ==
+        unpacked_data.acceleration.value());
+  CHECK(kExpectedData.angle == unpacked_data.angle);
+}


### PR DESCRIPTION
## Summary

- I added Java protobuf and struct round-trip tests for `ChassisAccelerations`.
- I added equivalent C++ protobuf and struct round-trip tests.
- I verify all three acceleration components survive serialization.

## Validation

- `./gradlew :wpimath:test --tests 'org.wpilib.math.kinematics.proto.ChassisAccelerationsProtoTest' --tests 'org.wpilib.math.kinematics.struct.ChassisAccelerationsStructTest' --build-cache --no-daemon`
- targeted C++ syntax compilation for both new test files with GCC 14 and the project include paths
- `wpiformat`
- `git diff --check origin/main...HEAD`

I deferred the full C++ Catch2 executable run to CI because its local compilation exceeded the available run time.

Fixes #9038
