### PR TITLE
[datalog] Validate Java nested record lengths

### DIFF
--- a/datalog/src/main/java/org/wpilib/datalog/DataLogRecord.java
+++ b/datalog/src/main/java/org/wpilib/datalog/DataLogRecord.java
@@ -397,14 +397,18 @@ public class DataLogRecord {
   public String[] getStringArray() {
     ByteBuffer buf = getRawBuffer();
     try {
-      int size = buf.getInt();
+      long size = Integer.toUnsignedLong(buf.getInt());
       // sanity check size
       if (size > (buf.remaining() / 4)) {
         throw new InputMismatchException("invalid size");
       }
-      String[] arr = new String[size];
-      for (int i = 0; i < size; i++) {
+      int checkedSize = (int) size;
+      String[] arr = new String[checkedSize];
+      for (int i = 0; i < checkedSize; i++) {
         arr[i] = readInnerString(buf);
+      }
+      if (buf.hasRemaining()) {
+        throw new InputMismatchException("unexpected trailing data");
       }
       return arr;
     } catch (BufferUnderflowException | IndexOutOfBoundsException ex) {
@@ -413,13 +417,17 @@ public class DataLogRecord {
   }
 
   private String readInnerString(ByteBuffer buf) {
-    int size = buf.getInt();
-    if (size > buf.remaining()) {
-      throw new InputMismatchException("invalid string size");
+    try {
+      long size = Integer.toUnsignedLong(buf.getInt());
+      if (size > buf.remaining()) {
+        throw new InputMismatchException("invalid string size");
+      }
+      byte[] arr = new byte[(int) size];
+      buf.get(arr);
+      return new String(arr, StandardCharsets.UTF_8);
+    } catch (BufferUnderflowException | IndexOutOfBoundsException ex) {
+      throw new InputMismatchException();
     }
-    byte[] arr = new byte[size];
-    buf.get(arr);
-    return new String(arr, StandardCharsets.UTF_8);
   }
 
   private final int m_entry;

--- a/datalog/src/test/java/org/wpilib/datalog/DataLogRecordTest.java
+++ b/datalog/src/test/java/org/wpilib/datalog/DataLogRecordTest.java
@@ -1,0 +1,63 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.datalog;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.InputMismatchException;
+import org.junit.jupiter.api.Test;
+
+class DataLogRecordTest {
+  @Test
+  void startRecordRejectsUnsignedStringLengthLargerThanData() {
+    ByteBuffer data = ByteBuffer.allocate(17).order(ByteOrder.LITTLE_ENDIAN);
+    data.put((byte) 0);
+    data.putInt(1);
+    data.putInt(0xffffffff);
+    data.putLong(0);
+    data.flip();
+    DataLogRecord record = new DataLogRecord(0, 0, data);
+
+    assertTrue(record.isStart());
+    assertThrows(InputMismatchException.class, record::getStartData);
+  }
+
+  @Test
+  void metadataRecordRejectsUnsignedStringLengthLargerThanData() {
+    ByteBuffer data = ByteBuffer.allocate(9).order(ByteOrder.LITTLE_ENDIAN);
+    data.put((byte) 2);
+    data.putInt(1);
+    data.putInt(0xffffffff);
+    data.flip();
+    DataLogRecord record = new DataLogRecord(0, 0, data);
+
+    assertTrue(record.isSetMetadata());
+    assertThrows(InputMismatchException.class, record::getSetMetadataData);
+  }
+
+  @Test
+  void stringArrayRejectsUnsignedCountLargerThanData() {
+    ByteBuffer data = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+    data.putInt(0xffffffff);
+    data.flip();
+    DataLogRecord record = new DataLogRecord(1, 0, data);
+
+    assertThrows(InputMismatchException.class, record::getStringArray);
+  }
+
+  @Test
+  void stringArrayRejectsTrailingData() {
+    ByteBuffer data = ByteBuffer.allocate(5).order(ByteOrder.LITTLE_ENDIAN);
+    data.putInt(0);
+    data.put((byte) 0);
+    data.flip();
+    DataLogRecord record = new DataLogRecord(1, 0, data);
+
+    assertThrows(InputMismatchException.class, record::getStringArray);
+  }
+}


### PR DESCRIPTION
:robot: sez:

Nested string lengths and string-array counts are unsigned 32-bit fields, but
Java reads them into signed `int`. The checks only reject values greater than
the remaining bytes; negative values pass and are used as array sizes
(`DataLogRecord.java:397-421`).

`getStartData()` and `getSetMetadataData()` use the same `readInnerString()`
helper. Instead of the documented `InputMismatchException`, a high-bit length
throws `NegativeArraySizeException`, which the supplied printlog consumer does
not catch.