### PR TITLE
[wpinet] Fix llhttp exporting extra symbols on Windows

### DIFF
--- a/upstream_utils/llhttp_patches/0001-Fix-pedantic-warnings.patch
+++ b/upstream_utils/llhttp_patches/0001-Fix-pedantic-warnings.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Codex <codex@example.com>
 Date: Fri, 7 Aug 2026 14:17:27 -0700
-Subject: [PATCH] Fix pedantic warnings
+Subject: [PATCH 1/2] Fix pedantic warnings
 
 ---
  bin/generate.ts   | 22 +++++++++++++++--

--- a/upstream_utils/llhttp_patches/0002-Make-LLHTTP_EXPORT-empty.patch
+++ b/upstream_utils/llhttp_patches/0002-Make-LLHTTP_EXPORT-empty.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Codex <codex@example.com>
+Date: Sat, 15 Aug 2026 00:00:00 -0700
+Subject: [PATCH] Make LLHTTP_EXPORT empty
+
+wpinet automatically exports symbols, and llhttp's visibility and dllexport
+attributes interfere with other libraries.
+---
+ src/native/api.h | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/src/native/api.h b/src/native/api.h
+--- a/src/native/api.h
++++ b/src/native/api.h
+@@ -5,13 +5,7 @@ extern "C" {
+ #endif
+ #include <stddef.h>
+ 
+-#if defined(__wasm__)
+-#define LLHTTP_EXPORT __attribute__((visibility("default")))
+-#elif defined(_WIN32)
+-#define LLHTTP_EXPORT __declspec(dllexport)
+-#else
+ #define LLHTTP_EXPORT
+-#endif
+ 
+ typedef llhttp__internal_t llhttp_t;
+ typedef struct llhttp_settings_s llhttp_settings_t;

--- a/upstream_utils/llhttp_patches/0002-Make-LLHTTP_EXPORT-empty.patch
+++ b/upstream_utils/llhttp_patches/0002-Make-LLHTTP_EXPORT-empty.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Codex <codex@example.com>
 Date: Sat, 15 Aug 2026 00:00:00 -0700
-Subject: [PATCH] Make LLHTTP_EXPORT empty
+Subject: [PATCH 2/2] Make LLHTTP_EXPORT empty
 
 wpinet automatically exports symbols, and llhttp's visibility and dllexport
 attributes interfere with other libraries.
@@ -10,6 +10,7 @@ attributes interfere with other libraries.
  1 file changed, 6 deletions(-)
 
 diff --git a/src/native/api.h b/src/native/api.h
+index 0a58d4e064717e498b82148c9fd9539163131a21..e87a0a053353987ffb7ffb068ced9ae9256ea24d 100644
 --- a/src/native/api.h
 +++ b/src/native/api.h
 @@ -5,13 +5,7 @@ extern "C" {

--- a/wpinet/src/main/native/thirdparty/llhttp/include/llhttp.h
+++ b/wpinet/src/main/native/thirdparty/llhttp/include/llhttp.h
@@ -552,13 +552,7 @@ extern "C" {
 #endif
 #include <stddef.h>
 
-#if defined(__wasm__)
-#define LLHTTP_EXPORT __attribute__((visibility("default")))
-#elif defined(_WIN32)
-#define LLHTTP_EXPORT __declspec(dllexport)
-#else
 #define LLHTTP_EXPORT
-#endif
 
 typedef llhttp__internal_t llhttp_t;
 typedef struct llhttp_settings_s llhttp_settings_t;


### PR DESCRIPTION
dllexport in code is always unconditional. This means even when linking into static libraries, the function will be exported. This is breaking mrclib