### PR TITLE
[datalog] Respect Java ByteBuffer reader window

### DIFF
--- a/datalog/src/main/java/org/wpilib/datalog/DataLogReader.java
+++ b/datalog/src/main/java/org/wpilib/datalog/DataLogReader.java
@@ -17,12 +17,13 @@ import java.util.function.Consumer;
 /** Data log reader (reads logs written by the DataLog class). */
 public class DataLogReader implements Iterable<DataLogRecord> {
   /**
-   * Constructs from a byte buffer.
+   * Constructs from the bytes between the byte buffer's current position and limit. The reader does
+   * not modify the buffer's position, limit, or byte order.
    *
    * @param buffer byte buffer
    */
   public DataLogReader(ByteBuffer buffer) {
-    m_buf = buffer;
+    m_buf = buffer.slice().asReadOnlyBuffer();
     m_buf.order(ByteOrder.LITTLE_ENDIAN);
   }
 

--- a/datalog/src/test/java/org/wpilib/datalog/DataLogReaderTest.java
+++ b/datalog/src/test/java/org/wpilib/datalog/DataLogReaderTest.java
@@ -1,0 +1,48 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.datalog;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.junit.jupiter.api.Test;
+
+class DataLogReaderTest {
+  @Test
+  void ignoresDataBeforeBufferPosition() {
+    ByteBuffer buffer = ByteBuffer.allocate(50);
+    buffer.put(new byte[] {'W', 'P', 'I', 'L', 'O', 'G', 0, 1, 0, 0, 0, 0});
+    buffer.position(20);
+    buffer.limit(50);
+
+    DataLogReader reader = new DataLogReader(buffer);
+
+    assertFalse(reader.isValid());
+    assertEquals(20, buffer.position());
+    assertEquals(50, buffer.limit());
+    assertEquals(ByteOrder.BIG_ENDIAN, buffer.order());
+  }
+
+  @Test
+  void readsOnlyDataInsideBufferWindow() {
+    ByteBuffer buffer = ByteBuffer.allocate(50);
+    buffer.position(10);
+    buffer.put(new byte[] {'W', 'P', 'I', 'L', 'O', 'G', 0, 1, 0, 0, 0, 0});
+    buffer.put(new byte[] {0, 1, 4, 0, 'D', 'A', 'T', 'A'});
+    buffer.limit(buffer.position());
+    buffer.position(10);
+
+    DataLogReader reader = new DataLogReader(buffer);
+
+    assertTrue(reader.isValid());
+    assertArrayEquals(new byte[] {'D', 'A', 'T', 'A'}, reader.iterator().next().getRaw());
+    assertEquals(10, buffer.position());
+    assertEquals(ByteOrder.BIG_ENDIAN, buffer.order());
+  }
+}


### PR DESCRIPTION
:robot: sez:

The `DataLogReader(ByteBuffer)` constructor retains the caller's buffer
directly (`DataLogReader.java:24-26`). Validation and parsing use absolute
indices from zero, while size checks use `remaining()`
(`DataLogReader.java:49-57, 89-104, 149-150`).

For a buffer with nonzero position, the reader can validate and return bytes
before the caller's `[position, limit)` window. It also changes the byte order
of the caller's buffer as a side effect.