### PR TITLE
[javac] Add annotation processor to validate correct usage of opmode annotations

### DIFF
--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationProcessor.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationProcessor.java
@@ -1,0 +1,73 @@
+package org.wpilib.javacplugin;
+
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+
+/**
+ * Detects usages of OpMode annotations on classes that do not implement the OpMode interface and
+ * non-concrete types (abstract classes, enums, or interfaces) with an annotation.
+ */
+public class OpModeAnnotationProcessor extends AbstractProcessor {
+  @Override
+  public Set<String> getSupportedAnnotationTypes() {
+    return Set.of(
+        "org.wpilib.opmode.Autonomous", "org.wpilib.opmode.Teleop", "org.wpilib.opmode.Utility");
+  }
+
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latestSupported();
+  }
+
+  @Override
+  public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    final Messager messager = processingEnv.getMessager();
+
+    TypeElement opmodeType =
+        processingEnv.getElementUtils().getTypeElement("org.wpilib.opmode.OpMode");
+
+    for (TypeElement annotationType : annotations) {
+      for (Element element : roundEnv.getElementsAnnotatedWith(annotationType)) {
+        if (!(element instanceof TypeElement type)) {
+          // Can't get here; the annotation types only declare ElementType.TYPE as the target.
+          continue;
+        }
+
+        if (isNonConcreteType(type)) {
+          // Not an instantiable type
+          messager.printMessage(
+              Diagnostic.Kind.ERROR,
+              "The @"
+                  + annotationType.getSimpleName()
+                  + " OpMode annotation can only be used on non-abstract classes",
+              type);
+        }
+
+        if (!processingEnv.getTypeUtils().isAssignable(type.asType(), opmodeType.asType())) {
+          // Doesn't implement `OpMode` or extend a class that does
+          messager.printMessage(
+              Diagnostic.Kind.ERROR,
+              "The @"
+                  + annotationType.getSimpleName()
+                  + " OpMode annotation can only be used on classes that implement the "
+                  + "org.wpilib.opmode.OpMode interface or extend a class that does",
+              type);
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private static boolean isNonConcreteType(TypeElement type) {
+    return type.getModifiers().contains(Modifier.ABSTRACT) || type.getKind() == ElementKind.ENUM;
+  }
+}

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationProcessor.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationProcessor.java
@@ -1,3 +1,7 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package org.wpilib.javacplugin;
 
 import java.util.Set;

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationValidator.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationValidator.java
@@ -23,7 +23,7 @@ import javax.lang.model.element.VariableElement;
 import javax.tools.Diagnostic;
 
 /**
- * Validates opmode annotations {@code @Autonomous}, {@code @Teleop}, {@code @TestOpMode}.
+ * Validates opmode annotations {@code @Autonomous}, {@code @Teleop}, {@code @Utility}.
  *
  * <p>Requirements:
  *
@@ -83,9 +83,9 @@ public class OpModeAnnotationValidator implements TaskListener {
       CharSequence qname = typeElem.getQualifiedName();
       boolean isAutonomous = "org.wpilib.opmode.Autonomous".contentEquals(qname);
       boolean isTeleop = "org.wpilib.opmode.Teleop".contentEquals(qname);
-      boolean isTestOpMode = "org.wpilib.opmode.TestOpMode".contentEquals(qname);
+      boolean isUtilityOpMode = "org.wpilib.opmode.Utility".contentEquals(qname);
 
-      if (!(isAutonomous || isTeleop || isTestOpMode)) {
+      if (!(isAutonomous || isTeleop || isUtilityOpMode)) {
         return super.visitAnnotation(node, unused);
       }
 

--- a/javacPlugin/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/javacPlugin/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,2 @@
+org.wpilib.javacplugin.OpModeAnnotationProcessor
 org.wpilib.javacplugin.PostConstructionInitializerProcessor

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/OpModeAnnotationProcessorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/OpModeAnnotationProcessorTest.java
@@ -1,3 +1,7 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package org.wpilib.javacplugin;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/OpModeAnnotationProcessorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/OpModeAnnotationProcessorTest.java
@@ -1,0 +1,110 @@
+package org.wpilib.javacplugin;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.wpilib.javacplugin.CompileTestUtils.kJavaVersionOptions;
+
+import com.google.common.collect.Sets;
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class OpModeAnnotationProcessorTest {
+  private enum ClassType {
+    CONCRETE("class"),
+    ABSTRACT("abstract class"),
+    ENUM("enum"),
+    INTERFACE("interface"),
+    ;
+    private final String declaration;
+
+    ClassType(String declaration) {
+      this.declaration = declaration;
+    }
+  }
+
+  @ParameterizedTest(name = "@{0} [inherit={1}, classType={2}]")
+  @MethodSource("configurations")
+  void test(String annotationName, boolean inherit, ClassType classType) {
+    String source = generateOpModeClassSource(annotationName, inherit, classType);
+
+    Compilation compilation =
+        javac()
+            .withOptions(kJavaVersionOptions)
+            .withProcessors(new OpModeAnnotationProcessor())
+            .compile(JavaFileObjects.forSourceString("example.Example", source));
+
+    final String nonAbstractErrorMessage =
+        "The @" + annotationName + " OpMode annotation can only be used on non-abstract classes";
+    final String implementationErrorMessage =
+        "The @"
+            + annotationName
+            + " OpMode annotation can only be used on classes that implement the "
+            + "org.wpilib.opmode.OpMode interface or extend a class that does";
+
+    if (!inherit) {
+      assertThat(compilation).failed();
+      var errors = compilation.errors();
+      if (classType != ClassType.CONCRETE) {
+        assertEquals(2, errors.size());
+        var error1 = errors.getFirst();
+        var error2 = errors.getLast();
+        assertEquals(nonAbstractErrorMessage, error1.getMessage(null));
+        assertEquals(implementationErrorMessage, error2.getMessage(null));
+      } else {
+        assertEquals(1, errors.size());
+        var error1 = errors.getFirst();
+        assertEquals(implementationErrorMessage, error1.getMessage(null));
+      }
+    } else if (classType != ClassType.CONCRETE) {
+      assertThat(compilation).failed();
+      var errors = compilation.errors();
+      assertEquals(1, errors.size());
+      var error1 = errors.getFirst();
+      assertEquals(nonAbstractErrorMessage, error1.getMessage(null));
+    } else {
+      // Both inheriting and a concrete class; should be valid
+      assertThat(compilation).succeededWithoutWarnings();
+    }
+  }
+
+  private static String generateOpModeClassSource(
+      String annotationName, boolean inherit, ClassType classType) {
+    String sourceTemplate =
+        """
+        package example;
+
+        import org.wpilib.opmode.OpMode;
+        import org.wpilib.opmode.Autonomous;
+        import org.wpilib.opmode.Teleop;
+        import org.wpilib.opmode.Utility;
+
+        @%s
+        public %s Example %s {
+        }
+        """;
+
+    String extensionDeclaration =
+        classType == ClassType.INTERFACE ? "extends OpMode" : "implements OpMode";
+
+    return sourceTemplate.formatted(
+        annotationName, classType.declaration, inherit ? extensionDeclaration : "");
+  }
+
+  private static Stream<Arguments> configurations() {
+    Set<Object> annotations = Set.of("Autonomous", "Teleop", "Utility");
+    Set<Object> inheritOptions = Set.of(true, false);
+    Set<ClassType> classTypes = Set.of(ClassType.values());
+
+    Set<List<Object>> allCombinations =
+        Sets.cartesianProduct(annotations, inheritOptions, classTypes);
+
+    return allCombinations.stream().map(args -> Arguments.arguments(args.toArray()));
+  }
+}

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/OpModeAnnotationValidatorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/OpModeAnnotationValidatorTest.java
@@ -53,7 +53,7 @@ class OpModeAnnotationValidatorTest {
 
       @Retention(RetentionPolicy.RUNTIME)
       @Target(ElementType.TYPE)
-      public @interface TestOpMode {
+      public @interface Utility {
         String name() default "";
         String description() default "";
         String group() default "";
@@ -70,7 +70,7 @@ class OpModeAnnotationValidatorTest {
 
         @Autonomous(name = "Short Name", description = "Short Description", group = "Short Group")
         @Teleop(name = "Short Name", description = "Short Description", group = "Short Group")
-        @TestOpMode(name = "Short Name", description = "Short Description", group = "Short Group")
+        @Utility(name = "Short Name", description = "Short Description", group = "Short Group")
         class Example {
         }
         """;
@@ -84,7 +84,7 @@ class OpModeAnnotationValidatorTest {
                 JavaFileObjects.forSourceString(
                     "org.wpilib.opmode.Teleop", TELEOP_ANNOTATION_SOURCE),
                 JavaFileObjects.forSourceString(
-                    "org.wpilib.opmode.TestOpMode", TEST_OPMODE_ANNOTATION_SOURCE),
+                    "org.wpilib.opmode.Utility", TEST_OPMODE_ANNOTATION_SOURCE),
                 JavaFileObjects.forSourceString("wpilib.robot.Example", source));
 
     assertThat(compilation).succeededWithoutWarnings();
@@ -108,7 +108,7 @@ class OpModeAnnotationValidatorTest {
           description = "This is significantly longer than sixty four characters (it's ninety nine, if you bother to count!)",
           group = "More than twelve characters long"
         )
-        @TestOpMode(
+        @Utility(
           name = "This is much longer than thirty six characters (I counted them all myself)",
           description = "This is significantly longer than sixty four characters (it's ninety nine, if you bother to count!)",
           group = "More than twelve characters long"
@@ -126,7 +126,7 @@ class OpModeAnnotationValidatorTest {
                 JavaFileObjects.forSourceString(
                     "org.wpilib.opmode.Teleop", TELEOP_ANNOTATION_SOURCE),
                 JavaFileObjects.forSourceString(
-                    "org.wpilib.opmode.TestOpMode", TEST_OPMODE_ANNOTATION_SOURCE),
+                    "org.wpilib.opmode.Utility", TEST_OPMODE_ANNOTATION_SOURCE),
                 JavaFileObjects.forSourceString("wpilib.robot.Example", source));
 
     assertThat(compilation).failed();
@@ -155,13 +155,11 @@ class OpModeAnnotationValidatorTest {
 
     // TestOpMode
     assertEquals(
-        "@TestOpMode opmode name must be <= 32 characters (was 74)",
-        errors.get(6).getMessage(null));
+        "@Utility opmode name must be <= 32 characters (was 74)", errors.get(6).getMessage(null));
     assertEquals(
-        "@TestOpMode opmode group must be <= 12 characters (was 32)",
-        errors.get(7).getMessage(null));
+        "@Utility opmode group must be <= 12 characters (was 32)", errors.get(7).getMessage(null));
     assertEquals(
-        "@TestOpMode opmode description must be <= 64 characters (was 99)",
+        "@Utility opmode description must be <= 64 characters (was 99)",
         errors.get(8).getMessage(null));
   }
 }

--- a/styleguide/spotbugs-exclude.xml
+++ b/styleguide/spotbugs-exclude.xml
@@ -184,6 +184,7 @@
       <Class name="org.wpilib.math.system.LinearSystem" />
       <Class name="org.wpilib.math.trajectory.Trajectory" />
       <Class name="org.wpilib.command3.SchedulerTelemetryTests" />
+      <Class name="org.wpilib.javacplugin.OpModeAnnotationProcessorTest" />
     </Or>
   </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Opmode annotations can only be placed on concrete types (just `class` - not `abstract class`, `enum`, or `interface`), which must also implement the OpMode interface or inherit from a type that does (eg PeriodicOpMode)

Note that this is distinct from OpModeAnnotationValidator, which validates the AST and inspects string literals

Also fixes the validator code still referencing the renamed `@TestOpMode`; it was missed when the annotation was renamed in #8782 