### PR TITLE
[epilogue-processor] Fix Error Prone ReturnValueIgnored lint

### DIFF
--- a/epilogue-processor/src/test/java/org/wpilib/epilogue/processor/AnnotationProcessorTest.java
+++ b/epilogue-processor/src/test/java/org/wpilib/epilogue/processor/AnnotationProcessorTest.java
@@ -2300,10 +2300,11 @@ class AnnotationProcessorTest {
                 JavaFileObjects.forSourceString("example.package-info", packageInfo));
 
     assertThat(compilation).succeeded();
-    compilation.generatedSourceFiles().stream()
-        .filter(jfo -> jfo.getName().contains("Example"))
-        .findFirst()
-        .orElseThrow(() -> new IllegalStateException("Logger file was not generated!"));
+    var generatedFile =
+        compilation.generatedSourceFiles().stream()
+            .filter(jfo -> jfo.getName().contains("Example"))
+            .findFirst();
+    assertTrue(generatedFile.isPresent());
   }
 
   private void assertCompilationError(


### PR DESCRIPTION
The [ReturnValueIgnored](https://errorprone.info/bugpattern/ReturnValueIgnored) check is enabled in rules_java 9.0.0. 