### PR TITLE
Remove 3 suffix from Python shebang

### DIFF
--- a/commandsv2/generate_hids.py
+++ b/commandsv2/generate_hids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/commandsv3/generate_files.py
+++ b/commandsv3/generate_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/datalog/examples/printlog/datalog.py
+++ b/datalog/examples/printlog/datalog.py
@@ -1,4 +1,5 @@
-#! /usr/bin/env python3
+#! /usr/bin/env python
+
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.

--- a/drivers/generate_pwm_motor_controllers.py
+++ b/drivers/generate_pwm_motor_controllers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/fields/convert_apriltag_layouts.py
+++ b/fields/convert_apriltag_layouts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """
 This script converts all AprilTag field layout CSV files in

--- a/fields/generate_fields.py
+++ b/fields/generate_fields.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/ntcore/generate_topics.py
+++ b/ntcore/generate_topics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import json
 import sys

--- a/ntcore/src/main/python/devtools/gen-pubsub.py
+++ b/ntcore/src/main/python/devtools/gen-pubsub.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import sphinxify
 from cxxheaderparser.simple import parse_string

--- a/robotpyExamples/examples/ArcadeDrive/robot.py
+++ b/robotpyExamples/examples/ArcadeDrive/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/ArcadeDriveXboxController/robot.py
+++ b/robotpyExamples/examples/ArcadeDriveXboxController/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/ArmSimulation/robot.py
+++ b/robotpyExamples/examples/ArmSimulation/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/DSGamepadChooser/robot.py
+++ b/robotpyExamples/examples/DSGamepadChooser/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/DifferentialDriveBot/robot.py
+++ b/robotpyExamples/examples/DifferentialDriveBot/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/DifferentialDrivePoseEstimator/robot.py
+++ b/robotpyExamples/examples/DifferentialDrivePoseEstimator/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/DriveDistanceOffboard/robot.py
+++ b/robotpyExamples/examples/DriveDistanceOffboard/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/DutyCycleEncoder/robot.py
+++ b/robotpyExamples/examples/DutyCycleEncoder/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/ElevatorExponentialProfile/robot.py
+++ b/robotpyExamples/examples/ElevatorExponentialProfile/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/ElevatorExponentialSimulation/robot.py
+++ b/robotpyExamples/examples/ElevatorExponentialSimulation/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/ElevatorProfiledPID/robot.py
+++ b/robotpyExamples/examples/ElevatorProfiledPID/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/ElevatorSimulation/robot.py
+++ b/robotpyExamples/examples/ElevatorSimulation/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/ElevatorTrapezoidProfile/robot.py
+++ b/robotpyExamples/examples/ElevatorTrapezoidProfile/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/Encoder/robot.py
+++ b/robotpyExamples/examples/Encoder/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/GettingStarted/robot.py
+++ b/robotpyExamples/examples/GettingStarted/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/Gyro/robot.py
+++ b/robotpyExamples/examples/Gyro/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/HatchbotInlined/robot.py
+++ b/robotpyExamples/examples/HatchbotInlined/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/HatchbotTraditional/robot.py
+++ b/robotpyExamples/examples/HatchbotTraditional/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/MecanumBot/robot.py
+++ b/robotpyExamples/examples/MecanumBot/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/MecanumDrive/robot.py
+++ b/robotpyExamples/examples/MecanumDrive/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/MecanumDrivePoseEstimator/robot.py
+++ b/robotpyExamples/examples/MecanumDrivePoseEstimator/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/Mechanism2d/robot.py
+++ b/robotpyExamples/examples/Mechanism2d/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/RapidReactCommandBot/robot.py
+++ b/robotpyExamples/examples/RapidReactCommandBot/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/RomiReference/robot.py
+++ b/robotpyExamples/examples/RomiReference/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/SimpleDifferentialDriveSimulation/robot.py
+++ b/robotpyExamples/examples/SimpleDifferentialDriveSimulation/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/StateSpaceArm/robot.py
+++ b/robotpyExamples/examples/StateSpaceArm/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/StateSpaceElevator/robot.py
+++ b/robotpyExamples/examples/StateSpaceElevator/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/StateSpaceFlywheel/robot.py
+++ b/robotpyExamples/examples/StateSpaceFlywheel/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/StateSpaceFlywheelSysId/robot.py
+++ b/robotpyExamples/examples/StateSpaceFlywheelSysId/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/SwerveBot/robot.py
+++ b/robotpyExamples/examples/SwerveBot/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/SwerveDrivePoseEstimator/robot.py
+++ b/robotpyExamples/examples/SwerveDrivePoseEstimator/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/SysId/robot.py
+++ b/robotpyExamples/examples/SysId/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/TankDrive/robot.py
+++ b/robotpyExamples/examples/TankDrive/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/TankDriveXboxController/robot.py
+++ b/robotpyExamples/examples/TankDriveXboxController/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/UnitTest/robot.py
+++ b/robotpyExamples/examples/UnitTest/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/examples/XrpReference/robot.py
+++ b/robotpyExamples/examples/XrpReference/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/snippets/AddressableLED/robot.py
+++ b/robotpyExamples/snippets/AddressableLED/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/snippets/AprilTagsVision/robot.py
+++ b/robotpyExamples/snippets/AprilTagsVision/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/snippets/CANPDP/robot.py
+++ b/robotpyExamples/snippets/CANPDP/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/snippets/DigitalCommunication/robot.py
+++ b/robotpyExamples/snippets/DigitalCommunication/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/snippets/DutyCycleInput/robot.py
+++ b/robotpyExamples/snippets/DutyCycleInput/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/snippets/EventLoop/robot.py
+++ b/robotpyExamples/snippets/EventLoop/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/snippets/FlywheelBangBangController/robot.py
+++ b/robotpyExamples/snippets/FlywheelBangBangController/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/snippets/HttpCamera/robot.py
+++ b/robotpyExamples/snippets/HttpCamera/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/snippets/I2CCommunication/robot.py
+++ b/robotpyExamples/snippets/I2CCommunication/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/snippets/IntermediateVision/robot.py
+++ b/robotpyExamples/snippets/IntermediateVision/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/snippets/MotorControl/robot.py
+++ b/robotpyExamples/snippets/MotorControl/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/snippets/QuickVision/robot.py
+++ b/robotpyExamples/snippets/QuickVision/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/snippets/SelectCommand/robot.py
+++ b/robotpyExamples/snippets/SelectCommand/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/robotpyExamples/snippets/Solenoid/robot.py
+++ b/robotpyExamples/snippets/Solenoid/robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/tools/wpical/generate_mrcal.py
+++ b/tools/wpical/generate_mrcal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 import argparse
 import subprocess
 import sys

--- a/upstream_utils/ada.py
+++ b/upstream_utils/ada.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/apriltag.py
+++ b/upstream_utils/apriltag.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/argparse_lib.py
+++ b/upstream_utils/argparse_lib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/benchmark.py
+++ b/upstream_utils/benchmark.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import os
 import shutil

--- a/upstream_utils/catch2.py
+++ b/upstream_utils/catch2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import os
 import shutil

--- a/upstream_utils/debugging.py
+++ b/upstream_utils/debugging.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/double-conversion.py
+++ b/upstream_utils/double-conversion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import os
 import shutil

--- a/upstream_utils/eigen.py
+++ b/upstream_utils/eigen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/gcem.py
+++ b/upstream_utils/gcem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/imgui.py
+++ b/upstream_utils/imgui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/implot.py
+++ b/upstream_utils/implot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/json.py
+++ b/upstream_utils/json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/libdogleg.py
+++ b/upstream_utils/libdogleg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/libuv.py
+++ b/upstream_utils/libuv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/llhttp.py
+++ b/upstream_utils/llhttp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 import subprocess

--- a/upstream_utils/llvm.py
+++ b/upstream_utils/llvm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import re
 import shutil

--- a/upstream_utils/mpack.py
+++ b/upstream_utils/mpack.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import os
 import shutil

--- a/upstream_utils/mrcal.py
+++ b/upstream_utils/mrcal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/mrcal_java.py
+++ b/upstream_utils/mrcal_java.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import os
 import shutil

--- a/upstream_utils/nanopb.py
+++ b/upstream_utils/nanopb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/sleipnir.py
+++ b/upstream_utils/sleipnir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/stb.py
+++ b/upstream_utils/stb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import shutil
 from pathlib import Path

--- a/upstream_utils/upb.py
+++ b/upstream_utils/upb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import os
 import shutil

--- a/wpilibc/generate_first_ds_hids.py
+++ b/wpilibc/generate_first_ds_hids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/wpilibc/generate_hids.py
+++ b/wpilibc/generate_hids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/wpilibc/generate_wpilibc.py
+++ b/wpilibc/generate_wpilibc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/wpilibj/generate_first_ds_hids.py
+++ b/wpilibj/generate_first_ds_hids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/wpilibj/generate_hids.py
+++ b/wpilibj/generate_hids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/wpilibj/generate_wpilibj.py
+++ b/wpilibj/generate_wpilibj.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/wpimath/docs/ExponentialProfile/ExponentialProfileModel.py
+++ b/wpimath/docs/ExponentialProfile/ExponentialProfileModel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 from sympy import (
     Eq,

--- a/wpimath/generate_nanopb.py
+++ b/wpimath/generate_nanopb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/wpimath/generate_numbers.py
+++ b/wpimath/generate_numbers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/wpimath/generate_quickbuf.py
+++ b/wpimath/generate_quickbuf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/wpimath/generate_wpimath.py
+++ b/wpimath/generate_wpimath.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import sys
 from pathlib import Path
 

--- a/wpimath/src/main/python/tools/create_units.py
+++ b/wpimath/src/main/python/tools/create_units.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import io
 import inspect

--- a/wpimath/src/test/generate_biquad_fixtures.py
+++ b/wpimath/src/test/generate_biquad_fixtures.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
+
 """Reproducibility script for the BiquadFilter test golden values.
 
 Run this script (requires scipy + numpy) to print every scipy-derived

