### PR TITLE
[wpilibc] Republish SmartDashboard sendables after UID reuse

### DIFF
--- a/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
@@ -94,7 +94,7 @@ void SmartDashboard::PutData(std::string_view key, wpi::util::Sendable* data) {
   std::scoped_lock lock(inst.tablesToDataMutex);
   auto& uid = inst.tablesToData[key];
   wpi::util::Sendable* sddata = wpi::util::SendableRegistry::GetSendable(uid);
-  if (sddata != data) {
+  if (sddata != data || !wpi::util::SendableRegistry::IsPublished(uid)) {
     uid = wpi::util::SendableRegistry::GetUniqueId(data);
     auto dataTable = inst.table->GetSubTable(key);
     auto builder = std::make_unique<SendableBuilderImpl>();

--- a/wpilibc/src/test/native/cpp/smartdashboard/SmartDashboardTest.cpp
+++ b/wpilibc/src/test/native/cpp/smartdashboard/SmartDashboardTest.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "wpi/smartdashboard/SmartDashboard.hpp"
+
+#include <memory>
+#include <string_view>
+#include <utility>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "wpi/util/sendable/Sendable.hpp"
+#include "wpi/util/sendable/SendableBuilder.hpp"
+#include "wpi/util/sendable/SendableHelper.hpp"
+#include "wpi/util/sendable/SendableRegistry.hpp"
+
+namespace {
+
+class TestSendable : public wpi::util::Sendable,
+                     public wpi::util::SendableHelper<TestSendable> {
+ public:
+  TestSendable() {
+    wpi::util::SendableRegistry::Add(this, "SmartDashboardTestSendable");
+  }
+
+  void InitSendable(wpi::util::SendableBuilder&) override { ++initCount; }
+
+  int initCount = 0;
+};
+
+}  // namespace
+
+TEST_CASE("SmartDashboardTest republishes sendable after UID reuse",
+          "[wpilibc][smartdashboard]") {
+  constexpr std::string_view key = "SendableUidReuse";
+
+  wpi::util::SendableRegistry::UID firstUid;
+  {
+    TestSendable first;
+    firstUid = wpi::util::SendableRegistry::GetUniqueId(&first);
+    wpi::SmartDashboard::PutData(key, &first);
+    REQUIRE(first.initCount == 1);
+  }
+
+  std::unique_ptr<TestSendable> replacement;
+  for (int i = 0; i < 10000; ++i) {
+    auto candidate = std::make_unique<TestSendable>();
+    if (wpi::util::SendableRegistry::GetUniqueId(candidate.get()) == firstUid) {
+      replacement = std::move(candidate);
+      break;
+    }
+  }
+
+  REQUIRE(replacement);
+  wpi::SmartDashboard::PutData(key, replacement.get());
+  REQUIRE(replacement->initCount == 1);
+  wpi::SmartDashboard::PutData(key, replacement.get());
+  CHECK(replacement->initCount == 1);
+}

--- a/wpiutil/src/main/native/cpp/sendable/SendableRegistry.cpp
+++ b/wpiutil/src/main/native/cpp/sendable/SendableRegistry.cpp
@@ -322,6 +322,19 @@ Sendable* SendableRegistry::GetSendable(UID uid) {
   return inst.components[uid - 1]->sendable;
 }
 
+bool SendableRegistry::IsPublished(UID uid) {
+  auto& inst = GetInstance();
+  if (uid == 0) {
+    return false;
+  }
+  std::scoped_lock lock(inst.mutex);
+  if ((uid - 1) >= inst.components.size() || !inst.components[uid - 1]) {
+    return false;
+  }
+  auto& builder = inst.components[uid - 1]->builder;
+  return builder && builder->IsPublished();
+}
+
 void SendableRegistry::Publish(UID sendableUid,
                                std::unique_ptr<SendableBuilder> builder) {
   auto& inst = GetInstance();

--- a/wpiutil/src/main/native/include/wpi/util/sendable/SendableRegistry.hpp
+++ b/wpiutil/src/main/native/include/wpi/util/sendable/SendableRegistry.hpp
@@ -221,6 +221,14 @@ class SendableRegistry final {
   static Sendable* GetSendable(UID uid);
 
   /**
+   * Gets whether an object is published.
+   *
+   * @param uid unique id
+   * @return whether the object is published
+   */
+  static bool IsPublished(UID uid);
+
+  /**
    * Publishes an object in the registry.
    *
    * @param sendableUid sendable unique id

--- a/wpiutil/src/main/python/semiwrap/SendableRegistry.yml
+++ b/wpiutil/src/main/python/semiwrap/SendableRegistry.yml
@@ -49,6 +49,7 @@ classes:
         ignore: true
       GetUniqueId:
       GetSendable:
+      IsPublished:
       Publish:
       Update:
       EnsureInitialized:


### PR DESCRIPTION
SmartDashboard keeps key-to-UID mappings after sendables are destroyed, while SendableRegistry recycles those UIDs. If a later sendable receives a stale mapped UID, PutData mistakes it for the already-published object and skips builder and listener initialization. Test-order-dependent UID reuse consequently made command dashboard button tests flaky.

Check that a matching UID still has a published builder before treating PutData as a no-op, and republish it otherwise. Add a deterministic UID-reuse regression test.