### PR TITLE
[bazel] Register default Java toolchain with compiler flags

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,10 +2,46 @@ load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load("@rules_java//java:java_binary.bzl", "java_binary")
 load("@rules_java//java:java_plugin.bzl", "java_plugin")
+load("@rules_java//java/toolchains:java_package_configuration.bzl", "java_package_configuration")
+load("@rules_java//toolchains:default_java_toolchain.bzl", "default_java_toolchain")
 load("@rules_pkg//:mappings.bzl", "pkg_files")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("//shared/bazel/rules:publishing.bzl", "publish_all")
 load("//shared/bazel/rules/robotpy:compatibility_select.bzl", "robotpy_compatibility_select")
+
+default_java_toolchain(
+    name = "java_toolchain",
+    java_runtime = "@rules_java//toolchains:remotejdk_25",
+    package_configuration = [
+        ":allwpilib_toolchain_config",
+        "//wpilibjExamples:toolchain_config",
+    ],
+    source_version = "25",
+    target_version = "25",
+)
+
+java_package_configuration(
+    name = "allwpilib_toolchain_config",
+    javacopts = [
+        "-Werror",
+        "-XDstringConcat=inline",
+        "-Xlint:all",
+        # ignore AutoCloseable warnings
+        "-Xlint:-try",
+        # ignore missing serialVersionUID warnings
+        "-Xlint:-serial",
+        # ignore unclaimed annotation warning from annotation processing
+        "-Xlint:-processing",
+    ],
+    # Apply our flags to just our repository. Otherwise, Bazel will compile its
+    # tools with our flags, and not all of them are warning-free.
+    packages = ["allwpilib_packages"],
+)
+
+package_group(
+    name = "allwpilib_packages",
+    packages = ["//..."],
+)
 
 java_plugin(
     name = "avaje_jsonb_generator",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -57,6 +57,8 @@ use_repo(pip, "allwpilib_pip_deps")
 
 bazel_dep(name = "rules_jvm_external", version = "6.8")
 
+register_toolchains("//:java_toolchain_definition")
+
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     name = "maven",

--- a/wpilibjExamples/BUILD.bazel
+++ b/wpilibjExamples/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_java//java/toolchains:java_package_configuration.bzl", "java_package_configuration")
 load("@rules_jvm_external//:defs.bzl", "maven_export")
 load("@rules_python//python:defs.bzl", "py_test")
 load(":build_java_examples.bzl", "build_commands", "build_examples", "build_snippets", "build_templates", "build_tests", "first_level_folders")
@@ -30,6 +31,20 @@ example_test_folders = first_level_folders(
 snippet_test_folders = first_level_folders(
     glob(["src/test/java/org/wpilib/snippets/*/**/*.java"]),
     "src/test/java/org/wpilib/snippets/",
+)
+
+java_package_configuration(
+    name = "toolchain_config",
+    javacopts = [
+        "-Xlint:-this-escape",
+    ],
+    packages = [":packages"],
+    visibility = ["//visibility:public"],
+)
+
+package_group(
+    name = "packages",
+    packages = ["//wpilibjExamples/..."],
 )
 
 halsim_deps = [


### PR DESCRIPTION
This matches our Gradle build. There's a few differences (Bazel adds `-g` by default to javac) but it's very close.