### PR TITLE
[glass] Add NT button for System server, add force restart

### DIFF
--- a/glass/src/libnt/native/cpp/NetworkTablesSettings.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTablesSettings.cpp
@@ -30,6 +30,7 @@ void NetworkTablesSettings::Thread::Main() {
 
     // clear restart flag
     m_restart = false;
+    bool reconnect = std::exchange(m_reconnect, false);
 
     int mode;
     bool dsClient;
@@ -41,9 +42,9 @@ void NetworkTablesSettings::Thread::Main() {
       // release lock while stopping to avoid blocking GUI
       lock.unlock();
 
-      // if just changing servers in client mode, no need to stop and restart
+      // Changing servers can be done in place unless a reconnect was requested.
       unsigned int curMode = wpi::nt::GetNetworkMode(m_inst);
-      if ((mode == 0 || mode == 2) ||
+      if (reconnect || (mode == 0 || mode == 2) ||
           (mode == 1 && (curMode & NT_NET_MODE_CLIENT) == 0)) {
         wpi::nt::StopClient(m_inst);
         wpi::nt::StopServer(m_inst);
@@ -100,7 +101,7 @@ NetworkTablesSettings::NetworkTablesSettings(std::string_view clientName,
       m_port{storage.GetInt("port", NT_DEFAULT_PORT)},
       m_dsClient{storage.GetBool("dsClient", true)},
       m_requireTeamNumberMatch{
-          storage.GetBool("requireTeamNumberMatch", true)} {
+          storage.GetBool("requireTeamNumberMatch", false)} {
   m_thread.Start(inst);
 }
 
@@ -113,6 +114,7 @@ void NetworkTablesSettings::Update() {
   // do actual operation on thread
   auto thr = m_thread.GetThread();
   thr->m_restart = true;
+  thr->m_reconnect |= std::exchange(m_reconnect, false);
   thr->m_mode = m_mode.GetValue();
   thr->m_iniName = m_persistentFilename;
   thr->m_serverTeam = m_serverTeam;
@@ -132,6 +134,8 @@ static void LimitPortRange(int* port) {
   }
 }
 
+static constexpr int kSystemServerPort = 6810;
+
 bool NetworkTablesSettings::Display() {
   m_mode.Combo("Mode", m_serverOption ? 3 : 2);
   switch (m_mode.GetValue()) {
@@ -149,6 +153,10 @@ bool NetworkTablesSettings::Display() {
       ImGui::SameLine();
       if (ImGui::SmallButton("Default")) {
         m_port = NT_DEFAULT_PORT;
+      }
+      ImGui::SameLine();
+      if (ImGui::SmallButton("System Server")) {
+        m_port = kSystemServerPort;
       }
       ImGui::InputText("Network Identity", &m_clientName);
       if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
@@ -193,6 +201,13 @@ bool NetworkTablesSettings::Display() {
       break;
   }
   if (ImGui::Button("Apply")) {
+    m_reconnect = false;
+    m_restart = true;
+    return true;
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Apply and Reconnect")) {
+    m_reconnect = true;
     m_restart = true;
     return true;
   }

--- a/glass/src/libnt/native/include/wpi/glass/networktables/NetworkTablesSettings.hpp
+++ b/glass/src/libnt/native/include/wpi/glass/networktables/NetworkTablesSettings.hpp
@@ -34,6 +34,7 @@ class NetworkTablesSettings {
 
  private:
   bool m_restart = true;
+  bool m_reconnect = false;
   bool m_serverOption = true;
   EnumSetting m_mode;
   std::string& m_persistentFilename;
@@ -52,6 +53,7 @@ class NetworkTablesSettings {
 
     NT_Inst m_inst;
     bool m_restart = false;
+    bool m_reconnect = false;
     int m_mode;
     std::string m_iniName;
     std::string m_serverTeam;


### PR DESCRIPTION
I get really annoyed that I have to set the system to disabled and then client in order to reconnect when switching ports. Also a button to switch to the System server port is super useful