### PR TITLE
[cmd3] Add robot mode scopes

### DIFF
--- a/commandsv2/src/test/java/org/wpilib/command2/CommandTestBase.java
+++ b/commandsv2/src/test/java/org/wpilib/command2/CommandTestBase.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.wpilib.command2.Command.InterruptionBehavior;
 import org.wpilib.driverstation.RobotState;
+import org.wpilib.driverstation.internal.DriverStationBackend;
 import org.wpilib.simulation.DriverStationSim;
 
 /** Basic setup for all {@link Command tests}. */
@@ -25,6 +26,7 @@ public class CommandTestBase {
     CommandScheduler.getInstance().clearComposedCommands();
     CommandScheduler.getInstance().unregisterAllSubsystems();
 
+    DriverStationBackend.clearUserProgramStarted();
     setDSEnabled(true);
   }
 

--- a/commandsv2/src/test/java/org/wpilib/command2/button/RobotModeTriggersTest.java
+++ b/commandsv2/src/test/java/org/wpilib/command2/button/RobotModeTriggersTest.java
@@ -19,6 +19,7 @@ class RobotModeTriggersTest extends CommandTestBase {
     DriverStationSim.setRobotMode(RobotMode.AUTONOMOUS);
     DriverStationSim.setEnabled(true);
     DriverStationSim.notifyNewData();
+    DriverStationBackend.observeUserProgramStarting();
     Trigger auto = RobotModeTriggers.autonomous();
     assertTrue(auto.getAsBoolean());
   }

--- a/commandsv2/src/test/java/org/wpilib/command2/button/RobotModeTriggersTest.java
+++ b/commandsv2/src/test/java/org/wpilib/command2/button/RobotModeTriggersTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.wpilib.command2.CommandTestBase;
+import org.wpilib.driverstation.internal.DriverStationBackend;
 import org.wpilib.hardware.hal.RobotMode;
 import org.wpilib.simulation.DriverStationSim;
 
@@ -28,6 +29,7 @@ class RobotModeTriggersTest extends CommandTestBase {
     DriverStationSim.setRobotMode(RobotMode.TELEOPERATED);
     DriverStationSim.setEnabled(true);
     DriverStationSim.notifyNewData();
+    DriverStationBackend.observeUserProgramStarting();
     Trigger teleop = RobotModeTriggers.teleop();
     assertTrue(teleop.getAsBoolean());
   }
@@ -38,6 +40,7 @@ class RobotModeTriggersTest extends CommandTestBase {
     DriverStationSim.setRobotMode(RobotMode.UTILITY);
     DriverStationSim.setEnabled(true);
     DriverStationSim.notifyNewData();
+    DriverStationBackend.observeUserProgramStarting();
     Trigger test = RobotModeTriggers.utility();
     assertTrue(test.getAsBoolean());
   }
@@ -47,6 +50,7 @@ class RobotModeTriggersTest extends CommandTestBase {
     DriverStationSim.resetData();
     DriverStationSim.setEnabled(false);
     DriverStationSim.notifyNewData();
+    DriverStationBackend.observeUserProgramStarting();
     Trigger disabled = RobotModeTriggers.disabled();
     assertTrue(disabled.getAsBoolean());
   }

--- a/commandsv2/src/test/native/cpp/wpi/command/button/RobotModeTriggersTest.cpp
+++ b/commandsv2/src/test/native/cpp/wpi/command/button/RobotModeTriggersTest.cpp
@@ -18,6 +18,7 @@ TEST_CASE("RobotModeTriggersTest Autonomous", "[commandsv2][command]") {
   DriverStationSim::SetRobotMode(wpi::hal::RobotMode::AUTONOMOUS);
   DriverStationSim::SetEnabled(true);
   DriverStationSim::NotifyNewData();
+  wpi::internal::DriverStationBackend::ObserveUserProgramStarting();
   Trigger autonomous = RobotModeTriggers::Autonomous();
   CHECK(autonomous.Get());
 }
@@ -27,6 +28,7 @@ TEST_CASE("RobotModeTriggersTest Teleop", "[commandsv2][command]") {
   DriverStationSim::SetRobotMode(wpi::hal::RobotMode::TELEOPERATED);
   DriverStationSim::SetEnabled(true);
   DriverStationSim::NotifyNewData();
+  wpi::internal::DriverStationBackend::ObserveUserProgramStarting();
   Trigger teleop = RobotModeTriggers::Teleop();
   CHECK(teleop.Get());
 }
@@ -36,6 +38,7 @@ TEST_CASE("RobotModeTriggersTest Disabled", "[commandsv2][command]") {
   DriverStationSim::SetEnabled(false);
   DriverStationSim::NotifyNewData();
   Trigger disabled = RobotModeTriggers::Disabled();
+  wpi::internal::DriverStationBackend::ObserveUserProgramStarting();
   CHECK(disabled.Get());
 }
 
@@ -45,5 +48,6 @@ TEST_CASE("RobotModeTriggersTest UtilityMode", "[commandsv2][command]") {
   DriverStationSim::SetEnabled(true);
   DriverStationSim::NotifyNewData();
   Trigger test = RobotModeTriggers::Utility();
+  wpi::internal::DriverStationBackend::ObserveUserProgramStarting();
   CHECK(test.Get());
 }

--- a/commandsv3/src/main/java/org/wpilib/command3/BindingScope.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/BindingScope.java
@@ -89,11 +89,13 @@ interface BindingScope {
     }
   }
 
+  interface RobotModeScope extends BindingScope {}
+
   /**
    * A binding scoped to the autonomous robot mode, but not any particular opmode. Comes into play
    * when robot programs are using commands v3 but not opmodes.
    */
