### PR TITLE
[wpinet] Stop processing failed macOS mDNS resolves

### DIFF
--- a/wpinet/src/main/native/macOS/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/macOS/MulticastServiceResolver.cpp
@@ -94,6 +94,7 @@ void ServiceResolveReply(DNSServiceRef sdRef, DNSServiceFlags flags,
         resolveState->pImpl->ResolveStates.begin(),
         resolveState->pImpl->ResolveStates.end(),
         [resolveState](auto& a) { return a.get() == resolveState; }));
+    return;
   }
 
   resolveState->data.port = ntohs(port);


### PR DESCRIPTION
From https://developer.apple.com/documentation/dnssd/dnsserviceresolvereply:

> errorCode
>*   Will be [kDNSServiceErr_NoError](https://developer.apple.com/documentation/dnssd/kdnsserviceerr_noerror) (0) on success, otherwise will indicate the failure that occurred. Other parameters are undefined if the errorCode is nonzero.
