### PR TITLE
Don't export wpimath functions during static builds

### DIFF
--- a/wpimath/CMakeLists.txt
+++ b/wpimath/CMakeLists.txt
@@ -64,7 +64,9 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 set_target_properties(wpimath PROPERTIES DEBUG_POSTFIX "d")
 
 set_property(TARGET wpimath PROPERTY FOLDER "libraries")
-target_compile_definitions(wpimath PRIVATE WPILIB_EXPORTS SLEIPNIR_EXPORTS)
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(wpimath PRIVATE WPILIB_EXPORTS SLEIPNIR_EXPORTS)
+endif()
 
 target_compile_features(wpimath PUBLIC cxx_std_23)
 if(MSVC)


### PR DESCRIPTION
On windows, dllexport always exports, even when linked from a static library. This can expose extra functions in a shared library if it links with static wpimath. Solve this by only setting the export functions when building shared libraries in cmake