### PR TITLE
[wpimath] Make Translation2d.getAngle() return optional

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/geometry/Translation2d.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/Translation2d.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.Optional;
 import org.wpilib.math.geometry.proto.Translation2dProto;
 import org.wpilib.math.geometry.struct.Translation2dStruct;
 import org.wpilib.math.interpolation.Interpolatable;
@@ -189,10 +190,14 @@ public final class Translation2d
   /**
    * Returns the angle this translation forms with the positive X axis.
    *
-   * @return The angle of the translation
+   * @return The angle of the translation, or an empty Optional if the angle was undefined.
    */
-  public Rotation2d getAngle() {
-    return new Rotation2d(m_x, m_y);
+  public Optional<Rotation2d> getAngle() {
+    if (Math.hypot(m_x, m_y) > 1e-6) {
+      return Optional.of(new Rotation2d(m_x, m_y));
+    } else {
+      return Optional.empty();
+    }
   }
 
   /**

--- a/wpimath/src/main/native/include/wpi/math/geometry/Translation2d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Translation2d.hpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <initializer_list>
+#include <optional>
 #include <span>
 
 #include <Eigen/Core>
@@ -143,10 +144,15 @@ class WPILIB_DLLEXPORT Translation2d final {
   /**
    * Returns the angle this translation forms with the positive X axis.
    *
-   * @return The angle of the translation
+   * @return The angle of the translation, or an empty optional if the angle was
+   *     undefined.
    */
-  constexpr Rotation2d Angle() const {
-    return Rotation2d{m_x.value(), m_y.value()};
+  constexpr std::optional<Rotation2d> Angle() const {
+    if (wpi::units::math::hypot(m_x, m_y) > 1e-6_m) {
+      return Rotation2d{m_x.value(), m_y.value()};
+    } else {
+      return {};
+    }
   }
 
   /**

--- a/wpimath/src/test/java/org/wpilib/math/kinematics/SwerveDriveKinematicsTest.java
+++ b/wpimath/src/test/java/org/wpilib/math/kinematics/SwerveDriveKinematicsTest.java
@@ -445,7 +445,7 @@ class SwerveDriveKinematicsTest {
         Arrays.stream(m_kinematics.getModules())
             .map(
                 m -> {
-                  Rotation2d radiusAngle = m.getAngle();
+                  Rotation2d radiusAngle = m.getAngle().orElse(Rotation2d.kZero);
 
                   // Tangential acceleration: perpendicular to radius (90° CCW from radius)
                   Rotation2d tangentialDirection = radiusAngle.rotateBy(Rotation2d.kCCW_Pi_2);

--- a/wpimath/src/test/native/cpp/kinematics/SwerveDriveKinematicsTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/SwerveDriveKinematicsTest.cpp
@@ -426,7 +426,8 @@ TEST_CASE_METHOD(SwerveDriveKinematicsTest,
 
   std::array<Rotation2d, 4> expectedAngles;
   for (size_t i = 0; i < 4; i++) {
-    Rotation2d radiusAngle = m_kinematics.GetModules()[i].Angle();
+    Rotation2d radiusAngle =
+        m_kinematics.GetModules()[i].Angle().value_or(0_deg);
 
     // Tangential acceleration: perpendicular to radius (90° CCW from radius)
     Rotation2d tangentialDirection = radiusAngle + Rotation2d{90_deg};


### PR DESCRIPTION
This avoids violating the Rotation2d constructor's invariants and gives users a better handle for deciding what angle to use instead.