### PR TITLE
[glass,wpigui] Fix bugs in glass UI and tweak styling

### DIFF
--- a/glass/src/lib/native/cpp/hardware/AnalogInput.cpp
+++ b/glass/src/lib/native/cpp/hardware/AnalogInput.cpp
@@ -32,7 +32,8 @@ void wpi::glass::DisplayAnalogInput(AnalogInputModel* model, int index) {
   }
 
   if (auto simDevice = model->GetSimDevice()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    ImGui::PushStyleColor(ImGuiCol_Text,
+                          ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::LabelText(label, "%s", simDevice);
     ImGui::PopStyleColor();
   } else {

--- a/glass/src/lib/native/cpp/hardware/AnalogInput.cpp
+++ b/glass/src/lib/native/cpp/hardware/AnalogInput.cpp
@@ -32,7 +32,7 @@ void wpi::glass::DisplayAnalogInput(AnalogInputModel* model, int index) {
   }
 
   if (auto simDevice = model->GetSimDevice()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::LabelText(label, "%s", simDevice);
     ImGui::PopStyleColor();
   } else {

--- a/glass/src/lib/native/cpp/hardware/DIO.cpp
+++ b/glass/src/lib/native/cpp/hardware/DIO.cpp
@@ -13,7 +13,8 @@
 using namespace wpi::glass;
 
 static void LabelSimDevice(const char* name, const char* simDeviceName) {
-  ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+  ImGui::PushStyleColor(ImGuiCol_Text,
+                        ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
   ImGui::LabelText(name, "%s", simDeviceName);
   ImGui::PopStyleColor();
 }
@@ -43,7 +44,8 @@ void DisplayDIOImpl(DIOModel* model, int index, bool outputsEnabled) {
     if (auto simDevice = encoder->GetSimDevice()) {
       LabelSimDevice(label, simDevice);
     } else {
-      ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+      ImGui::PushStyleColor(ImGuiCol_Text,
+                            ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
       ImGui::LabelText(label, "Encoder[%d,%d]", encoder->GetChannelA(),
                        encoder->GetChannelB());
       ImGui::PopStyleColor();
@@ -71,7 +73,8 @@ void DisplayDIOImpl(DIOModel* model, int index, bool outputsEnabled) {
       LabelSimDevice(label, simDevice);
     } else {
       if (!exists) {
-        ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+        ImGui::PushStyleColor(ImGuiCol_Text,
+                              ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
         dioData->LabelText(label, "unknown");
         ImGui::PopStyleColor();
       } else if (model->IsReadOnly()) {

--- a/glass/src/lib/native/cpp/hardware/DIO.cpp
+++ b/glass/src/lib/native/cpp/hardware/DIO.cpp
@@ -13,7 +13,7 @@
 using namespace wpi::glass;
 
 static void LabelSimDevice(const char* name, const char* simDeviceName) {
-  ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+  ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
   ImGui::LabelText(name, "%s", simDeviceName);
   ImGui::PopStyleColor();
 }
@@ -43,7 +43,7 @@ void DisplayDIOImpl(DIOModel* model, int index, bool outputsEnabled) {
     if (auto simDevice = encoder->GetSimDevice()) {
       LabelSimDevice(label, simDevice);
     } else {
-      ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+      ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
       ImGui::LabelText(label, "Encoder[%d,%d]", encoder->GetChannelA(),
                        encoder->GetChannelB());
       ImGui::PopStyleColor();
@@ -71,7 +71,7 @@ void DisplayDIOImpl(DIOModel* model, int index, bool outputsEnabled) {
       LabelSimDevice(label, simDevice);
     } else {
       if (!exists) {
-        ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+        ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
         dioData->LabelText(label, "unknown");
         ImGui::PopStyleColor();
       } else if (model->IsReadOnly()) {

--- a/glass/src/lib/native/cpp/hardware/Encoder.cpp
+++ b/glass/src/lib/native/cpp/hardware/Encoder.cpp
@@ -54,7 +54,8 @@ void EncoderModel::SetName(std::string_view name) {
 
 void wpi::glass::DisplayEncoder(EncoderModel* model) {
   if (auto simDevice = model->GetSimDevice()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    ImGui::PushStyleColor(ImGuiCol_Text,
+                          ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::TextUnformatted(simDevice);
     ImGui::PopStyleColor();
     return;

--- a/glass/src/lib/native/cpp/hardware/Encoder.cpp
+++ b/glass/src/lib/native/cpp/hardware/Encoder.cpp
@@ -54,7 +54,7 @@ void EncoderModel::SetName(std::string_view name) {
 
 void wpi::glass::DisplayEncoder(EncoderModel* model) {
   if (auto simDevice = model->GetSimDevice()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::TextUnformatted(simDevice);
     ImGui::PopStyleColor();
     return;

--- a/glass/src/lib/native/cpp/hardware/Gyro.cpp
+++ b/glass/src/lib/native/cpp/hardware/Gyro.cpp
@@ -23,7 +23,7 @@ void wpi::glass::DisplayGyro(GyroModel* m) {
 
   auto angle = m->GetAngleData();
   if (!angle || !m->Exists()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown Gyro");
     ImGui::PopStyleColor();
     return;

--- a/glass/src/lib/native/cpp/hardware/Gyro.cpp
+++ b/glass/src/lib/native/cpp/hardware/Gyro.cpp
@@ -23,7 +23,8 @@ void wpi::glass::DisplayGyro(GyroModel* m) {
 
   auto angle = m->GetAngleData();
   if (!angle || !m->Exists()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    ImGui::PushStyleColor(ImGuiCol_Text,
+                          ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown Gyro");
     ImGui::PopStyleColor();
     return;

--- a/glass/src/lib/native/cpp/hardware/MotorController.cpp
+++ b/glass/src/lib/native/cpp/hardware/MotorController.cpp
@@ -16,7 +16,8 @@ void wpi::glass::DisplayMotorController(MotorControllerModel* m) {
   // is null.
   auto dc = m->GetPercentData();
   if (!dc || !m->Exists()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    ImGui::PushStyleColor(ImGuiCol_Text,
+                          ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown MotorController");
     ImGui::PopStyleColor();
     return;
@@ -25,7 +26,8 @@ void wpi::glass::DisplayMotorController(MotorControllerModel* m) {
   // Set the buttons and sliders to read-only if the model is read-only.
   if (m->IsReadOnly()) {
     ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
-    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_Text));
+    ImGui::PushStyleColor(ImGuiCol_Text,
+                          ImGui::GetStyleColorVec4(ImGuiCol_Text));
   }
 
   // Add button to zero output.

--- a/glass/src/lib/native/cpp/hardware/MotorController.cpp
+++ b/glass/src/lib/native/cpp/hardware/MotorController.cpp
@@ -16,7 +16,7 @@ void wpi::glass::DisplayMotorController(MotorControllerModel* m) {
   // is null.
   auto dc = m->GetPercentData();
   if (!dc || !m->Exists()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown MotorController");
     ImGui::PopStyleColor();
     return;
@@ -25,7 +25,7 @@ void wpi::glass::DisplayMotorController(MotorControllerModel* m) {
   // Set the buttons and sliders to read-only if the model is read-only.
   if (m->IsReadOnly()) {
     ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
-    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(210, 210, 210, 255));
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_Text));
   }
 
   // Add button to zero output.

--- a/glass/src/lib/native/cpp/other/CommandScheduler.cpp
+++ b/glass/src/lib/native/cpp/other/CommandScheduler.cpp
@@ -33,7 +33,7 @@ void wpi::glass::DisplayCommandScheduler(CommandSchedulerModel* m) {
       ImGui::PopID();
     }
   } else {
-    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown Scheduler");
     ImGui::PopStyleColor();
   }

--- a/glass/src/lib/native/cpp/other/CommandScheduler.cpp
+++ b/glass/src/lib/native/cpp/other/CommandScheduler.cpp
@@ -33,7 +33,8 @@ void wpi::glass::DisplayCommandScheduler(CommandSchedulerModel* m) {
       ImGui::PopID();
     }
   } else {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    ImGui::PushStyleColor(ImGuiCol_Text,
+                          ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown Scheduler");
     ImGui::PopStyleColor();
   }

--- a/glass/src/lib/native/cpp/other/CommandSelector.cpp
+++ b/glass/src/lib/native/cpp/other/CommandSelector.cpp
@@ -27,7 +27,8 @@ void wpi::glass::DisplayCommandSelector(CommandSelectorModel* m) {
       }
     }
   } else {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    ImGui::PushStyleColor(ImGuiCol_Text,
+                          ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown Command");
     ImGui::PopStyleColor();
   }

--- a/glass/src/lib/native/cpp/other/CommandSelector.cpp
+++ b/glass/src/lib/native/cpp/other/CommandSelector.cpp
@@ -27,7 +27,7 @@ void wpi::glass::DisplayCommandSelector(CommandSelectorModel* m) {
       }
     }
   } else {
-    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown Command");
     ImGui::PopStyleColor();
   }

--- a/glass/src/lib/native/cpp/other/DS.cpp
+++ b/glass/src/lib/native/cpp/other/DS.cpp
@@ -94,7 +94,7 @@ void wpi::glass::DisplayDS(DSModel* model, bool editableDsAttached) {
 void wpi::glass::DisplayDSReadOnly(DSModel* model) {
   bool exists = model->Exists();
   if (!exists) {
-    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
   }
 
   if (auto data = model->GetEStopData()) {

--- a/glass/src/lib/native/cpp/other/DS.cpp
+++ b/glass/src/lib/native/cpp/other/DS.cpp
@@ -94,7 +94,8 @@ void wpi::glass::DisplayDS(DSModel* model, bool editableDsAttached) {
 void wpi::glass::DisplayDSReadOnly(DSModel* model) {
   bool exists = model->Exists();
   if (!exists) {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    ImGui::PushStyleColor(ImGuiCol_Text,
+                          ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
   }
 
   if (auto data = model->GetEStopData()) {

--- a/glass/src/lib/native/cpp/other/Drive.cpp
+++ b/glass/src/lib/native/cpp/other/Drive.cpp
@@ -18,7 +18,8 @@ using namespace wpi::glass;
 void wpi::glass::DisplayDrive(DriveModel* m) {
   // Check if the model exists.
   if (!m->Exists()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    ImGui::PushStyleColor(ImGuiCol_Text,
+                          ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown Drive");
     ImGui::PopStyleColor();
     return;
@@ -116,7 +117,8 @@ void wpi::glass::DisplayDrive(DriveModel* m) {
   // Set the buttons and sliders to read-only if the model is read-only.
   if (m->IsReadOnly()) {
     ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
-    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_Text));
+    ImGui::PushStyleColor(ImGuiCol_Text,
+                          ImGui::GetStyleColorVec4(ImGuiCol_Text));
   }
 
   // Add sliders for the wheel percentages.

--- a/glass/src/lib/native/cpp/other/Drive.cpp
+++ b/glass/src/lib/native/cpp/other/Drive.cpp
@@ -18,7 +18,7 @@ using namespace wpi::glass;
 void wpi::glass::DisplayDrive(DriveModel* m) {
   // Check if the model exists.
   if (!m->Exists()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown Drive");
     ImGui::PopStyleColor();
     return;
@@ -116,7 +116,7 @@ void wpi::glass::DisplayDrive(DriveModel* m) {
   // Set the buttons and sliders to read-only if the model is read-only.
   if (m->IsReadOnly()) {
     ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
-    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(210, 210, 210, 255));
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_Text));
   }
 
   // Add sliders for the wheel percentages.

--- a/glass/src/lib/native/cpp/other/PIDController.cpp
+++ b/glass/src/lib/native/cpp/other/PIDController.cpp
@@ -60,7 +60,7 @@ void wpi::glass::DisplayPIDController(PIDControllerModel* m) {
                                     [=](auto v) { m->SetIZone(v); });
     }
   } else {
-    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown PID Controller");
     ImGui::PopStyleColor();
   }

--- a/glass/src/lib/native/cpp/other/PIDController.cpp
+++ b/glass/src/lib/native/cpp/other/PIDController.cpp
@@ -60,7 +60,8 @@ void wpi::glass::DisplayPIDController(PIDControllerModel* m) {
                                     [=](auto v) { m->SetIZone(v); });
     }
   } else {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    ImGui::PushStyleColor(ImGuiCol_Text,
+                          ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown PID Controller");
     ImGui::PopStyleColor();
   }

--- a/glass/src/lib/native/cpp/other/ProfiledPIDController.cpp
+++ b/glass/src/lib/native/cpp/other/ProfiledPIDController.cpp
@@ -69,7 +69,8 @@ void wpi::glass::DisplayProfiledPIDController(ProfiledPIDControllerModel* m) {
       createTuningParameter("Goal", &value, [=](auto v) { m->SetGoal(v); });
     }
   } else {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    ImGui::PushStyleColor(ImGuiCol_Text,
+                          ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown PID Controller");
     ImGui::PopStyleColor();
   }

--- a/glass/src/lib/native/cpp/other/ProfiledPIDController.cpp
+++ b/glass/src/lib/native/cpp/other/ProfiledPIDController.cpp
@@ -69,7 +69,7 @@ void wpi::glass::DisplayProfiledPIDController(ProfiledPIDControllerModel* m) {
       createTuningParameter("Goal", &value, [=](auto v) { m->SetGoal(v); });
     }
   } else {
-    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown PID Controller");
     ImGui::PopStyleColor();
   }

--- a/glass/src/lib/native/cpp/other/Subsystem.cpp
+++ b/glass/src/lib/native/cpp/other/Subsystem.cpp
@@ -21,7 +21,8 @@ void wpi::glass::DisplaySubsystem(SubsystemModel* m) {
     ImGui::Text("%s", ("Default Command: " + defaultCommand).c_str());
     ImGui::Text("%s", ("Current Command: " + currentCommand).c_str());
   } else {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    ImGui::PushStyleColor(ImGuiCol_Text,
+                          ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown Subsystem");
     ImGui::PopStyleColor();
   }

--- a/glass/src/lib/native/cpp/other/Subsystem.cpp
+++ b/glass/src/lib/native/cpp/other/Subsystem.cpp
@@ -21,7 +21,7 @@ void wpi::glass::DisplaySubsystem(SubsystemModel* m) {
     ImGui::Text("%s", ("Default Command: " + defaultCommand).c_str());
     ImGui::Text("%s", ("Current Command: " + currentCommand).c_str());
   } else {
-    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::Text("Unknown Subsystem");
     ImGui::PopStyleColor();
   }

--- a/glass/src/libnt/native/cpp/NetworkTablesProvider.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTablesProvider.cpp
@@ -92,7 +92,7 @@ void NetworkTablesProvider::DisplayMenu() {
         auto typeEntry = m_typeCache.FindValue(entry->name);
         if (typeEntry) {
           ImGui::SameLine();
-          ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+          ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
           ImGui::Text("%s", typeEntry->stringVal.c_str());
           ImGui::PopStyleColor();
           ImGui::SameLine();

--- a/glass/src/libnt/native/cpp/NetworkTablesProvider.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTablesProvider.cpp
@@ -92,7 +92,8 @@ void NetworkTablesProvider::DisplayMenu() {
         auto typeEntry = m_typeCache.FindValue(entry->name);
         if (typeEntry) {
           ImGui::SameLine();
-          ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+          ImGui::PushStyleColor(
+              ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
           ImGui::Text("%s", typeEntry->stringVal.c_str());
           ImGui::PopStyleColor();
           ImGui::SameLine();

--- a/wpigui/src/main/native/cpp/wpigui.cpp
+++ b/wpigui/src/main/native/cpp/wpigui.cpp
@@ -1648,12 +1648,9 @@ static void ApplyCommonStyle(Style selectedStyle) {
   plotStyle.Colors[ImPlotCol_AxisText] = palette.textDisabled;
   plotStyle.Colors[ImPlotCol_AxisGrid] = withAlpha(palette.border, 0.60f);
   plotStyle.Colors[ImPlotCol_AxisTick] = palette.border;
-  plotStyle.Colors[ImPlotCol_AxisBgHovered] =
-      withAlpha(palette.accent, 0.35f);
-  plotStyle.Colors[ImPlotCol_AxisBgActive] =
-      withAlpha(palette.accent, 0.55f);
-  plotStyle.Colors[ImPlotCol_Selection] =
-      withAlpha(palette.accent, 0.45f);
+  plotStyle.Colors[ImPlotCol_AxisBgHovered] = withAlpha(palette.accent, 0.35f);
+  plotStyle.Colors[ImPlotCol_AxisBgActive] = withAlpha(palette.accent, 0.55f);
+  plotStyle.Colors[ImPlotCol_Selection] = withAlpha(palette.accent, 0.45f);
   plotStyle.Colors[ImPlotCol_Crosshairs] = palette.accentStrong;
   plotStyle.PlotBorderSize = 1.0f;
   plotStyle.MinorAlpha = 0.18f;
@@ -1700,7 +1697,6 @@ void gui::SetStyle(Style style) {
 void gui::SetFPS(int fps) {
   SetFPSInternal(fps);
 }
-
 
 std::string gui::GetPlatformSaveFileDir() {
 #if defined(_MSC_VER)

--- a/wpigui/src/main/native/cpp/wpigui.cpp
+++ b/wpigui/src/main/native/cpp/wpigui.cpp
@@ -1061,16 +1061,16 @@ bool gui::Initialize(const char* title, int width, int height,
     }
   }
 
+  if (!InitRenderer(windowFlags, rendererPreference)) {
+    CleanupFailedInitialize();
+    return false;
+  }
+
   for (auto&& makeFont : gContext->makeFonts) {
     if (makeFont.GetName() == gContext->defaultFontName) {
       io.FontDefault = makeFont.GetFont();
       break;
     }
-  }
-
-  if (!InitRenderer(windowFlags, rendererPreference)) {
-    CleanupFailedInitialize();
-    return false;
   }
 
   // Update window settings
@@ -1689,6 +1689,10 @@ void gui::SetStyle(Style style) {
     case Style::DEEP_DARK:
       StyleColorsDeepDark();
       break;
+    default:
+      style = Style::CLASSIC;
+      ImGui::StyleColorsClassic();
+      break;
   }
   ApplyCommonStyle(style);
 }
@@ -1697,9 +1701,6 @@ void gui::SetFPS(int fps) {
   SetFPSInternal(fps);
 }
 
-void gui::SetClearColor(ImVec4 color) {
-  gContext->clearColor = color;
-}
 
 std::string gui::GetPlatformSaveFileDir() {
 #if defined(_MSC_VER)

--- a/wpigui/src/main/native/cpp/wpigui.cpp
+++ b/wpigui/src/main/native/cpp/wpigui.cpp
@@ -1061,6 +1061,13 @@ bool gui::Initialize(const char* title, int width, int height,
     }
   }
 
+  for (auto&& makeFont : gContext->makeFonts) {
+    if (makeFont.GetName() == gContext->defaultFontName) {
+      io.FontDefault = makeFont.GetFont();
+      break;
+    }
+  }
+
   if (!InitRenderer(windowFlags, rendererPreference)) {
     CleanupFailedInitialize();
     return false;
@@ -1462,8 +1469,213 @@ static void StyleColorsDeepDark() {
   style.TabRounding = 4;
 }
 
+static void ApplyCommonStyle(Style selectedStyle) {
+  ImGuiStyle& style = ImGui::GetStyle();
+  ImVec4* colors = style.Colors;
+
+  struct Palette {
+    ImVec4 text;
+    ImVec4 textDisabled;
+    ImVec4 canvas;
+    ImVec4 window;
+    ImVec4 surface;
+    ImVec4 control;
+    ImVec4 border;
+    ImVec4 accent;
+    ImVec4 accentStrong;
+  } palette;
+
+  switch (selectedStyle) {
+    case Style::CLASSIC:
+      palette = {ImVec4(0.96f, 0.97f, 0.98f, 1.00f),
+                 ImVec4(0.66f, 0.69f, 0.73f, 1.00f),
+                 ImVec4(0.075f, 0.085f, 0.10f, 1.00f),
+                 ImVec4(0.16f, 0.17f, 0.19f, 1.00f),
+                 ImVec4(0.21f, 0.23f, 0.26f, 1.00f),
+                 ImVec4(0.27f, 0.29f, 0.33f, 1.00f),
+                 ImVec4(0.48f, 0.52f, 0.58f, 0.72f),
+                 ImVec4(0.20f, 0.68f, 0.82f, 1.00f),
+                 ImVec4(0.12f, 0.78f, 0.94f, 1.00f)};
+      break;
+    case Style::DARK:
+      palette = {ImVec4(0.93f, 0.96f, 1.00f, 1.00f),
+                 ImVec4(0.60f, 0.68f, 0.78f, 1.00f),
+                 ImVec4(0.012f, 0.025f, 0.055f, 1.00f),
+                 ImVec4(0.045f, 0.075f, 0.125f, 1.00f),
+                 ImVec4(0.065f, 0.105f, 0.17f, 1.00f),
+                 ImVec4(0.095f, 0.15f, 0.235f, 1.00f),
+                 ImVec4(0.29f, 0.39f, 0.54f, 0.68f),
+                 ImVec4(0.31f, 0.64f, 0.98f, 1.00f),
+                 ImVec4(0.52f, 0.78f, 1.00f, 1.00f)};
+      break;
+    case Style::LIGHT:
+      palette = {ImVec4(0.12f, 0.12f, 0.12f, 1.00f),
+                 ImVec4(0.42f, 0.42f, 0.42f, 1.00f),
+                 ImVec4(0.92f, 0.92f, 0.92f, 1.00f),
+                 ImVec4(1.00f, 1.00f, 1.00f, 1.00f),
+                 ImVec4(0.98f, 0.98f, 0.98f, 1.00f),
+                 ImVec4(0.90f, 0.90f, 0.90f, 1.00f),
+                 ImVec4(0.62f, 0.62f, 0.62f, 1.00f),
+                 ImVec4(0.20f, 0.47f, 0.82f, 1.00f),
+                 ImVec4(0.10f, 0.35f, 0.70f, 1.00f)};
+      break;
+    case Style::DEEP_DARK:
+      palette = {ImVec4(0.96f, 0.97f, 0.99f, 1.00f),
+                 ImVec4(0.62f, 0.65f, 0.70f, 1.00f),
+                 ImVec4(0.005f, 0.007f, 0.012f, 1.00f),
+                 ImVec4(0.025f, 0.028f, 0.035f, 1.00f),
+                 ImVec4(0.055f, 0.06f, 0.075f, 1.00f),
+                 ImVec4(0.09f, 0.10f, 0.125f, 1.00f),
+                 ImVec4(0.34f, 0.37f, 0.43f, 0.68f),
+                 ImVec4(0.35f, 0.72f, 0.90f, 1.00f),
+                 ImVec4(0.55f, 0.86f, 1.00f, 1.00f)};
+      break;
+  }
+
+  auto withAlpha = [](ImVec4 color, float alpha) {
+    color.w = alpha;
+    return color;
+  };
+  colors[ImGuiCol_Text] = palette.text;
+  colors[ImGuiCol_TextDisabled] = palette.textDisabled;
+  colors[ImGuiCol_WindowBg] = palette.window;
+  colors[ImGuiCol_ChildBg] = palette.surface;
+  colors[ImGuiCol_PopupBg] = palette.surface;
+  colors[ImGuiCol_Border] = palette.border;
+  colors[ImGuiCol_BorderShadow] = withAlpha(palette.canvas, 0.35f);
+  colors[ImGuiCol_FrameBg] = palette.control;
+  colors[ImGuiCol_FrameBgHovered] = withAlpha(palette.accent, 0.35f);
+  colors[ImGuiCol_FrameBgActive] = withAlpha(palette.accent, 0.55f);
+  colors[ImGuiCol_TitleBg] = palette.window;
+  colors[ImGuiCol_TitleBgActive] = palette.surface;
+  colors[ImGuiCol_MenuBarBg] = palette.surface;
+  colors[ImGuiCol_ScrollbarBg] = palette.canvas;
+  colors[ImGuiCol_ScrollbarGrab] = withAlpha(palette.border, 0.80f);
+  colors[ImGuiCol_ScrollbarGrabHovered] = palette.accent;
+  colors[ImGuiCol_ScrollbarGrabActive] = palette.accentStrong;
+  colors[ImGuiCol_CheckMark] = palette.accentStrong;
+  colors[ImGuiCol_SliderGrab] = palette.accent;
+  colors[ImGuiCol_SliderGrabActive] = palette.accentStrong;
+  colors[ImGuiCol_Button] = palette.control;
+  colors[ImGuiCol_ButtonHovered] = withAlpha(palette.accent, 0.55f);
+  colors[ImGuiCol_ButtonActive] = withAlpha(palette.accentStrong, 0.78f);
+  colors[ImGuiCol_Header] = withAlpha(palette.control, 0.92f);
+  colors[ImGuiCol_HeaderHovered] = withAlpha(palette.accent, 0.48f);
+  colors[ImGuiCol_HeaderActive] = withAlpha(palette.accent, 0.68f);
+  colors[ImGuiCol_Separator] = palette.border;
+  colors[ImGuiCol_SeparatorHovered] = palette.accent;
+  colors[ImGuiCol_SeparatorActive] = palette.accentStrong;
+  colors[ImGuiCol_ResizeGrip] = withAlpha(palette.border, 0.65f);
+  colors[ImGuiCol_ResizeGripHovered] = palette.accent;
+  colors[ImGuiCol_ResizeGripActive] = palette.accentStrong;
+  colors[ImGuiCol_InputTextCursor] = palette.accentStrong;
+  colors[ImGuiCol_Tab] = palette.control;
+  colors[ImGuiCol_TabHovered] = withAlpha(palette.accent, 0.62f);
+  colors[ImGuiCol_TabActive] = withAlpha(palette.accent, 0.42f);
+  colors[ImGuiCol_TabUnfocused] = palette.window;
+  colors[ImGuiCol_TabUnfocusedActive] = palette.surface;
+  colors[ImGuiCol_DockingPreview] = withAlpha(palette.accent, 0.70f);
+  colors[ImGuiCol_DockingEmptyBg] = palette.canvas;
+  colors[ImGuiCol_PlotLines] = palette.accent;
+  colors[ImGuiCol_PlotLinesHovered] = palette.accentStrong;
+  colors[ImGuiCol_PlotHistogram] = palette.accent;
+  colors[ImGuiCol_PlotHistogramHovered] = palette.accentStrong;
+  colors[ImGuiCol_TableHeaderBg] = palette.control;
+  colors[ImGuiCol_TableBorderStrong] = palette.border;
+  colors[ImGuiCol_TableBorderLight] = withAlpha(palette.border, 0.45f);
+  colors[ImGuiCol_TextLink] = palette.accentStrong;
+  colors[ImGuiCol_TextSelectedBg] = withAlpha(palette.accent, 0.42f);
+  colors[ImGuiCol_DragDropTarget] = palette.accentStrong;
+  colors[ImGuiCol_NavHighlight] = palette.accentStrong;
+  colors[ImGuiCol_NavWindowingHighlight] = palette.accentStrong;
+  colors[ImGuiCol_NavWindowingDimBg] = withAlpha(palette.canvas, 0.55f);
+  colors[ImGuiCol_ModalWindowDimBg] = withAlpha(palette.canvas, 0.55f);
+  style.WindowPadding = ImVec2(14.0f, 12.0f);
+  style.FramePadding = ImVec2(9.0f, 6.0f);
+  style.CellPadding = ImVec2(10.0f, 7.0f);
+  style.ItemSpacing = ImVec2(10.0f, 8.0f);
+  style.ItemInnerSpacing = ImVec2(8.0f, 6.0f);
+  style.TouchExtraPadding = ImVec2(1.0f, 1.0f);
+  style.IndentSpacing = 24.0f;
+  style.ScrollbarSize = 14.0f;
+  style.GrabMinSize = 13.0f;
+  style.WindowBorderSize = 1.0f;
+  style.ChildBorderSize = 1.0f;
+  style.PopupBorderSize = 1.0f;
+  style.FrameBorderSize = 1.0f;
+  style.TabBorderSize = 0.0f;
+  style.WindowRounding = 4.0f;
+  style.ChildRounding = 3.0f;
+  style.FrameRounding = 2.0f;
+  style.PopupRounding = 4.0f;
+  style.ScrollbarRounding = 5.0f;
+  style.GrabRounding = 2.0f;
+  style.TabRounding = 3.0f;
+  style.LogSliderDeadzone = 4.0f;
+  style.WindowBorderHoverPadding = 4.0f;
+  style.ScrollbarPadding = 2.0f;
+  style.ImageRounding = 4.0f;
+  style.ImageBorderSize = 0.0f;
+  style.TabMinWidthBase = 64.0f;
+  style.TabMinWidthShrink = 48.0f;
+  style.TabBarBorderSize = 1.0f;
+  style.TabBarOverlineSize = 0.0f;
+  style.TreeLinesFlags = ImGuiTreeNodeFlags_DrawLinesNone;
+  style.DragDropTargetRounding = 4.0f;
+  style.DragDropTargetBorderSize = 2.0f;
+  style.DragDropTargetPadding = 2.0f;
+  style.SeparatorSize = 1.0f;
+  style.SeparatorTextBorderSize = 0.0f;
+  style.SeparatorTextAlign = ImVec2(0.0f, 0.5f);
+  style.SeparatorTextPadding = ImVec2(0.0f, 8.0f);
+  style.DockingSeparatorSize = 4.0f;
+  style.HoverStationaryDelay = 0.15f;
+  style.HoverDelayShort = 0.35f;
+  style.HoverDelayNormal = 0.60f;
+  style.HoverFlagsForTooltipMouse =
+      ImGuiHoveredFlags_Stationary | ImGuiHoveredFlags_DelayShort;
+  style.HoverFlagsForTooltipNav = ImGuiHoveredFlags_DelayNormal;
+
+  ImPlotStyle& plotStyle = ImPlot::GetStyle();
+  plotStyle.Colors[ImPlotCol_FrameBg] = palette.control;
+  plotStyle.Colors[ImPlotCol_PlotBg] = palette.window;
+  plotStyle.Colors[ImPlotCol_PlotBorder] = palette.border;
+  plotStyle.Colors[ImPlotCol_LegendBg] = palette.surface;
+  plotStyle.Colors[ImPlotCol_LegendBorder] = palette.border;
+  plotStyle.Colors[ImPlotCol_LegendText] = palette.text;
+  plotStyle.Colors[ImPlotCol_TitleText] = palette.text;
+  plotStyle.Colors[ImPlotCol_InlayText] = palette.text;
+  plotStyle.Colors[ImPlotCol_AxisText] = palette.textDisabled;
+  plotStyle.Colors[ImPlotCol_AxisGrid] = withAlpha(palette.border, 0.60f);
+  plotStyle.Colors[ImPlotCol_AxisTick] = palette.border;
+  plotStyle.Colors[ImPlotCol_AxisBgHovered] =
+      withAlpha(palette.accent, 0.35f);
+  plotStyle.Colors[ImPlotCol_AxisBgActive] =
+      withAlpha(palette.accent, 0.55f);
+  plotStyle.Colors[ImPlotCol_Selection] =
+      withAlpha(palette.accent, 0.45f);
+  plotStyle.Colors[ImPlotCol_Crosshairs] = palette.accentStrong;
+  plotStyle.PlotBorderSize = 1.0f;
+  plotStyle.MinorAlpha = 0.18f;
+  plotStyle.MajorTickLen = ImVec2(6.0f, 6.0f);
+  plotStyle.MinorTickLen = ImVec2(3.0f, 3.0f);
+  plotStyle.PlotPadding = ImVec2(12.0f, 12.0f);
+  plotStyle.LabelPadding = ImVec2(8.0f, 6.0f);
+  plotStyle.LegendPadding = ImVec2(10.0f, 10.0f);
+  plotStyle.LegendInnerPadding = ImVec2(8.0f, 6.0f);
+  plotStyle.LegendSpacing = ImVec2(8.0f, 4.0f);
+  plotStyle.MousePosPadding = ImVec2(10.0f, 8.0f);
+  plotStyle.AnnotationPadding = ImVec2(6.0f, 4.0f);
+  plotStyle.Colormap = ImPlotColormap_Paired;
+
+  gContext->clearColor = palette.canvas;
+}
+
 void gui::SetStyle(Style style) {
   gContext->style = static_cast<int>(style);
+  if (!ImGui::GetCurrentContext()) {
+    return;
+  }
   switch (style) {
     case Style::CLASSIC:
       ImGui::StyleColorsClassic();
@@ -1478,6 +1690,7 @@ void gui::SetStyle(Style style) {
       StyleColorsDeepDark();
       break;
   }
+  ApplyCommonStyle(style);
 }
 
 void gui::SetFPS(int fps) {

--- a/wpigui/src/main/native/cpp/wpigui.cpp
+++ b/wpigui/src/main/native/cpp/wpigui.cpp
@@ -899,7 +899,7 @@ static void UpdateFontScale() {
   if (fontScale < 0.5) {
     fontScale = 0.5;
   }
-  ImGui::GetStyle().FontSizeBase = 10;
+  ImGui::GetStyle().FontSizeBase = 11;
   ImGui::GetStyle().FontScaleDpi = fontScale;
 }
 

--- a/wpigui/src/main/native/cpp/wpigui.cpp
+++ b/wpigui/src/main/native/cpp/wpigui.cpp
@@ -1632,12 +1632,12 @@ static void ApplyCommonStyle(Style selectedStyle) {
   style.HoverStationaryDelay = 0.15f;
   style.HoverDelayShort = 0.35f;
   style.HoverDelayNormal = 0.60f;
-  style.HoverFlagsForTooltipMouse =
-      ImGuiHoveredFlags_Stationary | ImGuiHoveredFlags_DelayShort |
-      ImGuiHoveredFlags_AllowWhenDisabled;
-  style.HoverFlagsForTooltipNav =
-      ImGuiHoveredFlags_NoSharedDelay | ImGuiHoveredFlags_DelayNormal |
-      ImGuiHoveredFlags_AllowWhenDisabled;
+  style.HoverFlagsForTooltipMouse = ImGuiHoveredFlags_Stationary |
+                                    ImGuiHoveredFlags_DelayShort |
+                                    ImGuiHoveredFlags_AllowWhenDisabled;
+  style.HoverFlagsForTooltipNav = ImGuiHoveredFlags_NoSharedDelay |
+                                  ImGuiHoveredFlags_DelayNormal |
+                                  ImGuiHoveredFlags_AllowWhenDisabled;
 
   ImPlotStyle& plotStyle = ImPlot::GetStyle();
   plotStyle.Colors[ImPlotCol_FrameBg] = palette.control;

--- a/wpigui/src/main/native/cpp/wpigui.cpp
+++ b/wpigui/src/main/native/cpp/wpigui.cpp
@@ -1633,8 +1633,11 @@ static void ApplyCommonStyle(Style selectedStyle) {
   style.HoverDelayShort = 0.35f;
   style.HoverDelayNormal = 0.60f;
   style.HoverFlagsForTooltipMouse =
-      ImGuiHoveredFlags_Stationary | ImGuiHoveredFlags_DelayShort;
-  style.HoverFlagsForTooltipNav = ImGuiHoveredFlags_DelayNormal;
+      ImGuiHoveredFlags_Stationary | ImGuiHoveredFlags_DelayShort |
+      ImGuiHoveredFlags_AllowWhenDisabled;
+  style.HoverFlagsForTooltipNav =
+      ImGuiHoveredFlags_NoSharedDelay | ImGuiHoveredFlags_DelayNormal |
+      ImGuiHoveredFlags_AllowWhenDisabled;
 
   ImPlotStyle& plotStyle = ImPlot::GetStyle();
   plotStyle.Colors[ImPlotCol_FrameBg] = palette.control;

--- a/wpigui/src/main/native/include/wpi/gui/wpigui.hpp
+++ b/wpigui/src/main/native/include/wpi/gui/wpigui.hpp
@@ -222,12 +222,6 @@ void SetStyle(Style style);
  */
 void SetFPS(int fps);
 
-/**
- * Sets the clear (background) color.
- *
- * @param color Color
- */
-void SetClearColor(ImVec4 color);
 
 /**
  * Gets the (platform-specific) absolute directory for save files.

--- a/wpigui/src/main/native/include/wpi/gui/wpigui.hpp
+++ b/wpigui/src/main/native/include/wpi/gui/wpigui.hpp
@@ -222,7 +222,6 @@ void SetStyle(Style style);
  */
 void SetFPS(int fps);
 
-
 /**
  * Gets the (platform-specific) absolute directory for save files.
  *

--- a/wpigui/src/main/native/include/wpi/gui/wpigui_internal.hpp
+++ b/wpigui/src/main/native/include/wpi/gui/wpigui_internal.hpp
@@ -29,7 +29,7 @@ struct SavedSettings {
   int userScale = 100;
   int style = 0;
   int fps = 120;
-  std::string defaultFontName = "Proggy Dotted";
+  std::string defaultFontName = "Roboto Regular";
 };
 
 struct Context : public SavedSettings {


### PR DESCRIPTION
This PR accomplishes a few things:

- Fixes a bug where custom font choices were not applied after restarting
- Fixes a bug where some UI customizations were improperly implied so they only appeared after toggling to the Deep Dark theme
- Sets the default font to Roboto Regular (what the 2027 DS uses)
- Increases font size for readability (previous 10 was quite small)
- Tweaks padding and rounding for a more modern feel
- Tweaks color themes to be a little bit nicer
- Fixes a bug where some plot details became unreadable in light themes
<img width="1510" height="801" alt="image" src="https://github.com/user-attachments/assets/521ffd41-33df-45e7-925b-cfc0c25940bb" />
<img width="1512" height="799" alt="image" src="https://github.com/user-attachments/assets/e5cdebe4-1cce-4c31-a02c-061a12187da9" />
<img width="1512" height="799" alt="image" src="https://github.com/user-attachments/assets/3856bb6a-2ede-4070-9a8a-510e478b2c13" />
<img width="1512" height="799" alt="image" src="https://github.com/user-attachments/assets/d2da2ba3-9382-4470-84a1-548f5c76aab6" />
