### PR TITLE
[ntcore] Validate subscription periodic intervals

### DIFF
--- a/ntcore/src/main/native/cpp/PubSubOptions.hpp
+++ b/ntcore/src/main/native/cpp/PubSubOptions.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include "wpi/nt/ntcore_cpp.hpp"
 
 namespace wpi::nt {
@@ -27,6 +29,16 @@ class PubSubOptionsImpl : public PubSubOptions {
         pollStorage = 1;
       }
     }
+  }
+
+  static constexpr unsigned int RoundPeriodicMs(unsigned int periodicMs) {
+    constexpr unsigned int kResolution = 10;
+    unsigned int rounded = periodicMs - periodicMs % kResolution;
+    if (periodicMs % kResolution >= kResolution / 2 &&
+        rounded <= std::numeric_limits<unsigned int>::max() - kResolution) {
+      rounded += kResolution;
+    }
+    return rounded;
   }
 
   static constexpr unsigned int kDefaultPeriodicMs = 100;

--- a/ntcore/src/main/native/cpp/net/ClientImpl.cpp
+++ b/ntcore/src/main/native/cpp/net/ClientImpl.cpp
@@ -4,7 +4,6 @@
 
 #include "ClientImpl.hpp"
 
-#include <cmath>
 #include <limits>
 #include <memory>
 #include <numeric>
@@ -194,7 +193,7 @@ void ClientImpl::Publish(int32_t pubuid, std::string_view name,
     publisher = std::make_unique<PublisherData>();
   }
   publisher->options = options;
-  publisher->periodMs = std::lround(options.periodicMs / 10.0) * 10;
+  publisher->periodMs = PubSubOptionsImpl::RoundPeriodicMs(options.periodicMs);
   if (publisher->periodMs < kMinPeriodMs) {
     publisher->periodMs = kMinPeriodMs;
   }

--- a/ntcore/src/main/native/cpp/net/WireDecoder.cpp
+++ b/ntcore/src/main/native/cpp/net/WireDecoder.cpp
@@ -5,8 +5,10 @@
 #include "WireDecoder.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <concepts>
 #include <format>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -245,8 +247,15 @@ static bool WireDecodeTextImpl(std::string_view in, T& out,
                 error = "periodic value must be a number";
                 goto err;
               }
+              if (!std::isfinite(val) || val < 0 ||
+                  val > static_cast<double>(
+                            std::numeric_limits<unsigned int>::max()) /
+                            1000.0) {
+                error = "periodic value out of range";
+                goto err;
+              }
               options.periodic = val;
-              options.periodicMs = val * 1000;
+              options.periodicMs = static_cast<unsigned int>(val * 1000.0);
             }
 
             // send all changes

--- a/ntcore/src/main/native/cpp/server/ServerSubscriber.hpp
+++ b/ntcore/src/main/native/cpp/server/ServerSubscriber.hpp
@@ -6,7 +6,6 @@
 
 #include <stdint.h>
 
-#include <cmath>
 #include <span>
 #include <string>
 #include <string_view>
@@ -29,7 +28,7 @@ class ServerSubscriber {
         m_topicNames{topicNames.begin(), topicNames.end()},
         m_subuid{subuid},
         m_options{options},
-        m_periodMs(std::lround(options.periodicMs / 10.0) * 10) {
+        m_periodMs(PubSubOptionsImpl::RoundPeriodicMs(options.periodicMs)) {
     UpdateMeta();
     if (m_periodMs < kMinPeriodMs) {
       m_periodMs = kMinPeriodMs;
@@ -43,7 +42,7 @@ class ServerSubscriber {
     m_topicNames = {topicNames_.begin(), topicNames_.end()};
     m_options = options_;
     UpdateMeta();
-    m_periodMs = std::lround(options_.periodicMs / 10.0) * 10;
+    m_periodMs = PubSubOptionsImpl::RoundPeriodicMs(options_.periodicMs);
     if (m_periodMs < kMinPeriodMs) {
       m_periodMs = kMinPeriodMs;
     }

--- a/ntcore/src/test/native/cpp/net/WireDecoderTest.cpp
+++ b/ntcore/src/test/native/cpp/net/WireDecoderTest.cpp
@@ -234,6 +234,23 @@ TEST_CASE_METHOD(WireDecodeTextClientTest, "WireDecodeTextClientTest Unpublish",
 }
 
 TEST_CASE_METHOD(WireDecodeTextClientTest,
+                 "WireDecodeTextClientTest PeriodicOutOfRange",
+                 "[ntcore][wire][decoder]") {
+  net::WireDecodeText(
+      "[{\"method\":\"subscribe\",\"params\":{\"subuid\":1,"
+      "\"topics\":[\"test\"],\"options\":{\"periodic\":-1}}}]",
+      handler, logger);
+  net::WireDecodeText(
+      "[{\"method\":\"subscribe\",\"params\":{\"subuid\":2,"
+      "\"topics\":[\"test\"],\"options\":{\"periodic\":1e100}}}]",
+      handler, logger);
+
+  logger.CheckMessages({{NT_LOG_WARNING, "0: periodic value out of range"sv},
+                        {NT_LOG_WARNING, "0: periodic value out of range"sv}});
+  CheckNoClientCalls(handler);
+}
+
+TEST_CASE_METHOD(WireDecodeTextClientTest,
                  "WireDecodeTextClientTest UnpublishMultiple",
                  "[ntcore][wire][decoder]") {
   net::WireDecodeText(

--- a/ntcore/src/test/native/cpp/server/ServerSubscriberTest.cpp
+++ b/ntcore/src/test/native/cpp/server/ServerSubscriberTest.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "server/ServerSubscriber.hpp"
+
+#include <limits>
+#include <span>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "PubSubOptions.hpp"
+
+namespace wpi::nt {
+
+TEST_CASE("ServerSubscriberTest MaximumPeriodicInterval", "[ntcore][server]") {
+  std::span<const std::string> noTopics;
+  PubSubOptionsImpl options;
+  options.periodicMs = std::numeric_limits<unsigned int>::max();
+
+  SECTION("constructor") {
+    server::ServerSubscriber subscriber{"client", noTopics, 1, options};
+    CHECK(subscriber.GetPeriodMs() == 4294967290u);
+  }
+
+  SECTION("update") {
+    server::ServerSubscriber subscriber{"client", noTopics, 1,
+                                        PubSubOptionsImpl{}};
+    subscriber.Update(noTopics, options);
+    CHECK(subscriber.GetPeriodMs() == 4294967290u);
+  }
+}
+
+}  // namespace wpi::nt


### PR DESCRIPTION
:robot: sez:

---

The JSON decoder accepts any value classified as a number, multiplies it by
1000, and assigns the `double` directly to `unsigned int`:

```cpp
options.periodic = val;
options.periodicMs = val * 1000;
```

C++ floating-to-integer conversion is undefined when the truncated value is
outside the destination type's representable range. Negative values, very
large exponents, and non-finite parser results are not rejected first.

---

Make periodic rounding overflow-safe
    
Use unsigned integer arithmetic when rounding periodic intervals to 10 ms. Saturate values whose rounded result is not representable, and cover ServerSubscriber construction and updates at UINT_MAX.