### PR TITLE
[wpilib] put the OpModeRobot#addOpMode class/lambda arguments at the end

### DIFF
--- a/design-docs/opmodes.md
+++ b/design-docs/opmodes.md
@@ -153,18 +153,16 @@ The `OpModeRobot` class is the base class for the user's `Robot` class.  It exte
 ```java
 public abstract class OpModeRobot extends RobotBase {
   // OpMode registration methods
-  public void addOpModeFactory(Supplier<OpMode> factory, RobotMode mode,
-      String name, String group, String description,
-      Color textColor, Color backgroundColor) {...}
+  public void addOpMode(RobotMode mode, String name, String group, String description,
+      Color textColor, Color backgroundColor, Supplier<OpMode> factory) {...}
 
   // add a particular opmode class (Java only)
-  public void addOpMode(Class<? extends OpMode> cls, RobotMode mode,
-      String name, String group, String description,
-      Color textColor, Color backgroundColor) {...}
-  public void addAnnotatedOpMode(Class<? extends OpMode> cls) {...}
+  public void addOpMode(RobotMode mode, String name, String group, String description,
+      Color textColor, Color backgroundColor, Class<? extends OpMode> cls) {...}
+  private void addAnnotatedOpMode(Class<? extends OpMode> cls) {...}
 
   // add all annotated opmodes in a package and nested packages
-  public void addAnnotatedOpModeClasses(Package pkg) {...}
+  private void addAnnotatedOpModeClasses(Package pkg) {...}
 
   public void removeOpMode(RobotMode mode, String name) {...}
   public void publishOpModes() {...}

--- a/wpilibc/src/main/native/cpp/framework/OpModeRobot.cpp
+++ b/wpilibc/src/main/native/cpp/framework/OpModeRobot.cpp
@@ -209,11 +209,12 @@ void OpModeRobotBase::EndCompetition() {
   }
 }
 
-void OpModeRobotBase::AddOpModeFactory(
-    OpModeFactory factory, RobotMode mode, std::string_view name,
-    std::string_view group, std::string_view description,
-    const wpi::util::Color& textColor,
-    const wpi::util::Color& backgroundColor) {
+void OpModeRobotBase::AddOpModeFactory(RobotMode mode, std::string_view name,
+                                       std::string_view group,
+                                       std::string_view description,
+                                       const wpi::util::Color& textColor,
+                                       const wpi::util::Color& backgroundColor,
+                                       OpModeFactory factory) {
   int64_t id = RobotState::AddOpMode(mode, name, group, description, textColor,
                                      backgroundColor);
   if (id != 0) {
@@ -221,14 +222,19 @@ void OpModeRobotBase::AddOpModeFactory(
   }
 }
 
-void OpModeRobotBase::AddOpModeFactory(OpModeFactory factory, RobotMode mode,
-                                       std::string_view name,
+void OpModeRobotBase::AddOpModeFactory(RobotMode mode, std::string_view name,
                                        std::string_view group,
-                                       std::string_view description) {
+                                       std::string_view description,
+                                       OpModeFactory factory) {
   int64_t id = RobotState::AddOpMode(mode, name, group, description);
   if (id != 0) {
     m_opModes[id] = OpModeData{std::string{name}, std::move(factory)};
   }
+}
+
+void OpModeRobotBase::AddOpModeFactory(RobotMode mode, std::string_view name,
+                                       OpModeFactory factory) {
+  AddOpModeFactory(mode, name, {}, {}, std::move(factory));
 }
 
 void OpModeRobotBase::RemoveOpMode(RobotMode mode, std::string_view name) {

--- a/wpilibc/src/main/native/include/wpi/framework/OpModeRobot.hpp
+++ b/wpilibc/src/main/native/include/wpi/framework/OpModeRobot.hpp
@@ -165,34 +165,46 @@ class OpModeRobotBase : public RobotBase {
    * opmode. It's necessary to call PublishOpModes() to make the added modes
    * visible to the driver station.
    *
-   * @param factory factory function
    * @param mode robot mode
    * @param name name of the operating mode
    * @param group group of the operating mode
    * @param description description of the operating mode
    * @param textColor text color
    * @param backgroundColor background color
+   * @param factory factory function
    */
-  void AddOpModeFactory(OpModeFactory factory, RobotMode mode,
-                        std::string_view name, std::string_view group,
-                        std::string_view description,
+  void AddOpModeFactory(RobotMode mode, std::string_view name,
+                        std::string_view group, std::string_view description,
                         const wpi::util::Color& textColor,
-                        const wpi::util::Color& backgroundColor);
+                        const wpi::util::Color& backgroundColor,
+                        OpModeFactory factory);
 
   /**
    * Adds an operating mode option using a factory function that creates the
    * opmode. It's necessary to call PublishOpModes() to make the added modes
    * visible to the driver station.
    *
-   * @param factory factory function
    * @param mode robot mode
    * @param name name of the operating mode
    * @param group group of the operating mode
    * @param description description of the operating mode
+   * @param factory factory function
    */
-  void AddOpModeFactory(OpModeFactory factory, RobotMode mode,
-                        std::string_view name, std::string_view group = {},
-                        std::string_view description = {});
+  void AddOpModeFactory(RobotMode mode, std::string_view name,
+                        std::string_view group, std::string_view description,
+                        OpModeFactory factory);
+
+  /**
+   * Adds an operating mode option using a factory function that creates the
+   * opmode. It's necessary to call PublishOpModes() to make the added modes
+   * visible to the driver station.
+   *
+   * @param mode robot mode
+   * @param name name of the operating mode
+   * @param factory factory function
+   */
+  void AddOpModeFactory(RobotMode mode, std::string_view name,
+                        OpModeFactory factory);
 
   /**
    * Removes an operating mode option. It's necessary to call PublishOpModes()
@@ -311,11 +323,11 @@ class OpModeRobot : public OpModeRobotBase {
                  const wpi::util::Color& backgroundColor) {
     if constexpr (detail::OneArgOpMode<T, Derived>) {
       AddOpModeFactory(
-          [this] { return std::make_unique<T>(*static_cast<Derived*>(this)); },
-          mode, name, group, description, textColor, backgroundColor);
+          mode, name, group, description, textColor, backgroundColor,
+          [this] { return std::make_unique<T>(*static_cast<Derived*>(this)); });
     } else if constexpr (detail::NoArgOpMode<T>) {
-      AddOpModeFactory([] { return std::make_unique<T>(); }, mode, name, group,
-                       description, textColor, backgroundColor);
+      AddOpModeFactory(mode, name, group, description, textColor,
+                       backgroundColor, [] { return std::make_unique<T>(); });
     }
   }
 
@@ -336,12 +348,12 @@ class OpModeRobot : public OpModeRobotBase {
                  std::string_view group = {},
                  std::string_view description = {}) {
     if constexpr (detail::OneArgOpMode<T, Derived>) {
-      AddOpModeFactory(
-          [this] { return std::make_unique<T>(*static_cast<Derived*>(this)); },
-          mode, name, group, description);
+      AddOpModeFactory(mode, name, group, description, [this] {
+        return std::make_unique<T>(*static_cast<Derived*>(this));
+      });
     } else if constexpr (detail::NoArgOpMode<T>) {
-      AddOpModeFactory([] { return std::make_unique<T>(); }, mode, name, group,
-                       description);
+      AddOpModeFactory(mode, name, group, description,
+                       [] { return std::make_unique<T>(); });
     }
   }
 };

--- a/wpilibc/src/main/python/semiwrap/OpModeRobot.yml
+++ b/wpilibc/src/main/python/semiwrap/OpModeRobot.yml
@@ -13,8 +13,9 @@ classes:
       NonePeriodic:
       AddOpModeFactory:
         overloads:
-          OpModeFactory, RobotMode, std::string_view, std::string_view, std::string_view:
-          ? OpModeFactory, RobotMode, std::string_view, std::string_view, std::string_view, const wpi::util::Color&, const wpi::util::Color&
+          RobotMode, std::string_view, OpModeFactory:
+          RobotMode, std::string_view, std::string_view, std::string_view, OpModeFactory:
+          ? RobotMode, std::string_view, std::string_view, std::string_view, const wpi::util::Color&, const wpi::util::Color&, OpModeFactory
           :
       RemoveOpMode:
       PublishOpModes:

--- a/wpilibc/src/main/python/wpilib/opmoderobot.py
+++ b/wpilibc/src/main/python/wpilib/opmoderobot.py
@@ -62,15 +62,15 @@ class OpModeRobot(OpModeRobotBase):
 
         if text_color is None or background_color is None:
             self.add_opmode_factory(
-                make_opmode_instance, mode, name, group or "", description or ""
+                mode, name, group or "", description or "", make_opmode_instance
             )
         else:
             self.add_opmode_factory(
-                make_opmode_instance,
                 mode,
                 name,
                 group or "",
                 description or "",
                 text_color,
                 background_color,
+                make_opmode_instance,
             )

--- a/wpilibc/src/test/native/cpp/OpModeLifecycleTest.cpp
+++ b/wpilibc/src/test/native/cpp/OpModeLifecycleTest.cpp
@@ -97,9 +97,9 @@ TEST_CASE_METHOD(OpModeLifecycleTest, "OpModeLifecycleTest EnabledTransition",
                  "[wpilibc]") {
   Counts counts;
   LifecycleRobot robot;
-  robot.AddOpModeFactory(
-      [&] { return std::make_unique<LifecycleOpMode>(counts); },
-      wpi::RobotMode::TELEOPERATED, "TestOpMode");
+  robot.AddOpModeFactory(wpi::RobotMode::TELEOPERATED, "TestOpMode", [&] {
+    return std::make_unique<LifecycleOpMode>(counts);
+  });
   robot.PublishOpModes();
 
   std::thread robotThread{[&] { robot.StartCompetition(); }};
@@ -144,12 +144,12 @@ TEST_CASE_METHOD(OpModeLifecycleTest,
   Counts counts1;
   Counts counts2;
   LifecycleRobot robot;
-  robot.AddOpModeFactory(
-      [&] { return std::make_unique<LifecycleOpMode>(counts1); },
-      wpi::RobotMode::TELEOPERATED, "OpMode1");
-  robot.AddOpModeFactory(
-      [&] { return std::make_unique<LifecycleOpMode>(counts2); },
-      wpi::RobotMode::TELEOPERATED, "OpMode2");
+  robot.AddOpModeFactory(wpi::RobotMode::TELEOPERATED, "OpMode1", [&] {
+    return std::make_unique<LifecycleOpMode>(counts1);
+  });
+  robot.AddOpModeFactory(wpi::RobotMode::TELEOPERATED, "OpMode2", [&] {
+    return std::make_unique<LifecycleOpMode>(counts2);
+  });
   robot.PublishOpModes();
 
   std::thread robotThread{[&] { robot.StartCompetition(); }};
@@ -202,12 +202,12 @@ TEST_CASE_METHOD(OpModeLifecycleTest,
   Counts counts1;
   Counts counts2;
   LifecycleRobot robot;
-  robot.AddOpModeFactory(
-      [&] { return std::make_unique<LifecycleOpMode>(counts1); },
-      wpi::RobotMode::TELEOPERATED, "OpMode1");
-  robot.AddOpModeFactory(
-      [&] { return std::make_unique<LifecycleOpMode>(counts2); },
-      wpi::RobotMode::TELEOPERATED, "OpMode2");
+  robot.AddOpModeFactory(wpi::RobotMode::TELEOPERATED, "OpMode1", [&] {
+    return std::make_unique<LifecycleOpMode>(counts1);
+  });
+  robot.AddOpModeFactory(wpi::RobotMode::TELEOPERATED, "OpMode2", [&] {
+    return std::make_unique<LifecycleOpMode>(counts2);
+  });
   robot.PublishOpModes();
 
   std::thread robotThread{[&] { robot.StartCompetition(); }};
@@ -246,9 +246,9 @@ TEST_CASE_METHOD(OpModeLifecycleTest,
                  "[wpilibc]") {
   std::atomic<uint32_t> callbackCount{0};
   LifecycleRobot robot;
-  robot.AddOpModeFactory(
-      [&] { return std::make_unique<CallbackOpMode>(callbackCount); },
-      wpi::RobotMode::TELEOPERATED, "CallbackOpMode");
+  robot.AddOpModeFactory(wpi::RobotMode::TELEOPERATED, "CallbackOpMode", [&] {
+    return std::make_unique<CallbackOpMode>(callbackCount);
+  });
   robot.PublishOpModes();
 
   std::thread robotThread{[&] { robot.StartCompetition(); }};
@@ -282,9 +282,9 @@ TEST_CASE_METHOD(OpModeLifecycleTest, "OpModeLifecycleTest InitialEnabledState",
                  "[wpilibc]") {
   Counts counts;
   LifecycleRobot robot;
-  robot.AddOpModeFactory(
-      [&] { return std::make_unique<LifecycleOpMode>(counts); },
-      wpi::RobotMode::TELEOPERATED, "TestOpMode");
+  robot.AddOpModeFactory(wpi::RobotMode::TELEOPERATED, "TestOpMode", [&] {
+    return std::make_unique<LifecycleOpMode>(counts);
+  });
   robot.PublishOpModes();
 
   std::thread robotThread{[&] { robot.StartCompetition(); }};
@@ -314,9 +314,9 @@ TEST_CASE_METHOD(OpModeLifecycleTest,
                  "OpModeLifecycleTest ReconstructionOnDisable", "[wpilibc]") {
   Counts counts;
   LifecycleRobot robot;
-  robot.AddOpModeFactory(
-      [&] { return std::make_unique<LifecycleOpMode>(counts); },
-      wpi::RobotMode::TELEOPERATED, "TestOpMode");
+  robot.AddOpModeFactory(wpi::RobotMode::TELEOPERATED, "TestOpMode", [&] {
+    return std::make_unique<LifecycleOpMode>(counts);
+  });
   robot.PublishOpModes();
 
   std::thread robotThread{[&] { robot.StartCompetition(); }};
@@ -363,9 +363,9 @@ TEST_CASE_METHOD(OpModeLifecycleTest, "OpModeLifecycleTest DeselectOpMode",
                  "[wpilibc]") {
   Counts counts;
   LifecycleRobot robot;
-  robot.AddOpModeFactory(
-      [&] { return std::make_unique<LifecycleOpMode>(counts); },
-      wpi::RobotMode::TELEOPERATED, "TestOpMode");
+  robot.AddOpModeFactory(wpi::RobotMode::TELEOPERATED, "TestOpMode", [&] {
+    return std::make_unique<LifecycleOpMode>(counts);
+  });
   robot.PublishOpModes();
 
   std::thread robotThread{[&] { robot.StartCompetition(); }};
@@ -397,9 +397,9 @@ TEST_CASE_METHOD(OpModeLifecycleTest, "OpModeLifecycleTest DsDisconnect",
                  "[wpilibc]") {
   Counts counts;
   LifecycleRobot robot;
-  robot.AddOpModeFactory(
-      [&] { return std::make_unique<LifecycleOpMode>(counts); },
-      wpi::RobotMode::TELEOPERATED, "TestOpMode");
+  robot.AddOpModeFactory(wpi::RobotMode::TELEOPERATED, "TestOpMode", [&] {
+    return std::make_unique<LifecycleOpMode>(counts);
+  });
   robot.PublishOpModes();
 
   std::thread robotThread{[&] { robot.StartCompetition(); }};

--- a/wpilibj/src/main/java/org/wpilib/framework/OpModeRobot.java
+++ b/wpilibj/src/main/java/org/wpilib/framework/OpModeRobot.java
@@ -155,23 +155,23 @@ public abstract class OpModeRobot extends RobotBase {
    * Adds an opmode using a factory function that creates the opmode. It's necessary to call
    * publishOpModes() to make the added mode visible to the driver station.
    *
-   * @param factory factory function to create the opmode
    * @param mode robot mode
    * @param name name of the operating mode
    * @param group group of the operating mode
    * @param description description of the operating mode
    * @param textColor text color, or null for default
    * @param backgroundColor background color, or null for default
+   * @param factory factory function to create the opmode
    * @throws IllegalArgumentException if class does not meet criteria
    */
-  public void addOpModeFactory(
-      Supplier<OpMode> factory,
+  public void addOpMode(
       RobotMode mode,
       String name,
       String group,
       String description,
       Color textColor,
-      Color backgroundColor) {
+      Color backgroundColor,
+      Supplier<OpMode> factory) {
     long id = RobotState.addOpMode(mode, name, group, description, textColor, backgroundColor);
     m_opModes.put(id, new OpModeFactory(name, factory));
   }
@@ -180,44 +180,43 @@ public abstract class OpModeRobot extends RobotBase {
    * Adds an opmode using a factory function that creates the opmode. It's necessary to call
    * publishOpModes() to make the added mode visible to the driver station.
    *
-   * @param factory factory function to create the opmode
    * @param mode robot mode
    * @param name name of the operating mode
    * @param group group of the operating mode
    * @param description description of the operating mode
+   * @param factory factory function to create the opmode
    * @throws IllegalArgumentException if class does not meet criteria
    */
-  public void addOpModeFactory(
-      Supplier<OpMode> factory, RobotMode mode, String name, String group, String description) {
-    addOpModeFactory(factory, mode, name, group, description, null, null);
+  public void addOpMode(
+      RobotMode mode, String name, String group, String description, Supplier<OpMode> factory) {
+    addOpMode(mode, name, group, description, null, null, factory);
   }
 
   /**
    * Adds an opmode using a factory function that creates the opmode. It's necessary to call
    * publishOpModes() to make the added mode visible to the driver station.
    *
-   * @param factory factory function to create the opmode
    * @param mode robot mode
    * @param name name of the operating mode
    * @param group group of the operating mode
+   * @param factory factory function to create the opmode
    * @throws IllegalArgumentException if class does not meet criteria
    */
-  public void addOpModeFactory(
-      Supplier<OpMode> factory, RobotMode mode, String name, String group) {
-    addOpModeFactory(factory, mode, name, group, "");
+  public void addOpMode(RobotMode mode, String name, String group, Supplier<OpMode> factory) {
+    addOpMode(mode, name, group, "", factory);
   }
 
   /**
    * Adds an opmode using a factory function that creates the opmode. It's necessary to call
    * publishOpModes() to make the added mode visible to the driver station.
    *
-   * @param factory factory function to create the opmode
    * @param mode robot mode
    * @param name name of the operating mode
+   * @param factory factory function to create the opmode
    * @throws IllegalArgumentException if class does not meet criteria
    */
-  public void addOpModeFactory(Supplier<OpMode> factory, RobotMode mode, String name) {
-    addOpModeFactory(factory, mode, name, "");
+  public void addOpMode(RobotMode mode, String name, Supplier<OpMode> factory) {
+    addOpMode(mode, name, "", factory);
   }
 
   /**
@@ -227,32 +226,32 @@ public abstract class OpModeRobot extends RobotBase {
    * specific parameter type is used). It's necessary to call publishOpModes() to make the added
    * mode visible to the driver station.
    *
-   * @param cls class to add
    * @param mode robot mode
    * @param name name of the operating mode
    * @param group group of the operating mode
    * @param description description of the operating mode
    * @param textColor text color, or null for default
    * @param backgroundColor background color, or null for default
+   * @param cls class to add
    * @throws IllegalArgumentException if class does not meet criteria
    */
   public void addOpMode(
-      Class<? extends OpMode> cls,
       RobotMode mode,
       String name,
       String group,
       String description,
       Color textColor,
-      Color backgroundColor) {
+      Color backgroundColor,
+      Class<? extends OpMode> cls) {
     checkOpModeClass(cls);
-    addOpModeFactory(
-        () -> constructOpModeClass(cls),
+    addOpMode(
         mode,
         name,
         group,
         description,
         textColor,
-        backgroundColor);
+        backgroundColor,
+        () -> constructOpModeClass(cls));
   }
 
   /**
@@ -262,16 +261,16 @@ public abstract class OpModeRobot extends RobotBase {
    * specific parameter type is used). It's necessary to call publishOpModes() to make the added
    * mode visible to the driver station.
    *
-   * @param cls class to add
    * @param mode robot mode
    * @param name name of the operating mode
    * @param group group of the operating mode
    * @param description description of the operating mode
+   * @param cls class to add
    * @throws IllegalArgumentException if class does not meet criteria
    */
   public void addOpMode(
-      Class<? extends OpMode> cls, RobotMode mode, String name, String group, String description) {
-    addOpMode(cls, mode, name, group, description, null, null);
+      RobotMode mode, String name, String group, String description, Class<? extends OpMode> cls) {
+    addOpMode(mode, name, group, description, null, null, cls);
   }
 
   /**
@@ -281,14 +280,14 @@ public abstract class OpModeRobot extends RobotBase {
    * specific parameter type is used). It's necessary to call publishOpModes() to make the added
    * mode visible to the driver station.
    *
-   * @param cls class to add
    * @param mode robot mode
    * @param name name of the operating mode
    * @param group group of the operating mode
+   * @param cls class to add
    * @throws IllegalArgumentException if class does not meet criteria
    */
-  public void addOpMode(Class<? extends OpMode> cls, RobotMode mode, String name, String group) {
-    addOpMode(cls, mode, name, group, "");
+  public void addOpMode(RobotMode mode, String name, String group, Class<? extends OpMode> cls) {
+    addOpMode(mode, name, group, "", cls);
   }
 
   /**
@@ -298,13 +297,13 @@ public abstract class OpModeRobot extends RobotBase {
    * specific parameter type is used). It's necessary to call publishOpModes() to make the added
    * mode visible to the driver station.
    *
-   * @param cls class to add
    * @param mode robot mode
    * @param name name of the operating mode
+   * @param cls class to add
    * @throws IllegalArgumentException if class does not meet criteria
    */
-  public void addOpMode(Class<? extends OpMode> cls, RobotMode mode, String name) {
-    addOpMode(cls, mode, name, "");
+  public void addOpMode(RobotMode mode, String name, Class<? extends OpMode> cls) {
+    addOpMode(mode, name, "", cls);
   }
 
   private void addOpModeClassImpl(

--- a/wpilibj/src/test/java/org/wpilib/framework/OpModeLifecycleTest.java
+++ b/wpilibj/src/test/java/org/wpilib/framework/OpModeLifecycleTest.java
@@ -29,28 +29,16 @@ class OpModeLifecycleTest {
     return OpModeOption.makeId(mode, name.hashCode());
   }
 
-  static class MockOpMode implements OpMode {
-    public final AtomicInteger constructedCount;
-    public final AtomicInteger disabledPeriodicCount;
-    public final AtomicInteger startCount;
-    public final AtomicInteger periodicCount;
-    public final AtomicInteger endCount;
-    public final AtomicInteger closeCount;
-
-    MockOpMode(
-        AtomicInteger constructedCount,
-        AtomicInteger disabledPeriodicCount,
-        AtomicInteger startCount,
-        AtomicInteger periodicCount,
-        AtomicInteger endCount,
-        AtomicInteger closeCount) {
-      this.constructedCount = constructedCount;
-      this.disabledPeriodicCount = disabledPeriodicCount;
-      this.startCount = startCount;
-      this.periodicCount = periodicCount;
-      this.endCount = endCount;
-      this.closeCount = closeCount;
-      this.constructedCount.incrementAndGet();
+  record MockOpMode(
+      AtomicInteger constructedCount,
+      AtomicInteger disabledPeriodicCount,
+      AtomicInteger startCount,
+      AtomicInteger periodicCount,
+      AtomicInteger endCount,
+      AtomicInteger closeCount)
+      implements OpMode {
+    MockOpMode {
+      constructedCount.incrementAndGet();
     }
 
     @Override
@@ -127,7 +115,9 @@ class OpModeLifecycleTest {
     AtomicInteger closeCount = new AtomicInteger(0);
 
     LifecycleRobot robot = new LifecycleRobot();
-    robot.addOpModeFactory(
+    robot.addOpMode(
+        RobotMode.TELEOPERATED,
+        "TestOpMode",
         () ->
             new MockOpMode(
                 constructedCount,
@@ -135,9 +125,7 @@ class OpModeLifecycleTest {
                 startCount,
                 periodicCount,
                 endCount,
-                closeCount),
-        RobotMode.TELEOPERATED,
-        "TestOpMode");
+                closeCount));
     robot.publishOpModes();
 
     Thread robotThread = new Thread(robot::startCompetition);
@@ -192,7 +180,9 @@ class OpModeLifecycleTest {
     AtomicInteger closeCount2 = new AtomicInteger(0);
 
     LifecycleRobot robot = new LifecycleRobot();
-    robot.addOpModeFactory(
+    robot.addOpMode(
+        RobotMode.TELEOPERATED,
+        "OpMode1",
         () ->
             new MockOpMode(
                 constructedCount1,
@@ -200,10 +190,10 @@ class OpModeLifecycleTest {
                 startCount1,
                 periodicCount1,
                 endCount1,
-                closeCount1),
+                closeCount1));
+    robot.addOpMode(
         RobotMode.TELEOPERATED,
-        "OpMode1");
-    robot.addOpModeFactory(
+        "OpMode2",
         () ->
             new MockOpMode(
                 constructedCount2,
@@ -211,9 +201,7 @@ class OpModeLifecycleTest {
                 startCount2,
                 periodicCount2,
                 endCount2,
-                closeCount2),
-        RobotMode.TELEOPERATED,
-        "OpMode2");
+                closeCount2));
     robot.publishOpModes();
 
     Thread robotThread = new Thread(robot::startCompetition);
@@ -273,7 +261,9 @@ class OpModeLifecycleTest {
     AtomicInteger closeCount2 = new AtomicInteger(0);
 
     LifecycleRobot robot = new LifecycleRobot();
-    robot.addOpModeFactory(
+    robot.addOpMode(
+        RobotMode.TELEOPERATED,
+        "OpMode1",
         () ->
             new MockOpMode(
                 constructedCount1,
@@ -281,10 +271,10 @@ class OpModeLifecycleTest {
                 startCount1,
                 periodicCount1,
                 endCount1,
-                closeCount1),
+                closeCount1));
+    robot.addOpMode(
         RobotMode.TELEOPERATED,
-        "OpMode1");
-    robot.addOpModeFactory(
+        "OpMode2",
         () ->
             new MockOpMode(
                 constructedCount2,
@@ -292,9 +282,7 @@ class OpModeLifecycleTest {
                 startCount2,
                 periodicCount2,
                 endCount2,
-                closeCount2),
-        RobotMode.TELEOPERATED,
-        "OpMode2");
+                closeCount2));
     robot.publishOpModes();
 
     Thread robotThread = new Thread(robot::startCompetition);
@@ -329,8 +317,8 @@ class OpModeLifecycleTest {
   void testGetCallbacksRunImmediatelyWhileDisabled() throws InterruptedException {
     AtomicInteger callbackCount = new AtomicInteger(0);
     LifecycleRobot robot = new LifecycleRobot();
-    robot.addOpModeFactory(
-        () -> new CallbackOpMode(callbackCount), RobotMode.TELEOPERATED, "CallbackOpMode");
+    robot.addOpMode(
+        RobotMode.TELEOPERATED, "CallbackOpMode", () -> new CallbackOpMode(callbackCount));
     robot.publishOpModes();
 
     Thread robotThread = new Thread(robot::startCompetition);
@@ -369,7 +357,9 @@ class OpModeLifecycleTest {
     AtomicInteger closeCount = new AtomicInteger(0);
 
     LifecycleRobot robot = new LifecycleRobot();
-    robot.addOpModeFactory(
+    robot.addOpMode(
+        RobotMode.TELEOPERATED,
+        "TestOpMode",
         () ->
             new MockOpMode(
                 constructedCount,
@@ -377,9 +367,7 @@ class OpModeLifecycleTest {
                 startCount,
                 periodicCount,
                 endCount,
-                closeCount),
-        RobotMode.TELEOPERATED,
-        "TestOpMode");
+                closeCount));
     robot.publishOpModes();
 
     Thread robotThread = new Thread(robot::startCompetition);
@@ -416,7 +404,9 @@ class OpModeLifecycleTest {
     AtomicInteger closeCount = new AtomicInteger(0);
 
     LifecycleRobot robot = new LifecycleRobot();
-    robot.addOpModeFactory(
+    robot.addOpMode(
+        RobotMode.TELEOPERATED,
+        "TestOpMode",
         () ->
             new MockOpMode(
                 constructedCount,
@@ -424,9 +414,7 @@ class OpModeLifecycleTest {
                 startCount,
                 periodicCount,
                 endCount,
-                closeCount),
-        RobotMode.TELEOPERATED,
-        "TestOpMode");
+                closeCount));
     robot.publishOpModes();
 
     Thread robotThread = new Thread(robot::startCompetition);
@@ -481,7 +469,9 @@ class OpModeLifecycleTest {
     AtomicInteger closeCount = new AtomicInteger(0);
 
     LifecycleRobot robot = new LifecycleRobot();
-    robot.addOpModeFactory(
+    robot.addOpMode(
+        RobotMode.TELEOPERATED,
+        "TestOpMode",
         () ->
             new MockOpMode(
                 constructedCount,
@@ -489,9 +479,7 @@ class OpModeLifecycleTest {
                 startCount,
                 periodicCount,
                 endCount,
-                closeCount),
-        RobotMode.TELEOPERATED,
-        "TestOpMode");
+                closeCount));
     robot.publishOpModes();
 
     Thread robotThread = new Thread(robot::startCompetition);
@@ -528,7 +516,9 @@ class OpModeLifecycleTest {
     AtomicInteger closeCount = new AtomicInteger(0);
 
     LifecycleRobot robot = new LifecycleRobot();
-    robot.addOpModeFactory(
+    robot.addOpMode(
+        RobotMode.TELEOPERATED,
+        "TestOpMode",
         () ->
             new MockOpMode(
                 constructedCount,
@@ -536,9 +526,7 @@ class OpModeLifecycleTest {
                 startCount,
                 periodicCount,
                 endCount,
-                closeCount),
-        RobotMode.TELEOPERATED,
-        "TestOpMode");
+                closeCount));
     robot.publishOpModes();
 
     Thread robotThread = new Thread(robot::startCompetition);

--- a/wpilibj/src/test/java/org/wpilib/framework/OpModeRobotTest.java
+++ b/wpilibj/src/test/java/org/wpilib/framework/OpModeRobotTest.java
@@ -117,24 +117,24 @@ class OpModeRobotTest {
   void addOpMode() {
     class MyMockRobot extends MockRobot {
       MyMockRobot() {
-        addOpModeFactory(
-            () -> new MockOpMode(),
+        addOpMode(
             RobotMode.AUTONOMOUS,
             "NoArgOpMode-Auto",
             "Group",
             "Description",
             Color.WHITE,
-            Color.BLACK);
-        addOpModeFactory(
-            () -> new OneArgOpMode(this),
+            Color.BLACK,
+            MockOpMode::new);
+        addOpMode(
             RobotMode.UTILITY,
             "OneArgOpMode-Test",
             "Group",
             "Description",
             Color.WHITE,
-            Color.BLACK);
-        addOpModeFactory(() -> new MockOpMode(), RobotMode.TELEOPERATED, "NoArgOpMode");
-        addOpModeFactory(() -> new OneArgOpMode(this), RobotMode.TELEOPERATED, "OneArgOpMode");
+            Color.BLACK,
+            () -> new OneArgOpMode(this));
+        addOpMode(RobotMode.TELEOPERATED, "NoArgOpMode", MockOpMode::new);
+        addOpMode(RobotMode.TELEOPERATED, "OneArgOpMode", () -> new OneArgOpMode(this));
         publishOpModes();
       }
     }
@@ -191,8 +191,8 @@ class OpModeRobotTest {
   void clearOpModes() {
     class MyMockRobot extends MockRobot {
       MyMockRobot() {
-        addOpModeFactory(() -> new MockOpMode(), RobotMode.TELEOPERATED, "NoArgOpMode");
-        addOpModeFactory(() -> new OneArgOpMode(this), RobotMode.TELEOPERATED, "OneArgOpMode");
+        addOpMode(RobotMode.TELEOPERATED, "NoArgOpMode", MockOpMode::new);
+        addOpMode(RobotMode.TELEOPERATED, "OneArgOpMode", () -> new OneArgOpMode(this));
         publishOpModes();
       }
     }
@@ -210,8 +210,8 @@ class OpModeRobotTest {
   void removeOpMode() {
     class MyMockRobot extends MockRobot {
       MyMockRobot() {
-        addOpModeFactory(() -> new MockOpMode(), RobotMode.TELEOPERATED, "NoArgOpMode");
-        addOpModeFactory(() -> new OneArgOpMode(this), RobotMode.TELEOPERATED, "OneArgOpMode");
+        addOpMode(RobotMode.TELEOPERATED, "NoArgOpMode", MockOpMode::new);
+        addOpMode(RobotMode.TELEOPERATED, "OneArgOpMode", () -> new OneArgOpMode(this));
         publishOpModes();
       }
     }
@@ -231,8 +231,8 @@ class OpModeRobotTest {
   void nonePeriodic() throws InterruptedException {
     class MyMockRobot extends MockRobot {
       MyMockRobot() {
-        addOpModeFactory(() -> new MockOpMode(), RobotMode.TELEOPERATED, "NoArgOpMode");
-        addOpModeFactory(() -> new OneArgOpMode(this), RobotMode.TELEOPERATED, "OneArgOpMode");
+        addOpMode(RobotMode.TELEOPERATED, "NoArgOpMode", MockOpMode::new);
+        addOpMode(RobotMode.TELEOPERATED, "OneArgOpMode", () -> new OneArgOpMode(this));
         publishOpModes();
       }
     }
@@ -256,7 +256,7 @@ class OpModeRobotTest {
   void robotPeriodic() throws InterruptedException {
     class MyMockRobot extends MockRobot {
       MyMockRobot() {
-        addOpModeFactory(() -> new MockOpMode(), RobotMode.TELEOPERATED, "TestOpMode");
+        addOpMode(RobotMode.TELEOPERATED, "TestOpMode", MockOpMode::new);
         publishOpModes();
       }
     }


### PR DESCRIPTION
this just looks nicer imo tbh (and allows kotlin users to get trailing lambda syntax)

I didn't do it for C++ bc it breaks the way C++ default arguments work