### PR TITLE
[wpimath] Fix typo in isStabilizable() and isDetectable() Javadocs

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/system/LinearSystemUtil.java
+++ b/wpimath/src/main/java/org/wpilib/math/system/LinearSystemUtil.java
@@ -18,8 +18,8 @@ public final class LinearSystemUtil {
    * Returns true if (A, B) is a stabilizable pair.
    *
    * <p>(A, B) is stabilizable if and only if the uncontrollable eigenvalues of A, if any, have
-   * absolute values less than one, where an eigenvalue is uncontrollable if rank([λI - A, B]) %3C n
-   * where n is the number of states.
+   * absolute values less than one, where an eigenvalue is uncontrollable if rank([λI - A, B]) &lt;
+   * n where n is the number of states.
    *
    * @param <States> Num representing the size of A.
    * @param <Inputs> Num representing the columns of B.
@@ -37,8 +37,8 @@ public final class LinearSystemUtil {
    * Returns true if (A, C) is a detectable pair.
    *
    * <p>(A, C) is detectable if and only if the unobservable eigenvalues of A, if any, have absolute
-   * values less than one, where an eigenvalue is unobservable if rank([λI - A; C]) %3C n where n is
-   * the number of states.
+   * values less than one, where an eigenvalue is unobservable if rank([λI - A; C]) &lt; n where n
+   * is the number of states.
    *
    * @param <States> Num representing the size of A.
    * @param <Outputs> Num representing the rows of C.


### PR DESCRIPTION
Javadoc doesn't render the `%3C` as a less-than symbol:
https://github.wpilib.org/allwpilib/docs/development/java/org/wpilib/math/system/LinearSystemUtil.html#isStabilizable(org.wpilib.math.linalg.Matrix,org.wpilib.math.linalg.Matrix)

<img width="1365" height="1069" alt="Screenshot_20260810_160451" src="https://github.com/user-attachments/assets/e99bf7aa-8197-46e1-9f8e-17a87ce9b6d7" />