### PR TITLE
[bazel] Fix Bazel 9 compatibility

### DIFF
--- a/shared/bazel/rules/jni_rules.bzl
+++ b/shared/bazel/rules/jni_rules.bzl
@@ -62,7 +62,6 @@ _jni_headers = rule(
         ),
     },
     fragments = ["cpp"],
-    incompatible_use_toolchain_transition = True,
     provides = [CcInfo],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
 )

--- a/shared/bazel/thirdparty/mrclib/mrclib.MODULE.bazel
+++ b/shared/bazel/thirdparty/mrclib/mrclib.MODULE.bazel
@@ -19,7 +19,9 @@ _LIB_ARTIFACTS = {
 
 http_archive(
     name = "mrclib_headers",
-    build_file_content = """
+    build_file_content = """\
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 cc_library(
     name = "headers",
     hdrs = glob(["**"]),


### PR DESCRIPTION
`incompatible_use_toolchain_transition` has done nothing since Bazel 7.