### PR TITLE
[wpigui] Disable input trickling

### DIFF
--- a/wpigui/src/main/native/cpp/wpigui.cpp
+++ b/wpigui/src/main/native/cpp/wpigui.cpp
@@ -974,6 +974,9 @@ bool gui::Initialize(const char* title, int width, int height,
   ImGuiIO& io = ImGui::GetIO();
   io.ConfigFlags |= configFlags;
 
+  // https://github.com/wpilibsuite/allwpilib/issues/9272
+  io.ConfigInputTrickleEventQueue = false;
+
   // Hook ini handler to save settings
   ImGuiSettingsHandler iniHandler;
   iniHandler.TypeName = "MainWindow";


### PR DESCRIPTION
Closes #9272. Fixes the GUI lagging when too many scroll and motion
events are fed to the queue at once (most noticeable by spamming scroll
inputs)

Signed-off-by: crueter <crueter@eden-emu.dev>
