### PR TITLE
[wpinet] Fix bugs in WPI_GetMulticastServiceResolverData

### DIFF
--- a/wpinet/src/main/native/cpp/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/cpp/MulticastServiceResolver.cpp
@@ -71,6 +71,7 @@ WPI_EventHandle WPI_GetMulticastServiceResolverEventHandle(
 
 WPI_ServiceData* WPI_GetMulticastServiceResolverData(
     WPI_MulticastServiceResolverHandle handle, int32_t* dataCount) {
+  *dataCount = 0;
   std::vector<wpi::net::MulticastServiceResolver::ServiceData> allData;
   {
     auto& manager = wpi::net::GetMulticastManager();
@@ -79,7 +80,6 @@ WPI_ServiceData* WPI_GetMulticastServiceResolverData(
     allData = resolver->GetData();
   }
   if (allData.empty()) {
-    *dataCount = 0;
     return nullptr;
   }
   size_t allocSize = sizeof(WPI_ServiceData) * allData.size();
@@ -146,6 +146,7 @@ WPI_ServiceData* WPI_GetMulticastServiceResolverData(
     currentData++;
   }
 
+  *dataCount = static_cast<int32_t>(allData.size());
   return rootArray;
 }
 

--- a/wpinet/src/main/native/cpp/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/cpp/MulticastServiceResolver.cpp
@@ -107,7 +107,7 @@ WPI_ServiceData* WPI_GetMulticastServiceResolverData(
     return nullptr;
   }
   WPI_ServiceData* rootArray = reinterpret_cast<WPI_ServiceData*>(cDataRaw);
-  cDataRaw += (sizeof(WPI_ServiceData) + allData.size());
+  cDataRaw += sizeof(WPI_ServiceData) * allData.size();
   WPI_ServiceData* currentData = rootArray;
 
   for (auto&& data : allData) {

--- a/wpinet/src/main/native/include/wpi/net/MulticastServiceResolver.hpp
+++ b/wpinet/src/main/native/include/wpi/net/MulticastServiceResolver.hpp
@@ -94,6 +94,8 @@ class MulticastServiceResolver {
   struct Impl;
 
  private:
+  friend class MulticastServiceResolverCTest;
+
   void PushData(ServiceData&& data) {
     std::scoped_lock lock{mutex};
 

--- a/wpinet/src/test/native/cpp/MulticastServiceResolverCTest.cpp
+++ b/wpinet/src/test/native/cpp/MulticastServiceResolverCTest.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+#define private public
+#include "wpi/net/MulticastServiceResolver.hpp"
+#undef private
+
+#include "MulticastHandleManager.hpp"
+
+TEST_CASE("C API resolver returns result count",
+          "[multicast][service-discovery]") {
+  auto handle = WPI_CreateMulticastServiceResolver("_count._tcp");
+  auto& manager = wpi::net::GetMulticastManager();
+  {
+    std::scoped_lock lock{manager.mutex};
+    auto& data = manager.resolvers[handle]->queue.emplace_back();
+    data.hostName = "host";
+    data.serviceName = "service";
+  }
+
+  int32_t count = -1;
+  WPI_ServiceData* result = WPI_GetMulticastServiceResolverData(handle, &count);
+  REQUIRE(result != nullptr);
+  CHECK(count == 1);
+
+  WPI_FreeServiceData(result, count);
+  WPI_FreeMulticastServiceResolver(handle);
+}

--- a/wpinet/src/test/native/cpp/MulticastServiceResolverCTest.cpp
+++ b/wpinet/src/test/native/cpp/MulticastServiceResolverCTest.cpp
@@ -2,31 +2,30 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include <functional>
-#include <memory>
-#include <string>
-#include <string_view>
 #include <utility>
-#include <vector>
 
 #include <catch2/catch_test_macros.hpp>
 
-#define private public
-#include "wpi/net/MulticastServiceResolver.hpp"
-#undef private
-
 #include "MulticastHandleManager.hpp"
+#include "wpi/net/MulticastServiceResolver.hpp"
 
-TEST_CASE("C API resolver returns result count",
-          "[multicast][service-discovery]") {
-  auto handle = WPI_CreateMulticastServiceResolver("_count._tcp");
-  auto& manager = wpi::net::GetMulticastManager();
-  {
-    std::scoped_lock lock{manager.mutex};
-    auto& data = manager.resolvers[handle]->queue.emplace_back();
+namespace wpi::net {
+
+class MulticastServiceResolverCTest {
+ protected:
+  static void AddData(WPI_MulticastServiceResolverHandle handle) {
+    MulticastServiceResolver::ServiceData data;
     data.hostName = "host";
     data.serviceName = "service";
+    GetMulticastManager().resolvers[handle]->PushData(std::move(data));
   }
+};
+
+TEST_CASE_METHOD(MulticastServiceResolverCTest,
+                 "C API resolver returns result count",
+                 "[multicast][service-discovery]") {
+  auto handle = WPI_CreateMulticastServiceResolver("_count._tcp");
+  AddData(handle);
 
   int32_t count = -1;
   WPI_ServiceData* result = WPI_GetMulticastServiceResolverData(handle, &count);
@@ -36,3 +35,20 @@ TEST_CASE("C API resolver returns result count",
   WPI_FreeServiceData(result, count);
   WPI_FreeMulticastServiceResolver(handle);
 }
+
+TEST_CASE_METHOD(MulticastServiceResolverCTest, "C API resolver result layout",
+                 "[multicast][service-discovery]") {
+  auto handle = WPI_CreateMulticastServiceResolver("_layout._tcp");
+  AddData(handle);
+
+  int32_t count = 0;
+  WPI_ServiceData* result = WPI_GetMulticastServiceResolverData(handle, &count);
+  REQUIRE(result != nullptr);
+  CHECK(result[0].hostName ==
+        reinterpret_cast<const char*>(result) + sizeof(WPI_ServiceData));
+
+  WPI_FreeServiceData(result, 1);
+  WPI_FreeMulticastServiceResolver(handle);
+}
+
+}  // namespace wpi::net

--- a/wpinet/src/test/native/cpp/MulticastServiceResolverCTest.cpp
+++ b/wpinet/src/test/native/cpp/MulticastServiceResolverCTest.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+#define private public
+#include "wpi/net/MulticastServiceResolver.hpp"
+#undef private
+
+#include "MulticastHandleManager.hpp"
+
+TEST_CASE("C API resolver result layout", "[multicast][service-discovery]") {
+  auto handle = WPI_CreateMulticastServiceResolver("_layout._tcp");
+  auto& manager = wpi::net::GetMulticastManager();
+  {
+    std::scoped_lock lock{manager.mutex};
+    auto& data = manager.resolvers[handle]->queue.emplace_back();
+    data.hostName = "host";
+    data.serviceName = "service";
+  }
+
+  int32_t count = 0;
+  WPI_ServiceData* result = WPI_GetMulticastServiceResolverData(handle, &count);
+  REQUIRE(result != nullptr);
+  CHECK(result[0].hostName ==
+        reinterpret_cast<const char*>(result) + sizeof(WPI_ServiceData));
+
+  WPI_FreeServiceData(result, 1);
+  WPI_FreeMulticastServiceResolver(handle);
+}


### PR DESCRIPTION
:robot: sez:

---

`WPI_GetMulticastServiceResolverData()` allocates a leading array of
`allData.size()` `WPI_ServiceData` structures, but advances the payload cursor
by `sizeof(WPI_ServiceData) + allData.size()` instead of their product
(`wpinet/src/main/native/cpp/MulticastServiceResolver.cpp:85,109-110`).

With one result, the cursor starts one byte beyond the structure and the final
payload copy writes one byte beyond the allocation. With multiple results, the
string and TXT payload overwrites later structures in the returned array,
corrupting their pointers and counts. The queued strings and number of results
come from mDNS responses, so a link-local responder can shape the corrupted
data before a C application calls the getter.

---

`WPI_GetMulticastServiceResolverData(handle, dataCount)` writes `*dataCount = 0`
only when the queue is empty (`MulticastServiceResolver.cpp:81-83`). On a
successful nonempty result it returns an array without ever setting the count
(`:85-149`).

The array has no sentinel, so `dataCount` is the C caller's only way to know its
length. Conventional code that declares an uninitialized count and iterates to
the returned value consequently uses an indeterminate bound. Even callers that
initialize the count receive stale, incorrect data.