--- a/wpinet/src/main/python/examples/portfwd.py
+++ b/wpinet/src/main/python/examples/portfwd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import argparse
 import time

--- a/wpiunits/generate_units.py
+++ b/wpiunits/generate_units.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/wpiutil/generate_nanopb.py
+++ b/wpiutil/generate_nanopb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/wpiutil/src/main/python/examples/printlog.py
+++ b/wpiutil/src/main/python/examples/printlog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (c) FIRST and other WPILib contributors.
 # Open Source Software; you can modify and/or share it under the terms of

--- a/wpiutil/src/main/python/examples/writelog.py
+++ b/wpiutil/src/main/python/examples/writelog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import argparse
 import pathlib


### PR DESCRIPTION
Python 2 has been EOL since 2020, and all common distros no longer provide a package for it. Therefore, we can assume `python` is Python 3.

Here's the remaining instances:
```bash
[tav@myriad allwpilib]$ rg 'env python3'
wpiutil/src/main/native/thirdparty/nanopb/generator/nanopb_generator.py
1:#!/usr/bin/env python3

wpiutil/src/main/native/thirdparty/nanopb/generator/protoc
1:#!/usr/bin/env python3

wpiutil/src/main/native/thirdparty/nanopb/generator/nanopb_generator
1:#!/usr/bin/env python3

wpiutil/src/main/native/thirdparty/nanopb/generator/protoc-gen-nanopb
1:#!/usr/bin/env python3

upstream_utils/nanopb_patches/0001-Marked-imported-files-as-modified-by-WPILib.patch
22: #!/usr/bin/env python3
[tav@myriad allwpilib]$ rg 'env python2'
wpiutil/src/main/native/thirdparty/nanopb/generator/nanopb_generator.py2
1:#!/usr/bin/env python2
```