### PR TITLE
[wpiutil java] Add an Option type

### DIFF
--- a/wpiutil/src/main/java/org/wpilib/util/option/None.java
+++ b/wpiutil/src/main/java/org/wpilib/util/option/None.java
@@ -24,6 +24,15 @@ public record None<T>() implements Option<T> {
   @SuppressWarnings("rawtypes")
   private static final None NONE = new None();
 
+  /**
+   * Gets a {@code None} instance representing the absence of a value of type {@code T}.
+   *
+   * <p>Because {@code None} is stateless, this method returns the same singleton object every time
+   * it's invoked.
+   *
+   * @param <T> The type of values that could have been stored in the optional value.
+   * @return A {@code None} instance representing no data for type {@code T}.
+   */
   @SuppressWarnings("unchecked")
   public static <T> None<T> none() {
     return (None<T>) NONE;

--- a/wpiutil/src/main/java/org/wpilib/util/option/None.java
+++ b/wpiutil/src/main/java/org/wpilib/util/option/None.java
@@ -1,0 +1,96 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.util.option;
+
+import static java.util.Objects.requireNonNull;
+import static org.wpilib.util.ErrorMessages.requireNonNullParam;
+
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * An option type that does not contain a value.
+ *
+ * @param <T> The type of the optional value
+ */
+public record None<T>() implements Option<T> {
+  // This type has no state and is immutable, so all instances are functionally identical.
+  // Using a singleton cuts down on unnecessary object allocation.
+  @SuppressWarnings("rawtypes")
+  private static final None NONE = new None();
+
+  @SuppressWarnings("unchecked")
+  public static <T> None<T> none() {
+    return (None<T>) NONE;
+  }
+
+  @Override
+  public T orElse(T fallbackValue) {
+    requireNonNullParam(fallbackValue, "fallbackValue", "Option.orElse");
+    return fallbackValue;
+  }
+
+  @Override
+  public T orElseGet(Supplier<? extends T> fallbackSupplier) {
+    requireNonNullParam(fallbackSupplier, "fallbackSupplier", "Option.orElseGet");
+
+    var fallbackValue = fallbackSupplier.get();
+    requireNonNull(fallbackValue, "The supplier passed to Option.orElseGet returned null");
+    return fallbackValue;
+  }
+
+  @Override
+  public T orElseThrow() {
+    throw new NoSuchElementException("This option has no value");
+  }
+
+  @Override
+  public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
+    requireNonNullParam(exceptionSupplier, "exceptionSupplier", "Option.orElseThrow");
+
+    var exception = exceptionSupplier.get();
+    requireNonNull(exception, "The supplier passed to Option.orElseThrow returned null");
+    throw exception;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Option<T> or(Supplier<? extends Option<? extends T>> supplier) {
+    requireNonNullParam(supplier, "supplier", "Option.or");
+
+    var other = supplier.get();
+    requireNonNull(other, "The supplier passed to Option.or returned null");
+    return (Option<T>) other;
+  }
+
+  @Override
+  public Option<T> filter(Predicate<? super T> predicate) {
+    requireNonNullParam(predicate, "predicate", "Option.filter");
+
+    return none();
+  }
+
+  @Override
+  public <R> Option<R> map(Function<? super T, ? extends R> mapper) {
+    requireNonNullParam(mapper, "mapper", "Option.map");
+
+    return none();
+  }
+
+  @Override
+  public <R> Option<R> flatMap(Function<? super T, ? extends Option<? extends R>> mapper) {
+    requireNonNullParam(mapper, "mapper", "Option.flatMap");
+
+    return none();
+  }
+
+  @Override
+  public Stream<T> stream() {
+    return Stream.empty();
+  }
+}

--- a/wpiutil/src/main/java/org/wpilib/util/option/Option.java
+++ b/wpiutil/src/main/java/org/wpilib/util/option/Option.java
@@ -1,0 +1,217 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.util.option;
+
+import static org.wpilib.util.ErrorMessages.requireNonNullParam;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * Represents a value that may or may not be present. Options are useful for handling data that may
+ * or may not be present without risking potential NullPointerExceptions or NoSuchElementExceptions.
+ *
+ * <p>This interface is intended to be used with pattern-matching {@code if} and {@code switch}
+ * statements, a Java language feature introduced in Java 21. See the <a
+ * href="https://docs.oracle.com/en/java/javase/21/language/record-patterns.html">official Java
+ * documentation</a> for more information on this language feature.
+ *
+ * <pre>{@code
+ * // Usage in if statements:
+ * Option<String> potentialText = fetchData(); // Pretend this function exists for sake of example
+ * if (potentialText instanceof Some(String text)) {
+ *   System.out.println("Got text: " + text);
+ * } else {
+ *   System.err.println("Didn't get any text");
+ * }
+ *
+ * // Usage in switch statements:
+ * switch (potentialText) {
+ *   case Some(String text) -> System.out.println("Got text: " + text);
+ *   case None() -> System.err.println("Didn't get any text");
+ * }
+ * }</pre>
+ *
+ * @param <T> The type of the values that can potentially be stored in the option
+ * @see <a
+ *     href="https://docs.oracle.com/en/java/javase/21/language/record-patterns.html">https://docs.oracle.com/en/java/javase/21/language/record-patterns.html</a>
+ */
+public sealed interface Option<T> permits Some, None {
+  /**
+   * Creates a new option wrapping a value. An exception is thrown if the value is null. If you want
+   * to safely handle values that are possibly null, use {@link Option#ofNullable(Object)} instead.
+   *
+   * @param value The value to wrap. Cannot be null.
+   * @param <T> The type of the values that can potentially be stored in the option
+   * @return An option for the value.
+   * @throws NullPointerException if {@code value} is {@code null}
+   */
+  static <T> Option<T> some(T value) {
+    return Some.of(value);
+  }
+
+  /**
+   * Creates an empty option containing no data.
+   *
+   * @param <T> The type of values that could have potentially been stored in the option
+   * @return A no-value option
+   */
+  static <T> None<T> none() {
+    return None.none();
+  }
+
+  /**
+   * Creates an option wrapping a potentially null value. If the value is null, an empty {@link
+   * None} value is returned, otherwise a {@link Some} wrapping the non-null value is returned.
+   *
+   * @param value The value to wrap. May be null.
+   * @param <T> The type of values that can be stored in the option
+   * @return An option corresponding to the given nullable value
+   */
+  static <T> Option<T> ofNullable(T value) {
+    if (value != null) {
+      return new Some<>(value);
+    } else {
+      return none();
+    }
+  }
+
+  /**
+   * Creates a new option corresponding to a {@code java.util.Optional} object. If the optional is
+   * {@link Optional#isPresent() present}, a {@link Some} is option is returned; otherwise, a {@link
+   * None} option is returned.
+   *
+   * @param javaOptional The Java {@code Optional} object to wrap. Cannot be null.
+   * @param <T> The type of the values that can potentially be stored in the option.
+   * @return An option for the optional value.
+   */
+  static <T> Option<T> ofOptional(Optional<? extends T> javaOptional) {
+    requireNonNullParam(javaOptional, "javaOptional", "Option.ofOptional");
+
+    if (javaOptional.isPresent()) {
+      return new Some<>(javaOptional.get());
+    } else {
+      return none();
+    }
+  }
+
+  /**
+   * Gets the value of this option, falling back to {@code fallbackValue} if the option is empty.
+   *
+   * @param fallbackValue The default fallback value. Cannot be null.
+   * @return The value of this option, if present, or the fallback value.
+   * @throws NullPointerException if {@code fallbackValue} is {@code null}
+   */
+  T orElse(T fallbackValue);
+
+  /**
+   * Gets the value of this option, falling back to a value provided by {@code supplier} if the
+   * option is empty.
+   *
+   * @param fallbackSupplier A supplier for fallback values. Cannot be null, and cannot return
+   *     nulls.
+   * @return The value of this option, if present, or a fallback value provided by {@code
+   *     fallbackSupplier}.
+   * @throws NullPointerException if {@code supplier} is {@code null}
+   * @throws NullPointerException if {@code supplier} returns {@code null}
+   */
+  T orElseGet(Supplier<? extends T> fallbackSupplier);
+
+  /**
+   * Gets the value of this option, throwing an exception if the option is empty.
+   *
+   * @return The value of this option, if present
+   * @throws NoSuchElementException if the option is empty
+   */
+  T orElseThrow();
+
+  /**
+   * Gets the value of this option, throwing an exception if the option is empty.
+   *
+   * @param exceptionSupplier A provider for an exception to throw if the option is empty. Cannot be
+   *     {@code null} and cannot return a {@code null} exception.
+   * @param <X> The type of the exception to throw if the option is empty.
+   * @return The value of this option, if present.
+   * @throws X if the option is empty
+   */
+  <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X;
+
+  /**
+   * If a value is present, returns an option holding the value, otherwise returns an option
+   * provided by the supplying function.
+   *
+   * @param supplier the supplying function that produces an option to return if this option is
+   *     empty.
+   * @return this option, if a value is present, or an option provided by the supplying function if
+   *     no value is present
+   * @throws NullPointerException if {@code supplier} is {@code null} or it returns a {@code null}
+   *     value
+   */
+  Option<T> or(Supplier<? extends Option<? extends T>> supplier);
+
+  /**
+   * Returns an option describing the value of this option if it matches the given predicate.
+   * Otherwise, returns an empty option.
+   *
+   * @param predicate The predicate to test the value against. Must not be null.
+   * @return An option containing the original value if the predicate is satisfied, or an empty
+   *     option if the predicate is not satisfied or if this option is empty.
+   * @throws NullPointerException if {@code predicate} is {@code null}
+   */
+  Option<T> filter(Predicate<? super T> predicate);
+
+  /**
+   * Applies a mapping function to the value in this option, returning a new option containing the
+   * result of the mapping function. The function may return {@code null}; if so, an empty option is
+   * returned. Applying a mapping function to an empty option always returns another empty option.
+   * This function is equivalent to the following switch statement:
+   *
+   * <pre>{@code
+   * Option<?> option = ...;
+   * Option<?> mapped = switch (option) {
+   *   case Some(var value) -> Option.of(mappingFunction.apply(value));
+   *   case None() -> Option.noValue();
+   * };
+   * }</pre>
+   *
+   * @param mapper The mapping function to apply.
+   * @param <R> The result type of the mapping function
+   * @return An option containing the result of the mapping operation, or an empty option if the
+   *     mapping function returned null
+   * @throws NullPointerException if {@code mapper} is {@code null}
+   */
+  <R> Option<R> map(Function<? super T, ? extends R> mapper);
+
+  /**
+   * Like {@link #map(Function)}, but where the function may return another {@code Option} object
+   * instead of a raw value. Useful to avoid stackups of nested {@code Option<Option<Option<...>>>}
+   * types.
+   *
+   * @param mapper The mapping function to apply
+   * @param <R> The result type of the mapping function
+   * @return An option containing the result of the mapping operation
+   */
+  <R> Option<R> flatMap(Function<? super T, ? extends Option<? extends R>> mapper);
+
+  /**
+   * If a value is present, returns a sequential {@link Stream} containing only that value,
+   * otherwise returns an empty {@code Stream}.
+   *
+   * <p>This method can be used to transform a {@code Stream} of optional elements to a {@code
+   * Stream} of present value elements:
+   *
+   * <pre>{@code
+   * Stream<Optional<T>> os = ..
+   * Stream<T> s = os.flatMap(Optional::stream)
+   * }</pre>
+   *
+   * @return the optional value as a {@code Stream}
+   */
+  Stream<T> stream();
+}

--- a/wpiutil/src/main/java/org/wpilib/util/option/Option.java
+++ b/wpiutil/src/main/java/org/wpilib/util/option/Option.java
@@ -176,7 +176,7 @@ public sealed interface Option<T> permits Some, None {
    * Option<?> option = ...;
    * Option<?> mapped = switch (option) {
    *   case Some(var value) -> Option.of(mappingFunction.apply(value));
-   *   case None() -> Option.noValue();
+   *   case None() -> Option.none();
    * };
    * }</pre>
    *
@@ -203,12 +203,12 @@ public sealed interface Option<T> permits Some, None {
    * If a value is present, returns a sequential {@link Stream} containing only that value,
    * otherwise returns an empty {@code Stream}.
    *
-   * <p>This method can be used to transform a {@code Stream} of optional elements to a {@code
-   * Stream} of present value elements:
+   * <p>This method can be used to transform a {@code Stream} of option elements to a {@code Stream}
+   * of present value elements:
    *
    * <pre>{@code
-   * Stream<Optional<T>> os = ..
-   * Stream<T> s = os.flatMap(Optional::stream)
+   * Stream<Option<T>> os = ..
+   * Stream<T> s = os.flatMap(Option::stream)
    * }</pre>
    *
    * @return the optional value as a {@code Stream}

--- a/wpiutil/src/main/java/org/wpilib/util/option/Some.java
+++ b/wpiutil/src/main/java/org/wpilib/util/option/Some.java
@@ -1,0 +1,111 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.util.option;
+
+import static java.util.Objects.requireNonNull;
+import static org.wpilib.util.ErrorMessages.requireNonNullParam;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * An option type that contains a value.
+ *
+ * @param value The value of the option. This is never {@code null}
+ * @param <T> The type of the value
+ */
+public record Some<T>(T value) implements Option<T> {
+  /**
+   * Creates a new option wrapping a value. An exception is thrown if the value is null. If you want
+   * to safely handle values that are possibly null, use {@link Option#ofNullable(Object)} instead.
+   *
+   * @param value The value to wrap. Cannot be null.
+   * @param <T> The type of the values that can potentially be stored in the option
+   * @return An option for the value.
+   * @throws NullPointerException if {@code value} is {@code null}
+   */
+  public static <T> Some<T> of(T value) {
+    requireNonNullParam(value, "value", "Some.of");
+
+    return new Some<>(value);
+  }
+
+  /**
+   * Canonical constructor. Prefer {@link Some#some(Object)} instead of constructing values
+   * directly.
+   *
+   * @param value The value of the option. Cannot be {@code null}
+   * @throws NullPointerException if {@code value} is {@code null}
+   */
+  public Some {
+    requireNonNullParam(value, "value", "Some");
+  }
+
+  @Override
+  public T orElse(T fallbackValue) {
+    requireNonNullParam(fallbackValue, "fallbackValue", "Option.orElse");
+    return value;
+  }
+
+  @Override
+  public T orElseGet(Supplier<? extends T> fallbackSupplier) {
+    requireNonNullParam(fallbackSupplier, "fallbackSupplier", "Option.orElseGet");
+    return value;
+  }
+
+  @Override
+  public T orElseThrow() {
+    return value;
+  }
+
+  @Override
+  public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) {
+    requireNonNullParam(exceptionSupplier, "exceptionSupplier", "Option.orElseThrow");
+
+    return value;
+  }
+
+  @Override
+  public Option<T> or(Supplier<? extends Option<? extends T>> supplier) {
+    requireNonNullParam(supplier, "supplier", "Option.or");
+
+    return this;
+  }
+
+  @Override
+  public Option<T> filter(Predicate<? super T> predicate) {
+    requireNonNullParam(predicate, "predicate", "Option.filter");
+
+    if (predicate.test(value)) {
+      return this;
+    } else {
+      return Option.none();
+    }
+  }
+
+  @Override
+  public <R> Option<R> map(Function<? super T, ? extends R> mapper) {
+    requireNonNullParam(mapper, "mapper", "Option.map");
+
+    return Option.ofNullable(mapper.apply(value));
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <R> Option<R> flatMap(Function<? super T, ? extends Option<? extends R>> mapper) {
+    requireNonNullParam(mapper, "mapper", "Option.flatMap");
+
+    var result = mapper.apply(value);
+    requireNonNull(result, "The mapping function passed to Option.flatMap returned null");
+    return (Option<R>) result;
+  }
+
+  @Override
+  public Stream<T> stream() {
+    return Stream.of(value);
+  }
+}

--- a/wpiutil/src/main/java/org/wpilib/util/option/package-info.java
+++ b/wpiutil/src/main/java/org/wpilib/util/option/package-info.java
@@ -1,0 +1,13 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+/**
+ * Provides APIs for working with optional data in a null safe manner. The {@link
+ * org.wpilib.util.option.Option} class provides methods for creating objects that respresent a
+ * value ({@link org.wpilib.util.option.Some}) or the absence of a value ({@link
+ * org.wpilib.util.option.None})
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Option_type">Option Types on Wikipedia</a>
+ */
+package org.wpilib.util.option;

--- a/wpiutil/src/test/java/org/wpilib/util/OptionTest.java
+++ b/wpiutil/src/test/java/org/wpilib/util/OptionTest.java
@@ -1,0 +1,45 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.wpilib.util.option.None;
+import org.wpilib.util.option.Option;
+
+class OptionTest {
+  @Test
+  void noneReturnsSameObject() {
+    assertSame(None.none(), Option.none());
+  }
+
+  @Test
+  void ofNullableAcceptsNull() {
+    assertSame(Option.none(), Option.ofNullable(null));
+  }
+
+  @Test
+  void ofOptionalCannotBeNull() {
+    var err = assertThrows(NullPointerException.class, () -> Option.ofOptional(null));
+    assertTrue(
+        err.getMessage().contains("Parameter javaOptional in method Option.ofOptional was null"),
+        err.getMessage());
+  }
+
+  @Test
+  void ofOptionalEmptyReturnsNone() {
+    assertSame(Option.none(), Option.ofOptional(Optional.empty()));
+  }
+
+  @Test
+  void ofOptionalPresentReturnsValue() {
+    assertEquals(Option.some("value"), Option.ofOptional(Optional.of("value")));
+  }
+}

--- a/wpiutil/src/test/java/org/wpilib/util/option/NoneTest.java
+++ b/wpiutil/src/test/java/org/wpilib/util/option/NoneTest.java
@@ -1,0 +1,177 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.util.option;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Test;
+
+class NoneTest {
+  @Test
+  void orElseReturnsFallback() {
+    var none = None.none();
+    assertEquals("foo", none.orElse("foo"));
+  }
+
+  @Test
+  void orElseThrowsOnNull() {
+    var none = None.none();
+    var err = assertThrowsExactly(NullPointerException.class, () -> none.orElse(null));
+    assertTrue(
+        err.getMessage().contains("Parameter fallbackValue in method Option.orElse was null"));
+  }
+
+  @Test
+  void orElseGetReturnsFallback() {
+    var none = None.none();
+    assertEquals("foo", none.orElseGet(() -> "foo"));
+  }
+
+  @Test
+  void orElseGetThrowsOnNullSupplier() {
+    var none = None.none();
+    var err = assertThrowsExactly(NullPointerException.class, () -> none.orElseGet(null));
+    assertTrue(
+        err.getMessage()
+            .contains("Parameter fallbackSupplier in method Option.orElseGet was null"));
+  }
+
+  @Test
+  void orElseGetThrowsOnNullSupplierResult() {
+    var none = None.none();
+    var err = assertThrowsExactly(NullPointerException.class, () -> none.orElseGet(() -> null));
+    assertTrue(err.getMessage().contains("The supplier passed to Option.orElseGet returned null"));
+  }
+
+  @Test
+  void orElseThrowThrows() {
+    var none = None.none();
+    var err = assertThrowsExactly(NoSuchElementException.class, none::orElseThrow);
+    assertEquals("This option has no value", err.getMessage());
+  }
+
+  @Test
+  void orElseThrowSupplierThrows() {
+    var none = None.none();
+    var err =
+        assertThrowsExactly(
+            NoSuchElementException.class,
+            () -> none.orElseThrow(() -> new NoSuchElementException("boom!")));
+    assertEquals("boom!", err.getMessage());
+  }
+
+  @Test
+  void orElseThrowsSupplierThrowsOnNullSupplier() {
+    var none = None.none();
+    var err = assertThrowsExactly(NullPointerException.class, () -> none.orElseThrow(null));
+    assertTrue(
+        err.getMessage()
+            .contains("Parameter exceptionSupplier in method Option.orElseThrow was null"));
+  }
+
+  @Test
+  void orElseThrowsSupplierThrowsOnNullSupplierResult() {
+    var none = None.none();
+    var err = assertThrowsExactly(NullPointerException.class, () -> none.orElseThrow(() -> null));
+    assertEquals("The supplier passed to Option.orElseThrow returned null", err.getMessage());
+  }
+
+  @Test
+  void orReturnsOther() {
+    var none = None.<String>none();
+    var other = Some.of("foo");
+    assertSame(other, none.or(() -> other));
+    assertSame(other, other.or(() -> none));
+  }
+
+  @Test
+  void orThrowsWithNullSupplier() {
+    var none = None.none();
+    var err = assertThrowsExactly(NullPointerException.class, () -> none.or(null));
+    assertTrue(err.getMessage().contains("Parameter supplier in method Option.or was null"));
+  }
+
+  @Test
+  void orThrowsWithNullSupplierResult() {
+    var none = None.none();
+    var err = assertThrowsExactly(NullPointerException.class, () -> none.or(() -> null));
+    assertTrue(err.getMessage().contains("The supplier passed to Option.or returned null"));
+  }
+
+  @Test
+  void filterOnTrueReturnsNone() {
+    var none = None.none();
+    var result = none.filter(_ -> true);
+    assertSame(none, result);
+  }
+
+  @Test
+  void filterOnFalseReturnsNone() {
+    var none = None.none();
+    var result = none.filter(_ -> false);
+    assertSame(none, result);
+  }
+
+  @Test
+  void filterThrowsOnNullPredicate() {
+    var none = None.none();
+    var err = assertThrowsExactly(NullPointerException.class, () -> none.filter(null));
+    assertTrue(err.getMessage().contains("Parameter predicate in method Option.filter was null"));
+  }
+
+  @Test
+  void mapReturnsNone() {
+    var none = None.none();
+    var result = none.map(x -> "foo");
+    assertSame(none, result);
+  }
+
+  @Test
+  void mapThrowsOnNullFunction() {
+    var none = None.none();
+    var err = assertThrowsExactly(NullPointerException.class, () -> none.map(null));
+    assertTrue(err.getMessage().contains("Parameter mapper in method Option.map was null"));
+  }
+
+  @Test
+  void mapDoesNotThrowOnNullFunctionResult() {
+    var none = None.none();
+    // mapper function should not be evaluated
+    var result = assertDoesNotThrow(() -> none.map(x -> null));
+    assertSame(none, result);
+  }
+
+  @Test
+  void flatMapReturnsNone() {
+    var none = None.none();
+    assertSame(none, none.flatMap(_ -> Some.of("foo")));
+  }
+
+  @Test
+  void flatMapThrowsOnNullFunction() {
+    var none = None.none();
+    var err = assertThrowsExactly(NullPointerException.class, () -> none.flatMap(null));
+    assertTrue(err.getMessage().contains("Parameter mapper in method Option.flatMap was null"));
+  }
+
+  @Test
+  void flatMapDoesNotThrowOnNullFunctionResult() {
+    var none = None.none();
+    var result = assertDoesNotThrow(() -> none.flatMap(x -> null));
+    assertSame(none, result);
+  }
+
+  @Test
+  void stream() {
+    var none = None.none();
+    var stream = none.stream();
+    assertEquals(0, stream.count());
+  }
+}

--- a/wpiutil/src/test/java/org/wpilib/util/option/SomeTest.java
+++ b/wpiutil/src/test/java/org/wpilib/util/option/SomeTest.java
@@ -1,0 +1,166 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.util.option;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SomeTest {
+  @Test
+  void ofRejectsNulls() {
+    var err = assertThrowsExactly(NullPointerException.class, () -> Some.of(null));
+    assertTrue(err.getMessage().contains("Parameter value in method Some.of was null"));
+  }
+
+  @Test
+  void constructorRejectsNulls() {
+    var err = assertThrowsExactly(NullPointerException.class, () -> new Some<>(null));
+    assertTrue(err.getMessage().contains("Parameter value in method Some was null"));
+  }
+
+  @Test
+  void ofAcceptsNonNullValues() {
+    var some = Some.of("value");
+    assertEquals("value", some.value());
+  }
+
+  @Test
+  void orElseReturnsValue() {
+    var some = Some.of("foo");
+    assertEquals("foo", some.orElse("bar"));
+  }
+
+  @Test
+  void orElseThrowsOnNullFallback() {
+    var some = Some.of("foo");
+    var err = assertThrowsExactly(NullPointerException.class, () -> some.orElse(null));
+    assertTrue(
+        err.getMessage().contains("Parameter fallbackValue in method Option.orElse was null"));
+  }
+
+  @Test
+  void orElseGet() {
+    var some = Some.of("foo");
+    assertEquals("foo", some.orElseGet(() -> "bar"));
+  }
+
+  @Test
+  void orElseGetThrowsOnNullFallback() {
+    var some = Some.of("foo");
+    var err = assertThrowsExactly(NullPointerException.class, () -> some.orElseGet(null));
+    assertTrue(
+        err.getMessage()
+            .contains("Parameter fallbackSupplier in method Option.orElseGet was null"));
+  }
+
+  @Test
+  void orElseThrowDoesNotThrow() {
+    var some = Some.of("foo");
+    assertEquals("foo", some.orElseThrow());
+  }
+
+  @Test
+  void orElseThrowSupplierDoesNotThrow() {
+    var some = Some.of("foo");
+    assertEquals("foo", some.orElseThrow(NullPointerException::new));
+  }
+
+  @Test
+  void orElseThrowSupplierThrowsOnNullSupplier() {
+    var some = Some.of("foo");
+    var err = assertThrowsExactly(NullPointerException.class, () -> some.orElseThrow(null));
+    assertTrue(
+        err.getMessage()
+            .contains("Parameter exceptionSupplier in method Option.orElseThrow was null"));
+  }
+
+  @Test
+  void orReturnsSelf() {
+    var some = Some.of("foo");
+    var other = Some.of("bar");
+    assertSame(some, some.or(() -> other));
+    assertSame(other, other.or(() -> some));
+  }
+
+  @Test
+  void filterOnTrueReturnsSelf() {
+    var some = Some.of("foo");
+    assertSame(some, some.filter(_ -> true));
+  }
+
+  @Test
+  void filterOnFalseReturnsNone() {
+    var some = Some.of("foo");
+    assertSame(None.none(), some.filter(_ -> false));
+  }
+
+  @Test
+  void filterThrowsOnNullPredicate() {
+    var some = Some.of("foo");
+    var err = assertThrowsExactly(NullPointerException.class, () -> some.filter(null));
+    assertTrue(err.getMessage().contains("Parameter predicate in method Option.filter was null"));
+  }
+
+  @Test
+  void mapReturningNullGivesNone() {
+    var some = Some.of("foo");
+    var result = some.map(_ -> null);
+    assertSame(None.none(), result);
+  }
+
+  @Test
+  void mapReturnsNewOption() {
+    var some = Some.of("foo");
+    var result = some.map(value -> value.repeat(2));
+    assertEquals(Some.of("foofoo"), result);
+  }
+
+  @Test
+  void mapThrowsOnNullFunction() {
+    var some = Some.of("foo");
+    var err = assertThrowsExactly(NullPointerException.class, () -> some.map(null));
+    assertTrue(err.getMessage().contains("Parameter mapper in method Option.map was null"));
+  }
+
+  @Test
+  void flatMap() {
+    var some = Some.of("foo");
+    var result = some.flatMap(x -> Some.of(x + "bar"));
+    assertEquals(Some.of("foobar"), result);
+  }
+
+  @Test
+  void flatMapThrowsOnNullFunction() {
+    var some = Some.of("foo");
+    var err = assertThrowsExactly(NullPointerException.class, () -> some.flatMap(null));
+    assertTrue(err.getMessage().contains("Parameter mapper in method Option.flatMap was null"));
+  }
+
+  @Test
+  void flatMapThrowsOnNullMapperOutput() {
+    var some = Some.of("foo");
+    var err = assertThrowsExactly(NullPointerException.class, () -> some.flatMap(_ -> null));
+    assertTrue(
+        err.getMessage().contains("The mapping function passed to Option.flatMap returned null"));
+  }
+
+  @Test
+  void stream() {
+    var some = Some.of("foo");
+    var result = some.stream().toList();
+    assertEquals(List.of("foo"), result);
+  }
+
+  @Test
+  void value() {
+    var some = Some.of("foo");
+    assertEquals("foo", some.value());
+  }
+}


### PR DESCRIPTION
Uses an ADT with subtypes `Some(T)` and `None()`, following typical naming practices from other languages

Key difference from `java.util.Optional` is that there's no unsafe `get()` method that can be called. `getOrThrow()` exists to make it clear that an exception will be thrown if there's no value. Users can also use pattern matching instanceof or switch expressions on the ADT types, which j.u.Optional does not provide.

Closes #7447 