### PR TITLE
[wpinet] Reduce delays in ParallelTCPServer and DsClient

### DIFF
--- a/wpinet/src/main/native/cpp/DsClient.cpp
+++ b/wpinet/src/main/native/cpp/DsClient.cpp
@@ -93,7 +93,7 @@ void DsClient::ParseJson() {
   WPI_DEBUG4(m_logger, "DsClient JSON: {}", m_json);
   std::string ip;
   try {
-    ip = wpi::util::json::parse_or_throw(m_json).at("robotIP").get_string();
+    ip = wpi::util::json::parse_or_throw(m_json).at("robotIp").get_string();
   } catch (std::logic_error& e) {
     WPI_INFO(m_logger, "DsClient JSON error: {}", e.what());
     return;

--- a/wpinet/src/main/native/cpp/ParallelTcpConnector.cpp
+++ b/wpinet/src/main/native/cpp/ParallelTcpConnector.cpp
@@ -112,6 +112,21 @@ void ParallelTcpConnector::Connect() {
 
   // kick off parallel lookups
   for (auto&& server : m_servers) {
+    sockaddr_in address4;
+    if (uv::NameToAddr(server.first, server.second, &address4) == 0) {
+      StartConnectionAttempt(reinterpret_cast<const sockaddr&>(address4),
+                             sizeof(address4), nullptr);
+      continue;
+    }
+
+    sockaddr_in6 address6;
+    if (!m_ipv4Only &&
+        uv::NameToAddr(server.first, server.second, &address6) == 0) {
+      StartConnectionAttempt(reinterpret_cast<const sockaddr&>(address6),
+                             sizeof(address6), nullptr);
+      continue;
+    }
+
     auto req = std::make_shared<uv::GetAddrInfoReq>();
     m_resolvers.emplace_back(req);
 
@@ -123,67 +138,7 @@ void ParallelTcpConnector::Connect() {
 
           // kick off parallel connection attempts
           for (auto ai = &addrinfo; ai; ai = ai->ai_next) {
-            // check for duplicates
-            bool duplicate = false;
-            for (auto&& attempt : m_attempts) {
-              if (AddressEquals(*ai->ai_addr, reinterpret_cast<const sockaddr&>(
-                                                  attempt.first))) {
-                duplicate = true;
-                break;
-              }
-            }
-            if (duplicate) {
-              continue;
-            }
-
-            auto tcp = uv::Tcp::Create(m_loop);
-            if (!tcp) {
-              continue;
-            }
-            m_attempts.emplace_back(CopyAddress(*ai->ai_addr, ai->ai_addrlen),
-                                    tcp);
-
-            auto connreq = std::make_shared<uv::TcpConnectReq>();
-            connreq->connected.connect(
-                [this, tcp = tcp.get()] {
-                  if (m_logger.min_level() <= wpi::util::WPI_LOG_DEBUG4) {
-                    std::string ip;
-                    unsigned int port = 0;
-                    uv::AddrToName(tcp->GetPeer(), &ip, &port);
-                    WPI_DEBUG4(m_logger,
-                               "successful connection ({}) to {} port {}",
-                               static_cast<void*>(tcp), ip, port);
-                  }
-                  if (IsConnected()) {
-                    tcp->Shutdown([tcp] { tcp->Close(); });
-                    return;
-                  }
-                  if (m_connected) {
-                    m_connected(*tcp);
-                  }
-                },
-                shared_from_this());
-
-            connreq->error = [selfWeak = weak_from_this(),
-                              tcp = tcp.get()](uv::Error err) {
-              if (auto self = selfWeak.lock()) {
-                WPI_DEBUG1(self->m_logger, "connect failure ({}): {}",
-                           static_cast<void*>(tcp), err.str());
-              }
-            };
-
-            if (m_logger.min_level() <= wpi::util::WPI_LOG_DEBUG4) {
-              std::string ip;
-              unsigned int port = 0;
-              uv::AddrToName(*reinterpret_cast<sockaddr_storage*>(ai->ai_addr),
-                             &ip, &port);
-              WPI_DEBUG4(
-                  m_logger,
-                  "Info({}) starting connection attempt ({}) to {} port {}",
-                  static_cast<void*>(req), static_cast<void*>(tcp.get()), ip,
-                  port);
-            }
-            tcp->Connect(*ai->ai_addr, connreq);
+            StartConnectionAttempt(*ai->ai_addr, ai->ai_addrlen, req);
           }
         },
         shared_from_this());
@@ -206,6 +161,63 @@ void ParallelTcpConnector::Connect() {
     uv::GetAddrInfo(m_loop, req, server.first, std::format("{}", server.second),
                     hints);
   }
+}
+
+void ParallelTcpConnector::StartConnectionAttempt(
+    const sockaddr& address, socklen_t addressLen,
+    uv::GetAddrInfoReq* resolver) {
+  for (auto&& attempt : m_attempts) {
+    if (AddressEquals(
+            address, reinterpret_cast<const sockaddr&>(attempt.first))) {
+      return;
+    }
+  }
+
+  auto addressCopy = CopyAddress(address, addressLen);
+  auto tcp = uv::Tcp::Create(m_loop);
+  if (!tcp) {
+    return;
+  }
+  m_attempts.emplace_back(addressCopy, tcp);
+
+  auto connreq = std::make_shared<uv::TcpConnectReq>();
+  connreq->connected.connect(
+      [this, tcp = tcp.get()] {
+        if (m_logger.min_level() <= wpi::util::WPI_LOG_DEBUG4) {
+          std::string ip;
+          unsigned int port = 0;
+          uv::AddrToName(tcp->GetPeer(), &ip, &port);
+          WPI_DEBUG4(m_logger, "successful connection ({}) to {} port {}",
+                     static_cast<void*>(tcp), ip, port);
+        }
+        if (IsConnected()) {
+          tcp->Shutdown([tcp] { tcp->Close(); });
+          return;
+        }
+        if (m_connected) {
+          m_connected(*tcp);
+        }
+      },
+      shared_from_this());
+
+  connreq->error = [selfWeak = weak_from_this(), tcp = tcp.get()](
+                       uv::Error err) {
+    if (auto self = selfWeak.lock()) {
+      WPI_DEBUG1(self->m_logger, "connect failure ({}): {}",
+                 static_cast<void*>(tcp), err.str());
+    }
+  };
+
+  if (m_logger.min_level() <= wpi::util::WPI_LOG_DEBUG4) {
+    std::string ip;
+    unsigned int port = 0;
+    uv::AddrToName(addressCopy, &ip, &port);
+    WPI_DEBUG4(m_logger,
+               "Info({}) starting connection attempt ({}) to {} port {}",
+               static_cast<void*>(resolver), static_cast<void*>(tcp.get()), ip,
+               port);
+  }
+  tcp->Connect(reinterpret_cast<const sockaddr&>(addressCopy), connreq);
 }
 
 void ParallelTcpConnector::CancelAll(wpi::net::uv::Tcp* except) {

--- a/wpinet/src/main/native/cpp/ParallelTcpConnector.cpp
+++ b/wpinet/src/main/native/cpp/ParallelTcpConnector.cpp
@@ -113,14 +113,15 @@ void ParallelTcpConnector::Connect() {
   // kick off parallel lookups
   for (auto&& server : m_servers) {
     sockaddr_in address4;
-    if (uv::NameToAddr(server.first, server.second, &address4) == 0) {
+    if (!server.first.empty() &&
+        uv::NameToAddr(server.first, server.second, &address4) == 0) {
       StartConnectionAttempt(reinterpret_cast<const sockaddr&>(address4),
                              sizeof(address4), nullptr);
       continue;
     }
 
     sockaddr_in6 address6;
-    if (!m_ipv4Only &&
+    if (!server.first.empty() && !m_ipv4Only &&
         uv::NameToAddr(server.first, server.second, &address6) == 0) {
       StartConnectionAttempt(reinterpret_cast<const sockaddr&>(address6),
                              sizeof(address6), nullptr);
@@ -167,8 +168,8 @@ void ParallelTcpConnector::StartConnectionAttempt(
     const sockaddr& address, socklen_t addressLen,
     uv::GetAddrInfoReq* resolver) {
   for (auto&& attempt : m_attempts) {
-    if (AddressEquals(
-            address, reinterpret_cast<const sockaddr&>(attempt.first))) {
+    if (AddressEquals(address,
+                      reinterpret_cast<const sockaddr&>(attempt.first))) {
       return;
     }
   }
@@ -200,8 +201,8 @@ void ParallelTcpConnector::StartConnectionAttempt(
       },
       shared_from_this());
 
-  connreq->error = [selfWeak = weak_from_this(), tcp = tcp.get()](
-                       uv::Error err) {
+  connreq->error = [selfWeak = weak_from_this(),
+                    tcp = tcp.get()](uv::Error err) {
     if (auto self = selfWeak.lock()) {
       WPI_DEBUG1(self->m_logger, "connect failure ({}): {}",
                  static_cast<void*>(tcp), err.str());
@@ -212,10 +213,9 @@ void ParallelTcpConnector::StartConnectionAttempt(
     std::string ip;
     unsigned int port = 0;
     uv::AddrToName(addressCopy, &ip, &port);
-    WPI_DEBUG4(m_logger,
-               "Info({}) starting connection attempt ({}) to {} port {}",
-               static_cast<void*>(resolver), static_cast<void*>(tcp.get()), ip,
-               port);
+    WPI_DEBUG4(
+        m_logger, "Info({}) starting connection attempt ({}) to {} port {}",
+        static_cast<void*>(resolver), static_cast<void*>(tcp.get()), ip, port);
   }
   tcp->Connect(reinterpret_cast<const sockaddr&>(addressCopy), connreq);
 }

--- a/wpinet/src/main/native/include/wpi/net/ParallelTcpConnector.hpp
+++ b/wpinet/src/main/native/include/wpi/net/ParallelTcpConnector.hpp
@@ -113,6 +113,8 @@ class ParallelTcpConnector
  private:
   bool IsConnected() const { return m_isConnected || m_servers.empty(); }
   void Connect();
+  void StartConnectionAttempt(const sockaddr& address, socklen_t addressLen,
+                              uv::GetAddrInfoReq* resolver);
   void CancelAll(wpi::net::uv::Tcp* except = nullptr);
 
   wpi::net::uv::Loop& m_loop;


### PR DESCRIPTION
There was an issue in ParallelTCPServer where the system was waiting for DNS before attempting connections.

Additionally, the DS json was incorrect, so that is now fixed too.

A connection goes from 3.2 seconds to 253 ms.