### PR TITLE
[wpiutil] Accept UTF-8 struct schema identifiers

### DIFF
--- a/wpiutil/doc/struct.adoc
+++ b/wpiutil/doc/struct.adoc
@@ -28,7 +28,7 @@ Python's struct module uses a character-based approach to describe data layout o
 [[schema]]
 == Schema
 
-The schema is a text-based format with similar syntax to the list of variable declarations in a C structure. The C syntax is flexible, easy to parse, and matches the intent of specifying a fixed size structure.
+The schema is a UTF-8 text-based format with similar syntax to the list of variable declarations in a C structure. The C syntax is flexible, easy to parse, and matches the intent of specifying a fixed size structure. Identifier names and user-defined type names may contain UTF-8 characters.
 
 Each member of the struct is defined by a single declaration. Each declaration is either a standard declaration or a bit-field declaration. Declarations are separated by semicolons. The last declaration may optionally have a trailing semicolon. Empty declarations (e.g. two semicolons back-to-back or separated by only whitespace) are allowed but are ignored. Unlike C structures, every declaration must be separated by a semicolon; commas cannot be used to declare multiple members with the same type. Declarations may also start and end with whitespace.
 

--- a/wpiutil/src/main/java/org/wpilib/util/struct/parser/Lexer.java
+++ b/wpiutil/src/main/java/org/wpilib/util/struct/parser/Lexer.java
@@ -39,7 +39,7 @@ public class Lexer {
       case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' -> scanInteger();
       case '\0' -> TokenKind.END_OF_INPUT;
       default -> {
-        if (Character.isLetter(m_current) || m_current == '_') {
+        if (Character.isLetter(m_current) || m_current == '_' || m_current >= 0x80) {
           yield scanIdentifier();
         }
         yield TokenKind.UNKNOWN;
@@ -79,7 +79,7 @@ public class Lexer {
   private TokenKind scanIdentifier() {
     do {
       get();
-    } while (Character.isLetterOrDigit(m_current) || m_current == '_');
+    } while (Character.isLetterOrDigit(m_current) || m_current == '_' || m_current >= 0x80);
     unget();
     return TokenKind.IDENTIFIER;
   }

--- a/wpiutil/src/main/native/cpp/struct/SchemaParser.cpp
+++ b/wpiutil/src/main/native/cpp/struct/SchemaParser.cpp
@@ -81,7 +81,7 @@ Token Lexer::Scan() {
     case -1:
       return {Token::END_OF_INPUT, {}};
     default:
-      if (isAlpha(m_current) || m_current == '_') {
+      if (isAlpha(m_current) || m_current == '_' || m_current >= 0x80) {
         [[likely]] return ScanIdentifier();
       }
       return MakeToken(Token::UNKNOWN);
@@ -99,7 +99,7 @@ Token Lexer::ScanInteger() {
 Token Lexer::ScanIdentifier() {
   do {
     Get();
-  } while (isAlnum(m_current) || m_current == '_');
+  } while (isAlnum(m_current) || m_current == '_' || m_current >= 0x80);
   Unget();
   return MakeToken(Token::IDENTIFIER);
 }

--- a/wpiutil/src/main/native/include/wpi/util/struct/SchemaParser.hpp
+++ b/wpiutil/src/main/native/include/wpi/util/struct/SchemaParser.hpp
@@ -89,7 +89,7 @@ class Lexer {
 
   void Get() {
     if (m_pos < m_in.size()) {
-      [[likely]] m_current = m_in[m_pos];
+      [[likely]] m_current = static_cast<unsigned char>(m_in[m_pos]);
     } else {
       m_current = -1;
     }
@@ -100,7 +100,7 @@ class Lexer {
     if (m_pos > 0) {
       [[likely]] m_pos--;
       if (m_pos < m_in.size()) {
-        [[likely]] m_current = m_in[m_pos];
+        [[likely]] m_current = static_cast<unsigned char>(m_in[m_pos]);
       } else {
         m_current = -1;
       }

--- a/wpiutil/src/test/java/org/wpilib/util/struct/parser/ParserTest.java
+++ b/wpiutil/src/test/java/org/wpilib/util/struct/parser/ParserTest.java
@@ -38,6 +38,19 @@ class ParserTest {
   }
 
   @Test
+  void testUtf8Identifiers() {
+    Parser p = new Parser("{\u00e9=1,\u4e8c=2} \u00c9tat donn\u00e9es;");
+    ParsedSchema schema = assertDoesNotThrow(p::parse);
+    assertEquals(schema.declarations.size(), 1);
+    var decl = schema.declarations.get(0);
+    assertEquals(decl.typeString, "\u00c9tat");
+    assertEquals(decl.name, "donn\u00e9es");
+    assertEquals(decl.enumValues.size(), 2);
+    assertEquals(decl.enumValues.get("\u00e9"), 1);
+    assertEquals(decl.enumValues.get("\u4e8c"), 2);
+  }
+
+  @Test
   void testSimpleTrailingSemi() {
     Parser p = new Parser("int32 a;");
     ParsedSchema schema = assertDoesNotThrow(p::parse);

--- a/wpiutil/src/test/java/org/wpilib/util/struct/parser/ParserTest.java
+++ b/wpiutil/src/test/java/org/wpilib/util/struct/parser/ParserTest.java
@@ -39,15 +39,15 @@ class ParserTest {
 
   @Test
   void testUtf8Identifiers() {
-    Parser p = new Parser("{\u00e9=1,\u4e8c=2} \u00c9tat donn\u00e9es;");
+    Parser p = new Parser("{😀=1,二=2} 🚀Type data💾;");
     ParsedSchema schema = assertDoesNotThrow(p::parse);
     assertEquals(schema.declarations.size(), 1);
     var decl = schema.declarations.get(0);
-    assertEquals(decl.typeString, "\u00c9tat");
-    assertEquals(decl.name, "donn\u00e9es");
+    assertEquals(decl.typeString, "🚀Type");
+    assertEquals(decl.name, "data💾");
     assertEquals(decl.enumValues.size(), 2);
-    assertEquals(decl.enumValues.get("\u00e9"), 1);
-    assertEquals(decl.enumValues.get("\u4e8c"), 2);
+    assertEquals(decl.enumValues.get("😀"), 1);
+    assertEquals(decl.enumValues.get("二"), 2);
   }
 
   @Test

--- a/wpiutil/src/test/native/cpp/struct/SchemaParserTest.cpp
+++ b/wpiutil/src/test/native/cpp/struct/SchemaParserTest.cpp
@@ -38,15 +38,15 @@ TEST_CASE("StructParserTest Simple", "[wpiutil][struct]") {
 }
 
 TEST_CASE("StructParserTest UTF8Identifiers", "[wpiutil][struct]") {
-  Parser p{"{\u00e9=1,\u4e8c=2} \u00c9tat donn\u00e9es;"};
+  Parser p{"{\U0001f600=1,\u4e8c=2} \U0001f680Type data\U0001f4be;"};
   ParsedSchema schema;
   REQUIRE(p.Parse(&schema));
   REQUIRE(schema.declarations.size() == 1u);
   auto& decl = schema.declarations[0];
-  CHECK(decl.typeString == "\u00c9tat");
-  CHECK(decl.name == "donn\u00e9es");
+  CHECK(decl.typeString == "\U0001f680Type");
+  CHECK(decl.name == "data\U0001f4be");
   REQUIRE(decl.enumValues.size() == 2u);
-  CHECK(decl.enumValues[0].first == "\u00e9");
+  CHECK(decl.enumValues[0].first == "\U0001f600");
   CHECK(decl.enumValues[0].second == 1);
   CHECK(decl.enumValues[1].first == "\u4e8c");
   CHECK(decl.enumValues[1].second == 2);

--- a/wpiutil/src/test/native/cpp/struct/SchemaParserTest.cpp
+++ b/wpiutil/src/test/native/cpp/struct/SchemaParserTest.cpp
@@ -37,6 +37,21 @@ TEST_CASE("StructParserTest Simple", "[wpiutil][struct]") {
   CHECK(decl.arraySize == 1u);
 }
 
+TEST_CASE("StructParserTest UTF8Identifiers", "[wpiutil][struct]") {
+  Parser p{"{\u00e9=1,\u4e8c=2} \u00c9tat donn\u00e9es;"};
+  ParsedSchema schema;
+  REQUIRE(p.Parse(&schema));
+  REQUIRE(schema.declarations.size() == 1u);
+  auto& decl = schema.declarations[0];
+  CHECK(decl.typeString == "\u00c9tat");
+  CHECK(decl.name == "donn\u00e9es");
+  REQUIRE(decl.enumValues.size() == 2u);
+  CHECK(decl.enumValues[0].first == "\u00e9");
+  CHECK(decl.enumValues[0].second == 1);
+  CHECK(decl.enumValues[1].first == "\u4e8c");
+  CHECK(decl.enumValues[1].second == 2);
+}
+
 TEST_CASE("StructParserTest SimpleTrailingSemi", "[wpiutil][struct]") {
   Parser p{"int32 a;"};
   ParsedSchema schema;


### PR DESCRIPTION
Java already did, as did python's wpistruct mechanism. Now C++ does too, and the specification explicitly calls it out.

🤖 generated