-  final class AutonomousMode implements BindingScope {
+  final class AutonomousMode implements RobotModeScope {
     public static final AutonomousMode INSTANCE = new AutonomousMode();
 
     @Override
@@ -106,7 +108,7 @@ interface BindingScope {
    * A binding scoped to the teleop robot mode, but not any particular opmode. Comes into play when
    * robot programs are using commands v3 but not opmodes.
    */
-  final class TeleopMode implements BindingScope {
+  final class TeleopMode implements RobotModeScope {
     public static final TeleopMode INSTANCE = new TeleopMode();
 
     @Override
@@ -119,7 +121,7 @@ interface BindingScope {
    * A binding scoped to the utility robot mode, but not any particular opmode. Comes into play when
    * robot programs are using commands v3 but not opmodes.
    */
-  final class UtilityMode implements BindingScope {
+  final class UtilityMode implements RobotModeScope {
     public static final UtilityMode INSTANCE = new UtilityMode();
 
     @Override

--- a/commandsv3/src/main/java/org/wpilib/command3/BindingScope.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/BindingScope.java
@@ -4,6 +4,8 @@
 
 package org.wpilib.command3;
 
+import org.wpilib.hardware.hal.RobotMode;
+
 /**
  * A scope for when a binding is live. Bindings tied to a scope must be deleted when the scope
  * becomes inactive.
@@ -26,14 +28,27 @@ interface BindingScope {
    */
   static BindingScope createNarrowestScope(Scheduler scheduler) {
     Command currentCommand = scheduler.currentCommand();
-    long currentOpMode = OpModeFetcher.getFetcher().getOpModeId();
+    RobotStateFetcher fetcher = RobotStateFetcher.getFetcher();
+    long currentOpMode = fetcher.getOpModeId();
+    RobotMode currentRobotMode = fetcher.getRobotMode();
 
     if (currentCommand != null) {
+      // Commands are the narrowest scope, so prioritize them first.
       return new ForCommand(scheduler, currentCommand);
     } else if (currentOpMode != 0) {
+      // Opmodes are more specific than general robot mode bindings.
       return new ForOpmode(currentOpMode);
     } else {
-      return Global.INSTANCE;
+      // Not in a command and not in an opmode. Use a robot mode scope, if applicable,
+      // or fall back to the global scope if the robot is disabled or in an unrecognized mode.
+      // The switch statement deliberately does not have a default case. We want the compiler to
+      // tell us to update the switch statement if the enum changes.
+      return switch (currentRobotMode) {
+        case AUTONOMOUS -> AutonomousMode.INSTANCE;
+        case TELEOPERATED -> TeleopMode.INSTANCE;
+        case UTILITY -> UtilityMode.INSTANCE;
+        case UNKNOWN -> Global.INSTANCE;
+      };
     }
   }
 
@@ -70,7 +85,48 @@ interface BindingScope {
   record ForOpmode(long opmodeId) implements BindingScope {
     @Override
     public boolean active() {
-      return OpModeFetcher.getFetcher().getOpModeId() == opmodeId;
+      return RobotStateFetcher.getFetcher().getOpModeId() == opmodeId;
     }
   }
+
+  /**
+   * A binding scoped to the autonomous robot mode, but not any particular opmode. Comes into play
+   * when robot programs are using commands v3 but not opmodes.
+   */
+  final class AutonomousMode implements BindingScope {
+    public static final AutonomousMode INSTANCE = new AutonomousMode();
+
+    @Override
+    public boolean active() {
+      return RobotStateFetcher.getFetcher().getRobotMode() == RobotMode.AUTONOMOUS;
+    }
+  }
+
+  /**
+   * A binding scoped to the teleop robot mode, but not any particular opmode. Comes into play when
+   * robot programs are using commands v3 but not opmodes.
+   */
+  final class TeleopMode implements BindingScope {
+    public static final TeleopMode INSTANCE = new TeleopMode();
+
+    @Override
+    public boolean active() {
+      return RobotStateFetcher.getFetcher().getRobotMode() == RobotMode.TELEOPERATED;
+    }
+  }
+
+  /**
+   * A binding scoped to the utility robot mode, but not any particular opmode. Comes into play when
+   * robot programs are using commands v3 but not opmodes.
+   */
+  final class UtilityMode implements BindingScope {
+    public static final UtilityMode INSTANCE = new UtilityMode();
+
+    @Override
+    public boolean active() {
+      return RobotStateFetcher.getFetcher().getRobotMode() == RobotMode.UTILITY;
+    }
+  }
+
+  // There is no scope for the "disabled" mode, since it would interfere with the global scope
 }

--- a/commandsv3/src/main/java/org/wpilib/command3/RobotStateFetcher.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/RobotStateFetcher.java
@@ -7,31 +7,34 @@ package org.wpilib.command3;
 import static org.wpilib.util.ErrorMessages.requireNonNullParam;
 
 import org.wpilib.driverstation.RobotState;
+import org.wpilib.hardware.hal.RobotMode;
 
 /**
- * Helper class for fetching information about the current opmode. This is a package-private class
- * so tests for this library don't need to hook into driverstation simulation and the HAL.
+ * Helper class for fetching information about the state of the robot. This is a package-private
+ * class so tests for this library don't need to hook into driverstation simulation and the HAL.
  */
-abstract class OpModeFetcher {
-  private static volatile OpModeFetcher s_fetcher;
+abstract class RobotStateFetcher {
+  private static volatile RobotStateFetcher s_fetcher;
 
   abstract long getOpModeId();
 
   abstract String getOpModeName();
 
+  abstract RobotMode getRobotMode();
+
   /**
-   * Gets the current fetcher implementation. If {@link #setFetcher(OpModeFetcher)} has not already
-   * been called to set an implementation, this will default to a {@link DriverStationOpModeFetcher}
-   * instance.
+   * Gets the current fetcher implementation. If {@link #setFetcher(RobotStateFetcher)} has not
+   * already been called to set an implementation, this will default to a {@link
+   * DriverStationRobotStateFetcher} instance.
    *
    * @return The fetcher instance to use to get opmode information.
    */
-  static OpModeFetcher getFetcher() {
+  static RobotStateFetcher getFetcher() {
     // Default to pull from the DS unless otherwise specified
     if (s_fetcher == null) {
-      synchronized (OpModeFetcher.class) {
+      synchronized (RobotStateFetcher.class) {
         if (s_fetcher == null) {
-          s_fetcher = new DriverStationOpModeFetcher();
+          s_fetcher = new DriverStationRobotStateFetcher();
         }
       }
     }
@@ -45,11 +48,11 @@ abstract class OpModeFetcher {
    *
    * @param fetcher The fetcher implementation to set. Cannot be null.
    */
-  static void setFetcher(OpModeFetcher fetcher) {
+  static void setFetcher(RobotStateFetcher fetcher) {
     s_fetcher = requireNonNullParam(fetcher, "fetcher", "setFetcher");
   }
 
-  static final class DriverStationOpModeFetcher extends OpModeFetcher {
+  static final class DriverStationRobotStateFetcher extends RobotStateFetcher {
     @Override
     public long getOpModeId() {
       return RobotState.getOpModeId();
@@ -58,6 +61,11 @@ abstract class OpModeFetcher {
     @Override
     public String getOpModeName() {
       return RobotState.getOpMode();
+    }
+
+    @Override
+    RobotMode getRobotMode() {
+      return RobotState.getRobotMode();
     }
   }
 }

--- a/commandsv3/src/main/java/org/wpilib/command3/Trigger.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Trigger.java
@@ -109,7 +109,19 @@ public class Trigger implements BooleanSupplier {
     m_scheduler = requireNonNullParam(scheduler, "scheduler", "Trigger");
     m_loop = requireNonNullParam(loop, "loop", "Trigger");
     m_condition = requireNonNullParam(condition, "condition", "Trigger");
-    m_creationScope = BindingScope.createNarrowestScope(m_scheduler);
+
+    // Treat robot mode scopes as globals for the purposes of trigger object lifetimes.
+    // Any bindings made to the trigger will still use the appropriate scopes, but this prevents
+    // bugs where a trigger created in eg `autonomousInit()` and cached, then later rebound in
+    // `teleopInit()`, would get removed from the scheduler _after_ the new binding was added in
+    // `teleopInit()` due to init functions running _before_ `robotPeriodic()`.
+    // This does open the possibility for these triggers to never be cleaned up, but robot mode
+    // changes are so infrequent that it's not a big deal.
+    m_creationScope =
+        switch (BindingScope.createNarrowestScope(m_scheduler)) {
+          case BindingScope.RobotModeScope _ -> BindingScope.Global.INSTANCE;
+          case BindingScope useMe -> useMe;
+        };
 
     m_scheduler.addBoundTrigger(this);
     m_loop.bind(m_eventLoopCallback);

--- a/commandsv3/src/test/java/org/wpilib/command3/CommandTestBase.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/CommandTestBase.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.wpilib.hardware.hal.RobotMode;
 import org.wpilib.system.RobotController;
 
 class CommandTestBase {
@@ -18,6 +19,7 @@ class CommandTestBase {
   protected List<SchedulerEvent> m_events;
   protected long m_opModeId = 0;
   protected String m_opModeName = "";
+  protected RobotMode m_robotMode = RobotMode.UNKNOWN;
 
   @BeforeEach
   void initScheduler() {
@@ -29,8 +31,8 @@ class CommandTestBase {
 
   @BeforeEach
   void initOpmodeFetcher() {
-    OpModeFetcher.setFetcher(
-        new OpModeFetcher() {
+    RobotStateFetcher.setFetcher(
+        new RobotStateFetcher() {
           @Override
           long getOpModeId() {
             return m_opModeId;
@@ -40,6 +42,11 @@ class CommandTestBase {
           String getOpModeName() {
             return m_opModeName;
           }
+
+          @Override
+          RobotMode getRobotMode() {
+            return m_robotMode;
+          }
         });
   }
 
@@ -47,6 +54,7 @@ class CommandTestBase {
   void resetOpmodeFetcher() {
     m_opModeId = 0;
     m_opModeName = "";
+    m_robotMode = RobotMode.UNKNOWN;
   }
 
   /**

--- a/commandsv3/src/test/java/org/wpilib/command3/MockHardwareExtension.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/MockHardwareExtension.java
@@ -6,14 +6,15 @@ package org.wpilib.command3;
 
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.wpilib.hardware.hal.RobotMode;
 
 public class MockHardwareExtension implements BeforeEachCallback {
   @Override
   public void beforeEach(ExtensionContext context) {
-    OpModeFetcher.setFetcher(new MockOpModeFetcher());
+    RobotStateFetcher.setFetcher(new MockRobotStateFetcher());
   }
 
-  private static final class MockOpModeFetcher extends OpModeFetcher {
+  private static final class MockRobotStateFetcher extends RobotStateFetcher {
     @Override
     long getOpModeId() {
       return 0;
@@ -22,6 +23,11 @@ public class MockHardwareExtension implements BeforeEachCallback {
     @Override
     String getOpModeName() {
       return "";
+    }
+
+    @Override
+    RobotMode getRobotMode() {
+      return RobotMode.UNKNOWN;
     }
   }
 }

--- a/commandsv3/src/test/java/org/wpilib/command3/TriggerTest.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/TriggerTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.Test;
+import org.wpilib.hardware.hal.RobotMode;
 import org.wpilib.system.RobotController;
 
 class TriggerTest extends CommandTestBase {
@@ -189,26 +190,8 @@ class TriggerTest extends CommandTestBase {
 
   @Test
   void bindingScopesToOpmodeIfAvailable() {
-    var fetcher =
-        new OpModeFetcher() {
-          long m_id = 12345;
-
-          void clear() {
-            m_id = 0;
-          }
-
-          @Override
-          long getOpModeId() {
-            return m_id;
-          }
-
-          @Override
-          String getOpModeName() {
-            return "This is an opmode!";
-          }
-        };
-    OpModeFetcher.setFetcher(fetcher);
-
+    m_opModeId = 12345;
+    m_opModeName = "This is an opmode!";
     var triggerSignal = new AtomicBoolean(false);
     var trigger = new Trigger(m_scheduler, triggerSignal::get);
 
@@ -219,9 +202,37 @@ class TriggerTest extends CommandTestBase {
     m_scheduler.run();
     assertTrue(m_scheduler.isRunning(command), "Command should have started when triggered");
 
-    fetcher.clear();
+    m_opModeId = 0;
+    m_opModeName = "";
     m_scheduler.run();
     assertFalse(m_scheduler.isRunning(command), "Command should have stopped when opmode exited");
+  }
+
+  @Test
+  void bindingScopesToRobotModeIfAvailable() {
+    for (RobotMode mode : RobotMode.values()) {
+      if (mode == RobotMode.UNKNOWN) {
+        // global scope, skip
+        continue;
+      }
+
+      m_robotMode = mode;
+
+      var triggerSignal = new AtomicBoolean(false);
+      var trigger = new Trigger(m_scheduler, triggerSignal::get);
+
+      var command = Command.noRequirements(Coroutine::park).named("Command");
+      trigger.whileTrue(command);
+
+      triggerSignal.set(true);
+      m_scheduler.run();
+      assertTrue(m_scheduler.isRunning(command), "Command should have started when triggered");
+
+      m_robotMode = RobotMode.UNKNOWN;
+      m_scheduler.run();
+      assertFalse(
+          m_scheduler.isRunning(command), "Command should have stopped when robot mode exited");
+    }
   }
 
   // The scheduler lifecycle polls triggers at the start of `run()`

--- a/commandsv3/src/test/java/org/wpilib/command3/TriggerTest.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/TriggerTest.java
@@ -235,6 +235,78 @@ class TriggerTest extends CommandTestBase {
     }
   }
 
+  @Test
+  void triggerCreatedInOneModeSurvivesTransitionsToAllOtherModes() {
+    for (RobotMode sourceMode : concreteRobotModes()) {
+      for (RobotMode destinationMode : concreteRobotModes()) {
+        if (sourceMode == destinationMode) {
+          continue;
+        }
+
+        m_robotMode = sourceMode;
+
+        var triggerSignal = new AtomicBoolean(false);
+        var trigger = new Trigger(m_scheduler, triggerSignal::get);
+
+        var sourceModeCommand = Command.noRequirements(Coroutine::park).named("SourceModeCommand");
+        trigger.whileTrue(sourceModeCommand);
+
+        triggerSignal.set(true);
+        m_scheduler.run();
+        assertTrue(
+            m_scheduler.isRunning(sourceModeCommand),
+            () ->
+                "Command should have started in source mode "
+                    + sourceMode
+                    + " before transition to "
+                    + destinationMode);
+
+        // TRANSITION SOURCE -> DESTINATION
+
+        m_robotMode = destinationMode;
+        m_scheduler.run();
+        assertFalse(
+            m_scheduler.isRunning(sourceModeCommand),
+            () ->
+                "Source mode binding should be inactive after transition "
+                    + sourceMode
+                    + " -> "
+                    + destinationMode);
+
+        triggerSignal.set(false);
+        m_scheduler.run();
+
+        var destinationModeCommand =
+            Command.noRequirements(Coroutine::park).named("DestinationModeCommand");
+        trigger.whileTrue(destinationModeCommand);
+
+        triggerSignal.set(true);
+        m_scheduler.run();
+        assertTrue(
+            m_scheduler.isRunning(destinationModeCommand),
+            () ->
+                "Trigger should still be active after transition "
+                    + sourceMode
+                    + " -> "
+                    + destinationMode);
+
+        triggerSignal.set(false);
+        m_scheduler.run();
+        assertFalse(
+            m_scheduler.isRunning(destinationModeCommand),
+            () ->
+                "Destination mode command should cancel on falling edge after transition "
+                    + sourceMode
+                    + " -> "
+                    + destinationMode);
+      }
+    }
+  }
+
+  private static List<RobotMode> concreteRobotModes() {
+    return List.of(RobotMode.AUTONOMOUS, RobotMode.TELEOPERATED, RobotMode.UTILITY);
+  }
+
   // The scheduler lifecycle polls triggers at the start of `run()`
   // Even though the trigger condition is set, the command exits and the trigger's scope goes
   // inactive before the next `run()` call can poll the trigger

--- a/wpilibc/src/main/native/cpp/driverstation/internal/DriverStationBackend.cpp
+++ b/wpilibc/src/main/native/cpp/driverstation/internal/DriverStationBackend.cpp
@@ -935,11 +935,42 @@ void DriverStationBackend::ObserveUserProgramStarting() {
 }
 
 RobotMode DriverStationBackend::GetRobotMode() {
+  hal::ControlWord controlWord = GetControlWord();
   if (!::GetInstance().userProgramStarted) {
     return RobotMode::UNKNOWN;
   }
 
-  return GetControlWord().GetRobotMode();
+  return controlWord.GetRobotMode();
+}
+
+bool DriverStationBackend::IsAutonomousEnabled() {
+  hal::ControlWord controlWord = GetControlWord();
+  if (!::GetInstance().userProgramStarted) {
+    return false;
+  }
+
+  return controlWord.GetRobotMode() == RobotMode::AUTONOMOUS &&
+         controlWord.IsEnabled() && controlWord.IsDSAttached();
+}
+
+bool DriverStationBackend::IsTeleopEnabled() {
+  hal::ControlWord controlWord = GetControlWord();
+  if (!::GetInstance().userProgramStarted) {
+    return false;
+  }
+
+  return controlWord.GetRobotMode() == RobotMode::TELEOPERATED &&
+         controlWord.IsEnabled() && controlWord.IsDSAttached();
+}
+
+bool DriverStationBackend::IsUtilityEnabled() {
+  hal::ControlWord controlWord = GetControlWord();
+  if (!::GetInstance().userProgramStarted) {
+    return false;
+  }
+
+  return controlWord.GetRobotMode() == RobotMode::UTILITY &&
+         controlWord.IsEnabled() && controlWord.IsDSAttached();
 }
 
 int64_t DriverStationBackend::GetOpModeId() {

--- a/wpilibc/src/main/native/cpp/driverstation/internal/DriverStationBackend.cpp
+++ b/wpilibc/src/main/native/cpp/driverstation/internal/DriverStationBackend.cpp
@@ -934,6 +934,14 @@ void DriverStationBackend::ObserveUserProgramStarting() {
   HAL_ObserveUserProgramStarting();
 }
 
+RobotMode DriverStationBackend::GetRobotMode() {
+  if (!::GetInstance().userProgramStarted) {
+    return RobotMode::UNKNOWN;
+  }
+
+  return GetControlWord().GetRobotMode();
+}
+
 int64_t DriverStationBackend::GetOpModeId() {
   if (!::GetInstance().userProgramStarted) {
     return 0;

--- a/wpilibc/src/main/native/include/wpi/driverstation/internal/DriverStationBackend.hpp
+++ b/wpilibc/src/main/native/include/wpi/driverstation/internal/DriverStationBackend.hpp
@@ -321,7 +321,7 @@ class DriverStationBackend final {
    * @return True if the robot is being commanded to be in autonomous mode and
    * enabled.
    */
-  static bool IsAutonomousEnabled() { return IsAutonomous() && IsEnabled(); }
+  static bool IsAutonomousEnabled();
 
   /**
    * Check if the DS is commanding teleop mode.
@@ -348,7 +348,7 @@ class DriverStationBackend final {
    * @return True if the robot is being commanded to be in teleop mode and
    * enabled.
    */
-  static bool IsTeleopEnabled() { return IsTeleop() && IsEnabled(); }
+  static bool IsTeleopEnabled();
 
   /**
    * Check if the DS is commanding utility mode.
@@ -375,7 +375,7 @@ class DriverStationBackend final {
    * @return True if the robot is being commanded to be in Utility mode and
    * enabled.
    */
-  static bool IsUtilityEnabled() { return IsUtility() && IsEnabled(); }
+  static bool IsUtilityEnabled();
 
   /**
    * Adds an operating mode option. It's necessary to call PublishOpModes() to

--- a/wpilibc/src/main/native/include/wpi/driverstation/internal/DriverStationBackend.hpp
+++ b/wpilibc/src/main/native/include/wpi/driverstation/internal/DriverStationBackend.hpp
@@ -285,57 +285,97 @@ class DriverStationBackend final {
    * <p>Note that this does not indicate whether the robot is enabled or
    * disabled.
    *
+   * <p>This method always returns RobotMode::UNKNOWN while the main robot
+   * class is being constructed and initialized (more specifically, it returns
+   * RobotMode::UNKNOWN until ObserveUserProgramStarting() is called, which
+   * the WPILib framework will automatically call during
+   * TimedRobot::StartCompetition() and OpModeRobot::StartCompetition()).
+   *
    * @return robot mode
    */
-  static RobotMode GetRobotMode() { return GetControlWord().GetRobotMode(); }
+  static RobotMode GetRobotMode();
 
   /**
    * Check if the DS is commanding autonomous mode.
    *
+   * <p>This method always returns false while the main robot class is being
+   * constructed and initialized (more specifically, it returns false until
+   * ObserveUserProgramStarting() is called, which the WPILib framework will
+   * automatically call during TimedRobot::StartCompetition() and
+   * OpModeRobot::StartCompetition()).
+   *
    * @return True if the robot is being commanded to be in autonomous mode
    */
-  static bool IsAutonomous() { return GetControlWord().IsAutonomous(); }
+  static bool IsAutonomous() { return GetRobotMode() == RobotMode::AUTONOMOUS; }
 
   /**
    * Check if the DS is commanding autonomous mode and if it has enabled the
    * robot.
    *
+   * <p>This method always returns false while the main robot class is being
+   * constructed and initialized (more specifically, it returns false until
+   * ObserveUserProgramStarting() is called, which the WPILib framework will
+   * automatically call during TimedRobot::StartCompetition() and
+   * OpModeRobot::StartCompetition()).
+   *
    * @return True if the robot is being commanded to be in autonomous mode and
    * enabled.
    */
-  static bool IsAutonomousEnabled() {
-    return GetControlWord().IsAutonomousEnabled();
-  }
+  static bool IsAutonomousEnabled() { return IsAutonomous() && IsEnabled(); }
 
   /**
    * Check if the DS is commanding teleop mode.
    *
+   * <p>This method always returns false while the main robot class is being
+   * constructed and initialized (more specifically, it returns false until
+   * ObserveUserProgramStarting() is called, which the WPILib framework will
+   * automatically call during TimedRobot::StartCompetition() and
+   * OpModeRobot::StartCompetition()).
+   *
    * @return True if the robot is being commanded to be in teleop mode
    */
-  static bool IsTeleop() { return GetControlWord().IsTeleop(); }
+  static bool IsTeleop() { return GetRobotMode() == RobotMode::TELEOPERATED; }
 
   /**
    * Check if the DS is commanding teleop mode and if it has enabled the robot.
    *
+   * <p>This method always returns false while the main robot class is being
+   * constructed and initialized (more specifically, it returns false until
+   * ObserveUserProgramStarting() is called, which the WPILib framework will
+   * automatically call during TimedRobot::StartCompetition() and
+   * OpModeRobot::StartCompetition()).
+   *
    * @return True if the robot is being commanded to be in teleop mode and
    * enabled.
    */
-  static bool IsTeleopEnabled() { return GetControlWord().IsTeleopEnabled(); }
+  static bool IsTeleopEnabled() { return IsTeleop() && IsEnabled(); }
 
   /**
    * Check if the DS is commanding utility mode.
    *
+   * <p>This method always returns false while the main robot class is being
+   * constructed and initialized (more specifically, it returns false until
+   * ObserveUserProgramStarting() is called, which the WPILib framework will
+   * automatically call during TimedRobot::StartCompetition() and
+   * OpModeRobot::StartCompetition()).
+   *
    * @return True if the robot is being commanded to be in utility mode
    */
-  static bool IsUtility() { return GetControlWord().IsUtility(); }
+  static bool IsUtility() { return GetRobotMode() == RobotMode::UTILITY; }
 
   /**
    * Check if the DS is commanding Utility mode and if it has enabled the robot.
    *
+   * <p>This method always returns false while the main robot class is being
+   * constructed and initialized (more specifically, it returns false until
+   * ObserveUserProgramStarting() is called, which the WPILib framework will
+   * automatically call during TimedRobot::StartCompetition() and
+   * OpModeRobot::StartCompetition()).
+   *
    * @return True if the robot is being commanded to be in Utility mode and
    * enabled.
    */
-  static bool IsUtilityEnabled() { return GetControlWord().IsUtilityEnabled(); }
+  static bool IsUtilityEnabled() { return IsUtility() && IsEnabled(); }
 
   /**
    * Adds an operating mode option. It's necessary to call PublishOpModes() to

--- a/wpilibc/src/test/native/cpp/simulation/DriverStationSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/DriverStationSimTest.cpp
@@ -39,6 +39,7 @@ TEST_CASE("DriverStationTest AutonomousMode", "[wpilibc][simulation]") {
   HAL_Initialize();
   DriverStationSim::ResetData();
   DriverStationSim::NotifyNewData();
+  wpi::internal::DriverStationBackend::ObserveUserProgramStarting();
 
   CHECK_FALSE(RobotState::IsAutonomous());
   EnumCallback callback;
@@ -57,6 +58,7 @@ TEST_CASE("DriverStationTest Mode", "[wpilibc][simulation]") {
   HAL_Initialize();
   DriverStationSim::ResetData();
   DriverStationSim::NotifyNewData();
+  wpi::internal::DriverStationBackend::ObserveUserProgramStarting();
 
   CHECK_FALSE(RobotState::IsUtility());
   EnumCallback callback;

--- a/wpilibc/src/test/native/cpp/simulation/DriverStationSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/DriverStationSimTest.cpp
@@ -49,6 +49,12 @@ TEST_CASE("DriverStationTest AutonomousMode", "[wpilibc][simulation]") {
   DriverStationSim::NotifyNewData();
   CHECK(DriverStationSim::GetRobotMode() == RobotMode::AUTONOMOUS);
   CHECK(RobotState::IsAutonomous());
+  CHECK_FALSE(RobotState::IsAutonomousEnabled());
+
+  DriverStationSim::SetEnabled(true);
+  DriverStationSim::NotifyNewData();
+  CHECK(RobotState::IsAutonomousEnabled());
+
   CHECK(RobotState::GetRobotMode() == RobotMode::AUTONOMOUS);
   CHECK(callback.WasTriggered());
   CHECK(callback.GetLastValue() == HAL_ROBOT_MODE_AUTONOMOUS);
@@ -68,6 +74,12 @@ TEST_CASE("DriverStationTest Mode", "[wpilibc][simulation]") {
   DriverStationSim::NotifyNewData();
   CHECK(DriverStationSim::GetRobotMode() == RobotMode::UTILITY);
   CHECK(RobotState::IsUtility());
+  CHECK_FALSE(RobotState::IsUtilityEnabled());
+
+  DriverStationSim::SetEnabled(true);
+  DriverStationSim::NotifyNewData();
+  CHECK(RobotState::IsUtilityEnabled());
+
   CHECK(RobotState::GetRobotMode() == RobotMode::UTILITY);
   CHECK(callback.WasTriggered());
   CHECK(callback.GetLastValue() == HAL_ROBOT_MODE_UTILITY);

--- a/wpilibj/src/main/java/org/wpilib/driverstation/internal/DriverStationBackend.java
+++ b/wpilibj/src/main/java/org/wpilib/driverstation/internal/DriverStationBackend.java
@@ -723,7 +723,7 @@ public final class DriverStationBackend {
   private static boolean m_silenceJoystickAlerts;
   private static final JoystickAlerts[] m_joystickAlerts = new JoystickAlerts[JOYSTICK_PORTS];
 
-  private static boolean m_userProgramStarted = false;
+  private static volatile boolean m_userProgramStarted = false;
   private static final Map<Long, OpModeOption> m_opModes = new HashMap<>();
   private static final ReentrantLock m_opModesMutex = new ReentrantLock();
 
@@ -1433,7 +1433,12 @@ public final class DriverStationBackend {
    * @return True if autonomous should be set and the robot should be enabled.
    */
   public static boolean isAutonomousEnabled() {
-    return isAutonomous() && isEnabled();
+    m_cacheDataMutex.lock();
+    try {
+      return isAutonomous() && isEnabled();
+    } finally {
+      m_cacheDataMutex.unlock();
+    }
   }
 
   /**
@@ -1463,7 +1468,12 @@ public final class DriverStationBackend {
    * @return True if operator-controlled mode should be set and the robot should be enabled.
    */
   public static boolean isTeleopEnabled() {
-    return isTeleop() && isEnabled();
+    m_cacheDataMutex.lock();
+    try {
+      return isTeleop() && isEnabled();
+    } finally {
+      m_cacheDataMutex.unlock();
+    }
   }
 
   /**
@@ -1493,7 +1503,12 @@ public final class DriverStationBackend {
    * @return True if utility mode should be set and the robot should be enabled.
    */
   public static boolean isUtilityEnabled() {
-    return isUtility() && isEnabled();
+    m_cacheDataMutex.lock();
+    try {
+      return isUtility() && isEnabled();
+    } finally {
+      m_cacheDataMutex.unlock();
+    }
   }
 
   private static int convertColorToInt(Color color) {

--- a/wpilibj/src/main/java/org/wpilib/driverstation/internal/DriverStationBackend.java
+++ b/wpilibj/src/main/java/org/wpilib/driverstation/internal/DriverStationBackend.java
@@ -1387,9 +1387,8 @@ public final class DriverStationBackend {
    *
    * <p>This method always returns {@link RobotMode#UNKNOWN} while the main robot class is being
    * constructed and initialized (more specifically, it returns {@link RobotMode#UNKNOWN} until
-   * {@link #observeUserProgramStarting()} is called, which the WPILib framework will
-   * automatically call during {@link TimedRobot#startCompetition()} and {@link
-   * OpModeRobot#startCompetition()}).
+   * {@link #observeUserProgramStarting()} is called, which the WPILib framework will automatically
+   * call during {@link TimedRobot#startCompetition()} and {@link OpModeRobot#startCompetition()}).
    *
    * @return robot mode
    */
@@ -1410,8 +1409,8 @@ public final class DriverStationBackend {
    * Gets a value indicating whether the Driver Station requires the robot to be running in
    * autonomous mode.
    *
-   * <p>This method always returns {@code false} while the main robot class is being constructed
-   * and initialized (more specifically, it returns {@code false} until {@link
+   * <p>This method always returns {@code false} while the main robot class is being constructed and
+   * initialized (more specifically, it returns {@code false} until {@link
    * #observeUserProgramStarting()} is called, which the WPILib framework will automatically call
    * during {@link TimedRobot#startCompetition()} and {@link OpModeRobot#startCompetition()}).
    *
@@ -1425,8 +1424,8 @@ public final class DriverStationBackend {
    * Gets a value indicating whether the Driver Station requires the robot to be running in
    * autonomous mode and enabled.
    *
-   * <p>This method always returns {@code false} while the main robot class is being constructed
-   * and initialized (more specifically, it returns {@code false} until {@link
+   * <p>This method always returns {@code false} while the main robot class is being constructed and
+   * initialized (more specifically, it returns {@code false} until {@link
    * #observeUserProgramStarting()} is called, which the WPILib framework will automatically call
    * during {@link TimedRobot#startCompetition()} and {@link OpModeRobot#startCompetition()}).
    *
@@ -1445,8 +1444,8 @@ public final class DriverStationBackend {
    * Gets a value indicating whether the Driver Station requires the robot to be running in
    * operator-controlled mode.
    *
-   * <p>This method always returns {@code false} while the main robot class is being constructed
-   * and initialized (more specifically, it returns {@code false} until {@link
+   * <p>This method always returns {@code false} while the main robot class is being constructed and
+   * initialized (more specifically, it returns {@code false} until {@link
    * #observeUserProgramStarting()} is called, which the WPILib framework will automatically call
    * during {@link TimedRobot#startCompetition()} and {@link OpModeRobot#startCompetition()}).
    *
@@ -1460,8 +1459,8 @@ public final class DriverStationBackend {
    * Gets a value indicating whether the Driver Station requires the robot to be running in
    * operator-controller mode and enabled.
    *
-   * <p>This method always returns {@code false} while the main robot class is being constructed
-   * and initialized (more specifically, it returns {@code false} until {@link
+   * <p>This method always returns {@code false} while the main robot class is being constructed and
+   * initialized (more specifically, it returns {@code false} until {@link
    * #observeUserProgramStarting()} is called, which the WPILib framework will automatically call
    * during {@link TimedRobot#startCompetition()} and {@link OpModeRobot#startCompetition()}).
    *
@@ -1480,8 +1479,8 @@ public final class DriverStationBackend {
    * Gets a value indicating whether the Driver Station requires the robot to be running in Utility
    * mode.
    *
-   * <p>This method always returns {@code false} while the main robot class is being constructed
-   * and initialized (more specifically, it returns {@code false} until {@link
+   * <p>This method always returns {@code false} while the main robot class is being constructed and
+   * initialized (more specifically, it returns {@code false} until {@link
    * #observeUserProgramStarting()} is called, which the WPILib framework will automatically call
    * during {@link TimedRobot#startCompetition()} and {@link OpModeRobot#startCompetition()}).
    *
@@ -1495,8 +1494,8 @@ public final class DriverStationBackend {
    * Gets a value indicating whether the Driver Station requires the robot to be running in Utility
    * mode and enabled.
    *
-   * <p>This method always returns {@code false} while the main robot class is being constructed
-   * and initialized (more specifically, it returns {@code false} until {@link
+   * <p>This method always returns {@code false} while the main robot class is being constructed and
+   * initialized (more specifically, it returns {@code false} until {@link
    * #observeUserProgramStarting()} is called, which the WPILib framework will automatically call
    * during {@link TimedRobot#startCompetition()} and {@link OpModeRobot#startCompetition()}).
    *

--- a/wpilibj/src/main/java/org/wpilib/driverstation/internal/DriverStationBackend.java
+++ b/wpilibj/src/main/java/org/wpilib/driverstation/internal/DriverStationBackend.java
@@ -22,6 +22,7 @@ import org.wpilib.driverstation.MatchType;
 import org.wpilib.driverstation.POVDirection;
 import org.wpilib.driverstation.TouchpadFinger;
 import org.wpilib.framework.OpModeRobot;
+import org.wpilib.framework.RobotBase;
 import org.wpilib.framework.TimedRobot;
 import org.wpilib.hardware.hal.AllianceStationID;
 import org.wpilib.hardware.hal.ControlWord;
@@ -1698,6 +1699,28 @@ public final class DriverStationBackend {
   public static void observeUserProgramStarting() {
     m_userProgramStarted = true;
     DriverStationJNI.observeUserProgramStarting();
+  }
+
+  /**
+   * For internal unit testing in WPILib. Not for team use. Has no effect unless called in
+   * simulation mode.
+   *
+   * <p>Resets the {@code m_userProgramStarted} flag for unit tests. Does not reset anything in the
+   * JNI layer.
+   */
+  public static void clearUserProgramStarted() {
+    if (!RobotBase.isSimulation()) {
+      // NOP unless running in sim. We don't want teams to call this; it would prevent their
+      // programs from transitioning between modes and from detecting opmode selections.
+      reportWarning(
+          "DriverStationBackend.clearUserProgramStarted() was called! "
+              + "This method exists solely for internal WPILib unit tests "
+              + "and does nothing in team code.",
+          true);
+      return;
+    }
+
+    m_userProgramStarted = false;
   }
 
   /**

--- a/wpilibj/src/main/java/org/wpilib/driverstation/internal/DriverStationBackend.java
+++ b/wpilibj/src/main/java/org/wpilib/driverstation/internal/DriverStationBackend.java
@@ -1385,9 +1385,19 @@ public final class DriverStationBackend {
    *
    * <p>Note that this does not indicate whether the robot is enabled or disabled.
    *
+   * <p>This method always returns {@link RobotMode#UNKNOWN} while the main robot class is being
+   * constructed and initialized (more specifically, it returns {@link RobotMode#UNKNOWN} until
+   * {@link #observeUserProgramStarting()} is called, which the WPILib framework will
+   * automatically call during {@link TimedRobot#startCompetition()} and {@link
+   * OpModeRobot#startCompetition()}).
+   *
    * @return robot mode
    */
   public static RobotMode getRobotMode() {
+    if (!m_userProgramStarted) {
+      return RobotMode.UNKNOWN;
+    }
+
     m_cacheDataMutex.lock();
     try {
       return m_controlWord.getRobotMode();
@@ -1400,85 +1410,90 @@ public final class DriverStationBackend {
    * Gets a value indicating whether the Driver Station requires the robot to be running in
    * autonomous mode.
    *
+   * <p>This method always returns {@code false} while the main robot class is being constructed
+   * and initialized (more specifically, it returns {@code false} until {@link
+   * #observeUserProgramStarting()} is called, which the WPILib framework will automatically call
+   * during {@link TimedRobot#startCompetition()} and {@link OpModeRobot#startCompetition()}).
+   *
    * @return True if autonomous mode should be enabled, false otherwise.
    */
   public static boolean isAutonomous() {
-    m_cacheDataMutex.lock();
-    try {
-      return m_controlWord.isAutonomous();
-    } finally {
-      m_cacheDataMutex.unlock();
-    }
+    return getRobotMode() == RobotMode.AUTONOMOUS;
   }
 
   /**
    * Gets a value indicating whether the Driver Station requires the robot to be running in
    * autonomous mode and enabled.
    *
+   * <p>This method always returns {@code false} while the main robot class is being constructed
+   * and initialized (more specifically, it returns {@code false} until {@link
+   * #observeUserProgramStarting()} is called, which the WPILib framework will automatically call
+   * during {@link TimedRobot#startCompetition()} and {@link OpModeRobot#startCompetition()}).
+   *
    * @return True if autonomous should be set and the robot should be enabled.
    */
   public static boolean isAutonomousEnabled() {
-    m_cacheDataMutex.lock();
-    try {
-      return m_controlWord.isAutonomousEnabled();
-    } finally {
-      m_cacheDataMutex.unlock();
-    }
+    return isAutonomous() && isEnabled();
   }
 
   /**
    * Gets a value indicating whether the Driver Station requires the robot to be running in
    * operator-controlled mode.
    *
+   * <p>This method always returns {@code false} while the main robot class is being constructed
+   * and initialized (more specifically, it returns {@code false} until {@link
+   * #observeUserProgramStarting()} is called, which the WPILib framework will automatically call
+   * during {@link TimedRobot#startCompetition()} and {@link OpModeRobot#startCompetition()}).
+   *
    * @return True if operator-controlled mode should be enabled, false otherwise.
    */
   public static boolean isTeleop() {
-    return m_controlWord.isTeleop();
+    return getRobotMode() == RobotMode.TELEOPERATED;
   }
 
   /**
    * Gets a value indicating whether the Driver Station requires the robot to be running in
    * operator-controller mode and enabled.
    *
+   * <p>This method always returns {@code false} while the main robot class is being constructed
+   * and initialized (more specifically, it returns {@code false} until {@link
+   * #observeUserProgramStarting()} is called, which the WPILib framework will automatically call
+   * during {@link TimedRobot#startCompetition()} and {@link OpModeRobot#startCompetition()}).
+   *
    * @return True if operator-controlled mode should be set and the robot should be enabled.
    */
   public static boolean isTeleopEnabled() {
-    m_cacheDataMutex.lock();
-    try {
-      return m_controlWord.isTeleopEnabled();
-    } finally {
-      m_cacheDataMutex.unlock();
-    }
+    return isTeleop() && isEnabled();
   }
 
   /**
    * Gets a value indicating whether the Driver Station requires the robot to be running in Utility
    * mode.
    *
+   * <p>This method always returns {@code false} while the main robot class is being constructed
+   * and initialized (more specifically, it returns {@code false} until {@link
+   * #observeUserProgramStarting()} is called, which the WPILib framework will automatically call
+   * during {@link TimedRobot#startCompetition()} and {@link OpModeRobot#startCompetition()}).
+   *
    * @return True if utility mode should be enabled, false otherwise.
    */
   public static boolean isUtility() {
-    m_cacheDataMutex.lock();
-    try {
-      return m_controlWord.isUtility();
-    } finally {
-      m_cacheDataMutex.unlock();
-    }
+    return getRobotMode() == RobotMode.UTILITY;
   }
 
   /**
    * Gets a value indicating whether the Driver Station requires the robot to be running in Utility
    * mode and enabled.
    *
+   * <p>This method always returns {@code false} while the main robot class is being constructed
+   * and initialized (more specifically, it returns {@code false} until {@link
+   * #observeUserProgramStarting()} is called, which the WPILib framework will automatically call
+   * during {@link TimedRobot#startCompetition()} and {@link OpModeRobot#startCompetition()}).
+   *
    * @return True if utility mode should be set and the robot should be enabled.
    */
   public static boolean isUtilityEnabled() {
-    m_cacheDataMutex.lock();
-    try {
-      return m_controlWord.isUtilityEnabled();
-    } finally {
-      m_cacheDataMutex.unlock();
-    }
+    return isUtility() && isEnabled();
   }
 
   private static int convertColorToInt(Color color) {

--- a/wpilibj/src/test/java/org/wpilib/driverstation/DriverStationTest.java
+++ b/wpilibj/src/test/java/org/wpilib/driverstation/DriverStationTest.java
@@ -25,6 +25,11 @@ import org.wpilib.simulation.SimHooks;
 import org.wpilib.util.Alert;
 
 class DriverStationTest {
+  @AfterEach
+  void tearDown() {
+    DriverStationBackend.clearUserProgramStarted();
+  }
+
   @ParameterizedTest
   @MethodSource("isConnectedProvider")
   void testIsConnected(int axisCount, int buttonCount, int povCount, boolean expected) {

--- a/wpilibj/src/test/java/org/wpilib/driverstation/DriverStationTest.java
+++ b/wpilibj/src/test/java/org/wpilib/driverstation/DriverStationTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.wpilib.driverstation.internal.DriverStationBackend;
+import org.wpilib.hardware.hal.RobotMode;
 import org.wpilib.hardware.hal.simulation.DriverStationDataJNI;
 import org.wpilib.simulation.AlertSim;
 import org.wpilib.simulation.DriverStationSim;
@@ -62,6 +63,31 @@ class DriverStationTest {
         "0x1234",
         String.format(
             "0x%x", Long.parseLong(opmodeName.substring(1, opmodeName.length() - 1)) & 0xFFFF));
+  }
+
+  @Test
+  void getRobotModeAndChecksAreGatedUntilUserProgramStarts() {
+    DriverStationSim.setEnabled(true);
+    DriverStationSim.setRobotMode(RobotMode.AUTONOMOUS);
+    DriverStationSim.notifyNewData();
+
+    assertEquals(RobotMode.UNKNOWN, RobotState.getRobotMode());
+    assertFalse(RobotState.isAutonomous());
+    assertFalse(RobotState.isAutonomousEnabled());
+    assertFalse(RobotState.isTeleop());
+    assertFalse(RobotState.isTeleopEnabled());
+    assertFalse(RobotState.isUtility());
+    assertFalse(RobotState.isUtilityEnabled());
+
+    DriverStationBackend.observeUserProgramStarting();
+
+    assertEquals(RobotMode.AUTONOMOUS, RobotState.getRobotMode());
+    assertTrue(RobotState.isAutonomous());
+    assertTrue(RobotState.isAutonomousEnabled());
+    assertFalse(RobotState.isTeleop());
+    assertFalse(RobotState.isTeleopEnabled());
+    assertFalse(RobotState.isUtility());
+    assertFalse(RobotState.isUtilityEnabled());
   }
 
   static Stream<Arguments> isConnectedProvider() {

--- a/wpilibj/src/test/java/org/wpilib/simulation/DriverStationSimTest.java
+++ b/wpilibj/src/test/java/org/wpilib/simulation/DriverStationSimTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -24,6 +25,17 @@ import org.wpilib.simulation.testutils.DoubleCallback;
 import org.wpilib.simulation.testutils.EnumCallback;
 
 class DriverStationSimTest {
+  @AfterEach
+  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+  void resetUserProgramFlag() throws ReflectiveOperationException {
+    DriverStationSim.resetData();
+    DriverStationSim.notifyNewData();
+
+    var field = DriverStationBackend.class.getDeclaredField("m_userProgramStarted");
+    field.setAccessible(true);
+    field.set(null, false);
+  }
+
   @Test
   void testEnabled() {
     HAL.initialize();
@@ -45,6 +57,7 @@ class DriverStationSimTest {
   void testAutonomous() {
     HAL.initialize();
     DriverStationSim.resetData();
+    DriverStationBackend.observeUserProgramStarting();
 
     assertFalse(RobotState.isAutonomous());
     EnumCallback callback = new EnumCallback();
@@ -63,6 +76,7 @@ class DriverStationSimTest {
   void testTest() {
     HAL.initialize();
     DriverStationSim.resetData();
+    DriverStationBackend.observeUserProgramStarting();
 
     assertFalse(RobotState.isUtility());
     EnumCallback callback = new EnumCallback();


### PR DESCRIPTION
They're similar to opmode scopes, but we need to support these as well because many teams will not be using opmodes.

Change the driverstation class behavior to only return the active robot mode after the user program has started, matching the existing opmode behavior, to prevent issues with bindings that should be globally scoped suddenly and unexpectedly being scoped to eg teleop or autonomous if a robot reboots mid-match.