### PR TITLE
[bazel] Allow remote execution of tests

### DIFF
--- a/datalog/BUILD.bazel
+++ b/datalog/BUILD.bazel
@@ -142,7 +142,6 @@ cc_test(
     size = "small",
     srcs = glob(["src/test/native/**/*.cpp"]),
     tags = [
-        "exclusive",
         "no-asan",
         "no-tsan",
     ],
@@ -156,7 +155,6 @@ cc_test(
 wpilib_java_junit5_test(
     name = "datalog-java-test",
     srcs = glob(["src/test/java/**/*.java"]),
-    tags = ["exclusive"],
     deps = [
         ":datalog-java",
         "//wpiutil:wpiutil-java",

--- a/ntcore/BUILD.bazel
+++ b/ntcore/BUILD.bazel
@@ -191,7 +191,7 @@ cc_test(
         "src/test/native/**/*.hpp",
     ]),
     tags = [
-        "exclusive",
+        "exclusive-if-local",
         "no-asan",
         "no-tsan",
     ],
@@ -205,7 +205,7 @@ cc_test(
 wpilib_java_junit5_test(
     name = "ntcore-java-test",
     srcs = glob(["src/test/java/**/*.java"]),
-    tags = ["exclusive"],
+    tags = ["exclusive-if-local"],
     deps = [
         ":ntcore-java",
         "//wpiutil:wpiutil-java",

--- a/telemetry/BUILD.bazel
+++ b/telemetry/BUILD.bazel
@@ -67,7 +67,6 @@ cc_test(
     size = "small",
     srcs = glob(["src/test/native/**/*.cpp"]),
     tags = [
-        "exclusive",
         "no-asan",
         "no-tsan",
     ],
@@ -80,7 +79,6 @@ cc_test(
 wpilib_java_junit5_test(
     name = "telemetry-java-test",
     srcs = glob(["src/test/java/**/*.java"]),
-    tags = ["exclusive"],
     deps = [
         ":telemetry-java",
         "//wpiutil:wpiutil-java",
@@ -129,7 +127,6 @@ define_pybind_library(
 robotpy_py_test(
     "python_tests",
     srcs = glob(["src/test/python/**/*.py"]),
-    tags = ["exclusive"],
     deps = [
         ":robotpy-telemetry",
         "//wpiutil:robotpy-wpiutil",

--- a/tunables/BUILD.bazel
+++ b/tunables/BUILD.bazel
@@ -41,7 +41,6 @@ cc_test(
     size = "small",
     srcs = glob(["src/test/native/**/*.cpp"]),
     tags = [
-        "exclusive",
         "no-asan",
         "no-tsan",
     ],
@@ -83,7 +82,6 @@ package_default_cc_project(
 wpilib_java_junit5_test(
     name = "tunables-java-test",
     srcs = glob(["src/test/java/**/*.java"]),
-    tags = ["exclusive"],
     deps = [
         ":tunables-java",
         "//wpiutil:wpiutil-java",
@@ -132,7 +130,6 @@ define_pybind_library(
 robotpy_py_test(
     "python_tests",
     srcs = glob(["src/test/python/**/*.py"]),
-    tags = ["exclusive"],
     deps = [
         ":robotpy-tunables",
         "//wpiutil:robotpy-wpiutil",

--- a/wpilibc/BUILD.bazel
+++ b/wpilibc/BUILD.bazel
@@ -287,7 +287,7 @@ define_pybind_library(
 robotpy_py_test(
     "python_tests",
     srcs = glob(["src/test/python/**/*.py"]),
-    tags = ["exclusive"],
+    tags = ["exclusive-if-local"],
     deps = [
         ":robotpy-wpilib",
         requirement("pytest"),

--- a/wpilibcExamples/build_cpp_examples.bzl
+++ b/wpilibcExamples/build_cpp_examples.bzl
@@ -44,7 +44,10 @@ def build_examples(folders, halsim_deps = []):
         )
         cc_binary(
             name = folder + "-example",
-            srcs = native.glob(["src/main/cpp/examples/" + folder + "/cpp/**/*.cpp", "src/main/cpp/examples/" + folder + "/c/**/*.c"], allow_empty = True),
+            srcs = native.glob([
+                "src/main/cpp/examples/" + folder + "/cpp/**/*.cpp",
+                "src/main/cpp/examples/" + folder + "/c/**/*.c",
+            ], allow_empty = True),
             deps = [
                 "//apriltag",
                 "//fields",
@@ -121,7 +124,11 @@ def build_tests(example_test_folders, snippet_test_folders):
         cc_test(
             name = folder + "-test",
             size = "small",
-            srcs = native.glob([example_test_folder + "/**/*.cpp", example_src_folder + "/cpp/**/*.cpp", example_src_folder + "/c/**/*.c"], allow_empty = True),
+            srcs = native.glob([
+                example_test_folder + "/**/*.cpp",
+                example_src_folder + "/cpp/**/*.cpp",
+                example_src_folder + "/c/**/*.c",
+            ], allow_empty = True),
             deps = [
                 "//commandsv2",
                 "//drivers",
@@ -129,7 +136,13 @@ def build_tests(example_test_folders, snippet_test_folders):
                 "//thirdparty/catch2",
             ],
             defines = ["RUNNING_WPILIB_TESTS=1"],
-            tags = ["wpi-example", "no-tsan", "no-asan", "no-ubsan", "exclusive"],
+            tags = [
+                "wpi-example",
+                "no-tsan",
+                "no-asan",
+                "no-ubsan",
+                "exclusive-if-local",
+            ],
         )
     for folder in snippet_test_folders:
         snippet_src_folder = "src/main/cpp/snippets/" + folder
@@ -137,7 +150,10 @@ def build_tests(example_test_folders, snippet_test_folders):
         cc_test(
             name = folder + "-test",
             size = "small",
-            srcs = native.glob([snippet_test_folder + "/**/*.cpp", snippet_src_folder + "/**/*.cpp"], allow_empty = True),
+            srcs = native.glob([
+                snippet_test_folder + "/**/*.cpp",
+                snippet_src_folder + "/**/*.cpp",
+            ], allow_empty = True),
             deps = [
                 "//commandsv2",
                 "//drivers",
@@ -145,5 +161,11 @@ def build_tests(example_test_folders, snippet_test_folders):
                 "//thirdparty/catch2",
             ],
             defines = ["RUNNING_WPILIB_TESTS=1"],
-            tags = ["wpi-example", "no-tsan", "no-asan", "no-ubsan", "exclusive"],
+            tags = [
+                "wpi-example",
+                "no-tsan",
+                "no-asan",
+                "no-ubsan",
+                "exclusive-if-local",
+            ],
         )


### PR DESCRIPTION
With this the only test target that requires local execution is `//:requirements.test`.