### PR TITLE
Fix bazel to work on Linux ARM64 hosts

### DIFF
--- a/shared/bazel/BUILD.bazel
+++ b/shared/bazel/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
+
 package(default_visibility = ["//visibility:public"])
 
 windows_flags = [
@@ -52,28 +54,37 @@ platform(
     ],
 )
 
+linux_exec_properties = {
+    "OSFamily": "Linux",
+    "container-image": "docker://wpilib/debian-base:trixie@sha256:4c20e850c88d9766a3aeaaf12901c9ca5e511b6ce59930046c187ce576fa1eeb",
+    "dockerAddCapabilities": "SYS_PTRACE",
+    "dockerReuse": "True",
+}
+
 platform(
-    name = "linux_host",
+    name = "linux_arm64",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    exec_properties = linux_exec_properties,
     flags = [
     ] + gcc_flags,
-    parents = [
-        "@platforms//host",
-    ],
 )
 
 platform(
     name = "linux_x86_64",
-    exec_properties = {
-        "OSFamily": "Linux",
-        "container-image": "docker://wpilib/debian-base:trixie@sha256:4c20e850c88d9766a3aeaaf12901c9ca5e511b6ce59930046c187ce576fa1eeb",
-        "dockerAddCapabilities": "SYS_PTRACE",
-        "dockerReuse": "True",
-    },
+    exec_properties = linux_exec_properties,
     flags = [
     ] + gcc_flags,
     parents = [
         "@wpilib_toolchains//platforms/linux_x86_64",
     ],
+)
+
+alias(
+    name = "linux_host",
+    actual = ":linux_arm64" if "@platforms//cpu:aarch64" in HOST_CONSTRAINTS else ":linux_x86_64",
 )
 
 platform(

--- a/shared/bazel/BUILD.bazel
+++ b/shared/bazel/BUILD.bazel
@@ -53,6 +53,15 @@ platform(
 )
 
 platform(
+    name = "linux_host",
+    flags = [
+    ] + gcc_flags,
+    parents = [
+        "@platforms//host",
+    ],
+)
+
+platform(
     name = "linux_x86_64",
     exec_properties = {
         "OSFamily": "Linux",

--- a/shared/bazel/compiler_flags/linux_flags.rc
+++ b/shared/bazel/compiler_flags/linux_flags.rc
@@ -36,5 +36,5 @@ build:linux --host_per_file_copt=external/.*\.cpp$,external/.*\.cc$@-Wno-missing
 build:linux --features=set_soname
 build:linux --host_features=set_soname
 
-build:linux --host_platform=//shared/bazel:linux_x86_64
-build:linux --platforms=//shared/bazel:linux_x86_64
+build:linux --host_platform=//shared/bazel:linux_host
+build:linux --platforms=//shared/bazel:linux_host

--- a/shared/bazel/rules/robotpy/robotpy_rules.bzl
+++ b/shared/bazel/rules/robotpy/robotpy_rules.bzl
@@ -5,6 +5,19 @@ load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_python//python:packaging.bzl", "py_wheel")
 load("//shared/bazel/rules/robotpy:compatibility_select.bzl", "robotpy_compatibility_select")
 
+_LINUX_PYBIND_COPTS = [
+    "-Wno-attributes",
+    "-Wno-unused-value",
+    "-Wno-deprecated",
+    "-Wno-deprecated-declarations",
+    "-Wno-unused-parameter",
+    "-Wno-redundant-move",
+    "-Wno-unused-but-set-variable",
+    "-Wno-unused-variable",
+    "-Wno-pessimizing-move",
+    "-Wno-overloaded-virtual",
+]
+
 def create_pybind_library(
         name,
         extension_name,
@@ -62,18 +75,8 @@ def create_pybind_library(
                 "-Wno-pessimizing-move",
                 "-Wno-unused-value",
             ],
-            "@bazel_tools//src/conditions:linux_x86_64": [
-                "-Wno-attributes",
-                "-Wno-unused-value",
-                "-Wno-deprecated",
-                "-Wno-deprecated-declarations",
-                "-Wno-unused-parameter",
-                "-Wno-redundant-move",
-                "-Wno-unused-but-set-variable",
-                "-Wno-unused-variable",
-                "-Wno-pessimizing-move",
-                "-Wno-overloaded-virtual",
-            ],
+            "@bazel_tools//src/conditions:linux_aarch64": _LINUX_PYBIND_COPTS,
+            "@bazel_tools//src/conditions:linux_x86_64": _LINUX_PYBIND_COPTS,
             "@bazel_tools//src/conditions:windows": [
             ],
         }),


### PR DESCRIPTION
I have no idea if this is the right fix, but 🤖 says it should still work on x86.

... but also, I feel like there was a different workaround for this in the past, but I don't remember what it was.