### PR TITLE
[bazel] Always enable strict action env

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,7 @@ common --enable_platform_specific_config
 # Make bazel 8 work for us.
 build --experimental_cc_static_library
 build --experimental_cc_shared_library
+build --incompatible_strict_action_env
 
 build --java_language_version=25
 build --java_runtime_version=remotejdk_25
@@ -71,7 +72,7 @@ build:linux --strategy=NpmLifecycleHook=remote,sandboxed,standalone
 build:macos --strategy=NpmLifecycleHook=remote,sandboxed,standalone
 
 common:remote --config=common_cache
-build:remote --incompatible_strict_action_env --experimental_inmemory_dotd_files --experimental_inmemory_jdeps_files --experimental_remote_merkle_tree_cache --incompatible_allow_tags_propagation
+build:remote --experimental_inmemory_dotd_files --experimental_inmemory_jdeps_files --experimental_remote_merkle_tree_cache --incompatible_allow_tags_propagation
 # Specify your cluster as follows:
 # build:remote --remote_executor=grpcs://engflow.example.com --bes_backend=grpcs://engflow.example.com --bes_results_url=https://engflow.example.com/invocation/
 build:remote --jobs=100


### PR DESCRIPTION
`--incompatible_strict_action_env` is enabled by default in Bazel 9, so there's no reason to always enable it now. Not always enabling this flag results in busting the analysis cache, slowing down builds when switching between RBE and local execution.

    WARNING: Build option --incompatible_strict_action_env has changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).

I get a fair few cache misses when using our bazel-remote cache locally; this flag defaulting to false seems to be a major culprit.