### PR TITLE
[wpiutil] Fix Signal_mt connect race

### DIFF
--- a/wpiutil/src/main/native/thirdparty/sigslot/include/wpi/util/Signal.h
+++ b/wpiutil/src/main/native/thirdparty/sigslot/include/wpi/util/Signal.h
@@ -584,13 +584,18 @@ public:
      */
     template <typename Callable>
     void connect(Callable && c) {
-        if (!m_func) {
-          m_func = std::forward<Callable>(c);
-        } else {
-          using slot_t = detail::Slot<Callable, arg_list>;
-          auto s = std::make_shared<slot_t>(std::forward<Callable>(c));
-          add_slot(s);
+        std::function<void(T...)> func{std::forward<Callable>(c)};
+        {
+            lock_type lock(m_mutex);
+            if (!m_func) {
+                m_func = std::move(func);
+                return;
+            }
         }
+
+        using slot_t = detail::Slot<std::function<void(T...)>, arg_list>;
+        auto s = std::make_shared<slot_t>(std::move(func));
+        add_slot(s);
     }
 
     /**

--- a/wpiutil/src/main/native/thirdparty/sigslot/include/wpi/util/Signal.h
+++ b/wpiutil/src/main/native/thirdparty/sigslot/include/wpi/util/Signal.h
@@ -584,17 +584,16 @@ public:
      */
     template <typename Callable>
     void connect(Callable && c) {
-        std::function<void(T...)> func{std::forward<Callable>(c)};
         {
             lock_type lock(m_mutex);
             if (!m_func) {
-                m_func = std::move(func);
+                m_func = std::forward<Callable>(c);
                 return;
             }
         }
 
-        using slot_t = detail::Slot<std::function<void(T...)>, arg_list>;
-        auto s = std::make_shared<slot_t>(std::move(func));
+        using slot_t = detail::Slot<Callable, arg_list>;
+        auto s = std::make_shared<slot_t>(std::forward<Callable>(c));
         add_slot(s);
     }
 

--- a/wpiutil/src/test/native/cpp/sigslot/signal-threaded.cpp
+++ b/wpiutil/src/test/native/cpp/sigslot/signal-threaded.cpp
@@ -37,6 +37,7 @@ SOFTWARE.
 
 #include <array>
 #include <atomic>
+#include <barrier>
 #include <thread>
 
 #include <catch2/catch_template_test_macros.hpp>
@@ -105,6 +106,27 @@ TEST_CASE("SignalTest ThreadedEmission", "[wpiutil][sigslot]") {
   }
 
   REQUIRE(sum == 100000);
+}
+
+TEST_CASE("SignalTest ConcurrentConnectAndEmission", "[wpiutil][sigslot]") {
+  Signal_mt<> sig;
+  std::barrier syncPoint{2};
+  std::thread emitter{[&] {
+    for (int i = 0; i < 10000; ++i) {
+      syncPoint.arrive_and_wait();
+      sig();
+      syncPoint.arrive_and_wait();
+    }
+  }};
+
+  for (int i = 0; i < 10000; ++i) {
+    sig.disconnect_all();
+    syncPoint.arrive_and_wait();
+    sig.connect([] {});
+    syncPoint.arrive_and_wait();
+  }
+
+  emitter.join();
 }
 
 }  // namespace wpi::util


### PR DESCRIPTION
Likely fixes TSAN issue raised by https://github.com/wpilibsuite/allwpilib/pull/9261. Here's what the 🤖  says:

---

`Signal_mt` is documented as thread-safe, but its first `connect()` accessed the internal `std::function` without locking. If another thread emitted the signal simultaneously, it could read the function while it was being initialized, causing a data race and potentially invoking a partially constructed callback.

The fix constructs the callback first, then installs it while holding the signal mutex. Subsequent connections continue through the existing locked slot path. A barrier-synchronized regression test repeatedly connects and emits concurrently and verifies the race is clean under TSan.