### PR TITLE
[datalog] Make Java FileLogger close idempotent

### DIFF
--- a/datalog/src/main/java/org/wpilib/datalog/FileLogger.java
+++ b/datalog/src/main/java/org/wpilib/datalog/FileLogger.java
@@ -4,12 +4,14 @@
 
 package org.wpilib.datalog;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
  * A class version of `tail -f`, otherwise known as `tail -f` at home. Watches a file and puts the
  * data into a data log. Only works on Linux-based platforms.
  */
 public class FileLogger implements AutoCloseable {
-  private final long m_impl;
+  private final AtomicLong m_impl;
 
   /**
    * Construct a FileLogger. When the specified file is modified, appended data will be appended to
@@ -20,11 +22,14 @@ public class FileLogger implements AutoCloseable {
    * @param key The log key to append data to.
    */
   public FileLogger(String file, DataLog log, String key) {
-    m_impl = DataLogJNI.createFileLogger(file, log.getImpl(), key);
+    m_impl = new AtomicLong(DataLogJNI.createFileLogger(file, log.getImpl(), key));
   }
 
   @Override
   public void close() {
-    DataLogJNI.freeFileLogger(m_impl);
+    long impl = m_impl.getAndSet(0);
+    if (impl != 0) {
+      DataLogJNI.freeFileLogger(impl);
+    }
   }
 }

--- a/datalog/src/test/java/org/wpilib/datalog/FileLoggerTest.java
+++ b/datalog/src/test/java/org/wpilib/datalog/FileLoggerTest.java
@@ -1,0 +1,61 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.datalog;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FileLoggerTest {
+  @Test
+  void closeIsIdempotent(@TempDir Path tempDir) throws Exception {
+    Path file = tempDir.resolve("console.txt");
+    file.toFile().createNewFile();
+
+    try (DataLogWriter log = new DataLogWriter(new ByteArrayOutputStream())) {
+      FileLogger logger = new FileLogger(file.toString(), log, "console");
+      logger.close();
+      logger.close();
+    }
+  }
+
+  @Test
+  void closeIsThreadSafe(@TempDir Path tempDir) throws Exception {
+    Path file = tempDir.resolve("console.txt");
+    file.toFile().createNewFile();
+
+    try (DataLogWriter log = new DataLogWriter(new ByteArrayOutputStream())) {
+      FileLogger logger = new FileLogger(file.toString(), log, "console");
+      CountDownLatch ready = new CountDownLatch(2);
+      CountDownLatch start = new CountDownLatch(1);
+      Thread first = closeOnSignal(logger, ready, start);
+      Thread second = closeOnSignal(logger, ready, start);
+
+      ready.await();
+      start.countDown();
+      first.join();
+      second.join();
+    }
+  }
+
+  private static Thread closeOnSignal(
+      FileLogger logger, CountDownLatch ready, CountDownLatch start) {
+    Thread thread =
+        new Thread(
+            () -> {
+              ready.countDown();
+              try {
+                start.await();
+              } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+              }
+              logger.close();
+            });
+    thread.start();
+    return thread;
+  }
+}

--- a/datalog/src/test/java/org/wpilib/datalog/FileLoggerTest.java
+++ b/datalog/src/test/java/org/wpilib/datalog/FileLoggerTest.java
@@ -5,6 +5,7 @@
 package org.wpilib.datalog;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.Test;
@@ -14,7 +15,7 @@ class FileLoggerTest {
   @Test
   void closeIsIdempotent(@TempDir Path tempDir) throws Exception {
     Path file = tempDir.resolve("console.txt");
-    file.toFile().createNewFile();
+    Files.createFile(file);
 
     try (DataLogWriter log = new DataLogWriter(new ByteArrayOutputStream())) {
       FileLogger logger = new FileLogger(file.toString(), log, "console");
@@ -26,14 +27,14 @@ class FileLoggerTest {
   @Test
   void closeIsThreadSafe(@TempDir Path tempDir) throws Exception {
     Path file = tempDir.resolve("console.txt");
-    file.toFile().createNewFile();
+    Files.createFile(file);
 
     try (DataLogWriter log = new DataLogWriter(new ByteArrayOutputStream())) {
       FileLogger logger = new FileLogger(file.toString(), log, "console");
       CountDownLatch ready = new CountDownLatch(2);
       CountDownLatch start = new CountDownLatch(1);
       Thread first = closeOnSignal(logger, ready, start);
-      Thread second = closeOnSignal(logger, ready, start);
+      final Thread second = closeOnSignal(logger, ready, start);
 
       ready.await();
       start.countDown();


### PR DESCRIPTION
:robot: sez:

Java `FileLogger` stores its native handle in a `final long` and passes the same
value to `freeFileLogger()` on every `close()` call
(`FileLogger.java:11-29`). The JNI function unconditionally applies `delete` to
that address (`DataLogJNI.cpp:718-723`). A second close therefore destructs and
frees the same C++ object again.

This also races if two Java threads call `close()` concurrently.
