### PR TITLE
[build] Remove mrclib link by default from sim builds

### DIFF
--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -219,7 +219,9 @@ model {
                 lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
                 lib project: ':cscore', library: 'cscore', linkage: 'shared'
                 lib project: ':cscore', library: 'cscoreJNIShared', linkage: 'shared'
-                nativeUtils.useRequiredLibrary(binary, 'mrclib')
+                if (binary.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                    nativeUtils.useRequiredLibrary(binary, 'mrclib')
+                }
                 lib project: ':hal', library: 'hal', linkage: 'shared'
                 lib project: ':hal', library: 'halJNIShared', linkage: 'shared'
                 project(':ntcore').addNtcoreDependency(binary, 'shared')
@@ -274,7 +276,9 @@ model {
                 lib project: ':apriltag', library: 'apriltag', linkage: 'static'
                 lib project: ':cameraserver', library: 'cameraserver', linkage: 'static'
                 lib project: ':cscore', library: 'cscore', linkage: 'static'
-                nativeUtils.useRequiredLibrary(binary, 'mrclib')
+                if (binary.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                    nativeUtils.useRequiredLibrary(binary, 'mrclib')
+                }
                 lib project: ':hal', library: 'hal', linkage: 'static'
                 project(':ntcore').addNtcoreDependency(binary, 'static')
                 lib project: ':wpilibc', library: 'wpilibc', linkage: 'static'

--- a/cameraserver/build.gradle
+++ b/cameraserver/build.gradle
@@ -12,6 +12,7 @@ evaluationDependsOn(':wpilibj')
 evaluationDependsOn(':wpimath')
 
 apply from: "${rootDir}/shared/javacpp/setupBuild.gradle"
+apply from: "${rootDir}/shared/libmrclib.gradle"
 
 dependencies {
     implementation project(':wpiutil')
@@ -49,7 +50,9 @@ model {
                 return
             }
             project(':ntcore').addNtcoreDependency(it, 'shared')
-            nativeUtils.useRequiredLibrary(it, 'mrclib')
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                nativeUtils.useRequiredLibrary(it, 'mrclib')
+            }
             lib project: ':hal', library: 'hal', linkage: 'shared'
             lib project: ':cscore', library: 'cscore', linkage: 'shared'
             lib project: ':wpilibc', library: 'wpilibc', linkage: 'shared'

--- a/commandsv2/build.gradle
+++ b/commandsv2/build.gradle
@@ -11,6 +11,7 @@ evaluationDependsOn(':wpilibc')
 evaluationDependsOn(':wpilibj')
 
 apply from: "${rootDir}/shared/javacpp/setupBuild.gradle"
+apply from: "${rootDir}/shared/libmrclib.gradle"
 
 dependencies {
     implementation project(':wpiutil')
@@ -59,7 +60,9 @@ model {
             }
             lib project: ':wpilibc', library: 'wpilibc', linkage: 'shared'
             project(':ntcore').addNtcoreDependency(it, 'shared')
-            nativeUtils.useRequiredLibrary(it, 'mrclib')
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                nativeUtils.useRequiredLibrary(it, 'mrclib')
+            }
             lib project: ':hal', library: 'hal', linkage: 'shared'
             lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'

--- a/drivers/build.gradle
+++ b/drivers/build.gradle
@@ -10,6 +10,7 @@ evaluationDependsOn(':wpilibj')
 evaluationDependsOn(':wpimath')
 
 apply from: "${rootDir}/shared/javacpp/setupBuild.gradle"
+apply from: "${rootDir}/shared/libmrclib.gradle"
 
 dependencies {
     implementation project(':hal')
@@ -51,7 +52,9 @@ model {
             }
             lib project: ':wpilibc', library: 'wpilibc', linkage: 'shared'
             project(':ntcore').addNtcoreDependency(it, 'shared')
-            nativeUtils.useRequiredLibrary(it, 'mrclib')
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                nativeUtils.useRequiredLibrary(it, 'mrclib')
+            }
             lib project: ':hal', library: 'hal', linkage: 'shared'
             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
             lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
@@ -59,7 +62,9 @@ model {
 
             if (it.component.name == "${nativeName}Dev") {
                 project(':ntcore').addNtcoreJniDependency(it)
-                nativeUtils.useRequiredLibrary(it, 'mrclib')
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                    nativeUtils.useRequiredLibrary(it, 'mrclib')
+                }
                 lib project: ':hal', library: 'hal', linkage: 'shared'
                 lib project: ':hal', library: 'halJNIShared', linkage: 'shared'
                 lib project: ':wpinet', library: 'wpinetJNIShared', linkage: 'shared'

--- a/hal/BUILD.bazel
+++ b/hal/BUILD.bazel
@@ -19,7 +19,9 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-SYSTEMCORE_SRCS = glob(["src/main/native/systemcore/**"])
+MRCLIB_SRCS = glob(["src/main/native/cpp/mrclib/**"])
+
+SYSTEMCORE_SRCS = glob(["src/main/native/systemcore/**"]) + MRCLIB_SRCS
 
 SIM_SRCS = glob(["src/main/native/sim/**"])
 
@@ -70,7 +72,7 @@ wpilib_cc_library(
         "@mrclib_headers//:headers",
     ] + select({
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": [
-            ":wpiHalMrc",
+            "//shared/bazel/thirdparty/mrclib",
         ],
         "//conditions:default": [
             "//ntcore:ntcore_c_headers",
@@ -80,7 +82,7 @@ wpilib_cc_library(
 
 cc_library(
     name = "wpiHalMrc",
-    srcs = glob(["src/main/native/cpp/mrclib/**"]),
+    srcs = MRCLIB_SRCS,
     visibility = ["//visibility:public"],
     deps = [
         ":wpiHal-headers",

--- a/hal/BUILD.bazel
+++ b/hal/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@allwpilib_pip_deps//:requirements.bzl", "requirement")
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_pkg//:mappings.bzl", "pkg_files")
 load("//hal:robotpy_native_build_info.bzl", "define_native_wrapper")
@@ -49,7 +49,10 @@ wpilib_cc_library(
         [
             "src/main/native/cpp/**",
         ],
-        exclude = ["src/main/native/cpp/jni/**"],
+        exclude = [
+            "src/main/native/cpp/jni/**",
+            "src/main/native/cpp/mrclib/**",
+        ],
     ),
     hdrs = glob(["src/main/native/include/**/*"]),
     extra_src_pkg_files = [
@@ -62,14 +65,28 @@ wpilib_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//ntcore",
-        "//shared/bazel/thirdparty/mrclib",
         "//wpinet",
         "//wpiutil",
+        "@mrclib_headers//:headers",
     ] + select({
+        "@wpilib_toolchains//constraints/is_systemcore:systemcore": [
+            ":wpiHalMrc",
+        ],
         "//conditions:default": [
             "//ntcore:ntcore_c_headers",
         ],
     }),
+)
+
+cc_library(
+    name = "wpiHalMrc",
+    srcs = glob(["src/main/native/cpp/mrclib/**"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":wpiHal-headers",
+        "//shared/bazel/thirdparty/mrclib",
+        "//wpiutil",
+    ],
 )
 
 wpilib_cc_shared_library(

--- a/hal/build.gradle
+++ b/hal/build.gradle
@@ -3,6 +3,7 @@ ext {
     setBaseName = 'wpiHal'
     devMain = 'org.wpilib.hardware.hal.DevMain'
     nativeTestSuiteName = "${nativeName}Test"
+    nativeCppSourceExcludes = ['mrclib/**/*.cpp']
     splitSetup = {
         if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
             it.sources {
@@ -59,12 +60,37 @@ nativeUtils.exportsConfigs {
 }
 
 model {
+    components {
+        halMrc(NativeLibrarySpec) {
+            sources.cpp {
+                source {
+                    srcDirs 'src/main/native/cpp/mrclib'
+                    include '**/*.cpp'
+                }
+                exportedHeaders {
+                    srcDir 'src/main/native/include'
+                }
+            }
+            binaries.all {
+                if (it instanceof SharedLibraryBinarySpec) {
+                    it.buildable = false
+                    return
+                }
+                nativeUtils.useRequiredLibrary(it, 'mrclib')
+                lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
+            }
+        }
+    }
     binaries {
         all {
-            if (!it.buildable || !(it instanceof NativeBinarySpec)) {
+            if (!it.buildable || !(it instanceof NativeBinarySpec) || it.component.name == 'halMrc') {
                 return
             }
-            nativeUtils.useRequiredLibrary(it, 'mrclib')
+            nativeUtils.useRequiredLibrary(it, 'mrclibHeaders')
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                nativeUtils.useRequiredLibrary(it, 'mrclib')
+                lib library: 'halMrc', linkage: 'static'
+            }
             if (it.component.name == "${nativeName}JNI") {
                 project(':ntcore').addNtcoreDependency(it, 'static')
                 lib project: ':wpinet', library: 'wpinet', linkage: 'static'

--- a/hal/build.gradle
+++ b/hal/build.gradle
@@ -39,6 +39,7 @@ ext {
 }
 
 apply from: "${rootDir}/shared/jni/setupBuild.gradle"
+apply from: "${rootDir}/shared/libmrclib.gradle"
 
 cppSourcesZip {
     from('src/main/native/systemcore') {

--- a/hal/build.gradle
+++ b/hal/build.gradle
@@ -9,7 +9,10 @@ ext {
             it.sources {
                 systemCoreCpp(CppSourceSet) {
                     source {
-                        srcDirs = ['src/main/native/systemcore']
+                        srcDirs = [
+                            'src/main/native/systemcore',
+                            'src/main/native/cpp/mrclib'
+                        ]
                         include '**/*.cpp'
                     }
                     exportedHeaders {
@@ -89,7 +92,6 @@ model {
             nativeUtils.useRequiredLibrary(it, 'mrclibHeaders')
             if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
                 nativeUtils.useRequiredLibrary(it, 'mrclib')
-                lib library: 'halMrc', linkage: 'static'
             }
             if (it.component.name == "${nativeName}JNI") {
                 project(':ntcore').addNtcoreDependency(it, 'static')

--- a/hal/src/main/python/native-pyproject.toml
+++ b/hal/src/main/python/native-pyproject.toml
@@ -65,4 +65,4 @@ name = "wpihal"
 includedir = "src/native/wpihal/include"
 libdir = "src/native/wpihal/lib"
 shared_libraries = ["wpiHal"]
-requires = ["robotpy-native-wpiutil", "robotpy-native-ntcore", "robotpy-native-mrclib"]
+requires = ["robotpy-native-wpiutil", "robotpy-native-ntcore"]

--- a/romiVendordep/build.gradle
+++ b/romiVendordep/build.gradle
@@ -11,6 +11,7 @@ evaluationDependsOn(":wpilibc")
 evaluationDependsOn(":wpilibj")
 
 apply from: "${rootDir}/shared/javacpp/setupBuild.gradle"
+apply from: "${rootDir}/shared/libmrclib.gradle"
 
 dependencies {
     implementation project(":wpiutil")
@@ -36,7 +37,9 @@ model {
             }
             lib project: ":wpilibc", library: "wpilibc", linkage: "shared"
             project(":ntcore").addNtcoreDependency(it, "shared")
-            nativeUtils.useRequiredLibrary(it, 'mrclib')
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                nativeUtils.useRequiredLibrary(it, 'mrclib')
+            }
             lib project: ':hal', library: 'hal', linkage: 'shared'
             lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'

--- a/shared/javacpp/setupBuild.gradle
+++ b/shared/javacpp/setupBuild.gradle
@@ -19,7 +19,6 @@ project(':').libraryBuild.dependsOn build
 def nativeTestSuiteName = project.findProperty('nativeTestSuiteName') ?: "${nativeName}Test"
 
 apply from: "${rootDir}/shared/catch2.gradle"
-apply from: "${rootDir}/shared/libmrclib.gradle"
 
 model {
     components {

--- a/shared/jni/setupBuild.gradle
+++ b/shared/jni/setupBuild.gradle
@@ -44,6 +44,9 @@ model {
                         }
                         include '**/*.cpp', '**/*.cc'
                         exclude '**/jni/**/*.cpp'
+                        if (project.hasProperty('nativeCppSourceExcludes')) {
+                            nativeCppSourceExcludes.each { exclude it }
+                        }
                     }
                     exportedHeaders {
                         srcDirs 'src/main/native/include', "$buildDir/generated/source/proto/main/cpp"

--- a/shared/jni/setupBuild.gradle
+++ b/shared/jni/setupBuild.gradle
@@ -27,7 +27,6 @@ project(':').libraryBuild.dependsOn build
 def nativeTestSuiteName = project.findProperty('nativeTestSuiteName') ?: "${nativeName}Test"
 
 apply from: "${rootDir}/shared/catch2.gradle"
-apply from: "${rootDir}/shared/libmrclib.gradle"
 
 model {
     components {

--- a/shared/libmrclib.gradle
+++ b/shared/libmrclib.gradle
@@ -1,5 +1,13 @@
 nativeUtils {
     nativeDependencyContainer {
+        mrclibHeaders(getNativeDependencyTypeClass('WPIHeaderOnlyMavenDependency')) {
+            groupId = "org.wpilib.mrclib"
+            artifactId = "mrclib-cpp"
+            headerClassifier = "headers"
+            ext = "zip"
+            version = libs.versions.mrclib
+            targetPlatforms.addAll(nativeUtils.wpi.platforms.allPlatforms)
+        }
         mrclib(getNativeDependencyTypeClass('WPISharedMavenDependency')) {
             groupId = "org.wpilib.mrclib"
             artifactId = "mrclib-cpp"

--- a/shared/plugins/setupBuild.gradle
+++ b/shared/plugins/setupBuild.gradle
@@ -5,7 +5,6 @@ apply plugin: ExtraTasks
 if (!project.hasProperty('onlylinuxsystemcore')) {
     ext.skiplinuxsystemcore = true
     apply from: "${rootDir}/shared/config.gradle"
-    apply from: "${rootDir}/shared/libmrclib.gradle"
 
     model {
         components {
@@ -31,7 +30,6 @@ if (!project.hasProperty('onlylinuxsystemcore')) {
                         it.cppCompiler.define("HALSIM_InitExtension", "HALSIM_InitExtension_$name")
                     }
 
-                    nativeUtils.useRequiredLibrary(it, 'mrclib')
                     lib project: ':hal', library: 'hal', linkage: 'shared'
                     if (project.hasProperty('includeNtCore')) {
                         lib project: ':ntcore', library: 'ntcore', linkage: 'shared'
@@ -60,7 +58,6 @@ if (!project.hasProperty('onlylinuxsystemcore')) {
                 }
                 binaries.all {
                     if (!project.hasProperty('onlylinuxsystemcore')) {
-                        nativeUtils.useRequiredLibrary(it, 'mrclib')
                         lib project: ':hal', library: 'hal', linkage: 'shared'
                         lib library: pluginName
                         if (project.hasProperty('includeNtCore')) {

--- a/simulation/halsim_ds_socket/BUILD.bazel
+++ b/simulation/halsim_ds_socket/BUILD.bazel
@@ -25,6 +25,7 @@ wpilib_cc_library(
     deps = [
         ":headers",
         "//hal:wpiHal",
+        "//hal:wpiHalMrc",
         "//wpinet",
     ],
 )
@@ -44,6 +45,7 @@ wpilib_cc_library(
     deps = [
         ":headers",
         "//hal:wpiHal",
+        "//hal:wpiHalMrc",
         "//wpinet",
     ],
 )

--- a/simulation/halsim_ds_socket/build.gradle
+++ b/simulation/halsim_ds_socket/build.gradle
@@ -14,6 +14,7 @@ apply plugin: 'google-test-test-suite'
 apply from: "${rootDir}/shared/catch2.gradle"
 
 apply from: "${rootDir}/shared/plugins/setupBuild.gradle"
+apply from: "${rootDir}/shared/libmrclib.gradle"
 
 model {
     testSuites {

--- a/simulation/halsim_ds_socket/build.gradle
+++ b/simulation/halsim_ds_socket/build.gradle
@@ -38,6 +38,7 @@ model {
     binaries {
         all {
             nativeUtils.useRequiredLibrary(it, 'mrclib')
+            lib project: ':hal', library: 'halMrc', linkage: 'static'
             lib project: ':hal', library: 'hal', linkage: 'shared'
             project(':ntcore').addNtcoreDependency(it, 'shared')
             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
@@ -45,6 +46,7 @@ model {
         }
         withType(GoogleTestTestSuiteBinarySpec) {
             nativeUtils.useRequiredLibrary(it, 'mrclib')
+            lib project: ':hal', library: 'halMrc', linkage: 'static'
             lib project: ':hal', library: 'hal', linkage: 'shared'
             project(':ntcore').addNtcoreDependency(it, 'shared')
             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'

--- a/simulation/halsim_ds_socket/src/main/python/halsim_ds_socket/main.py
+++ b/simulation/halsim_ds_socket/src/main/python/halsim_ds_socket/main.py
@@ -17,7 +17,12 @@ def load_extension():
     logger.info("WPILib HAL Simulation DS Socket Extension %s", version)
 
     root = join(abspath(dirname(__file__)), "lib")
-    ext = join(root, os.listdir(root)[0])
+    extensions = (".dll", ".dylib", ".so")
+    ext = next(
+        join(root, filename)
+        for filename in os.listdir(root)
+        if filename.endswith(extensions)
+    )
 
     # Load MrcLib globally before loading the extension that links to it.
     import native.wpihal._init_robotpy_native_mrclib  # noqa: F401

--- a/simulation/halsim_ds_socket/src/main/python/halsim_ds_socket/main.py
+++ b/simulation/halsim_ds_socket/src/main/python/halsim_ds_socket/main.py
@@ -18,6 +18,10 @@ def load_extension():
 
     root = join(abspath(dirname(__file__)), "lib")
     ext = join(root, os.listdir(root)[0])
+
+    # Load MrcLib globally before loading the extension that links to it.
+    import native.wpihal._init_robotpy_native_mrclib  # noqa: F401
+
     retval = hal.load_one_extension(ext)
     if retval != 0:
         logger.warn("loading extension may have failed (error=%d)", retval)

--- a/simulation/halsim_ds_socket/src/test/python/test_halsim_ds_socket.py
+++ b/simulation/halsim_ds_socket/src/test/python/test_halsim_ds_socket.py
@@ -1,18 +1,30 @@
 import ctypes
-import pathlib
+import sys
+import types
 
 
-def test_halsim_ds_socket():
+def test_halsim_ds_socket(monkeypatch):
     # dependencies
     import native.wpihal._init_robotpy_native_wpihal
     import native.wpinet._init_robotpy_native_wpinet
 
     import halsim_ds_socket as base
 
-    loaded = 0
-    for fname in (pathlib.Path(base.__file__).parent / "lib").iterdir():
-        if fname.is_file() and fname.suffix in (".dll", ".dylib", ".so"):
-            ctypes.CDLL(str(fname))
-            loaded += 1
+    mrclib_init = "native.wpihal._init_robotpy_native_mrclib"
+    assert mrclib_init not in sys.modules
 
-    assert loaded
+    loaded = []
+
+    def load_one_extension(fname):
+        ctypes.CDLL(fname)
+        loaded.append(fname)
+        return 0
+
+    hal = types.ModuleType("hal")
+    hal.load_one_extension = load_one_extension
+    monkeypatch.setitem(sys.modules, "hal", hal)
+
+    base.load_extension()
+
+    assert len(loaded) == 1
+    assert mrclib_init in sys.modules

--- a/simulation/halsim_gui/build.gradle
+++ b/simulation/halsim_gui/build.gradle
@@ -46,7 +46,6 @@ model {
             lib project: ':fields', library: 'fields', linkage: 'static'
             lib project: ':fields', library: 'fieldimages', linkage: 'static'
             lib project: ':wpimath', library: 'wpimath', linkage: 'shared'
-            nativeUtils.useRequiredLibrary(it, 'mrclib')
             lib project: ':hal', library: 'hal', linkage: 'shared'
             project(':ntcore').addNtcoreDependency(it, 'shared')
             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
@@ -59,7 +58,6 @@ model {
             }
         }
         withType(GoogleTestTestSuiteBinarySpec) {
-            nativeUtils.useRequiredLibrary(it, 'mrclib')
             lib project: ':hal', library: 'hal', linkage: 'shared'
             project(':ntcore').addNtcoreDependency(it, 'shared')
             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'

--- a/simulation/halsim_ws_client/build.gradle
+++ b/simulation/halsim_ws_client/build.gradle
@@ -19,7 +19,6 @@ model {
                 return
             }
 
-            nativeUtils.useRequiredLibrary(it, 'mrclib')
             lib project: ':hal', library: 'hal', linkage: 'shared'
             project(':ntcore').addNtcoreDependency(it, 'shared')
             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'

--- a/simulation/halsim_ws_core/build.gradle
+++ b/simulation/halsim_ws_core/build.gradle
@@ -16,7 +16,6 @@ ext {
 
 apply from: "${rootDir}/shared/config.gradle"
 apply from: "${rootDir}/shared/plugins/publish.gradle"
-apply from: "${rootDir}/shared/libmrclib.gradle"
 
 model {
     components {
@@ -31,7 +30,6 @@ model {
                 }
             }
             binaries.all {
-                nativeUtils.useRequiredLibrary(it, 'mrclib')
                 lib project: ':hal', library: 'hal', linkage: 'shared'
                 project(':ntcore').addNtcoreDependency(it, 'shared')
                 lib project: ':wpinet', library: 'wpinet', linkage: 'shared'

--- a/simulation/halsim_ws_server/build.gradle
+++ b/simulation/halsim_ws_server/build.gradle
@@ -43,7 +43,6 @@ model {
                 return
             }
 
-            nativeUtils.useRequiredLibrary(it, 'mrclib')
             lib project: ':hal', library: 'hal', linkage: 'shared'
             project(':ntcore').addNtcoreDependency(it, 'shared')
             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
@@ -52,7 +51,6 @@ model {
         }
 
         withType(GoogleTestTestSuiteBinarySpec) {
-            nativeUtils.useRequiredLibrary(it, 'mrclib')
             lib project: ':hal', library: 'hal', linkage: 'shared'
             project(':ntcore').addNtcoreDependency(it, 'shared')
             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'

--- a/wpilibc/build.gradle
+++ b/wpilibc/build.gradle
@@ -104,7 +104,9 @@ model {
                 }
 
                 project(':ntcore').addNtcoreDependency(it, 'shared')
-                nativeUtils.useRequiredLibrary(it, 'mrclib')
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                    nativeUtils.useRequiredLibrary(it, 'mrclib')
+                }
                 lib project: ':hal', library: 'hal', linkage: 'shared'
                 lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
@@ -126,7 +128,9 @@ model {
             }
             binaries.all {
                 project(':ntcore').addNtcoreDependency(it, 'shared')
-                nativeUtils.useRequiredLibrary(it, 'mrclib')
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                    nativeUtils.useRequiredLibrary(it, 'mrclib')
+                }
                 lib project: ':hal', library: 'hal', linkage: 'shared'
                 lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
@@ -152,7 +156,9 @@ model {
             }
             binaries.all {
                 project(':ntcore').addNtcoreDependency(it, 'shared')
-                nativeUtils.useRequiredLibrary(it, 'mrclib')
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                    nativeUtils.useRequiredLibrary(it, 'mrclib')
+                }
                 lib project: ':hal', library: 'hal', linkage: 'shared'
                 lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
@@ -212,7 +218,9 @@ model {
         }
         withType(GoogleTestTestSuiteBinarySpec) {
             project(':ntcore').addNtcoreDependency(it, 'shared')
-            nativeUtils.useRequiredLibrary(it, 'mrclib')
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                nativeUtils.useRequiredLibrary(it, 'mrclib')
+            }
             lib project: ':hal', library: 'hal', linkage: 'shared'
             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
             lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'

--- a/wpilibj/build.gradle
+++ b/wpilibj/build.gradle
@@ -104,7 +104,9 @@ model {
                 lib project: ':wpinet', library: 'wpinetJNIShared', linkage: 'shared'
                 lib project: ':wpiutil', library: 'wpiutilJNIShared', linkage: 'shared'
                 lib project: ':wpimath', library: 'wpimathJNIShared', linkage: 'shared'
-                nativeUtils.useRequiredLibrary(it, 'mrclib')
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                    nativeUtils.useRequiredLibrary(it, 'mrclib')
+                }
                 lib project: ':hal', library: 'hal', linkage: 'shared'
                 lib project: ':hal', library: 'halJNIShared', linkage: 'shared'
             }

--- a/xrpVendordep/build.gradle
+++ b/xrpVendordep/build.gradle
@@ -11,6 +11,7 @@ evaluationDependsOn(":wpilibc")
 evaluationDependsOn(":wpilibj")
 
 apply from: "${rootDir}/shared/javacpp/setupBuild.gradle"
+apply from: "${rootDir}/shared/libmrclib.gradle"
 
 dependencies {
     implementation project(":wpiutil")
@@ -36,7 +37,9 @@ model {
             }
             lib project: ":wpilibc", library: "wpilibc", linkage: "shared"
             project(":ntcore").addNtcoreDependency(it, "shared")
-            nativeUtils.useRequiredLibrary(it, 'mrclib')
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.systemcore) {
+                nativeUtils.useRequiredLibrary(it, 'mrclib')
+            }
             lib project: ':hal', library: 'hal', linkage: 'shared'
             lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
             lib project: ':wpinet', library: 'wpinet', linkage: 'shared'


### PR DESCRIPTION
Mrclib isn't GPL compatible, which made the whole library not GPL compatible. This fixes that.