### PR TITLE
[telemetry] Add timestamp to backend API (TelemetryEntry)

### DIFF
--- a/benchmark/src/main/java/wpilib/robot/TelemetryTunableAllocationBenchmark.java
+++ b/benchmark/src/main/java/wpilib/robot/TelemetryTunableAllocationBenchmark.java
@@ -431,93 +431,93 @@ public class TelemetryTunableAllocationBenchmark {
     }
 
     @Override
-    public <T> void logStruct(T value, Struct<? super T> struct) {
+    public <T> void logStruct(T value, Struct<? super T> struct, long timestamp) {
       m_backend.m_objectSink = value;
       m_backend.m_sink += struct.getSize();
     }
 
     @Override
-    public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto) {
+    public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto, long timestamp) {
       m_backend.m_objectSink = value;
       m_backend.m_sink += proto.getTypeString().length();
     }
 
     @Override
-    public <T> void logStructArray(T[] value, Struct<? super T> struct) {
+    public <T> void logStructArray(T[] value, Struct<? super T> struct, long timestamp) {
       m_backend.m_objectSink = value;
       m_backend.m_sink += value.length + struct.getSize();
     }
 
     @Override
-    public void logBoolean(boolean value) {
+    public void logBoolean(boolean value, long timestamp) {
       m_backend.m_sink += value ? 1 : 0;
     }
 
     @Override
-    public void logLong(long value) {
+    public void logLong(long value, long timestamp) {
       m_backend.m_sink += value;
     }
 
     @Override
-    public void logFloat(float value) {
+    public void logFloat(float value, long timestamp) {
       m_backend.m_sink += Float.floatToRawIntBits(value);
     }
 
     @Override
-    public void logDouble(double value) {
+    public void logDouble(double value, long timestamp) {
       m_backend.m_sink += Double.doubleToRawLongBits(value);
     }
 
     @Override
-    public void logString(String value, String typeString) {
+    public void logString(String value, String typeString, long timestamp) {
       m_backend.m_objectSink = value;
       m_backend.m_sink += value.length() + typeString.length();
     }
 
     @Override
-    public void logBooleanArray(boolean[] value) {
+    public void logBooleanArray(boolean[] value, long timestamp) {
       m_backend.m_objectSink = value;
       m_backend.m_sink += value.length;
     }
 
     @Override
-    public void logShortArray(short[] value) {
+    public void logShortArray(short[] value, long timestamp) {
       m_backend.m_objectSink = value;
       m_backend.m_sink += value.length;
     }
 
     @Override
-    public void logIntArray(int[] value) {
+    public void logIntArray(int[] value, long timestamp) {
       m_backend.m_objectSink = value;
       m_backend.m_sink += value.length;
     }
 
     @Override
-    public void logLongArray(long[] value) {
+    public void logLongArray(long[] value, long timestamp) {
       m_backend.m_objectSink = value;
       m_backend.m_sink += value.length;
     }
 
     @Override
-    public void logFloatArray(float[] value) {
+    public void logFloatArray(float[] value, long timestamp) {
       m_backend.m_objectSink = value;
       m_backend.m_sink += value.length;
     }
 
     @Override
-    public void logDoubleArray(double[] value) {
+    public void logDoubleArray(double[] value, long timestamp) {
       m_backend.m_objectSink = value;
       m_backend.m_sink += value.length;
     }
 
     @Override
-    public void logStringArray(String[] value) {
+    public void logStringArray(String[] value, long timestamp) {
       m_backend.m_objectSink = value;
       m_backend.m_sink += value.length;
     }
 
     @Override
-    public void logRaw(byte[] value, String typeString) {
+    public void logRaw(byte[] value, String typeString, long timestamp) {
       m_backend.m_objectSink = value;
       m_backend.m_sink += value.length + typeString.length();
     }

--- a/telemetry/doc/cpp.md
+++ b/telemetry/doc/cpp.md
@@ -599,30 +599,46 @@ class TelemetryEntry {
   virtual void KeepDuplicates() = 0;
   virtual void SetProperty(std::string_view key, std::string_view value) = 0;
 
-  virtual void LogBoolean(bool value) = 0;
-  virtual void LogInt8(int8_t value) { LogInt64(value); }
-  virtual void LogInt16(int16_t value) { LogInt64(value); }
-  virtual void LogInt32(int32_t value) { LogInt64(value); }
-  virtual void LogInt64(int64_t value) = 0;
-  virtual void LogFloat(float value) = 0;
-  virtual void LogDouble(double value) = 0;
+  virtual void LogBoolean(bool value, int64_t timestamp) = 0;
+  virtual void LogInt8(int8_t value, int64_t timestamp) {
+    LogInt64(value, timestamp);
+  }
+  virtual void LogInt16(int16_t value, int64_t timestamp) {
+    LogInt64(value, timestamp);
+  }
+  virtual void LogInt32(int32_t value, int64_t timestamp) {
+    LogInt64(value, timestamp);
+  }
+  virtual void LogInt64(int64_t value, int64_t timestamp) = 0;
+  virtual void LogFloat(float value, int64_t timestamp) = 0;
+  virtual void LogDouble(double value, int64_t timestamp) = 0;
   virtual void LogString(std::string_view value,
-                         std::string_view typeString) = 0;
-  virtual void LogBooleanArray(std::span<const bool> value) = 0;
-  virtual void LogBooleanArray(std::span<const int> value) = 0;
-  virtual void LogInt16Array(std::span<const int16_t> value) = 0;
-  virtual void LogInt32Array(std::span<const int32_t> value) = 0;
-  virtual void LogInt64Array(std::span<const int64_t> value) = 0;
-  virtual void LogFloatArray(std::span<const float> value) = 0;
-  virtual void LogDoubleArray(std::span<const double> value) = 0;
-  virtual void LogStringArray(std::span<const std::string> value) = 0;
-  virtual void LogStringArray(std::span<const std::string_view> value) = 0;
+                         std::string_view typeString,
+                         int64_t timestamp) = 0;
+  virtual void LogBooleanArray(std::span<const bool> value,
+                               int64_t timestamp) = 0;
+  virtual void LogBooleanArray(std::span<const int> value,
+                               int64_t timestamp) = 0;
+  virtual void LogInt16Array(std::span<const int16_t> value,
+                             int64_t timestamp) = 0;
+  virtual void LogInt32Array(std::span<const int32_t> value,
+                             int64_t timestamp) = 0;
+  virtual void LogInt64Array(std::span<const int64_t> value,
+                             int64_t timestamp) = 0;
+  virtual void LogFloatArray(std::span<const float> value,
+                             int64_t timestamp) = 0;
+  virtual void LogDoubleArray(std::span<const double> value,
+                              int64_t timestamp) = 0;
+  virtual void LogStringArray(std::span<const std::string> value,
+                              int64_t timestamp) = 0;
+  virtual void LogStringArray(std::span<const std::string_view> value,
+                              int64_t timestamp) = 0;
   virtual void LogRaw(std::span<const uint8_t> value,
-                      std::string_view typeString) = 0;
+                      std::string_view typeString, int64_t timestamp) = 0;
 };
 ```
 
-This layer is primarily relevant to backend authors rather than normal robot-code authors. `TelemetryEntry` implementations must not throw from logging, metadata, or discard-checking methods; recoverable failures should be reported through `TelemetryRegistry::ReportWarning()` and skipped.
+This layer is primarily relevant to backend authors rather than normal robot-code authors. Each logging method receives a `timestamp` in nanoseconds in the same time base as `wpi::util::Now()`, or `0` to use the current time. `TelemetryEntry` implementations must not throw from logging, metadata, or discard-checking methods; recoverable failures should be reported through `TelemetryRegistry::ReportWarning()` and skipped.
 
 `wpi::telemetry::TelemetryBackend` also owns schema publication in C++:
 

--- a/telemetry/doc/telemetry.md
+++ b/telemetry/doc/telemetry.md
@@ -512,27 +512,27 @@ public interface TelemetryEntry {
   void keepDuplicates();
   void setProperty(String key, String value);
 
-  <T> void logStruct(T value, Struct<? super T> struct);
-  <T> void logProtobuf(T value, Protobuf<? super T, ?> proto);
-  <T> void logStructArray(T[] value, Struct<? super T> struct);
+  <T> void logStruct(T value, Struct<? super T> struct, long timestamp);
+  <T> void logProtobuf(T value, Protobuf<? super T, ?> proto, long timestamp);
+  <T> void logStructArray(T[] value, Struct<? super T> struct, long timestamp);
 
-  void logBoolean(boolean value);
-  default void logByte(byte value) {...}
-  default void logShort(short value) {...}
-  default void logInt(int value) {...}
-  void logLong(long value);
-  void logFloat(float value);
-  void logDouble(double value);
-  void logString(String value, String typeString);
+  void logBoolean(boolean value, long timestamp);
+  default void logByte(byte value, long timestamp) {...}
+  default void logShort(short value, long timestamp) {...}
+  default void logInt(int value, long timestamp) {...}
+  void logLong(long value, long timestamp);
+  void logFloat(float value, long timestamp);
+  void logDouble(double value, long timestamp);
+  void logString(String value, String typeString, long timestamp);
 
-  void logBooleanArray(boolean[] value);
-  void logShortArray(short[] value);
-  void logIntArray(int[] value);
-  void logLongArray(long[] value);
-  void logFloatArray(float[] value);
-  void logDoubleArray(double[] value);
-  void logStringArray(String[] value);
-  void logRaw(byte[] value, String typeString);
+  void logBooleanArray(boolean[] value, long timestamp);
+  void logShortArray(short[] value, long timestamp);
+  void logIntArray(int[] value, long timestamp);
+  void logLongArray(long[] value, long timestamp);
+  void logFloatArray(float[] value, long timestamp);
+  void logDoubleArray(double[] value, long timestamp);
+  void logStringArray(String[] value, long timestamp);
+  void logRaw(byte[] value, String typeString, long timestamp);
 }
 ```
 
@@ -544,7 +544,7 @@ Key behavior:
 
 - `logByte`, `logShort`, and `logInt` default to widening into `logLong`, so a backend can implement integer handling with a single required path.
 
-- Backends are responsible for storing, transporting, deduplicating, or timestamping values as appropriate for that transport.
+- Backends are responsible for storing, transporting, deduplicating, and applying timestamps as appropriate for that transport. The `timestamp` parameter is in nanoseconds in the same time base as `WPIUtilJNI.now()`, or `0` to use the current time.
 
 - Metadata (`setProperty`) and duplicate-preservation (`keepDuplicates`) are handled at the entry level rather than the table level.
 
@@ -564,68 +564,68 @@ public final class ConsoleTelemetryBackend implements TelemetryBackend {
       public void setProperty(String key, String value) {}
 
       @Override
-      public <T> void logStruct(T value, Struct<? super T> struct) {
+      public <T> void logStruct(T value, Struct<? super T> struct, long timestamp) {
         System.out.println(path + " = " + value + " [struct=" + struct.getTypeName() + "]");
       }
 
       @Override
-      public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto) {
+      public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto, long timestamp) {
         System.out.println(path + " = " + value + " [proto=" + proto.getTypeString() + "]");
       }
 
       @Override
-      public <T> void logStructArray(T[] value, Struct<? super T> struct) {
+      public <T> void logStructArray(T[] value, Struct<? super T> struct, long timestamp) {
         System.out.println(path + " = struct array length " + value.length);
       }
 
       @Override
-      public void logBoolean(boolean value) {
+      public void logBoolean(boolean value, long timestamp) {
         System.out.println(path + " = " + value);
       }
 
       @Override
-      public void logLong(long value) {
+      public void logLong(long value, long timestamp) {
         System.out.println(path + " = " + value);
       }
 
       @Override
-      public void logFloat(float value) {
+      public void logFloat(float value, long timestamp) {
         System.out.println(path + " = " + value);
       }
 
       @Override
-      public void logDouble(double value) {
+      public void logDouble(double value, long timestamp) {
         System.out.println(path + " = " + value);
       }
 
       @Override
-      public void logString(String value, String typeString) {
+      public void logString(String value, String typeString, long timestamp) {
         System.out.println(path + " = " + value + " [type=" + typeString + "]");
       }
 
       @Override
-      public void logBooleanArray(boolean[] value) {}
+      public void logBooleanArray(boolean[] value, long timestamp) {}
 
       @Override
-      public void logShortArray(short[] value) {}
+      public void logShortArray(short[] value, long timestamp) {}
 
       @Override
-      public void logIntArray(int[] value) {}
+      public void logIntArray(int[] value, long timestamp) {}
 
       @Override
-      public void logLongArray(long[] value) {}
+      public void logLongArray(long[] value, long timestamp) {}
 
       @Override
-      public void logFloatArray(float[] value) {}
+      public void logFloatArray(float[] value, long timestamp) {}
 
       @Override
-      public void logDoubleArray(double[] value) {}
+      public void logDoubleArray(double[] value, long timestamp) {}
 
       @Override
-      public void logStringArray(String[] value) {}
+      public void logStringArray(String[] value, long timestamp) {}
 
       @Override
-      public void logRaw(byte[] value, String typeString) {}
+      public void logRaw(byte[] value, String typeString, long timestamp) {}
     };
   }
 

--- a/telemetry/src/main/java/org/wpilib/telemetry/DiscardTelemetryBackend.java
+++ b/telemetry/src/main/java/org/wpilib/telemetry/DiscardTelemetryBackend.java
@@ -35,51 +35,51 @@ public class DiscardTelemetryBackend implements TelemetryBackend {
     public void setProperty(String key, String value) {}
 
     @Override
-    public <T> void logStruct(T value, Struct<? super T> struct) {}
+    public <T> void logStruct(T value, Struct<? super T> struct, long timestamp) {}
 
     @Override
-    public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto) {}
+    public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto, long timestamp) {}
 
     @Override
-    public <T> void logStructArray(T[] value, Struct<? super T> struct) {}
+    public <T> void logStructArray(T[] value, Struct<? super T> struct, long timestamp) {}
 
     @Override
-    public void logBoolean(boolean value) {}
+    public void logBoolean(boolean value, long timestamp) {}
 
     @Override
-    public void logLong(long value) {}
+    public void logLong(long value, long timestamp) {}
 
     @Override
-    public void logFloat(float value) {}
+    public void logFloat(float value, long timestamp) {}
 
     @Override
-    public void logDouble(double value) {}
+    public void logDouble(double value, long timestamp) {}
 
     @Override
-    public void logString(String value, String typeString) {}
+    public void logString(String value, String typeString, long timestamp) {}
 
     @Override
-    public void logBooleanArray(boolean[] value) {}
+    public void logBooleanArray(boolean[] value, long timestamp) {}
 
     @Override
-    public void logShortArray(short[] value) {}
+    public void logShortArray(short[] value, long timestamp) {}
 
     @Override
-    public void logIntArray(int[] value) {}
+    public void logIntArray(int[] value, long timestamp) {}
 
     @Override
-    public void logLongArray(long[] value) {}
+    public void logLongArray(long[] value, long timestamp) {}
 
     @Override
-    public void logFloatArray(float[] value) {}
+    public void logFloatArray(float[] value, long timestamp) {}
 
     @Override
-    public void logDoubleArray(double[] value) {}
+    public void logDoubleArray(double[] value, long timestamp) {}
 
     @Override
-    public void logStringArray(String[] value) {}
+    public void logStringArray(String[] value, long timestamp) {}
 
     @Override
-    public void logRaw(byte[] value, String typeString) {}
+    public void logRaw(byte[] value, String typeString, long timestamp) {}
   }
 }

--- a/telemetry/src/main/java/org/wpilib/telemetry/MockTelemetryBackend.java
+++ b/telemetry/src/main/java/org/wpilib/telemetry/MockTelemetryBackend.java
@@ -86,8 +86,9 @@ public class MockTelemetryBackend implements TelemetryBackend {
    *
    * @param path logged path
    * @param value logged value
+   * @param timestamp logged timestamp, or 0 to use the current time
    */
-  public record Action(String path, Object value) {}
+  public record Action(String path, Object value, long timestamp) {}
 
   private final Map<String, Entry> m_entries = new HashMap<>();
   private final List<Action> m_actions = new ArrayList<>();
@@ -175,13 +176,13 @@ public class MockTelemetryBackend implements TelemetryBackend {
     }
   }
 
-  private void log(Entry entry, Object value) {
+  private void log(Entry entry, Object value, long timestamp) {
     synchronized (this) {
       if (entry.m_removed) {
         return;
       }
       entry.m_last = m_actions.size();
-      m_actions.add(new Action(entry.m_path, value));
+      m_actions.add(new Action(entry.m_path, value, timestamp));
     }
   }
 
@@ -204,23 +205,23 @@ public class MockTelemetryBackend implements TelemetryBackend {
 
     @Override
     public void keepDuplicates() {
-      log(this, new KeepDuplicateValue(true));
+      log(this, new KeepDuplicateValue(true), 0);
     }
 
     @Override
     public void setProperty(String key, String value) {
-      log(this, new SetPropertyValue(key, value));
+      log(this, new SetPropertyValue(key, value), 0);
     }
 
     @Override
-    public <T> void logStruct(T value, Struct<? super T> struct) {
-      logStructImpl(value, struct);
+    public <T> void logStruct(T value, Struct<? super T> struct, long timestamp) {
+      logStructImpl(value, struct, timestamp);
     }
 
-    private <T> void logStructImpl(T value, Struct<T> struct) {
+    private <T> void logStructImpl(T value, Struct<T> struct, long timestamp) {
       if (struct.isImmutable()) {
         // log it directly
-        log(this, new LogStructValue<T>(value, struct));
+        log(this, new LogStructValue<T>(value, struct), timestamp);
       } else if (struct.isCloneable()) {
         T clonedValue;
         try {
@@ -228,26 +229,26 @@ public class MockTelemetryBackend implements TelemetryBackend {
         } catch (CloneNotSupportedException e) {
           TelemetryRegistry.reportWarning(
               m_path, "struct.isCloneable() returned true, but clone() raised exception");
-          log(this, new LogStructValue<T>(value, struct));
+          log(this, new LogStructValue<T>(value, struct), timestamp);
           return;
         }
-        log(this, new LogStructValue<T>(clonedValue, struct));
+        log(this, new LogStructValue<T>(clonedValue, struct), timestamp);
       } else {
         // log it directly, but warn
         TelemetryRegistry.reportWarning(m_path, "logging non-immutable and non-cloneable struct");
-        log(this, new LogStructValue<T>(value, struct));
+        log(this, new LogStructValue<T>(value, struct), timestamp);
       }
     }
 
     @Override
-    public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto) {
-      logProtobufImpl(value, proto);
+    public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto, long timestamp) {
+      logProtobufImpl(value, proto, timestamp);
     }
 
-    private <T> void logProtobufImpl(T value, Protobuf<T, ?> proto) {
+    private <T> void logProtobufImpl(T value, Protobuf<T, ?> proto, long timestamp) {
       if (proto.isImmutable()) {
         // log it directly
-        log(this, new LogProtobufValue<T>(value, proto));
+        log(this, new LogProtobufValue<T>(value, proto), timestamp);
       } else if (proto.isCloneable()) {
         T clonedValue;
         try {
@@ -255,26 +256,26 @@ public class MockTelemetryBackend implements TelemetryBackend {
         } catch (CloneNotSupportedException e) {
           TelemetryRegistry.reportWarning(
               m_path, "proto.isCloneable() returned true, but clone() raised exception");
-          log(this, new LogProtobufValue<T>(value, proto));
+          log(this, new LogProtobufValue<T>(value, proto), timestamp);
           return;
         }
-        log(this, new LogProtobufValue<T>(clonedValue, proto));
+        log(this, new LogProtobufValue<T>(clonedValue, proto), timestamp);
       } else {
         // log it directly, but warn
         TelemetryRegistry.reportWarning(m_path, "logging non-immutable and non-cloneable proto");
-        log(this, new LogProtobufValue<T>(value, proto));
+        log(this, new LogProtobufValue<T>(value, proto), timestamp);
       }
     }
 
     @Override
-    public <T> void logStructArray(T[] value, Struct<? super T> struct) {
-      logStructArrayImpl(value, struct);
+    public <T> void logStructArray(T[] value, Struct<? super T> struct, long timestamp) {
+      logStructArrayImpl(value, struct, timestamp);
     }
 
-    private <T> void logStructArrayImpl(T[] value, Struct<T> struct) {
+    private <T> void logStructArrayImpl(T[] value, Struct<T> struct, long timestamp) {
       if (struct.isImmutable()) {
         // log it directly
-        log(this, new LogStructArrayValue<T>(value.clone(), struct));
+        log(this, new LogStructArrayValue<T>(value.clone(), struct), timestamp);
       } else if (struct.isCloneable()) {
         @SuppressWarnings("unchecked")
         T[] clonedArray = (T[]) Array.newInstance(struct.getTypeClass(), value.length);
@@ -285,90 +286,90 @@ public class MockTelemetryBackend implements TelemetryBackend {
         } catch (CloneNotSupportedException e) {
           TelemetryRegistry.reportWarning(
               m_path, "struct.isCloneable() returned true, but clone() raised exception");
-          log(this, new LogStructArrayValue<T>(value.clone(), struct));
+          log(this, new LogStructArrayValue<T>(value.clone(), struct), timestamp);
           return;
         }
-        log(this, new LogStructArrayValue<T>(clonedArray, struct));
+        log(this, new LogStructArrayValue<T>(clonedArray, struct), timestamp);
       } else {
         // log it directly, but warn
         TelemetryRegistry.reportWarning(m_path, "logging non-immutable and non-cloneable struct");
-        log(this, new LogStructArrayValue<T>(value.clone(), struct));
+        log(this, new LogStructArrayValue<T>(value.clone(), struct), timestamp);
       }
     }
 
     @Override
-    public void logBoolean(boolean value) {
-      log(this, value);
+    public void logBoolean(boolean value, long timestamp) {
+      log(this, value, timestamp);
     }
 
     @Override
-    public void logShort(short value) {
-      log(this, value);
+    public void logShort(short value, long timestamp) {
+      log(this, value, timestamp);
     }
 
     @Override
-    public void logInt(int value) {
-      log(this, value);
+    public void logInt(int value, long timestamp) {
+      log(this, value, timestamp);
     }
 
     @Override
-    public void logLong(long value) {
-      log(this, value);
+    public void logLong(long value, long timestamp) {
+      log(this, value, timestamp);
     }
 
     @Override
-    public void logFloat(float value) {
-      log(this, value);
+    public void logFloat(float value, long timestamp) {
+      log(this, value, timestamp);
     }
 
     @Override
-    public void logDouble(double value) {
-      log(this, value);
+    public void logDouble(double value, long timestamp) {
+      log(this, value, timestamp);
     }
 
     @Override
-    public void logString(String value, String typeString) {
-      log(this, new LogStringValue(value, typeString));
+    public void logString(String value, String typeString, long timestamp) {
+      log(this, new LogStringValue(value, typeString), timestamp);
     }
 
     @Override
-    public void logBooleanArray(boolean[] value) {
-      log(this, value.clone());
+    public void logBooleanArray(boolean[] value, long timestamp) {
+      log(this, value.clone(), timestamp);
     }
 
     @Override
-    public void logShortArray(short[] value) {
-      log(this, value.clone());
+    public void logShortArray(short[] value, long timestamp) {
+      log(this, value.clone(), timestamp);
     }
 
     @Override
-    public void logIntArray(int[] value) {
-      log(this, value.clone());
+    public void logIntArray(int[] value, long timestamp) {
+      log(this, value.clone(), timestamp);
     }
 
     @Override
-    public void logLongArray(long[] value) {
-      log(this, value.clone());
+    public void logLongArray(long[] value, long timestamp) {
+      log(this, value.clone(), timestamp);
     }
 
     @Override
-    public void logFloatArray(float[] value) {
-      log(this, value.clone());
+    public void logFloatArray(float[] value, long timestamp) {
+      log(this, value.clone(), timestamp);
     }
 
     @Override
-    public void logDoubleArray(double[] value) {
-      log(this, value.clone());
+    public void logDoubleArray(double[] value, long timestamp) {
+      log(this, value.clone(), timestamp);
     }
 
     @Override
-    public void logStringArray(String[] value) {
-      log(this, value.clone());
+    public void logStringArray(String[] value, long timestamp) {
+      log(this, value.clone(), timestamp);
     }
 
     @Override
-    public void logRaw(byte[] value, String typeString) {
-      log(this, new LogRawValue(value.clone(), typeString));
+    public void logRaw(byte[] value, String typeString, long timestamp) {
+      log(this, new LogRawValue(value.clone(), typeString), timestamp);
     }
 
     private final String m_path;

--- a/telemetry/src/main/java/org/wpilib/telemetry/MockTelemetryBackend.java
+++ b/telemetry/src/main/java/org/wpilib/telemetry/MockTelemetryBackend.java
@@ -89,7 +89,17 @@ public class MockTelemetryBackend implements TelemetryBackend {
    * @param timestamp logged timestamp in nanoseconds in the same time base as {@link
    *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
-  public record Action(String path, Object value, long timestamp) {}
+  public record Action(String path, Object value, long timestamp) {
+    /**
+     * Constructs a logged action with the current-time timestamp sentinel.
+     *
+     * @param path logged path
+     * @param value logged value
+     */
+    public Action(String path, Object value) {
+      this(path, value, 0);
+    }
+  }
 
   private final Map<String, Entry> m_entries = new HashMap<>();
   private final List<Action> m_actions = new ArrayList<>();

--- a/telemetry/src/main/java/org/wpilib/telemetry/MockTelemetryBackend.java
+++ b/telemetry/src/main/java/org/wpilib/telemetry/MockTelemetryBackend.java
@@ -86,7 +86,8 @@ public class MockTelemetryBackend implements TelemetryBackend {
    *
    * @param path logged path
    * @param value logged value
-   * @param timestamp logged timestamp, or 0 to use the current time
+   * @param timestamp logged timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   public record Action(String path, Object value, long timestamp) {}
 

--- a/telemetry/src/main/java/org/wpilib/telemetry/MultiTelemetryBackend.java
+++ b/telemetry/src/main/java/org/wpilib/telemetry/MultiTelemetryBackend.java
@@ -183,7 +183,7 @@ public class MultiTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public <T> void logStruct(T value, Struct<? super T> struct) {
+    public <T> void logStruct(T value, Struct<? super T> struct, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -191,12 +191,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logStruct(value, struct);
+        m_entries.get(i).logStruct(value, struct, timestamp);
       }
     }
 
     @Override
-    public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto) {
+    public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -204,12 +204,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logProtobuf(value, proto);
+        m_entries.get(i).logProtobuf(value, proto, timestamp);
       }
     }
 
     @Override
-    public <T> void logStructArray(T[] value, Struct<? super T> struct) {
+    public <T> void logStructArray(T[] value, Struct<? super T> struct, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -217,12 +217,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logStructArray(value, struct);
+        m_entries.get(i).logStructArray(value, struct, timestamp);
       }
     }
 
     @Override
-    public void logBoolean(boolean value) {
+    public void logBoolean(boolean value, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -230,12 +230,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logBoolean(value);
+        m_entries.get(i).logBoolean(value, timestamp);
       }
     }
 
     @Override
-    public void logByte(byte value) {
+    public void logByte(byte value, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -243,12 +243,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logByte(value);
+        m_entries.get(i).logByte(value, timestamp);
       }
     }
 
     @Override
-    public void logShort(short value) {
+    public void logShort(short value, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -256,12 +256,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logShort(value);
+        m_entries.get(i).logShort(value, timestamp);
       }
     }
 
     @Override
-    public void logInt(int value) {
+    public void logInt(int value, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -269,12 +269,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logInt(value);
+        m_entries.get(i).logInt(value, timestamp);
       }
     }
 
     @Override
-    public void logLong(long value) {
+    public void logLong(long value, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -282,12 +282,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logLong(value);
+        m_entries.get(i).logLong(value, timestamp);
       }
     }
 
     @Override
-    public void logFloat(float value) {
+    public void logFloat(float value, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -295,12 +295,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logFloat(value);
+        m_entries.get(i).logFloat(value, timestamp);
       }
     }
 
     @Override
-    public void logDouble(double value) {
+    public void logDouble(double value, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -308,12 +308,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logDouble(value);
+        m_entries.get(i).logDouble(value, timestamp);
       }
     }
 
     @Override
-    public void logString(String value, String typeString) {
+    public void logString(String value, String typeString, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -321,12 +321,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logString(value, typeString);
+        m_entries.get(i).logString(value, typeString, timestamp);
       }
     }
 
     @Override
-    public void logBooleanArray(boolean[] value) {
+    public void logBooleanArray(boolean[] value, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -334,12 +334,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logBooleanArray(value);
+        m_entries.get(i).logBooleanArray(value, timestamp);
       }
     }
 
     @Override
-    public void logShortArray(short[] value) {
+    public void logShortArray(short[] value, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -347,12 +347,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logShortArray(value);
+        m_entries.get(i).logShortArray(value, timestamp);
       }
     }
 
     @Override
-    public void logIntArray(int[] value) {
+    public void logIntArray(int[] value, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -360,12 +360,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logIntArray(value);
+        m_entries.get(i).logIntArray(value, timestamp);
       }
     }
 
     @Override
-    public void logLongArray(long[] value) {
+    public void logLongArray(long[] value, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -373,12 +373,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logLongArray(value);
+        m_entries.get(i).logLongArray(value, timestamp);
       }
     }
 
     @Override
-    public void logFloatArray(float[] value) {
+    public void logFloatArray(float[] value, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -386,12 +386,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logFloatArray(value);
+        m_entries.get(i).logFloatArray(value, timestamp);
       }
     }
 
     @Override
-    public void logDoubleArray(double[] value) {
+    public void logDoubleArray(double[] value, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -399,12 +399,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logDoubleArray(value);
+        m_entries.get(i).logDoubleArray(value, timestamp);
       }
     }
 
     @Override
-    public void logStringArray(String[] value) {
+    public void logStringArray(String[] value, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -412,12 +412,12 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logStringArray(value);
+        m_entries.get(i).logStringArray(value, timestamp);
       }
     }
 
     @Override
-    public void logRaw(byte[] value, String typeString) {
+    public void logRaw(byte[] value, String typeString, long timestamp) {
       if (m_closed) {
         return;
       }
@@ -425,7 +425,7 @@ public class MultiTelemetryBackend implements TelemetryBackend {
         if (m_closed) {
           return;
         }
-        m_entries.get(i).logRaw(value, typeString);
+        m_entries.get(i).logRaw(value, typeString, timestamp);
       }
     }
   }

--- a/telemetry/src/main/java/org/wpilib/telemetry/TelemetryEntry.java
+++ b/telemetry/src/main/java/org/wpilib/telemetry/TelemetryEntry.java
@@ -46,8 +46,9 @@ public interface TelemetryEntry {
    * @param <T> data type
    * @param value the value
    * @param struct struct serializer for the value type or one of its supertypes
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  <T> void logStruct(T value, Struct<? super T> struct);
+  <T> void logStruct(T value, Struct<? super T> struct, long timestamp);
 
   /**
    * Logs an object with protobuf serialization.
@@ -55,8 +56,9 @@ public interface TelemetryEntry {
    * @param <T> data type
    * @param value the value
    * @param proto protobuf serializer for the value type or one of its supertypes
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  <T> void logProtobuf(T value, Protobuf<? super T, ?> proto);
+  <T> void logProtobuf(T value, Protobuf<? super T, ?> proto, long timestamp);
 
   /**
    * Logs an array of objects with struct serialization.
@@ -64,126 +66,143 @@ public interface TelemetryEntry {
    * @param <T> data type
    * @param value the value
    * @param struct struct serializer for the value type or one of its supertypes
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  <T> void logStructArray(T[] value, Struct<? super T> struct);
+  <T> void logStructArray(T[] value, Struct<? super T> struct, long timestamp);
 
   /**
    * Logs a boolean.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  void logBoolean(boolean value);
+  void logBoolean(boolean value, long timestamp);
 
   /**
    * Logs a byte.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  default void logByte(byte value) {
-    logLong(value);
+  default void logByte(byte value, long timestamp) {
+    logLong(value, timestamp);
   }
 
   /**
    * Logs a short.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  default void logShort(short value) {
-    logLong(value);
+  default void logShort(short value, long timestamp) {
+    logLong(value, timestamp);
   }
 
   /**
    * Logs an int.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  default void logInt(int value) {
-    logLong(value);
+  default void logInt(int value, long timestamp) {
+    logLong(value, timestamp);
   }
 
   /**
    * Logs a long.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  void logLong(long value);
+  void logLong(long value, long timestamp);
 
   /**
    * Logs a float.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  void logFloat(float value);
+  void logFloat(float value, long timestamp);
 
   /**
    * Logs a double.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  void logDouble(double value);
+  void logDouble(double value, long timestamp);
 
   /**
    * Logs a String.
    *
    * @param value the value
    * @param typeString the type string
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  void logString(String value, String typeString);
+  void logString(String value, String typeString, long timestamp);
 
   /**
    * Logs a boolean array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  void logBooleanArray(boolean[] value);
+  void logBooleanArray(boolean[] value, long timestamp);
 
   /**
    * Logs a short array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  void logShortArray(short[] value);
+  void logShortArray(short[] value, long timestamp);
 
   /**
    * Logs an int array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  void logIntArray(int[] value);
+  void logIntArray(int[] value, long timestamp);
 
   /**
    * Logs a long array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  void logLongArray(long[] value);
+  void logLongArray(long[] value, long timestamp);
 
   /**
    * Logs a float array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  void logFloatArray(float[] value);
+  void logFloatArray(float[] value, long timestamp);
 
   /**
    * Logs a double array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  void logDoubleArray(double[] value);
+  void logDoubleArray(double[] value, long timestamp);
 
   /**
    * Logs a String array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  void logStringArray(String[] value);
+  void logStringArray(String[] value, long timestamp);
 
   /**
    * Logs a byte array (raw value).
    *
    * @param value the value
    * @param typeString the type string
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  void logRaw(byte[] value, String typeString);
+  void logRaw(byte[] value, String typeString, long timestamp);
 }

--- a/telemetry/src/main/java/org/wpilib/telemetry/TelemetryEntry.java
+++ b/telemetry/src/main/java/org/wpilib/telemetry/TelemetryEntry.java
@@ -46,7 +46,8 @@ public interface TelemetryEntry {
    * @param <T> data type
    * @param value the value
    * @param struct struct serializer for the value type or one of its supertypes
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   <T> void logStruct(T value, Struct<? super T> struct, long timestamp);
 
@@ -56,7 +57,8 @@ public interface TelemetryEntry {
    * @param <T> data type
    * @param value the value
    * @param proto protobuf serializer for the value type or one of its supertypes
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   <T> void logProtobuf(T value, Protobuf<? super T, ?> proto, long timestamp);
 
@@ -66,7 +68,8 @@ public interface TelemetryEntry {
    * @param <T> data type
    * @param value the value
    * @param struct struct serializer for the value type or one of its supertypes
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   <T> void logStructArray(T[] value, Struct<? super T> struct, long timestamp);
 
@@ -74,7 +77,8 @@ public interface TelemetryEntry {
    * Logs a boolean.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   void logBoolean(boolean value, long timestamp);
 
@@ -82,7 +86,8 @@ public interface TelemetryEntry {
    * Logs a byte.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   default void logByte(byte value, long timestamp) {
     logLong(value, timestamp);
@@ -92,7 +97,8 @@ public interface TelemetryEntry {
    * Logs a short.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   default void logShort(short value, long timestamp) {
     logLong(value, timestamp);
@@ -102,7 +108,8 @@ public interface TelemetryEntry {
    * Logs an int.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   default void logInt(int value, long timestamp) {
     logLong(value, timestamp);
@@ -112,7 +119,8 @@ public interface TelemetryEntry {
    * Logs a long.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   void logLong(long value, long timestamp);
 
@@ -120,7 +128,8 @@ public interface TelemetryEntry {
    * Logs a float.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   void logFloat(float value, long timestamp);
 
@@ -128,7 +137,8 @@ public interface TelemetryEntry {
    * Logs a double.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   void logDouble(double value, long timestamp);
 
@@ -137,7 +147,8 @@ public interface TelemetryEntry {
    *
    * @param value the value
    * @param typeString the type string
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   void logString(String value, String typeString, long timestamp);
 
@@ -145,7 +156,8 @@ public interface TelemetryEntry {
    * Logs a boolean array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   void logBooleanArray(boolean[] value, long timestamp);
 
@@ -153,7 +165,8 @@ public interface TelemetryEntry {
    * Logs a short array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   void logShortArray(short[] value, long timestamp);
 
@@ -161,7 +174,8 @@ public interface TelemetryEntry {
    * Logs an int array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   void logIntArray(int[] value, long timestamp);
 
@@ -169,7 +183,8 @@ public interface TelemetryEntry {
    * Logs a long array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   void logLongArray(long[] value, long timestamp);
 
@@ -177,7 +192,8 @@ public interface TelemetryEntry {
    * Logs a float array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   void logFloatArray(float[] value, long timestamp);
 
@@ -185,7 +201,8 @@ public interface TelemetryEntry {
    * Logs a double array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   void logDoubleArray(double[] value, long timestamp);
 
@@ -193,7 +210,8 @@ public interface TelemetryEntry {
    * Logs a String array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   void logStringArray(String[] value, long timestamp);
 
@@ -202,7 +220,8 @@ public interface TelemetryEntry {
    *
    * @param value the value
    * @param typeString the type string
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as {@link
+   *     org.wpilib.util.WPIUtilJNI#now() WPIUtilJNI.now()}, or 0 to use the current time
    */
   void logRaw(byte[] value, String typeString, long timestamp);
 }

--- a/telemetry/src/main/java/org/wpilib/telemetry/TelemetryTable.java
+++ b/telemetry/src/main/java/org/wpilib/telemetry/TelemetryTable.java
@@ -150,7 +150,7 @@ public final class TelemetryTable {
       }
       if (publishType) {
         if (!entry.isDiscard()) {
-          entry.logString(typeString, "string");
+          entry.logString(typeString, "string", 0);
         }
         return true;
       }
@@ -423,7 +423,7 @@ public final class TelemetryTable {
           case Struct<?> s when s.getTypeClass().isAssignableFrom(value.getClass()) -> {
             @SuppressWarnings("unchecked")
             Struct<? super T> s2 = (Struct<? super T>) s;
-            entry.logStruct(value, s2);
+            entry.logStruct(value, s2, 0);
           }
           case Struct<?> s ->
               TelemetryRegistry.reportWarning(
@@ -453,7 +453,7 @@ public final class TelemetryTable {
           case Protobuf<?, ?> s when s.getTypeClass().isAssignableFrom(value.getClass()) -> {
             @SuppressWarnings("unchecked")
             Protobuf<? super T, ?> s2 = (Protobuf<? super T, ?>) s;
-            entry.logProtobuf(value, s2);
+            entry.logProtobuf(value, s2, 0);
           }
           case Protobuf<?, ?> s ->
               TelemetryRegistry.reportWarning(
@@ -472,55 +472,55 @@ public final class TelemetryTable {
       case Boolean v -> {
         TelemetryEntry entry = getEntry(name);
         if (!entry.isDiscard()) {
-          entry.logBoolean(v.booleanValue());
+          entry.logBoolean(v.booleanValue(), 0);
         }
       }
       case Float v -> {
         TelemetryEntry entry = getEntry(name);
         if (!entry.isDiscard()) {
-          entry.logFloat(v.floatValue());
+          entry.logFloat(v.floatValue(), 0);
         }
       }
       case Double v -> {
         TelemetryEntry entry = getEntry(name);
         if (!entry.isDiscard()) {
-          entry.logDouble(v.doubleValue());
+          entry.logDouble(v.doubleValue(), 0);
         }
       }
       case Byte v -> {
         TelemetryEntry entry = getEntry(name);
         if (!entry.isDiscard()) {
-          entry.logLong(v.longValue());
+          entry.logLong(v.longValue(), 0);
         }
       }
       case Short v -> {
         TelemetryEntry entry = getEntry(name);
         if (!entry.isDiscard()) {
-          entry.logLong(v.longValue());
+          entry.logLong(v.longValue(), 0);
         }
       }
       case Integer v -> {
         TelemetryEntry entry = getEntry(name);
         if (!entry.isDiscard()) {
-          entry.logLong(v.longValue());
+          entry.logLong(v.longValue(), 0);
         }
       }
       case Long v -> {
         TelemetryEntry entry = getEntry(name);
         if (!entry.isDiscard()) {
-          entry.logLong(v.longValue());
+          entry.logLong(v.longValue(), 0);
         }
       }
       case Number v -> {
         TelemetryEntry entry = getEntry(name);
         if (!entry.isDiscard()) {
-          entry.logDouble(v.doubleValue());
+          entry.logDouble(v.doubleValue(), 0);
         }
       }
       case String v -> {
         TelemetryEntry entry = getEntry(name);
         if (!entry.isDiscard()) {
-          entry.logString(v, "string");
+          entry.logString(v, "string", 0);
         }
       }
       case Collection<?> _ -> {
@@ -543,7 +543,7 @@ public final class TelemetryTable {
           // fall back to string
           TelemetryEntry entry = getEntry(name);
           if (!entry.isDiscard()) {
-            entry.logString(value.toString(), "string");
+            entry.logString(value.toString(), "string", 0);
           }
         }
       }
@@ -563,7 +563,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logStruct(value, struct);
+    entry.logStruct(value, struct, 0);
   }
 
   /**
@@ -579,7 +579,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logProtobuf(value, proto);
+    entry.logProtobuf(value, proto, 0);
   }
 
   /**
@@ -608,7 +608,7 @@ public final class TelemetryTable {
           case Struct<?> s when s.getTypeClass().isAssignableFrom(componentType) -> {
             @SuppressWarnings("unchecked")
             Struct<? super T> s2 = (Struct<? super T>) s;
-            entry.logStructArray(value, s2);
+            entry.logStructArray(value, s2, 0);
           }
           case Struct<?> s ->
               TelemetryRegistry.reportWarning(
@@ -629,28 +629,28 @@ public final class TelemetryTable {
         for (int i = 0; i < v.length; i++) {
           arr[i] = v[i].booleanValue();
         }
-        entry.logBooleanArray(arr);
+        entry.logBooleanArray(arr, 0);
       }
       case Byte[] v -> {
         byte[] arr = new byte[v.length];
         for (int i = 0; i < v.length; i++) {
           arr[i] = v[i].byteValue();
         }
-        entry.logRaw(arr, "raw");
+        entry.logRaw(arr, "raw", 0);
       }
       case Float[] v -> {
         float[] arr = new float[v.length];
         for (int i = 0; i < v.length; i++) {
           arr[i] = v[i].floatValue();
         }
-        entry.logFloatArray(arr);
+        entry.logFloatArray(arr, 0);
       }
       case Double[] v -> {
         double[] arr = new double[v.length];
         for (int i = 0; i < v.length; i++) {
           arr[i] = v[i].doubleValue();
         }
-        entry.logDoubleArray(arr);
+        entry.logDoubleArray(arr, 0);
       }
       case Number[] v -> {
         logNumberArray(entry, v);
@@ -662,7 +662,7 @@ public final class TelemetryTable {
         for (int i = 0; i < value.length; i++) {
           strs[i] = String.valueOf(value[i]);
         }
-        entry.logStringArray(strs);
+        entry.logStringArray(strs, 0);
       }
     }
   }
@@ -680,7 +680,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logStructArray(value, struct);
+    entry.logStructArray(value, struct, 0);
   }
 
   /**
@@ -774,7 +774,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logStructArray(toArray(value, struct.getTypeClass()), struct);
+    entry.logStructArray(toArray(value, struct.getTypeClass()), struct, 0);
   }
 
   /**
@@ -788,7 +788,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logBoolean(value);
+    entry.logBoolean(value, 0);
   }
 
   /**
@@ -802,7 +802,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logByte(value);
+    entry.logByte(value, 0);
   }
 
   /**
@@ -816,7 +816,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logShort(value);
+    entry.logShort(value, 0);
   }
 
   /**
@@ -830,7 +830,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logInt(value);
+    entry.logInt(value, 0);
   }
 
   /**
@@ -844,7 +844,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logLong(value);
+    entry.logLong(value, 0);
   }
 
   /**
@@ -858,7 +858,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logFloat(value);
+    entry.logFloat(value, 0);
   }
 
   /**
@@ -872,7 +872,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logDouble(value);
+    entry.logDouble(value, 0);
   }
 
   /**
@@ -886,7 +886,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logString(value, "string");
+    entry.logString(value, "string", 0);
   }
 
   /**
@@ -901,7 +901,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logString(value, typeString);
+    entry.logString(value, typeString, 0);
   }
 
   /**
@@ -915,7 +915,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logBooleanArray(value);
+    entry.logBooleanArray(value, 0);
   }
 
   /**
@@ -929,7 +929,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logShortArray(value);
+    entry.logShortArray(value, 0);
   }
 
   /**
@@ -943,7 +943,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logIntArray(value);
+    entry.logIntArray(value, 0);
   }
 
   /**
@@ -957,7 +957,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logLongArray(value);
+    entry.logLongArray(value, 0);
   }
 
   /**
@@ -971,7 +971,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logFloatArray(value);
+    entry.logFloatArray(value, 0);
   }
 
   /**
@@ -985,7 +985,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logDoubleArray(value);
+    entry.logDoubleArray(value, 0);
   }
 
   /**
@@ -999,7 +999,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logStringArray(value);
+    entry.logStringArray(value, 0);
   }
 
   /**
@@ -1013,7 +1013,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logRaw(value, "raw");
+    entry.logRaw(value, "raw", 0);
   }
 
   /**
@@ -1028,7 +1028,7 @@ public final class TelemetryTable {
     if (entry.isDiscard()) {
       return;
     }
-    entry.logRaw(value, typeString);
+    entry.logRaw(value, typeString, 0);
   }
 
   @SuppressWarnings("unchecked")
@@ -1075,7 +1075,7 @@ public final class TelemetryTable {
       }
       arr[i++] = v;
     }
-    entry.logBooleanArray(arr);
+    entry.logBooleanArray(arr, 0);
   }
 
   private void logByteCollection(String name, TelemetryEntry entry, Collection<?> value) {
@@ -1088,7 +1088,7 @@ public final class TelemetryTable {
       }
       arr[i++] = v.byteValue();
     }
-    entry.logRaw(arr, "raw");
+    entry.logRaw(arr, "raw", 0);
   }
 
   private void logFloatCollection(String name, TelemetryEntry entry, Collection<?> value) {
@@ -1101,7 +1101,7 @@ public final class TelemetryTable {
       }
       arr[i++] = v.floatValue();
     }
-    entry.logFloatArray(arr);
+    entry.logFloatArray(arr, 0);
   }
 
   private void logDoubleCollection(String name, TelemetryEntry entry, Collection<?> value) {
@@ -1114,7 +1114,7 @@ public final class TelemetryTable {
       }
       arr[i++] = v.doubleValue();
     }
-    entry.logDoubleArray(arr);
+    entry.logDoubleArray(arr, 0);
   }
 
   private void logLongCollection(String name, TelemetryEntry entry, Collection<?> value) {
@@ -1127,7 +1127,7 @@ public final class TelemetryTable {
       }
       arr[i++] = v.longValue();
     }
-    entry.logLongArray(arr);
+    entry.logLongArray(arr, 0);
   }
 
   private void logStringCollection(String name, TelemetryEntry entry, Collection<?> value) {
@@ -1140,7 +1140,7 @@ public final class TelemetryTable {
       }
       arr[i++] = v;
     }
-    entry.logStringArray(arr);
+    entry.logStringArray(arr, 0);
   }
 
   private void logStructCollection(
@@ -1151,7 +1151,7 @@ public final class TelemetryTable {
   private <T> void logStructCollectionImpl(
       String name, TelemetryEntry entry, Collection<?> value, Struct<T> struct) {
     try {
-      entry.logStructArray(toArray(value, struct.getTypeClass()), struct);
+      entry.logStructArray(toArray(value, struct.getTypeClass()), struct, 0);
     } catch (ArrayStoreException e) {
       collectionElementTypeMismatch(name, struct.getTypeClass(), null);
     }
@@ -1163,7 +1163,7 @@ public final class TelemetryTable {
     for (Object element : value) {
       strs[i++] = String.valueOf(element);
     }
-    entry.logStringArray(strs);
+    entry.logStringArray(strs, 0);
   }
 
   private void collectionElementTypeMismatch(String name, Class<?> expectedType, Object element) {
@@ -1182,13 +1182,13 @@ public final class TelemetryTable {
       for (int i = 0; i < value.length; i++) {
         arr[i] = value[i].longValue();
       }
-      entry.logLongArray(arr);
+      entry.logLongArray(arr, 0);
     } else {
       double[] arr = new double[value.length];
       for (int i = 0; i < value.length; i++) {
         arr[i] = value[i].doubleValue();
       }
-      entry.logDoubleArray(arr);
+      entry.logDoubleArray(arr, 0);
     }
   }
 }

--- a/telemetry/src/main/native/cpp/DiscardTelemetryBackend.cpp
+++ b/telemetry/src/main/native/cpp/DiscardTelemetryBackend.cpp
@@ -21,37 +21,46 @@ class Entry : public TelemetryEntry {
 
   void SetProperty(std::string_view key, std::string_view value) override {}
 
-  void LogBoolean(bool value) override {}
+  void LogBoolean(bool value, int64_t timestamp) override {}
 
-  void LogInt64(int64_t value) override {}
+  void LogInt64(int64_t value, int64_t timestamp) override {}
 
-  void LogFloat(float value) override {}
+  void LogFloat(float value, int64_t timestamp) override {}
 
-  void LogDouble(double value) override {}
+  void LogDouble(double value, int64_t timestamp) override {}
 
-  void LogString(std::string_view value, std::string_view typeString) override {
+  void LogString(std::string_view value, std::string_view typeString,
+                 int64_t timestamp) override {}
+
+  void LogBooleanArray(std::span<const bool> value,
+                       int64_t timestamp) override {}
+
+  void LogBooleanArray(std::span<const int> value, int64_t timestamp) override {
   }
 
-  void LogBooleanArray(std::span<const bool> value) override {}
+  void LogInt16Array(std::span<const int16_t> value,
+                     int64_t timestamp) override {}
 
-  void LogBooleanArray(std::span<const int> value) override {}
+  void LogInt32Array(std::span<const int32_t> value,
+                     int64_t timestamp) override {}
 
-  void LogInt16Array(std::span<const int16_t> value) override {}
+  void LogInt64Array(std::span<const int64_t> value,
+                     int64_t timestamp) override {}
 
-  void LogInt32Array(std::span<const int32_t> value) override {}
+  void LogFloatArray(std::span<const float> value, int64_t timestamp) override {
+  }
 
-  void LogInt64Array(std::span<const int64_t> value) override {}
+  void LogDoubleArray(std::span<const double> value,
+                      int64_t timestamp) override {}
 
-  void LogFloatArray(std::span<const float> value) override {}
+  void LogStringArray(std::span<const std::string> value,
+                      int64_t timestamp) override {}
 
-  void LogDoubleArray(std::span<const double> value) override {}
+  void LogStringArray(std::span<const std::string_view> value,
+                      int64_t timestamp) override {}
 
-  void LogStringArray(std::span<const std::string> value) override {}
-
-  void LogStringArray(std::span<const std::string_view> value) override {}
-
-  void LogRaw(std::span<const uint8_t> value,
-              std::string_view typeString) override {}
+  void LogRaw(std::span<const uint8_t> value, std::string_view typeString,
+              int64_t timestamp) override {}
 };
 }  // namespace
 

--- a/telemetry/src/main/native/cpp/MockTelemetryBackend.cpp
+++ b/telemetry/src/main/native/cpp/MockTelemetryBackend.cpp
@@ -39,75 +39,101 @@ class MockTelemetryBackend::Entry : public TelemetryEntry {
     AppendAction(SetPropertyValue{std::string{key}, std::string{value}});
   }
 
-  void LogBoolean(bool value) override { AppendAction(value); }
-
-  void LogInt16(int16_t value) override { AppendAction(value); }
-
-  void LogInt32(int32_t value) override { AppendAction(value); }
-
-  void LogInt64(int64_t value) override { AppendAction(value); }
-
-  void LogFloat(float value) override { AppendAction(value); }
-
-  void LogDouble(double value) override { AppendAction(value); }
-
-  void LogString(std::string_view value, std::string_view typeString) override {
-    AppendAction(LogStringValue{std::string{value}, std::string{typeString}});
+  void LogBoolean(bool value, int64_t timestamp) override {
+    AppendAction(value, timestamp);
   }
 
-  void LogBooleanArray(std::span<const bool> value) override {
+  void LogInt16(int16_t value, int64_t timestamp) override {
+    AppendAction(value, timestamp);
+  }
+
+  void LogInt32(int32_t value, int64_t timestamp) override {
+    AppendAction(value, timestamp);
+  }
+
+  void LogInt64(int64_t value, int64_t timestamp) override {
+    AppendAction(value, timestamp);
+  }
+
+  void LogFloat(float value, int64_t timestamp) override {
+    AppendAction(value, timestamp);
+  }
+
+  void LogDouble(double value, int64_t timestamp) override {
+    AppendAction(value, timestamp);
+  }
+
+  void LogString(std::string_view value, std::string_view typeString,
+                 int64_t timestamp) override {
+    AppendAction(LogStringValue{std::string{value}, std::string{typeString}},
+                 timestamp);
+  }
+
+  void LogBooleanArray(std::span<const bool> value,
+                       int64_t timestamp) override {
     AppendAction(
-        LogBooleanArrayValue{std::vector<int>{value.begin(), value.end()}});
+        LogBooleanArrayValue{std::vector<int>{value.begin(), value.end()}},
+        timestamp);
   }
 
-  void LogBooleanArray(std::span<const int> value) override {
+  void LogBooleanArray(std::span<const int> value, int64_t timestamp) override {
     AppendAction(
-        LogBooleanArrayValue{std::vector<int>{value.begin(), value.end()}});
+        LogBooleanArrayValue{std::vector<int>{value.begin(), value.end()}},
+        timestamp);
   }
 
-  void LogInt16Array(std::span<const int16_t> value) override {
-    AppendAction(std::vector<int16_t>{value.begin(), value.end()});
+  void LogInt16Array(std::span<const int16_t> value,
+                     int64_t timestamp) override {
+    AppendAction(std::vector<int16_t>{value.begin(), value.end()}, timestamp);
   }
 
-  void LogInt32Array(std::span<const int32_t> value) override {
-    AppendAction(std::vector<int32_t>{value.begin(), value.end()});
+  void LogInt32Array(std::span<const int32_t> value,
+                     int64_t timestamp) override {
+    AppendAction(std::vector<int32_t>{value.begin(), value.end()}, timestamp);
   }
 
-  void LogInt64Array(std::span<const int64_t> value) override {
-    AppendAction(std::vector<int64_t>{value.begin(), value.end()});
+  void LogInt64Array(std::span<const int64_t> value,
+                     int64_t timestamp) override {
+    AppendAction(std::vector<int64_t>{value.begin(), value.end()}, timestamp);
   }
 
-  void LogFloatArray(std::span<const float> value) override {
-    AppendAction(std::vector<float>{value.begin(), value.end()});
+  void LogFloatArray(std::span<const float> value, int64_t timestamp) override {
+    AppendAction(std::vector<float>{value.begin(), value.end()}, timestamp);
   }
 
-  void LogDoubleArray(std::span<const double> value) override {
-    AppendAction(std::vector<double>{value.begin(), value.end()});
+  void LogDoubleArray(std::span<const double> value,
+                      int64_t timestamp) override {
+    AppendAction(std::vector<double>{value.begin(), value.end()}, timestamp);
   }
 
-  void LogStringArray(std::span<const std::string> value) override {
-    AppendAction(std::vector<std::string>{value.begin(), value.end()});
+  void LogStringArray(std::span<const std::string> value,
+                      int64_t timestamp) override {
+    AppendAction(std::vector<std::string>{value.begin(), value.end()},
+                 timestamp);
   }
 
-  void LogStringArray(std::span<const std::string_view> value) override {
-    AppendAction(std::vector<std::string>{value.begin(), value.end()});
+  void LogStringArray(std::span<const std::string_view> value,
+                      int64_t timestamp) override {
+    AppendAction(std::vector<std::string>{value.begin(), value.end()},
+                 timestamp);
   }
 
-  void LogRaw(std::span<const uint8_t> value,
-              std::string_view typeString) override {
+  void LogRaw(std::span<const uint8_t> value, std::string_view typeString,
+              int64_t timestamp) override {
     AppendAction(LogRawValue{std::vector<uint8_t>{value.begin(), value.end()},
-                             std::string{typeString}});
+                             std::string{typeString}},
+                 timestamp);
   }
 
  private:
   template <typename T>
-  void AppendAction(T&& value) {
+  void AppendAction(T&& value, int64_t timestamp = 0) {
     std::scoped_lock lock{m_backend.m_mutex};
     if (m_removed) {
       return;
     }
     m_last = m_backend.m_actions.size();
-    m_backend.m_actions.emplace_back(m_path, std::forward<T>(value));
+    m_backend.m_actions.emplace_back(m_path, std::forward<T>(value), timestamp);
   }
 
   std::string m_path;

--- a/telemetry/src/main/native/cpp/MultiTelemetryBackend.cpp
+++ b/telemetry/src/main/native/cpp/MultiTelemetryBackend.cpp
@@ -60,79 +60,107 @@ class MultiTelemetryBackend::Entry : public TelemetryEntry {
     ForEachEntry([&](TelemetryEntry& entry) { entry.SetProperty(key, value); });
   }
 
-  void LogBoolean(bool value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogBoolean(value); });
-  }
-
-  void LogInt8(int8_t value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogInt8(value); });
-  }
-
-  void LogInt16(int16_t value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogInt16(value); });
-  }
-
-  void LogInt32(int32_t value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogInt32(value); });
-  }
-
-  void LogInt64(int64_t value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogInt64(value); });
-  }
-
-  void LogFloat(float value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogFloat(value); });
-  }
-
-  void LogDouble(double value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogDouble(value); });
-  }
-
-  void LogString(std::string_view value, std::string_view typeString) override {
+  void LogBoolean(bool value, int64_t timestamp) override {
     ForEachEntry(
-        [=](TelemetryEntry& entry) { entry.LogString(value, typeString); });
+        [=](TelemetryEntry& entry) { entry.LogBoolean(value, timestamp); });
   }
 
-  void LogBooleanArray(std::span<const bool> value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogBooleanArray(value); });
-  }
-
-  void LogBooleanArray(std::span<const int> value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogBooleanArray(value); });
-  }
-
-  void LogInt16Array(std::span<const int16_t> value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogInt16Array(value); });
-  }
-
-  void LogInt32Array(std::span<const int32_t> value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogInt32Array(value); });
-  }
-
-  void LogInt64Array(std::span<const int64_t> value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogInt64Array(value); });
-  }
-
-  void LogFloatArray(std::span<const float> value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogFloatArray(value); });
-  }
-
-  void LogDoubleArray(std::span<const double> value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogDoubleArray(value); });
-  }
-
-  void LogStringArray(std::span<const std::string> value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogStringArray(value); });
-  }
-
-  void LogStringArray(std::span<const std::string_view> value) override {
-    ForEachEntry([=](TelemetryEntry& entry) { entry.LogStringArray(value); });
-  }
-
-  void LogRaw(std::span<const uint8_t> value,
-              std::string_view typeString) override {
+  void LogInt8(int8_t value, int64_t timestamp) override {
     ForEachEntry(
-        [=](TelemetryEntry& entry) { entry.LogRaw(value, typeString); });
+        [=](TelemetryEntry& entry) { entry.LogInt8(value, timestamp); });
+  }
+
+  void LogInt16(int16_t value, int64_t timestamp) override {
+    ForEachEntry(
+        [=](TelemetryEntry& entry) { entry.LogInt16(value, timestamp); });
+  }
+
+  void LogInt32(int32_t value, int64_t timestamp) override {
+    ForEachEntry(
+        [=](TelemetryEntry& entry) { entry.LogInt32(value, timestamp); });
+  }
+
+  void LogInt64(int64_t value, int64_t timestamp) override {
+    ForEachEntry(
+        [=](TelemetryEntry& entry) { entry.LogInt64(value, timestamp); });
+  }
+
+  void LogFloat(float value, int64_t timestamp) override {
+    ForEachEntry(
+        [=](TelemetryEntry& entry) { entry.LogFloat(value, timestamp); });
+  }
+
+  void LogDouble(double value, int64_t timestamp) override {
+    ForEachEntry(
+        [=](TelemetryEntry& entry) { entry.LogDouble(value, timestamp); });
+  }
+
+  void LogString(std::string_view value, std::string_view typeString,
+                 int64_t timestamp) override {
+    ForEachEntry([=](TelemetryEntry& entry) {
+      entry.LogString(value, typeString, timestamp);
+    });
+  }
+
+  void LogBooleanArray(std::span<const bool> value,
+                       int64_t timestamp) override {
+    ForEachEntry([=](TelemetryEntry& entry) {
+      entry.LogBooleanArray(value, timestamp);
+    });
+  }
+
+  void LogBooleanArray(std::span<const int> value, int64_t timestamp) override {
+    ForEachEntry([=](TelemetryEntry& entry) {
+      entry.LogBooleanArray(value, timestamp);
+    });
+  }
+
+  void LogInt16Array(std::span<const int16_t> value,
+                     int64_t timestamp) override {
+    ForEachEntry(
+        [=](TelemetryEntry& entry) { entry.LogInt16Array(value, timestamp); });
+  }
+
+  void LogInt32Array(std::span<const int32_t> value,
+                     int64_t timestamp) override {
+    ForEachEntry(
+        [=](TelemetryEntry& entry) { entry.LogInt32Array(value, timestamp); });
+  }
+
+  void LogInt64Array(std::span<const int64_t> value,
+                     int64_t timestamp) override {
+    ForEachEntry(
+        [=](TelemetryEntry& entry) { entry.LogInt64Array(value, timestamp); });
+  }
+
+  void LogFloatArray(std::span<const float> value, int64_t timestamp) override {
+    ForEachEntry(
+        [=](TelemetryEntry& entry) { entry.LogFloatArray(value, timestamp); });
+  }
+
+  void LogDoubleArray(std::span<const double> value,
+                      int64_t timestamp) override {
+    ForEachEntry(
+        [=](TelemetryEntry& entry) { entry.LogDoubleArray(value, timestamp); });
+  }
+
+  void LogStringArray(std::span<const std::string> value,
+                      int64_t timestamp) override {
+    ForEachEntry(
+        [=](TelemetryEntry& entry) { entry.LogStringArray(value, timestamp); });
+  }
+
+  void LogStringArray(std::span<const std::string_view> value,
+                      int64_t timestamp) override {
+    ForEachEntry(
+        [=](TelemetryEntry& entry) { entry.LogStringArray(value, timestamp); });
+  }
+
+  void LogRaw(std::span<const uint8_t> value, std::string_view typeString,
+              int64_t timestamp) override {
+    ForEachEntry([=](TelemetryEntry& entry) {
+      entry.LogRaw(value, typeString, timestamp);
+    });
   }
 
  private:

--- a/telemetry/src/main/native/cpp/TelemetryTable.cpp
+++ b/telemetry/src/main/native/cpp/TelemetryTable.cpp
@@ -47,7 +47,7 @@ bool TelemetryTable::SetType(std::string_view typeString) {
       }
     }
     if (!entry->IsDiscard()) {
-      entry->LogString(typeString, "string");
+      entry->LogString(typeString, "string", 0);
     }
     return true;
   }
@@ -137,7 +137,7 @@ void TelemetryTable::Log(std::string_view name, bool value) {
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogBoolean(value);
+  entry->LogBoolean(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name, int8_t value) {
@@ -145,7 +145,7 @@ void TelemetryTable::Log(std::string_view name, int8_t value) {
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogInt8(value);
+  entry->LogInt8(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name, int16_t value) {
@@ -153,7 +153,7 @@ void TelemetryTable::Log(std::string_view name, int16_t value) {
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogInt16(value);
+  entry->LogInt16(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name, int32_t value) {
@@ -161,7 +161,7 @@ void TelemetryTable::Log(std::string_view name, int32_t value) {
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogInt32(value);
+  entry->LogInt32(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name, int64_t value) {
@@ -169,7 +169,7 @@ void TelemetryTable::Log(std::string_view name, int64_t value) {
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogInt64(value);
+  entry->LogInt64(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name, float value) {
@@ -177,7 +177,7 @@ void TelemetryTable::Log(std::string_view name, float value) {
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogFloat(value);
+  entry->LogFloat(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name, double value) {
@@ -185,7 +185,7 @@ void TelemetryTable::Log(std::string_view name, double value) {
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogDouble(value);
+  entry->LogDouble(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name, std::string_view value) {
@@ -193,7 +193,7 @@ void TelemetryTable::Log(std::string_view name, std::string_view value) {
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogString(value, "string");
+  entry->LogString(value, "string", 0);
 }
 
 void TelemetryTable::Log(std::string_view name, std::string_view value,
@@ -202,7 +202,7 @@ void TelemetryTable::Log(std::string_view name, std::string_view value,
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogString(value, typeString);
+  entry->LogString(value, typeString, 0);
 }
 
 void TelemetryTable::Log(std::string_view name, std::span<const bool> value) {
@@ -210,7 +210,7 @@ void TelemetryTable::Log(std::string_view name, std::span<const bool> value) {
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogBooleanArray(value);
+  entry->LogBooleanArray(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name,
@@ -219,7 +219,7 @@ void TelemetryTable::Log(std::string_view name,
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogInt16Array(value);
+  entry->LogInt16Array(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name,
@@ -228,7 +228,7 @@ void TelemetryTable::Log(std::string_view name,
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogInt32Array(value);
+  entry->LogInt32Array(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name,
@@ -237,7 +237,7 @@ void TelemetryTable::Log(std::string_view name,
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogInt64Array(value);
+  entry->LogInt64Array(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name, std::span<const float> value) {
@@ -245,7 +245,7 @@ void TelemetryTable::Log(std::string_view name, std::span<const float> value) {
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogFloatArray(value);
+  entry->LogFloatArray(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name, std::span<const double> value) {
@@ -253,7 +253,7 @@ void TelemetryTable::Log(std::string_view name, std::span<const double> value) {
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogDoubleArray(value);
+  entry->LogDoubleArray(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name,
@@ -262,7 +262,7 @@ void TelemetryTable::Log(std::string_view name,
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogStringArray(value);
+  entry->LogStringArray(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name,
@@ -271,7 +271,7 @@ void TelemetryTable::Log(std::string_view name,
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogStringArray(value);
+  entry->LogStringArray(value, 0);
 }
 
 void TelemetryTable::Log(std::string_view name,
@@ -280,7 +280,7 @@ void TelemetryTable::Log(std::string_view name,
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogRaw(value, "raw");
+  entry->LogRaw(value, "raw", 0);
 }
 
 void TelemetryTable::Log(std::string_view name, std::span<const uint8_t> value,
@@ -289,7 +289,7 @@ void TelemetryTable::Log(std::string_view name, std::span<const uint8_t> value,
   if (entry->IsDiscard()) {
     return;
   }
-  entry->LogRaw(value, typeString);
+  entry->LogRaw(value, typeString, 0);
 }
 
 TelemetryTable::EntryHandle TelemetryTable::GetEntry(std::string_view name) {

--- a/telemetry/src/main/native/include/wpi/telemetry/MockTelemetryBackend.hpp
+++ b/telemetry/src/main/native/include/wpi/telemetry/MockTelemetryBackend.hpp
@@ -58,8 +58,8 @@ class MockTelemetryBackend : public TelemetryBackend {
   /** A logged action. */
   struct Action {
     template <typename T>
-    Action(std::string_view path_, T value_)
-        : path{path_}, value{std::move(value_)} {}
+    Action(std::string_view path_, T value_, int64_t timestamp_ = 0)
+        : path{path_}, value{std::move(value_)}, timestamp{timestamp_} {}
 
     std::string path;
     std::variant<KeepDuplicatesValue, SetPropertyValue, bool, int16_t, int32_t,
@@ -68,6 +68,7 @@ class MockTelemetryBackend : public TelemetryBackend {
                  std::vector<int64_t>, std::vector<float>, std::vector<double>,
                  std::vector<std::string>, LogRawValue>
         value;
+    int64_t timestamp = 0;
   };
 
   struct Schema {

--- a/telemetry/src/main/native/include/wpi/telemetry/TelemetryEntry.hpp
+++ b/telemetry/src/main/native/include/wpi/telemetry/TelemetryEntry.hpp
@@ -55,131 +55,164 @@ class TelemetryEntry {
    * Logs a boolean.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogBoolean(bool value) = 0;
+  virtual void LogBoolean(bool value, int64_t timestamp) = 0;
 
   /**
    * Logs a byte.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogInt8(int8_t value) { LogInt64(value); }
+  virtual void LogInt8(int8_t value, int64_t timestamp) {
+    LogInt64(value, timestamp);
+  }
 
   /**
    * Logs a short.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogInt16(int16_t value) { LogInt64(value); }
+  virtual void LogInt16(int16_t value, int64_t timestamp) {
+    LogInt64(value, timestamp);
+  }
 
   /**
    * Logs an int.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogInt32(int32_t value) { LogInt64(value); }
+  virtual void LogInt32(int32_t value, int64_t timestamp) {
+    LogInt64(value, timestamp);
+  }
 
   /**
    * Logs a long.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogInt64(int64_t value) = 0;
+  virtual void LogInt64(int64_t value, int64_t timestamp) = 0;
 
   /**
    * Logs a float.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogFloat(float value) = 0;
+  virtual void LogFloat(float value, int64_t timestamp) = 0;
 
   /**
    * Logs a double.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogDouble(double value) = 0;
+  virtual void LogDouble(double value, int64_t timestamp) = 0;
 
   /**
    * Logs a String.
    *
    * @param value the value
    * @param typeString the type string
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogString(std::string_view value,
-                         std::string_view typeString) = 0;
+  virtual void LogString(std::string_view value, std::string_view typeString,
+                         int64_t timestamp) = 0;
 
   /**
    * Logs a boolean array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogBooleanArray(std::span<const bool> value) = 0;
+  virtual void LogBooleanArray(std::span<const bool> value,
+                               int64_t timestamp) = 0;
 
   /**
    * Logs a boolean array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogBooleanArray(std::span<const int> value) = 0;
+  virtual void LogBooleanArray(std::span<const int> value,
+                               int64_t timestamp) = 0;
 
   /**
    * Logs a short array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogInt16Array(std::span<const int16_t> value) = 0;
+  virtual void LogInt16Array(std::span<const int16_t> value,
+                             int64_t timestamp) = 0;
 
   /**
    * Logs an int array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogInt32Array(std::span<const int32_t> value) = 0;
+  virtual void LogInt32Array(std::span<const int32_t> value,
+                             int64_t timestamp) = 0;
 
   /**
    * Logs a long array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogInt64Array(std::span<const int64_t> value) = 0;
+  virtual void LogInt64Array(std::span<const int64_t> value,
+                             int64_t timestamp) = 0;
 
   /**
    * Logs a float array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogFloatArray(std::span<const float> value) = 0;
+  virtual void LogFloatArray(std::span<const float> value,
+                             int64_t timestamp) = 0;
 
   /**
    * Logs a double array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogDoubleArray(std::span<const double> value) = 0;
+  virtual void LogDoubleArray(std::span<const double> value,
+                              int64_t timestamp) = 0;
 
   /**
    * Logs a String array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogStringArray(std::span<const std::string> value) = 0;
+  virtual void LogStringArray(std::span<const std::string> value,
+                              int64_t timestamp) = 0;
 
   /**
    * Logs a String array.
    *
    * @param value the value
+   * @param timestamp timestamp, or 0 to use the current time
    */
-  virtual void LogStringArray(std::span<const std::string_view> value) = 0;
+  virtual void LogStringArray(std::span<const std::string_view> value,
+                              int64_t timestamp) = 0;
 
   /**
    * Logs a raw value (byte array).
    *
    * @param value the value
    * @param typeString the type string
+   * @param timestamp timestamp, or 0 to use the current time
    */
   virtual void LogRaw(std::span<const uint8_t> value,
-                      std::string_view typeString) = 0;
+                      std::string_view typeString, int64_t timestamp) = 0;
 };
 
 }  // namespace wpi::telemetry

--- a/telemetry/src/main/native/include/wpi/telemetry/TelemetryEntry.hpp
+++ b/telemetry/src/main/native/include/wpi/telemetry/TelemetryEntry.hpp
@@ -55,7 +55,8 @@ class TelemetryEntry {
    * Logs a boolean.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogBoolean(bool value, int64_t timestamp) = 0;
 
@@ -63,7 +64,8 @@ class TelemetryEntry {
    * Logs a byte.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogInt8(int8_t value, int64_t timestamp) {
     LogInt64(value, timestamp);
@@ -73,7 +75,8 @@ class TelemetryEntry {
    * Logs a short.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogInt16(int16_t value, int64_t timestamp) {
     LogInt64(value, timestamp);
@@ -83,7 +86,8 @@ class TelemetryEntry {
    * Logs an int.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogInt32(int32_t value, int64_t timestamp) {
     LogInt64(value, timestamp);
@@ -93,7 +97,8 @@ class TelemetryEntry {
    * Logs a long.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogInt64(int64_t value, int64_t timestamp) = 0;
 
@@ -101,7 +106,8 @@ class TelemetryEntry {
    * Logs a float.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogFloat(float value, int64_t timestamp) = 0;
 
@@ -109,7 +115,8 @@ class TelemetryEntry {
    * Logs a double.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogDouble(double value, int64_t timestamp) = 0;
 
@@ -118,7 +125,8 @@ class TelemetryEntry {
    *
    * @param value the value
    * @param typeString the type string
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogString(std::string_view value, std::string_view typeString,
                          int64_t timestamp) = 0;
@@ -127,7 +135,8 @@ class TelemetryEntry {
    * Logs a boolean array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogBooleanArray(std::span<const bool> value,
                                int64_t timestamp) = 0;
@@ -136,7 +145,8 @@ class TelemetryEntry {
    * Logs a boolean array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogBooleanArray(std::span<const int> value,
                                int64_t timestamp) = 0;
@@ -145,7 +155,8 @@ class TelemetryEntry {
    * Logs a short array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogInt16Array(std::span<const int16_t> value,
                              int64_t timestamp) = 0;
@@ -154,7 +165,8 @@ class TelemetryEntry {
    * Logs an int array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogInt32Array(std::span<const int32_t> value,
                              int64_t timestamp) = 0;
@@ -163,7 +175,8 @@ class TelemetryEntry {
    * Logs a long array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogInt64Array(std::span<const int64_t> value,
                              int64_t timestamp) = 0;
@@ -172,7 +185,8 @@ class TelemetryEntry {
    * Logs a float array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogFloatArray(std::span<const float> value,
                              int64_t timestamp) = 0;
@@ -181,7 +195,8 @@ class TelemetryEntry {
    * Logs a double array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogDoubleArray(std::span<const double> value,
                               int64_t timestamp) = 0;
@@ -190,7 +205,8 @@ class TelemetryEntry {
    * Logs a String array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogStringArray(std::span<const std::string> value,
                               int64_t timestamp) = 0;
@@ -199,7 +215,8 @@ class TelemetryEntry {
    * Logs a String array.
    *
    * @param value the value
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogStringArray(std::span<const std::string_view> value,
                               int64_t timestamp) = 0;
@@ -209,7 +226,8 @@ class TelemetryEntry {
    *
    * @param value the value
    * @param typeString the type string
-   * @param timestamp timestamp, or 0 to use the current time
+   * @param timestamp timestamp in nanoseconds in the same time base as
+   *     wpi::util::Now(), or 0 to use the current time
    */
   virtual void LogRaw(std::span<const uint8_t> value,
                       std::string_view typeString, int64_t timestamp) = 0;

--- a/telemetry/src/main/native/include/wpi/telemetry/TelemetryTable.hpp
+++ b/telemetry/src/main/native/include/wpi/telemetry/TelemetryTable.hpp
@@ -234,11 +234,11 @@ class TelemetryTable final {
         return;
       }
       if constexpr (sizeof...(I) == 0) {
-        entry->LogString(std::string_view{value}, "string");
+        entry->LogString(std::string_view{value}, "string", 0);
       } else if constexpr (sizeof...(I) == 1 &&
                            (std::constructible_from<std::string_view, I> &&
                             ...)) {
-        entry->LogString(std::string_view{value}, std::string_view{info...});
+        entry->LogString(std::string_view{value}, std::string_view{info...}, 0);
       } else {
         static_assert(impl::always_false<T>::value,
                       "Don't know how to serialize type");
@@ -267,14 +267,14 @@ class TelemetryTable final {
           if constexpr (wpi::util::is_constexpr([] { S::GetSize(); })) {
             uint8_t buf[S::GetSize()];
             S::Pack(buf, value);
-            entry->LogRaw(std::span{buf}, typeString);
+            entry->LogRaw(std::span{buf}, typeString, 0);
             return;
           }
         }
         wpi::util::SmallVector<uint8_t, 128> buf;
         buf.resize_for_overwrite(S::GetSize(info...));
         S::Pack(buf, value, info...);
-        entry->LogRaw(std::span{buf}, typeString);
+        entry->LogRaw(std::span{buf}, typeString, 0);
       } catch (const std::exception& e) {
         ReportWarning(path, "failed to publish struct value", e);
       } catch (...) {
@@ -297,7 +297,7 @@ class TelemetryTable final {
           ReportWarning(path, "failed to publish protobuf value");
           return;
         }
-        entry->LogRaw(buf, typeString);
+        entry->LogRaw(buf, typeString, 0);
       } catch (const std::exception& e) {
         ReportWarning(path, "failed to publish protobuf value", e);
       } catch (...) {
@@ -308,19 +308,19 @@ class TelemetryTable final {
       if (entry->IsDiscard()) {
         return;
       }
-      entry->LogInt64(static_cast<int64_t>(value));
+      entry->LogInt64(static_cast<int64_t>(value), 0);
     } else if constexpr (std::floating_point<T>) {
       auto entry = GetEntry(name);
       if (entry->IsDiscard()) {
         return;
       }
-      entry->LogDouble(static_cast<double>(value));
+      entry->LogDouble(static_cast<double>(value), 0);
     } else if constexpr (std::constructible_from<std::formatter<T>>) {
       auto entry = GetEntry(name);
       if (entry->IsDiscard()) {
         return;
       }
-      entry->LogString(std::format("{}", value), "string");
+      entry->LogString(std::format("{}", value), "string", 0);
     } else {
       static_assert(impl::always_false<T>::value,
                     "Don't know how to serialize type");
@@ -342,28 +342,28 @@ class TelemetryTable final {
     }
     using U = std::remove_cv_t<T>;
     if constexpr (std::same_as<U, bool>) {
-      entry->LogBooleanArray(value);
+      entry->LogBooleanArray(value, 0);
     } else if constexpr (std::same_as<U, int16_t>) {
-      entry->LogInt16Array(value);
+      entry->LogInt16Array(value, 0);
     } else if constexpr (std::same_as<U, int32_t>) {
-      entry->LogInt32Array(value);
+      entry->LogInt32Array(value, 0);
     } else if constexpr (std::same_as<U, int64_t>) {
-      entry->LogInt64Array(value);
+      entry->LogInt64Array(value, 0);
     } else if constexpr (std::same_as<U, float>) {
-      entry->LogFloatArray(value);
+      entry->LogFloatArray(value, 0);
     } else if constexpr (std::same_as<U, double>) {
-      entry->LogDoubleArray(value);
+      entry->LogDoubleArray(value, 0);
     } else if constexpr (std::same_as<U, std::string>) {
-      entry->LogStringArray(value);
+      entry->LogStringArray(value, 0);
     } else if constexpr (std::same_as<U, std::string_view>) {
-      entry->LogStringArray(value);
+      entry->LogStringArray(value, 0);
     } else if constexpr (std::same_as<U, uint8_t>) {
       if constexpr (sizeof...(I) == 0) {
-        entry->LogRaw(value, "raw");
+        entry->LogRaw(value, "raw", 0);
       } else if constexpr (sizeof...(I) == 1 &&
                            (std::constructible_from<std::string_view, I> &&
                             ...)) {
-        entry->LogRaw(value, std::string_view{info...});
+        entry->LogRaw(value, std::string_view{info...}, 0);
       } else {
         static_assert(impl::always_false<T>::value,
                       "Don't know how to serialize type");
@@ -374,7 +374,7 @@ class TelemetryTable final {
       for (auto&& v : value) {
         values.emplace_back(static_cast<int64_t>(v));
       }
-      entry->LogInt64Array(values);
+      entry->LogInt64Array(values, 0);
     } else if constexpr (wpi::util::StructSerializable<T, I...>) {
       auto structTypeString = wpi::util::GetStructTypeString<T>(info...);
       auto path = std::format("{}{}", m_path, name);
@@ -388,7 +388,7 @@ class TelemetryTable final {
             [&](auto bytes) {
               entry->LogRaw(
                   bytes,
-                  std::format("{}[]", std::string_view{structTypeString}));
+                  std::format("{}[]", std::string_view{structTypeString}), 0);
             },
             info...);
       } catch (const std::exception& e) {
@@ -402,7 +402,7 @@ class TelemetryTable final {
       for (auto&& v : value) {
         strings.emplace_back(std::format("{}", v));
       }
-      entry->LogStringArray(strings);
+      entry->LogStringArray(strings, 0);
     } else {
       static_assert(impl::always_false<T>::value,
                     "Don't know how to serialize type");

--- a/telemetry/src/main/python/semiwrap/TelemetryEntry.yml
+++ b/telemetry/src/main/python/semiwrap/TelemetryEntry.yml
@@ -15,8 +15,8 @@ classes:
       LogString:
       LogBooleanArray:
         overloads:
-          std::span<const bool>:
-          std::span<const int>:
+          std::span<const bool>, int64_t:
+          std::span<const int>, int64_t:
             ignore: true
       LogInt16Array:
       LogInt32Array:
@@ -25,29 +25,32 @@ classes:
       LogDoubleArray:
       LogStringArray:
         overloads:
-          std::span<const std::string>:
-          std::span<const std::string_view>:
+          std::span<const std::string>, int64_t:
+          std::span<const std::string_view>, int64_t:
             ignore: true
       LogRaw:
     trampoline_inline_code: |
-      void LogBooleanArray(std::span<const int> value) override {
+      void LogBooleanArray(std::span<const int> value,
+                           int64_t timestamp) override {
         using LookupBase = typename PyTrampolineCfg::Base;
         SEMIWRAP_OVERRIDE_PURE_NAME(TelemetryEntry, PYBIND11_TYPE(void),
-          LookupBase, "log_boolean_array", LogBooleanArray, value);
+          LookupBase, "log_boolean_array", LogBooleanArray, value, timestamp);
       }
 
-      void LogStringArray(std::span<const std::string_view> value) override {
+      void LogStringArray(std::span<const std::string_view> value,
+                          int64_t timestamp) override {
         using LookupBase = typename PyTrampolineCfg::Base;
         SEMIWRAP_OVERRIDE_PURE_NAME(TelemetryEntry, PYBIND11_TYPE(void),
-          LookupBase, "log_string_array", LogStringArray, value);
+          LookupBase, "log_string_array", LogStringArray, value, timestamp);
       }
     inline_code: |
       .def("log_boolean_array", static_cast<void (wpi::telemetry::TelemetryEntry::*)(
-             std::span<const int>)>(&wpi::telemetry::TelemetryEntry::LogBooleanArray),
-           py::arg("value"), release_gil(),
+             std::span<const int>, int64_t)>(
+             &wpi::telemetry::TelemetryEntry::LogBooleanArray),
+           py::arg("value"), py::arg("timestamp"), release_gil(),
            py::doc("Logs a boolean array."))
       .def("log_string_array", static_cast<void (wpi::telemetry::TelemetryEntry::*)(
-             std::span<const std::string_view>)>(
+             std::span<const std::string_view>, int64_t)>(
              &wpi::telemetry::TelemetryEntry::LogStringArray),
-           py::arg("value"), release_gil(),
+           py::arg("value"), py::arg("timestamp"), release_gil(),
            py::doc("Logs a String array."))

--- a/telemetry/src/main/python/telemetry/src/TelemetryPython.cpp
+++ b/telemetry/src/main/python/telemetry/src/TelemetryPython.cpp
@@ -120,26 +120,26 @@ class PyTelemetryTable {
       ValidateNoExplicitTelemetryType(elementType, typeString);
       auto entry = GetEntry(name);
       if (!entry->IsDiscard()) {
-        entry->LogBoolean(value.cast<bool>());
+        entry->LogBoolean(value.cast<bool>(), 0);
       }
     } else if (py::isinstance<py::int_>(value)) {
       ValidateNoExplicitTelemetryType(elementType, typeString);
       auto entry = GetEntry(name);
       if (!entry->IsDiscard()) {
-        entry->LogInt64(value.cast<int64_t>());
+        entry->LogInt64(value.cast<int64_t>(), 0);
       }
     } else if (py::isinstance<py::float_>(value)) {
       ValidateNoExplicitTelemetryType(elementType, typeString);
       auto entry = GetEntry(name);
       if (!entry->IsDiscard()) {
-        entry->LogDouble(value.cast<double>());
+        entry->LogDouble(value.cast<double>(), 0);
       }
     } else if (py::isinstance<py::str>(value)) {
       ValidateNoElementType(elementType);
       auto entry = GetEntry(name);
       if (!entry->IsDiscard()) {
         auto str = value.cast<std::string>();
-        entry->LogString(str, typeString.empty() ? "string" : typeString);
+        entry->LogString(str, typeString.empty() ? "string" : typeString, 0);
       }
     } else if (IsBytesLike(value)) {
       ValidateNoElementType(elementType);
@@ -148,7 +148,7 @@ class PyTelemetryTable {
         auto raw = BytesLikeToString(value);
         auto data = std::span<const uint8_t>{
             reinterpret_cast<const uint8_t*>(raw.data()), raw.size()};
-        entry->LogRaw(data, typeString.empty() ? "raw" : typeString);
+        entry->LogRaw(data, typeString.empty() ? "raw" : typeString, 0);
       }
     } else if (auto logTo = GetOptionalAttr(value, "log_to")) {
       ValidateNoExplicitTelemetryType(elementType, typeString);
@@ -172,7 +172,7 @@ class PyTelemetryTable {
       ValidateNoExplicitTelemetryType(elementType, typeString);
       auto entry = GetEntry(name);
       if (!entry->IsDiscard()) {
-        entry->LogString(py::str(value).cast<std::string>(), "string");
+        entry->LogString(py::str(value).cast<std::string>(), "string", 0);
       }
     }
   }
@@ -307,7 +307,7 @@ class PyTelemetryTable {
           }
           data[i] = item.cast<bool>();
         }
-        entry->LogBooleanArray(std::span<const bool>{data.get(), size});
+        entry->LogBooleanArray(std::span<const bool>{data.get(), size}, 0);
         break;
       }
       case SequenceKind::INTEGER: {
@@ -321,7 +321,7 @@ class PyTelemetryTable {
           }
           data.emplace_back(item.cast<int64_t>());
         }
-        entry->LogInt64Array(std::span<const int64_t>{data});
+        entry->LogInt64Array(std::span<const int64_t>{data}, 0);
         break;
       }
       case SequenceKind::DOUBLE: {
@@ -337,7 +337,7 @@ class PyTelemetryTable {
           }
           data.emplace_back(item.cast<double>());
         }
-        entry->LogDoubleArray(std::span<const double>{data});
+        entry->LogDoubleArray(std::span<const double>{data}, 0);
         break;
       }
       case SequenceKind::STRING: {
@@ -350,7 +350,7 @@ class PyTelemetryTable {
           }
           data.emplace_back(item.cast<std::string>());
         }
-        entry->LogStringArray(std::span<const std::string>{data});
+        entry->LogStringArray(std::span<const std::string>{data}, 0);
         break;
       }
       case SequenceKind::FALLBACK_STRING: {
@@ -360,7 +360,7 @@ class PyTelemetryTable {
           data.emplace_back(
               py::str(value[static_cast<py::ssize_t>(i)]).cast<std::string>());
         }
-        entry->LogStringArray(std::span<const std::string>{data});
+        entry->LogStringArray(std::span<const std::string>{data}, 0);
         break;
       }
     }
@@ -379,7 +379,7 @@ class PyTelemetryTable {
     std::vector<uint8_t> data(wpi::util::GetStructSize<WPyStruct>(info));
     WPyStruct wrapped{py::reinterpret_borrow<py::object>(value)};
     wpi::util::PackStruct(std::span<uint8_t>{data}, wrapped, info);
-    entry->LogRaw(std::span<const uint8_t>{data}, typeString);
+    entry->LogRaw(std::span<const uint8_t>{data}, typeString, 0);
   }
 
   void LogStructSequence(std::string_view name, const py::sequence& value,
@@ -413,7 +413,7 @@ class PyTelemetryTable {
     }
 
     typeString += "[]";
-    entry->LogRaw(std::span<const uint8_t>{data}, typeString);
+    entry->LogRaw(std::span<const uint8_t>{data}, typeString, 0);
   }
 
   wpi::telemetry::TelemetryTable* m_table;
@@ -427,6 +427,7 @@ py::object ActionValueToPython(
     const wpi::telemetry::MockTelemetryBackend::Action& action) {
   py::dict result;
   result["path"] = action.path;
+  result["timestamp"] = action.timestamp;
   std::visit(
       [&](const auto& value) {
         using T = std::decay_t<decltype(value)>;

--- a/telemetry/src/test/java/org/wpilib/telemetry/TelemetryTableTest.java
+++ b/telemetry/src/test/java/org/wpilib/telemetry/TelemetryTableTest.java
@@ -230,52 +230,52 @@ class TelemetryTableTest {
     public void setProperty(String key, String value) {}
 
     @Override
-    public <T> void logStruct(T value, Struct<? super T> struct) {}
+    public <T> void logStruct(T value, Struct<? super T> struct, long timestamp) {}
 
     @Override
-    public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto) {}
+    public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto, long timestamp) {}
 
     @Override
-    public <T> void logStructArray(T[] value, Struct<? super T> struct) {}
+    public <T> void logStructArray(T[] value, Struct<? super T> struct, long timestamp) {}
 
     @Override
-    public void logBoolean(boolean value) {}
+    public void logBoolean(boolean value, long timestamp) {}
 
     @Override
-    public void logLong(long value) {}
+    public void logLong(long value, long timestamp) {}
 
     @Override
-    public void logFloat(float value) {}
+    public void logFloat(float value, long timestamp) {}
 
     @Override
-    public void logDouble(double value) {}
+    public void logDouble(double value, long timestamp) {}
 
     @Override
-    public void logString(String value, String typeString) {}
+    public void logString(String value, String typeString, long timestamp) {}
 
     @Override
-    public void logBooleanArray(boolean[] value) {}
+    public void logBooleanArray(boolean[] value, long timestamp) {}
 
     @Override
-    public void logShortArray(short[] value) {}
+    public void logShortArray(short[] value, long timestamp) {}
 
     @Override
-    public void logIntArray(int[] value) {}
+    public void logIntArray(int[] value, long timestamp) {}
 
     @Override
-    public void logLongArray(long[] value) {}
+    public void logLongArray(long[] value, long timestamp) {}
 
     @Override
-    public void logFloatArray(float[] value) {}
+    public void logFloatArray(float[] value, long timestamp) {}
 
     @Override
-    public void logDoubleArray(double[] value) {}
+    public void logDoubleArray(double[] value, long timestamp) {}
 
     @Override
-    public void logStringArray(String[] value) {}
+    public void logStringArray(String[] value, long timestamp) {}
 
     @Override
-    public void logRaw(byte[] value, String typeString) {}
+    public void logRaw(byte[] value, String typeString, long timestamp) {}
 
     private final CountDownLatch m_enteredIsDiscard;
     private final CountDownLatch m_releaseIsDiscard;
@@ -315,54 +315,54 @@ class TelemetryTableTest {
       public void setProperty(String key, String value) {}
 
       @Override
-      public <T> void logStruct(T value, Struct<? super T> struct) {}
+      public <T> void logStruct(T value, Struct<? super T> struct, long timestamp) {}
 
       @Override
-      public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto) {}
+      public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto, long timestamp) {}
 
       @Override
-      public <T> void logStructArray(T[] value, Struct<? super T> struct) {}
+      public <T> void logStructArray(T[] value, Struct<? super T> struct, long timestamp) {}
 
       @Override
-      public void logBoolean(boolean value) {}
+      public void logBoolean(boolean value, long timestamp) {}
 
       @Override
-      public void logLong(long value) {}
+      public void logLong(long value, long timestamp) {}
 
       @Override
-      public void logFloat(float value) {}
+      public void logFloat(float value, long timestamp) {}
 
       @Override
-      public void logDouble(double value) {
+      public void logDouble(double value, long timestamp) {
         m_logGenerations.add(m_generation);
       }
 
       @Override
-      public void logString(String value, String typeString) {}
+      public void logString(String value, String typeString, long timestamp) {}
 
       @Override
-      public void logBooleanArray(boolean[] value) {}
+      public void logBooleanArray(boolean[] value, long timestamp) {}
 
       @Override
-      public void logShortArray(short[] value) {}
+      public void logShortArray(short[] value, long timestamp) {}
 
       @Override
-      public void logIntArray(int[] value) {}
+      public void logIntArray(int[] value, long timestamp) {}
 
       @Override
-      public void logLongArray(long[] value) {}
+      public void logLongArray(long[] value, long timestamp) {}
 
       @Override
-      public void logFloatArray(float[] value) {}
+      public void logFloatArray(float[] value, long timestamp) {}
 
       @Override
-      public void logDoubleArray(double[] value) {}
+      public void logDoubleArray(double[] value, long timestamp) {}
 
       @Override
-      public void logStringArray(String[] value) {}
+      public void logStringArray(String[] value, long timestamp) {}
 
       @Override
-      public void logRaw(byte[] value, String typeString) {}
+      public void logRaw(byte[] value, String typeString, long timestamp) {}
 
       private final int m_generation;
     }
@@ -415,58 +415,58 @@ class TelemetryTableTest {
       public void setProperty(String key, String value) {}
 
       @Override
-      public <T> void logStruct(T value, Struct<? super T> struct) {}
+      public <T> void logStruct(T value, Struct<? super T> struct, long timestamp) {}
 
       @Override
-      public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto) {}
+      public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto, long timestamp) {}
 
       @Override
-      public <T> void logStructArray(T[] value, Struct<? super T> struct) {}
+      public <T> void logStructArray(T[] value, Struct<? super T> struct, long timestamp) {}
 
       @Override
-      public void logBoolean(boolean value) {}
+      public void logBoolean(boolean value, long timestamp) {}
 
       @Override
-      public void logLong(long value) {}
+      public void logLong(long value, long timestamp) {}
 
       @Override
-      public void logFloat(float value) {
-        logDouble(value);
+      public void logFloat(float value, long timestamp) {
+        logDouble(value, timestamp);
       }
 
       @Override
-      public void logDouble(double value) {
+      public void logDouble(double value, long timestamp) {
         if (!m_closed) {
           m_logs++;
         }
       }
 
       @Override
-      public void logString(String value, String typeString) {}
+      public void logString(String value, String typeString, long timestamp) {}
 
       @Override
-      public void logBooleanArray(boolean[] value) {}
+      public void logBooleanArray(boolean[] value, long timestamp) {}
 
       @Override
-      public void logShortArray(short[] value) {}
+      public void logShortArray(short[] value, long timestamp) {}
 
       @Override
-      public void logIntArray(int[] value) {}
+      public void logIntArray(int[] value, long timestamp) {}
 
       @Override
-      public void logLongArray(long[] value) {}
+      public void logLongArray(long[] value, long timestamp) {}
 
       @Override
-      public void logFloatArray(float[] value) {}
+      public void logFloatArray(float[] value, long timestamp) {}
 
       @Override
-      public void logDoubleArray(double[] value) {}
+      public void logDoubleArray(double[] value, long timestamp) {}
 
       @Override
-      public void logStringArray(String[] value) {}
+      public void logStringArray(String[] value, long timestamp) {}
 
       @Override
-      public void logRaw(byte[] value, String typeString) {}
+      public void logRaw(byte[] value, String typeString, long timestamp) {}
 
       private boolean m_closed;
     }
@@ -713,7 +713,7 @@ class TelemetryTableTest {
   @Test
   void testMockBackendNormalizesPaths() {
     TelemetryEntry entry = m_mock.getEntry("drive//speed");
-    entry.logDouble(1.0);
+    entry.logDouble(1.0, 0);
 
     assertFalse(entry.isDiscard());
     assertEquals(1.0, m_mock.getLastValue("/drive/speed", Double.class));
@@ -725,7 +725,7 @@ class TelemetryTableTest {
     assertTrue(entry.isDiscard());
     assertNull(m_mock.getLastAction("/drive/speed"));
 
-    entry.logDouble(2.0);
+    entry.logDouble(2.0, 0);
 
     assertNull(m_mock.getLastAction("/drive/speed"));
 
@@ -733,7 +733,7 @@ class TelemetryTableTest {
     assertNotSame(newEntry, entry);
     assertFalse(newEntry.isDiscard());
 
-    newEntry.logDouble(3.0);
+    newEntry.logDouble(3.0, 0);
 
     assertEquals(3.0, m_mock.getLastValue("/drive/speed", Double.class));
   }
@@ -1495,7 +1495,7 @@ class TelemetryTableTest {
     CountingCloseTelemetryBackend child = new CountingCloseTelemetryBackend();
     MultiTelemetryBackend multi = new MultiTelemetryBackend(child, child);
 
-    multi.getEntry("/duplicate").logDouble(1.0);
+    multi.getEntry("/duplicate").logDouble(1.0, 0);
 
     assertEquals(2, child.getActions().size());
     assertEquals("/duplicate", child.getActions().get(0).path());
@@ -1529,13 +1529,13 @@ class TelemetryTableTest {
     TelemetryRegistry.registerBackend("", multi);
 
     TelemetryEntry staleEntry = TelemetryRegistry.getEntry("rerouted");
-    staleEntry.logDouble(1.0);
+    staleEntry.logDouble(1.0, 0);
     child.clear();
 
     TelemetryRegistry.registerBackend("/rerouted", new DiscardTelemetryBackend());
 
     assertTrue(staleEntry.isDiscard());
-    staleEntry.logDouble(2.0);
+    staleEntry.logDouble(2.0, 0);
     assertTrue(child.getActions().isEmpty());
   }
 
@@ -1548,7 +1548,7 @@ class TelemetryTableTest {
     multi.close();
 
     assertTrue(staleEntry.isDiscard());
-    staleEntry.logDouble(1.0);
+    staleEntry.logDouble(1.0, 0);
     assertTrue(child.getActions().isEmpty());
   }
 
@@ -1658,13 +1658,13 @@ class TelemetryTableTest {
     TelemetryRegistry.registerBackend("", backend);
 
     TelemetryEntry entry = TelemetryRegistry.getEntry("direct");
-    entry.logDouble(1.0);
+    entry.logDouble(1.0, 0);
     assertEquals(1, backend.getLogs());
 
     TelemetryRegistry.reset();
 
     assertEquals(1, backend.getRemoves());
-    entry.logDouble(2.0);
+    entry.logDouble(2.0, 0);
     assertEquals(1, backend.getLogs());
   }
 

--- a/telemetry/src/test/native/cpp/TelemetryTableTest.cpp
+++ b/telemetry/src/test/native/cpp/TelemetryTableTest.cpp
@@ -229,13 +229,15 @@ class BlockingTelemetryBackend : public wpi::telemetry::TelemetryBackend {
       (void)value;
     }
 
-    void LogBoolean(bool value) override { (void)value; }
+    void LogBoolean(bool value, int64_t) override { (void)value; }
 
-    void LogInt64(int64_t value) override { (void)value; }
+    void LogInt64(int64_t value, int64_t) override { (void)value; }
 
-    void LogFloat(float value) override { LogDouble(value); }
+    void LogFloat(float value, int64_t timestamp) override {
+      LogDouble(value, timestamp);
+    }
 
-    void LogDouble(double value) override {
+    void LogDouble(double value, int64_t) override {
       (void)value;
       ++m_state.logs;
       if (!m_state.block.load()) {
@@ -247,36 +249,51 @@ class BlockingTelemetryBackend : public wpi::telemetry::TelemetryBackend {
       m_state.releaseFuture.wait();
     }
 
-    void LogString(std::string_view value,
-                   std::string_view typeString) override {
+    void LogString(std::string_view value, std::string_view typeString,
+                   int64_t) override {
       (void)value;
       (void)typeString;
     }
 
-    void LogBooleanArray(std::span<const bool> value) override { (void)value; }
-
-    void LogBooleanArray(std::span<const int> value) override { (void)value; }
-
-    void LogInt16Array(std::span<const int16_t> value) override { (void)value; }
-
-    void LogInt32Array(std::span<const int32_t> value) override { (void)value; }
-
-    void LogInt64Array(std::span<const int64_t> value) override { (void)value; }
-
-    void LogFloatArray(std::span<const float> value) override { (void)value; }
-
-    void LogDoubleArray(std::span<const double> value) override { (void)value; }
-
-    void LogStringArray(std::span<const std::string> value) override {
+    void LogBooleanArray(std::span<const bool> value, int64_t) override {
       (void)value;
     }
 
-    void LogStringArray(std::span<const std::string_view> value) override {
+    void LogBooleanArray(std::span<const int> value, int64_t) override {
       (void)value;
     }
 
-    void LogRaw(std::span<const uint8_t> value,
-                std::string_view typeString) override {
+    void LogInt16Array(std::span<const int16_t> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogInt32Array(std::span<const int32_t> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogInt64Array(std::span<const int64_t> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogFloatArray(std::span<const float> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogDoubleArray(std::span<const double> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogStringArray(std::span<const std::string> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogStringArray(std::span<const std::string_view> value,
+                        int64_t) override {
+      (void)value;
+    }
+
+    void LogRaw(std::span<const uint8_t> value, std::string_view typeString,
+                int64_t) override {
       (void)value;
       (void)typeString;
     }
@@ -345,44 +362,59 @@ class BlockingIsDiscardBackend : public wpi::telemetry::TelemetryBackend {
       (void)value;
     }
 
-    void LogBoolean(bool value) override { (void)value; }
+    void LogBoolean(bool value, int64_t) override { (void)value; }
 
-    void LogInt64(int64_t value) override { (void)value; }
+    void LogInt64(int64_t value, int64_t) override { (void)value; }
 
-    void LogFloat(float value) override { (void)value; }
+    void LogFloat(float value, int64_t) override { (void)value; }
 
-    void LogDouble(double value) override { (void)value; }
+    void LogDouble(double value, int64_t) override { (void)value; }
 
-    void LogString(std::string_view value,
-                   std::string_view typeString) override {
+    void LogString(std::string_view value, std::string_view typeString,
+                   int64_t) override {
       (void)value;
       (void)typeString;
     }
 
-    void LogBooleanArray(std::span<const bool> value) override { (void)value; }
-
-    void LogBooleanArray(std::span<const int> value) override { (void)value; }
-
-    void LogInt16Array(std::span<const int16_t> value) override { (void)value; }
-
-    void LogInt32Array(std::span<const int32_t> value) override { (void)value; }
-
-    void LogInt64Array(std::span<const int64_t> value) override { (void)value; }
-
-    void LogFloatArray(std::span<const float> value) override { (void)value; }
-
-    void LogDoubleArray(std::span<const double> value) override { (void)value; }
-
-    void LogStringArray(std::span<const std::string> value) override {
+    void LogBooleanArray(std::span<const bool> value, int64_t) override {
       (void)value;
     }
 
-    void LogStringArray(std::span<const std::string_view> value) override {
+    void LogBooleanArray(std::span<const int> value, int64_t) override {
       (void)value;
     }
 
-    void LogRaw(std::span<const uint8_t> value,
-                std::string_view typeString) override {
+    void LogInt16Array(std::span<const int16_t> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogInt32Array(std::span<const int32_t> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogInt64Array(std::span<const int64_t> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogFloatArray(std::span<const float> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogDoubleArray(std::span<const double> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogStringArray(std::span<const std::string> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogStringArray(std::span<const std::string_view> value,
+                        int64_t) override {
+      (void)value;
+    }
+
+    void LogRaw(std::span<const uint8_t> value, std::string_view typeString,
+                int64_t) override {
       (void)value;
       (void)typeString;
     }
@@ -452,47 +484,62 @@ class GenerationTelemetryBackend : public wpi::telemetry::TelemetryBackend {
       (void)value;
     }
 
-    void LogBoolean(bool value) override { (void)value; }
+    void LogBoolean(bool value, int64_t) override { (void)value; }
 
-    void LogInt64(int64_t value) override { (void)value; }
+    void LogInt64(int64_t value, int64_t) override { (void)value; }
 
-    void LogFloat(float value) override { (void)value; }
+    void LogFloat(float value, int64_t) override { (void)value; }
 
-    void LogDouble(double value) override {
+    void LogDouble(double value, int64_t) override {
       (void)value;
       m_backend.m_logGenerations.emplace_back(m_generation);
     }
 
-    void LogString(std::string_view value,
-                   std::string_view typeString) override {
+    void LogString(std::string_view value, std::string_view typeString,
+                   int64_t) override {
       (void)value;
       (void)typeString;
     }
 
-    void LogBooleanArray(std::span<const bool> value) override { (void)value; }
-
-    void LogBooleanArray(std::span<const int> value) override { (void)value; }
-
-    void LogInt16Array(std::span<const int16_t> value) override { (void)value; }
-
-    void LogInt32Array(std::span<const int32_t> value) override { (void)value; }
-
-    void LogInt64Array(std::span<const int64_t> value) override { (void)value; }
-
-    void LogFloatArray(std::span<const float> value) override { (void)value; }
-
-    void LogDoubleArray(std::span<const double> value) override { (void)value; }
-
-    void LogStringArray(std::span<const std::string> value) override {
+    void LogBooleanArray(std::span<const bool> value, int64_t) override {
       (void)value;
     }
 
-    void LogStringArray(std::span<const std::string_view> value) override {
+    void LogBooleanArray(std::span<const int> value, int64_t) override {
       (void)value;
     }
 
-    void LogRaw(std::span<const uint8_t> value,
-                std::string_view typeString) override {
+    void LogInt16Array(std::span<const int16_t> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogInt32Array(std::span<const int32_t> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogInt64Array(std::span<const int64_t> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogFloatArray(std::span<const float> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogDoubleArray(std::span<const double> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogStringArray(std::span<const std::string> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogStringArray(std::span<const std::string_view> value,
+                        int64_t) override {
+      (void)value;
+    }
+
+    void LogRaw(std::span<const uint8_t> value, std::string_view typeString,
+                int64_t) override {
       (void)value;
       (void)typeString;
     }
@@ -569,49 +616,66 @@ class ClosingTelemetryBackend : public wpi::telemetry::TelemetryBackend {
       (void)value;
     }
 
-    void LogBoolean(bool value) override { (void)value; }
+    void LogBoolean(bool value, int64_t) override { (void)value; }
 
-    void LogInt64(int64_t value) override { (void)value; }
+    void LogInt64(int64_t value, int64_t) override { (void)value; }
 
-    void LogFloat(float value) override { LogDouble(value); }
+    void LogFloat(float value, int64_t timestamp) override {
+      LogDouble(value, timestamp);
+    }
 
-    void LogDouble(double value) override {
+    void LogDouble(double value, int64_t) override {
       (void)value;
       if (!m_removed.load()) {
         ++m_backend.m_logs;
       }
     }
 
-    void LogString(std::string_view value,
-                   std::string_view typeString) override {
+    void LogString(std::string_view value, std::string_view typeString,
+                   int64_t) override {
       (void)value;
       (void)typeString;
     }
 
-    void LogBooleanArray(std::span<const bool> value) override { (void)value; }
-
-    void LogBooleanArray(std::span<const int> value) override { (void)value; }
-
-    void LogInt16Array(std::span<const int16_t> value) override { (void)value; }
-
-    void LogInt32Array(std::span<const int32_t> value) override { (void)value; }
-
-    void LogInt64Array(std::span<const int64_t> value) override { (void)value; }
-
-    void LogFloatArray(std::span<const float> value) override { (void)value; }
-
-    void LogDoubleArray(std::span<const double> value) override { (void)value; }
-
-    void LogStringArray(std::span<const std::string> value) override {
+    void LogBooleanArray(std::span<const bool> value, int64_t) override {
       (void)value;
     }
 
-    void LogStringArray(std::span<const std::string_view> value) override {
+    void LogBooleanArray(std::span<const int> value, int64_t) override {
       (void)value;
     }
 
-    void LogRaw(std::span<const uint8_t> value,
-                std::string_view typeString) override {
+    void LogInt16Array(std::span<const int16_t> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogInt32Array(std::span<const int32_t> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogInt64Array(std::span<const int64_t> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogFloatArray(std::span<const float> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogDoubleArray(std::span<const double> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogStringArray(std::span<const std::string> value, int64_t) override {
+      (void)value;
+    }
+
+    void LogStringArray(std::span<const std::string_view> value,
+                        int64_t) override {
+      (void)value;
+    }
+
+    void LogRaw(std::span<const uint8_t> value, std::string_view typeString,
+                int64_t) override {
       (void)value;
       (void)typeString;
     }
@@ -759,7 +823,7 @@ TEST_CASE_METHOD(TelemetryTableTest,
                  "TelemetryTableTest MockBackendNormalizesPaths",
                  "[telemetry]") {
   auto entry = mock->GetEntry("drive//speed");
-  entry->LogDouble(1.0);
+  entry->LogDouble(1.0, 0);
 
   REQUIRE_FALSE(entry->IsDiscard());
   REQUIRE(mock->GetLastValue<double>("/drive/speed") == 1.0);
@@ -771,7 +835,7 @@ TEST_CASE_METHOD(TelemetryTableTest,
   REQUIRE(entry->IsDiscard());
   REQUIRE_FALSE(mock->GetLastAction("/drive/speed"));
 
-  entry->LogDouble(2.0);
+  entry->LogDouble(2.0, 0);
 
   REQUIRE_FALSE(mock->GetLastAction("/drive/speed"));
 
@@ -779,7 +843,7 @@ TEST_CASE_METHOD(TelemetryTableTest,
   REQUIRE(newEntry != entry);
   REQUIRE_FALSE(newEntry->IsDiscard());
 
-  newEntry->LogDouble(3.0);
+  newEntry->LogDouble(3.0, 0);
 
   REQUIRE(mock->GetLastValue<double>("/drive/speed") == 3.0);
 }
@@ -1470,8 +1534,8 @@ TEST_CASE_METHOD(
   auto staleEntry = multi->GetEntry("/stale");
 
   multi->RemoveEntry("/stale");
-  staleEntry->LogDouble(1.0);
-  multi->GetEntry("/stale")->LogDouble(2.0);
+  staleEntry->LogDouble(1.0, 0);
+  multi->GetEntry("/stale")->LogDouble(2.0, 0);
 
   std::vector<int> expected{2};
   REQUIRE(child->GetLogGenerations() == expected);
@@ -1580,7 +1644,7 @@ TEST_CASE_METHOD(
   wpi::telemetry::TelemetryRegistry::RegisterBackend("", oldBackend);
 
   auto entry = wpi::telemetry::TelemetryRegistry::GetEntry("direct");
-  entry->LogDouble(1.0);
+  entry->LogDouble(1.0, 0);
   REQUIRE(state->logs.load() == 1);
 
   oldBackend.reset();
@@ -1588,7 +1652,7 @@ TEST_CASE_METHOD(
       "", std::make_shared<wpi::telemetry::MockTelemetryBackend>());
 
   CHECK_FALSE(state->destroyed.load());
-  entry->LogDouble(2.0);
+  entry->LogDouble(2.0, 0);
   CHECK(state->logs.load() == 2);
 
   entry.reset();
@@ -1602,13 +1666,13 @@ TEST_CASE_METHOD(TelemetryTableTest,
   wpi::telemetry::TelemetryRegistry::RegisterBackend("", backend);
 
   auto entry = wpi::telemetry::TelemetryRegistry::GetEntry("direct");
-  entry->LogDouble(1.0);
+  entry->LogDouble(1.0, 0);
   REQUIRE(backend->GetLogs() == 1);
 
   wpi::telemetry::TelemetryRegistry::Reset();
 
   CHECK(backend->GetRemoves() == 1);
-  entry->LogDouble(2.0);
+  entry->LogDouble(2.0, 0);
   CHECK(backend->GetLogs() == 1);
 }
 

--- a/telemetry/src/test/python/test_telemetry.py
+++ b/telemetry/src/test/python/test_telemetry.py
@@ -36,43 +36,43 @@ class RecordingTelemetryEntry(telemetry.TelemetryEntry):
     def set_property(self, key: str, value: str) -> None:
         self.actions.append(("property", key, value))
 
-    def log_boolean(self, value: bool) -> None:
+    def log_boolean(self, value: bool, timestamp: int) -> None:
         self.actions.append(("boolean", value))
 
-    def log_int64(self, value: int) -> None:
+    def log_int64(self, value: int, timestamp: int) -> None:
         self.actions.append(("integer", value))
 
-    def log_float(self, value: float) -> None:
+    def log_float(self, value: float, timestamp: int) -> None:
         self.actions.append(("float", value))
 
-    def log_double(self, value: float) -> None:
+    def log_double(self, value: float, timestamp: int) -> None:
         self.actions.append(("double", value))
 
-    def log_string(self, value: str, type_string: str) -> None:
+    def log_string(self, value: str, type_string: str, timestamp: int) -> None:
         self.actions.append(("string", value, type_string))
 
-    def log_boolean_array(self, value) -> None:
+    def log_boolean_array(self, value, timestamp: int) -> None:
         self.actions.append(("boolean[]", list(value)))
 
-    def log_int16_array(self, value) -> None:
+    def log_int16_array(self, value, timestamp: int) -> None:
         self.actions.append(("integer[]", list(value)))
 
-    def log_int32_array(self, value) -> None:
+    def log_int32_array(self, value, timestamp: int) -> None:
         self.actions.append(("integer[]", list(value)))
 
-    def log_int64_array(self, value) -> None:
+    def log_int64_array(self, value, timestamp: int) -> None:
         self.actions.append(("integer[]", list(value)))
 
-    def log_float_array(self, value) -> None:
+    def log_float_array(self, value, timestamp: int) -> None:
         self.actions.append(("float[]", list(value)))
 
-    def log_double_array(self, value) -> None:
+    def log_double_array(self, value, timestamp: int) -> None:
         self.actions.append(("double[]", list(value)))
 
-    def log_string_array(self, value) -> None:
+    def log_string_array(self, value, timestamp: int) -> None:
         self.actions.append(("string[]", list(value)))
 
-    def log_raw(self, value, type_string: str) -> None:
+    def log_raw(self, value, type_string: str, timestamp: int) -> None:
         self.actions.append(("raw", bytes(value), type_string))
 
 
@@ -135,6 +135,7 @@ def test_telemetry_logs_python_object(backend):
 
     assert backend.get_last_action("/PythonValue/.type") == {
         "path": "/PythonValue/.type",
+        "timestamp": 0,
         "kind": "string",
         "value": "TestValue",
         "type_string": "string",
@@ -416,6 +417,7 @@ def test_struct_logging_registers_schema_and_raw_bytes(backend):
     }
     assert backend.get_last_action("/point") == {
         "path": "/point",
+        "timestamp": 0,
         "kind": "raw",
         "value": wpistruct.pack(point),
         "type_string": "struct:TelemetryPoint",
@@ -432,6 +434,7 @@ def test_struct_array_logging_registers_schema_and_raw_bytes(backend):
     )
     assert backend.get_last_action("/points") == {
         "path": "/points",
+        "timestamp": 0,
         "kind": "raw",
         "value": wpistruct.pack_array(points),
         "type_string": "struct:TelemetryPoint[]",
@@ -448,6 +451,7 @@ def test_empty_struct_array_with_element_type_logs_schema_and_empty_raw_bytes(
     )
     assert backend.get_last_action("/points") == {
         "path": "/points",
+        "timestamp": 0,
         "kind": "raw",
         "value": b"",
         "type_string": "struct:TelemetryPoint[]",

--- a/wpilibc/src/main/native/cpp/backend/DataLogTelemetryBackend.cpp
+++ b/wpilibc/src/main/native/cpp/backend/DataLogTelemetryBackend.cpp
@@ -82,7 +82,7 @@ class DataLogTelemetryBackend::Entry : public wpi::telemetry::TelemetryEntry {
   }
 
   template <typename EntryType, typename T>
-  void Log(T value) {
+  void Log(T value, int64_t timestamp) {
     bool typeMismatch = false;
     {
       std::scoped_lock lock{m_mutex};
@@ -96,9 +96,9 @@ class DataLogTelemetryBackend::Entry : public wpi::telemetry::TelemetryEntry {
       }
       if (auto entry = std::get_if<EntryType>(&m_entry)) {
         if (m_keepDuplicates) {
-          entry->Append(value);
+          entry->Append(value, timestamp);
         } else {
-          entry->Update(value);
+          entry->Update(value, timestamp);
         }
       } else {
         typeMismatch = true;
@@ -110,7 +110,7 @@ class DataLogTelemetryBackend::Entry : public wpi::telemetry::TelemetryEntry {
   }
 
   template <typename EntryType, typename T>
-  void LogTypeString(T value, std::string_view typeString) {
+  void LogTypeString(T value, std::string_view typeString, int64_t timestamp) {
     bool typeMismatch = false;
     {
       std::scoped_lock lock{m_mutex};
@@ -126,9 +126,9 @@ class DataLogTelemetryBackend::Entry : public wpi::telemetry::TelemetryEntry {
       if (auto entry = std::get_if<EntryType>(&m_entry);
           entry && m_typeString == typeString) {
         if (m_keepDuplicates) {
-          entry->Append(value);
+          entry->Append(value, timestamp);
         } else {
-          entry->Update(value);
+          entry->Update(value, timestamp);
         }
       } else {
         typeMismatch = true;
@@ -139,65 +139,75 @@ class DataLogTelemetryBackend::Entry : public wpi::telemetry::TelemetryEntry {
     }
   }
 
-  void LogBoolean(bool value) override {
-    Log<wpi::log::BooleanLogEntry>(value);
+  void LogBoolean(bool value, int64_t timestamp) override {
+    Log<wpi::log::BooleanLogEntry>(value, timestamp);
   }
 
-  void LogInt64(int64_t value) override {
-    Log<wpi::log::IntegerLogEntry>(value);
+  void LogInt64(int64_t value, int64_t timestamp) override {
+    Log<wpi::log::IntegerLogEntry>(value, timestamp);
   }
 
-  void LogFloat(float value) override { Log<wpi::log::FloatLogEntry>(value); }
-
-  void LogDouble(double value) override {
-    Log<wpi::log::DoubleLogEntry>(value);
+  void LogFloat(float value, int64_t timestamp) override {
+    Log<wpi::log::FloatLogEntry>(value, timestamp);
   }
 
-  void LogString(std::string_view value, std::string_view typeString) override {
-    LogTypeString<wpi::log::StringLogEntry>(value, typeString);
+  void LogDouble(double value, int64_t timestamp) override {
+    Log<wpi::log::DoubleLogEntry>(value, timestamp);
   }
 
-  void LogBooleanArray(std::span<const bool> value) override {
-    Log<wpi::log::BooleanArrayLogEntry>(value);
+  void LogString(std::string_view value, std::string_view typeString,
+                 int64_t timestamp) override {
+    LogTypeString<wpi::log::StringLogEntry>(value, typeString, timestamp);
   }
 
-  void LogBooleanArray(std::span<const int> value) override {
-    Log<wpi::log::BooleanArrayLogEntry>(value);
+  void LogBooleanArray(std::span<const bool> value,
+                       int64_t timestamp) override {
+    Log<wpi::log::BooleanArrayLogEntry>(value, timestamp);
   }
 
-  void LogInt16Array(std::span<const int16_t> value) override {
+  void LogBooleanArray(std::span<const int> value, int64_t timestamp) override {
+    Log<wpi::log::BooleanArrayLogEntry>(value, timestamp);
+  }
+
+  void LogInt16Array(std::span<const int16_t> value,
+                     int64_t timestamp) override {
     std::vector<int64_t> arr{value.begin(), value.end()};
-    LogInt64Array(arr);
+    LogInt64Array(arr, timestamp);
   }
 
-  void LogInt32Array(std::span<const int32_t> value) override {
+  void LogInt32Array(std::span<const int32_t> value,
+                     int64_t timestamp) override {
     std::vector<int64_t> arr{value.begin(), value.end()};
-    LogInt64Array(arr);
+    LogInt64Array(arr, timestamp);
   }
 
-  void LogInt64Array(std::span<const int64_t> value) override {
-    Log<wpi::log::IntegerArrayLogEntry>(value);
+  void LogInt64Array(std::span<const int64_t> value,
+                     int64_t timestamp) override {
+    Log<wpi::log::IntegerArrayLogEntry>(value, timestamp);
   }
 
-  void LogFloatArray(std::span<const float> value) override {
-    Log<wpi::log::FloatArrayLogEntry>(value);
+  void LogFloatArray(std::span<const float> value, int64_t timestamp) override {
+    Log<wpi::log::FloatArrayLogEntry>(value, timestamp);
   }
 
-  void LogDoubleArray(std::span<const double> value) override {
-    Log<wpi::log::DoubleArrayLogEntry>(value);
+  void LogDoubleArray(std::span<const double> value,
+                      int64_t timestamp) override {
+    Log<wpi::log::DoubleArrayLogEntry>(value, timestamp);
   }
 
-  void LogStringArray(std::span<const std::string> value) override {
-    Log<wpi::log::StringArrayLogEntry>(value);
+  void LogStringArray(std::span<const std::string> value,
+                      int64_t timestamp) override {
+    Log<wpi::log::StringArrayLogEntry>(value, timestamp);
   }
 
-  void LogStringArray(std::span<const std::string_view> value) override {
-    Log<wpi::log::StringArrayLogEntry>(value);
+  void LogStringArray(std::span<const std::string_view> value,
+                      int64_t timestamp) override {
+    Log<wpi::log::StringArrayLogEntry>(value, timestamp);
   }
 
-  void LogRaw(std::span<const uint8_t> value,
-              std::string_view typeString) override {
-    LogTypeString<wpi::log::RawLogEntry>(value, typeString);
+  void LogRaw(std::span<const uint8_t> value, std::string_view typeString,
+              int64_t timestamp) override {
+    LogTypeString<wpi::log::RawLogEntry>(value, typeString, timestamp);
   }
 
  private:

--- a/wpilibc/src/main/native/cpp/backend/DataLogTelemetryBackend.cpp
+++ b/wpilibc/src/main/native/cpp/backend/DataLogTelemetryBackend.cpp
@@ -90,7 +90,7 @@ class DataLogTelemetryBackend::Entry : public wpi::telemetry::TelemetryEntry {
         return;
       }
       if (std::holds_alternative<std::monostate>(m_entry)) {
-        EntryType entry{m_log, m_path, m_propertiesStr};
+        EntryType entry{m_log, m_path, m_propertiesStr, timestamp};
         m_entryIndex = entry.GetIndex();
         m_entry = std::move(entry);
       }
@@ -119,7 +119,8 @@ class DataLogTelemetryBackend::Entry : public wpi::telemetry::TelemetryEntry {
       }
       if (std::holds_alternative<std::monostate>(m_entry)) {
         m_typeString = typeString;
-        EntryType entry{m_log, m_path, m_propertiesStr, m_typeString};
+        EntryType entry{m_log, m_path, m_propertiesStr, m_typeString,
+                        timestamp};
         m_entryIndex = entry.GetIndex();
         m_entry = std::move(entry);
       }

--- a/wpilibc/src/main/native/cpp/backend/NetworkTablesTelemetryBackend.cpp
+++ b/wpilibc/src/main/native/cpp/backend/NetworkTablesTelemetryBackend.cpp
@@ -84,7 +84,7 @@ class NetworkTablesTelemetryBackend::Entry
     }
   }
 
-  void LogBoolean(bool value) override {
+  void LogBoolean(bool value, int64_t timestamp) override {
     bool typeMismatch = false;
     {
       std::scoped_lock lock{m_mutex};
@@ -94,14 +94,14 @@ class NetworkTablesTelemetryBackend::Entry
       if (!m_pub) {
         m_pub = Publish("boolean");
       }
-      typeMismatch = !m_pub.SetBoolean(value);
+      typeMismatch = !m_pub.SetBoolean(value, timestamp);
     }
     if (typeMismatch) {
       wpi::telemetry::TelemetryRegistry::ReportWarning(m_path, "type mismatch");
     }
   }
 
-  void LogInt64(int64_t value) override {
+  void LogInt64(int64_t value, int64_t timestamp) override {
     bool typeMismatch = false;
     {
       std::scoped_lock lock{m_mutex};
@@ -111,14 +111,14 @@ class NetworkTablesTelemetryBackend::Entry
       if (!m_pub) {
         m_pub = Publish("int");
       }
-      typeMismatch = !m_pub.SetInteger(value);
+      typeMismatch = !m_pub.SetInteger(value, timestamp);
     }
     if (typeMismatch) {
       wpi::telemetry::TelemetryRegistry::ReportWarning(m_path, "type mismatch");
     }
   }
 
-  void LogFloat(float value) override {
+  void LogFloat(float value, int64_t timestamp) override {
     bool typeMismatch = false;
     {
       std::scoped_lock lock{m_mutex};
@@ -128,14 +128,14 @@ class NetworkTablesTelemetryBackend::Entry
       if (!m_pub) {
         m_pub = Publish("float");
       }
-      typeMismatch = !m_pub.SetFloat(value);
+      typeMismatch = !m_pub.SetFloat(value, timestamp);
     }
     if (typeMismatch) {
       wpi::telemetry::TelemetryRegistry::ReportWarning(m_path, "type mismatch");
     }
   }
 
-  void LogDouble(double value) override {
+  void LogDouble(double value, int64_t timestamp) override {
     bool typeMismatch = false;
     {
       std::scoped_lock lock{m_mutex};
@@ -145,14 +145,15 @@ class NetworkTablesTelemetryBackend::Entry
       if (!m_pub) {
         m_pub = Publish("double");
       }
-      typeMismatch = !m_pub.SetDouble(value);
+      typeMismatch = !m_pub.SetDouble(value, timestamp);
     }
     if (typeMismatch) {
       wpi::telemetry::TelemetryRegistry::ReportWarning(m_path, "type mismatch");
     }
   }
 
-  void LogString(std::string_view value, std::string_view typeString) override {
+  void LogString(std::string_view value, std::string_view typeString,
+                 int64_t timestamp) override {
     bool typeMismatch = false;
     {
       std::scoped_lock lock{m_mutex};
@@ -162,14 +163,16 @@ class NetworkTablesTelemetryBackend::Entry
       if (!m_pub) {
         m_pub = Publish(typeString);
       }
-      typeMismatch = m_typeString != typeString || !m_pub.SetString(value);
+      typeMismatch =
+          m_typeString != typeString || !m_pub.SetString(value, timestamp);
     }
     if (typeMismatch) {
       wpi::telemetry::TelemetryRegistry::ReportWarning(m_path, "type mismatch");
     }
   }
 
-  void LogBooleanArray(std::span<const bool> value) override {
+  void LogBooleanArray(std::span<const bool> value,
+                       int64_t timestamp) override {
     bool typeMismatch = false;
     {
       std::scoped_lock lock{m_mutex};
@@ -179,14 +182,14 @@ class NetworkTablesTelemetryBackend::Entry
       if (!m_pub) {
         m_pub = Publish("boolean[]");
       }
-      typeMismatch = !m_pub.SetBooleanArray(value);
+      typeMismatch = !m_pub.SetBooleanArray(value, timestamp);
     }
     if (typeMismatch) {
       wpi::telemetry::TelemetryRegistry::ReportWarning(m_path, "type mismatch");
     }
   }
 
-  void LogBooleanArray(std::span<const int> value) override {
+  void LogBooleanArray(std::span<const int> value, int64_t timestamp) override {
     bool typeMismatch = false;
     {
       std::scoped_lock lock{m_mutex};
@@ -196,24 +199,27 @@ class NetworkTablesTelemetryBackend::Entry
       if (!m_pub) {
         m_pub = Publish("boolean[]");
       }
-      typeMismatch = !m_pub.SetBooleanArray(value);
+      typeMismatch = !m_pub.SetBooleanArray(value, timestamp);
     }
     if (typeMismatch) {
       wpi::telemetry::TelemetryRegistry::ReportWarning(m_path, "type mismatch");
     }
   }
 
-  void LogInt16Array(std::span<const int16_t> value) override {
+  void LogInt16Array(std::span<const int16_t> value,
+                     int64_t timestamp) override {
     std::vector<int64_t> arr{value.begin(), value.end()};
-    LogInt64Array(arr);
+    LogInt64Array(arr, timestamp);
   }
 
-  void LogInt32Array(std::span<const int32_t> value) override {
+  void LogInt32Array(std::span<const int32_t> value,
+                     int64_t timestamp) override {
     std::vector<int64_t> arr{value.begin(), value.end()};
-    LogInt64Array(arr);
+    LogInt64Array(arr, timestamp);
   }
 
-  void LogInt64Array(std::span<const int64_t> value) override {
+  void LogInt64Array(std::span<const int64_t> value,
+                     int64_t timestamp) override {
     bool typeMismatch = false;
     {
       std::scoped_lock lock{m_mutex};
@@ -223,14 +229,14 @@ class NetworkTablesTelemetryBackend::Entry
       if (!m_pub) {
         m_pub = Publish("int[]");
       }
-      typeMismatch = !m_pub.SetIntegerArray(value);
+      typeMismatch = !m_pub.SetIntegerArray(value, timestamp);
     }
     if (typeMismatch) {
       wpi::telemetry::TelemetryRegistry::ReportWarning(m_path, "type mismatch");
     }
   }
 
-  void LogFloatArray(std::span<const float> value) override {
+  void LogFloatArray(std::span<const float> value, int64_t timestamp) override {
     bool typeMismatch = false;
     {
       std::scoped_lock lock{m_mutex};
@@ -240,14 +246,15 @@ class NetworkTablesTelemetryBackend::Entry
       if (!m_pub) {
         m_pub = Publish("float[]");
       }
-      typeMismatch = !m_pub.SetFloatArray(value);
+      typeMismatch = !m_pub.SetFloatArray(value, timestamp);
     }
     if (typeMismatch) {
       wpi::telemetry::TelemetryRegistry::ReportWarning(m_path, "type mismatch");
     }
   }
 
-  void LogDoubleArray(std::span<const double> value) override {
+  void LogDoubleArray(std::span<const double> value,
+                      int64_t timestamp) override {
     bool typeMismatch = false;
     {
       std::scoped_lock lock{m_mutex};
@@ -257,14 +264,15 @@ class NetworkTablesTelemetryBackend::Entry
       if (!m_pub) {
         m_pub = Publish("double[]");
       }
-      typeMismatch = !m_pub.SetDoubleArray(value);
+      typeMismatch = !m_pub.SetDoubleArray(value, timestamp);
     }
     if (typeMismatch) {
       wpi::telemetry::TelemetryRegistry::ReportWarning(m_path, "type mismatch");
     }
   }
 
-  void LogStringArray(std::span<const std::string> value) override {
+  void LogStringArray(std::span<const std::string> value,
+                      int64_t timestamp) override {
     bool typeMismatch = false;
     {
       std::scoped_lock lock{m_mutex};
@@ -274,24 +282,25 @@ class NetworkTablesTelemetryBackend::Entry
       if (!m_pub) {
         m_pub = Publish("string[]");
       }
-      typeMismatch = !m_pub.SetStringArray(value);
+      typeMismatch = !m_pub.SetStringArray(value, timestamp);
     }
     if (typeMismatch) {
       wpi::telemetry::TelemetryRegistry::ReportWarning(m_path, "type mismatch");
     }
   }
 
-  void LogStringArray(std::span<const std::string_view> value) override {
+  void LogStringArray(std::span<const std::string_view> value,
+                      int64_t timestamp) override {
     std::vector<std::string> arr;
     arr.reserve(value.size());
     for (auto&& val : value) {
       arr.emplace_back(val);
     }
-    LogStringArray(arr);
+    LogStringArray(arr, timestamp);
   }
 
-  void LogRaw(std::span<const uint8_t> value,
-              std::string_view typeString) override {
+  void LogRaw(std::span<const uint8_t> value, std::string_view typeString,
+              int64_t timestamp) override {
     bool typeMismatch = false;
     {
       std::scoped_lock lock{m_mutex};
@@ -301,7 +310,8 @@ class NetworkTablesTelemetryBackend::Entry
       if (!m_pub) {
         m_pub = Publish(typeString);
       }
-      typeMismatch = m_typeString != typeString || !m_pub.SetRaw(value);
+      typeMismatch =
+          m_typeString != typeString || !m_pub.SetRaw(value, timestamp);
     }
     if (typeMismatch) {
       wpi::telemetry::TelemetryRegistry::ReportWarning(m_path, "type mismatch");

--- a/wpilibc/src/test/native/cpp/DataLogTelemetryBackendTest.cpp
+++ b/wpilibc/src/test/native/cpp/DataLogTelemetryBackendTest.cpp
@@ -39,6 +39,7 @@ class DataLogTelemetryBackendTest {
     std::string type;
     std::string metadata;
     std::vector<std::vector<uint8_t>> records;
+    std::vector<int64_t> timestamps;
   };
 
   struct LogSnapshot {
@@ -88,6 +89,8 @@ class DataLogTelemetryBackendTest {
           auto raw = record.GetRaw();
           snapshot.entries[it->second].records.emplace_back(raw.begin(),
                                                             raw.end());
+          snapshot.entries[it->second].timestamps.emplace_back(
+              record.GetTimestamp());
         }
       }
     }
@@ -263,6 +266,20 @@ TEST_CASE_METHOD(DataLogTelemetryBackendTest,
 }
 
 TEST_CASE_METHOD(DataLogTelemetryBackendTest,
+                 "DataLogTelemetryBackendTest LogsExplicitTimestamp",
+                 "[wpilibc][telemetry]") {
+  constexpr int64_t timestamp = 123456789;
+
+  backend->GetEntry("/timestamped")->LogDouble(2.5, timestamp);
+
+  auto snapshot = ReadSnapshot();
+  const auto& timestamped = Entry(snapshot, "timestamped");
+  REQUIRE_FALSE(timestamped.timestamps.empty());
+  CHECK(timestamp == timestamped.timestamps.back());
+  CHECK(2.5 == DecodeDouble(Last(timestamped)));
+}
+
+TEST_CASE_METHOD(DataLogTelemetryBackendTest,
                  "DataLogTelemetryBackendTest LogsArrayAndRawDataTypes",
                  "[wpilibc][telemetry]") {
   const bool boolValues[] = {true, false};
@@ -400,8 +417,8 @@ TEST_CASE_METHOD(DataLogTelemetryBackendTest,
   auto staleEntry = backend->GetEntry("/stale");
   backend->RemoveEntry("/stale");
 
-  staleEntry->LogDouble(1.25);
-  backend->GetEntry("/stale")->LogDouble(2.5);
+  staleEntry->LogDouble(1.25, 0);
+  backend->GetEntry("/stale")->LogDouble(2.5, 0);
 
   auto snapshot = ReadSnapshot();
   const auto& stale = Entry(snapshot, "stale");

--- a/wpilibc/src/test/native/cpp/DataLogTelemetryBackendTest.cpp
+++ b/wpilibc/src/test/native/cpp/DataLogTelemetryBackendTest.cpp
@@ -39,6 +39,7 @@ class DataLogTelemetryBackendTest {
     std::string type;
     std::string metadata;
     std::vector<std::vector<uint8_t>> records;
+    std::vector<int64_t> startTimestamps;
     std::vector<int64_t> timestamps;
   };
 
@@ -76,6 +77,7 @@ class DataLogTelemetryBackendTest {
         auto& entry = snapshot.entries[std::string{start.name}];
         entry.type = start.type;
         entry.metadata = start.metadata;
+        entry.startTimestamps.emplace_back(record.GetTimestamp());
       } else if (record.IsSetMetadata()) {
         wpi::log::MetadataRecordData metadata;
         CHECK(record.GetSetMetadataData(&metadata));
@@ -105,6 +107,13 @@ class DataLogTelemetryBackendTest {
   static const std::vector<uint8_t>& Last(const EntryData& entry) {
     REQUIRE_FALSE(entry.records.empty());
     return entry.records.back();
+  }
+
+  static void CheckStartAndLastTimestamp(const EntryData& entry,
+                                         int64_t timestamp) {
+    CHECK((std::vector<int64_t>{timestamp}) == entry.startTimestamps);
+    REQUIRE_FALSE(entry.timestamps.empty());
+    CHECK(timestamp == entry.timestamps.back());
   }
 
   static bool HasEntryWithType(const LogSnapshot& snapshot,
@@ -268,15 +277,21 @@ TEST_CASE_METHOD(DataLogTelemetryBackendTest,
 TEST_CASE_METHOD(DataLogTelemetryBackendTest,
                  "DataLogTelemetryBackendTest LogsExplicitTimestamp",
                  "[wpilibc][telemetry]") {
-  constexpr int64_t timestamp = 123456789;
+  constexpr int64_t timestamp = 123456000;
+  const uint8_t rawValue[] = {1, 2, 3};
 
   backend->GetEntry("/timestamped")->LogDouble(2.5, timestamp);
+  backend->GetEntry("/timestampedRaw")
+      ->LogRaw(std::span<const uint8_t>{rawValue}, "custom", timestamp);
 
   auto snapshot = ReadSnapshot();
   const auto& timestamped = Entry(snapshot, "timestamped");
-  REQUIRE_FALSE(timestamped.timestamps.empty());
-  CHECK(timestamp == timestamped.timestamps.back());
+  CheckStartAndLastTimestamp(timestamped, timestamp);
   CHECK(2.5 == DecodeDouble(Last(timestamped)));
+
+  const auto& timestampedRaw = Entry(snapshot, "timestampedRaw");
+  CheckStartAndLastTimestamp(timestampedRaw, timestamp);
+  CHECK((std::vector<uint8_t>{1, 2, 3}) == Last(timestampedRaw));
 }
 
 TEST_CASE_METHOD(DataLogTelemetryBackendTest,

--- a/wpilibc/src/test/native/cpp/NetworkTablesTelemetryBackendTest.cpp
+++ b/wpilibc/src/test/native/cpp/NetworkTablesTelemetryBackendTest.cpp
@@ -159,6 +159,19 @@ TEST_CASE_METHOD(NetworkTablesTelemetryBackendTest,
   CHECK("{\"ok\":true}" == json.GetString(""));
 }
 
+TEST_CASE_METHOD(NetworkTablesTelemetryBackendTest,
+                 "NetworkTablesTelemetryBackendTest PublishesExplicitTimestamp",
+                 "[wpilibc][telemetry]") {
+  constexpr int64_t timestamp = 123456789;
+  auto sub = inst.GetDoubleTopic("/Telemetry/timestamped").Subscribe(0.0);
+
+  backend->GetEntry("/timestamped")->LogDouble(2.5, timestamp);
+
+  auto value = sub.GetAtomic();
+  CHECK(timestamp == value.time);
+  CHECK(2.5 == value.value);
+}
+
 TEST_CASE_METHOD(
     NetworkTablesTelemetryBackendTest,
     "NetworkTablesTelemetryBackendTest PublishesArrayAndRawDataTypes",
@@ -378,13 +391,13 @@ TEST_CASE_METHOD(
   auto staleEntry = backend->GetEntry("/stale");
   backend->RemoveEntry("/stale");
 
-  staleEntry->LogDouble(1.25);
+  staleEntry->LogDouble(1.25, 0);
 
   auto topic = inst.GetTopic("/Telemetry/stale");
   CHECK_FALSE(topic.Exists());
 
   auto sub = topic.GenericSubscribe();
-  backend->GetEntry("/stale")->LogDouble(2.5);
+  backend->GetEntry("/stale")->LogDouble(2.5, 0);
 
   CHECK(topic.Exists());
   CHECK(2.5 == sub.GetDouble(0.0));

--- a/wpilibj/src/main/java/org/wpilib/backend/DataLogTelemetryBackend.java
+++ b/wpilibj/src/main/java/org/wpilib/backend/DataLogTelemetryBackend.java
@@ -192,16 +192,16 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public <T> void logStruct(T value, Struct<? super T> struct) {
+    public <T> void logStruct(T value, Struct<? super T> struct, long timestamp) {
       boolean typeMismatch = false;
       try {
         synchronized (this) {
           StructLogEntry<? super T> entry = initStruct(struct);
           if (entry != null) {
             if (m_keepDuplicates) {
-              entry.append(value);
+              entry.append(value, timestamp);
             } else {
-              entry.update(value);
+              entry.update(value, timestamp);
             }
           } else if (!m_closed) {
             typeMismatch = true;
@@ -237,16 +237,16 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto) {
+    public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto, long timestamp) {
       boolean typeMismatch = false;
       try {
         synchronized (this) {
           ProtobufLogEntry<? super T> entry = initProtobuf(proto);
           if (entry != null) {
             if (m_keepDuplicates) {
-              entry.append(value);
+              entry.append(value, timestamp);
             } else {
-              entry.update(value);
+              entry.update(value, timestamp);
             }
           } else if (!m_closed) {
             typeMismatch = true;
@@ -283,16 +283,16 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public <T> void logStructArray(T[] value, Struct<? super T> struct) {
+    public <T> void logStructArray(T[] value, Struct<? super T> struct, long timestamp) {
       boolean typeMismatch = false;
       try {
         synchronized (this) {
           StructArrayLogEntry<? super T> entry = initStructArray(struct);
           if (entry != null) {
             if (m_keepDuplicates) {
-              entry.append(value);
+              entry.append(value, timestamp);
             } else {
-              entry.update(value);
+              entry.update(value, timestamp);
             }
           } else if (!m_closed) {
             typeMismatch = true;
@@ -317,7 +317,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public void logBoolean(boolean value) {
+    public void logBoolean(boolean value, long timestamp) {
       boolean typeMismatch = false;
       synchronized (this) {
         if (m_closed) {
@@ -333,9 +333,9 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
         switch (entry) {
           case BooleanLogEntry e -> {
             if (m_keepDuplicates) {
-              e.append(value);
+              e.append(value, timestamp);
             } else {
-              e.update(value);
+              e.update(value, timestamp);
             }
           }
           default -> typeMismatch = true;
@@ -347,7 +347,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public void logLong(long value) {
+    public void logLong(long value, long timestamp) {
       boolean typeMismatch = false;
       synchronized (this) {
         if (m_closed) {
@@ -363,9 +363,9 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
         switch (entry) {
           case IntegerLogEntry e -> {
             if (m_keepDuplicates) {
-              e.append(value);
+              e.append(value, timestamp);
             } else {
-              e.update(value);
+              e.update(value, timestamp);
             }
           }
           default -> typeMismatch = true;
@@ -377,7 +377,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public void logFloat(float value) {
+    public void logFloat(float value, long timestamp) {
       boolean typeMismatch = false;
       synchronized (this) {
         if (m_closed) {
@@ -393,9 +393,9 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
         switch (entry) {
           case FloatLogEntry e -> {
             if (m_keepDuplicates) {
-              e.append(value);
+              e.append(value, timestamp);
             } else {
-              e.update(value);
+              e.update(value, timestamp);
             }
           }
           default -> typeMismatch = true;
@@ -407,7 +407,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public void logDouble(double value) {
+    public void logDouble(double value, long timestamp) {
       boolean typeMismatch = false;
       synchronized (this) {
         if (m_closed) {
@@ -423,9 +423,9 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
         switch (entry) {
           case DoubleLogEntry e -> {
             if (m_keepDuplicates) {
-              e.append(value);
+              e.append(value, timestamp);
             } else {
-              e.update(value);
+              e.update(value, timestamp);
             }
           }
           default -> typeMismatch = true;
@@ -437,7 +437,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public void logString(String value, String typeString) {
+    public void logString(String value, String typeString, long timestamp) {
       boolean typeMismatch = false;
       synchronized (this) {
         if (m_closed) {
@@ -454,9 +454,9 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
         switch (entry) {
           case StringLogEntry e when m_typeString.equals(typeString) -> {
             if (m_keepDuplicates) {
-              e.append(value);
+              e.append(value, timestamp);
             } else {
-              e.update(value);
+              e.update(value, timestamp);
             }
           }
           default -> typeMismatch = true;
@@ -468,7 +468,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public void logBooleanArray(boolean[] value) {
+    public void logBooleanArray(boolean[] value, long timestamp) {
       boolean typeMismatch = false;
       synchronized (this) {
         if (m_closed) {
@@ -484,9 +484,9 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
         switch (entry) {
           case BooleanArrayLogEntry e -> {
             if (m_keepDuplicates) {
-              e.append(value);
+              e.append(value, timestamp);
             } else {
-              e.update(value);
+              e.update(value, timestamp);
             }
           }
           default -> typeMismatch = true;
@@ -498,17 +498,17 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public void logShortArray(short[] value) {
-      logLongArray(toLongArray(value));
+    public void logShortArray(short[] value, long timestamp) {
+      logLongArray(toLongArray(value), timestamp);
     }
 
     @Override
-    public void logIntArray(int[] value) {
-      logLongArray(toLongArray(value));
+    public void logIntArray(int[] value, long timestamp) {
+      logLongArray(toLongArray(value), timestamp);
     }
 
     @Override
-    public void logLongArray(long[] value) {
+    public void logLongArray(long[] value, long timestamp) {
       boolean typeMismatch = false;
       synchronized (this) {
         if (m_closed) {
@@ -524,9 +524,9 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
         switch (entry) {
           case IntegerArrayLogEntry e -> {
             if (m_keepDuplicates) {
-              e.append(value);
+              e.append(value, timestamp);
             } else {
-              e.update(value);
+              e.update(value, timestamp);
             }
           }
           default -> typeMismatch = true;
@@ -554,7 +554,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public void logFloatArray(float[] value) {
+    public void logFloatArray(float[] value, long timestamp) {
       boolean typeMismatch = false;
       synchronized (this) {
         if (m_closed) {
@@ -570,9 +570,9 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
         switch (entry) {
           case FloatArrayLogEntry e -> {
             if (m_keepDuplicates) {
-              e.append(value);
+              e.append(value, timestamp);
             } else {
-              e.update(value);
+              e.update(value, timestamp);
             }
           }
           default -> typeMismatch = true;
@@ -584,7 +584,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public void logDoubleArray(double[] value) {
+    public void logDoubleArray(double[] value, long timestamp) {
       boolean typeMismatch = false;
       synchronized (this) {
         if (m_closed) {
@@ -600,9 +600,9 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
         switch (entry) {
           case DoubleArrayLogEntry e -> {
             if (m_keepDuplicates) {
-              e.append(value);
+              e.append(value, timestamp);
             } else {
-              e.update(value);
+              e.update(value, timestamp);
             }
           }
           default -> typeMismatch = true;
@@ -614,7 +614,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public void logStringArray(String[] value) {
+    public void logStringArray(String[] value, long timestamp) {
       boolean typeMismatch = false;
       synchronized (this) {
         if (m_closed) {
@@ -630,9 +630,9 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
         switch (entry) {
           case StringArrayLogEntry e -> {
             if (m_keepDuplicates) {
-              e.append(value);
+              e.append(value, timestamp);
             } else {
-              e.update(value);
+              e.update(value, timestamp);
             }
           }
           default -> typeMismatch = true;
@@ -644,7 +644,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public void logRaw(byte[] value, String typeString) {
+    public void logRaw(byte[] value, String typeString, long timestamp) {
       boolean typeMismatch = false;
       synchronized (this) {
         if (m_closed) {
@@ -661,9 +661,9 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
         switch (entry) {
           case RawLogEntry e when m_typeString.equals(typeString) -> {
             if (m_keepDuplicates) {
-              e.append(value);
+              e.append(value, timestamp);
             } else {
-              e.update(value);
+              e.update(value, timestamp);
             }
           }
           default -> typeMismatch = true;

--- a/wpilibj/src/main/java/org/wpilib/backend/DataLogTelemetryBackend.java
+++ b/wpilibj/src/main/java/org/wpilib/backend/DataLogTelemetryBackend.java
@@ -170,14 +170,15 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
       }
     }
 
-    private <T> StructLogEntry<T> initStruct(Struct<T> struct) {
+    private <T> StructLogEntry<T> initStruct(Struct<T> struct, long timestamp) {
       if (m_closed) {
         return null;
       }
       DataLogEntry entry = m_entry;
       return switch (entry) {
         case null -> {
-          StructLogEntry<T> e = StructLogEntry.create(m_log, m_path, struct, m_properties);
+          StructLogEntry<T> e =
+              StructLogEntry.create(m_log, m_path, struct, m_properties, timestamp);
           m_struct = struct;
           m_entry = e;
           yield e;
@@ -196,7 +197,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
       boolean typeMismatch = false;
       try {
         synchronized (this) {
-          StructLogEntry<? super T> entry = initStruct(struct);
+          StructLogEntry<? super T> entry = initStruct(struct, timestamp);
           if (entry != null) {
             if (m_keepDuplicates) {
               entry.append(value, timestamp);
@@ -215,14 +216,15 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
       }
     }
 
-    private <T> ProtobufLogEntry<T> initProtobuf(Protobuf<T, ?> proto) {
+    private <T> ProtobufLogEntry<T> initProtobuf(Protobuf<T, ?> proto, long timestamp) {
       if (m_closed) {
         return null;
       }
       DataLogEntry entry = m_entry;
       return switch (entry) {
         case null -> {
-          ProtobufLogEntry<T> e = ProtobufLogEntry.create(m_log, m_path, proto, m_properties);
+          ProtobufLogEntry<T> e =
+              ProtobufLogEntry.create(m_log, m_path, proto, m_properties, timestamp);
           m_proto = proto;
           m_entry = e;
           yield e;
@@ -241,7 +243,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
       boolean typeMismatch = false;
       try {
         synchronized (this) {
-          ProtobufLogEntry<? super T> entry = initProtobuf(proto);
+          ProtobufLogEntry<? super T> entry = initProtobuf(proto, timestamp);
           if (entry != null) {
             if (m_keepDuplicates) {
               entry.append(value, timestamp);
@@ -260,7 +262,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
       }
     }
 
-    private <T> StructArrayLogEntry<T> initStructArray(Struct<T> struct) {
+    private <T> StructArrayLogEntry<T> initStructArray(Struct<T> struct, long timestamp) {
       if (m_closed) {
         return null;
       }
@@ -268,7 +270,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
       return switch (entry) {
         case null -> {
           StructArrayLogEntry<T> e =
-              StructArrayLogEntry.create(m_log, m_path, struct, m_properties);
+              StructArrayLogEntry.create(m_log, m_path, struct, m_properties, timestamp);
           m_struct = struct;
           m_entry = e;
           yield e;
@@ -287,7 +289,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
       boolean typeMismatch = false;
       try {
         synchronized (this) {
-          StructArrayLogEntry<? super T> entry = initStructArray(struct);
+          StructArrayLogEntry<? super T> entry = initStructArray(struct, timestamp);
           if (entry != null) {
             if (m_keepDuplicates) {
               entry.append(value, timestamp);
@@ -326,7 +328,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
 
         DataLogEntry entry = m_entry;
         if (entry == null) {
-          entry = new BooleanLogEntry(m_log, m_path, m_properties);
+          entry = new BooleanLogEntry(m_log, m_path, m_properties, timestamp);
           m_entry = entry;
         }
 
@@ -356,7 +358,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
 
         DataLogEntry entry = m_entry;
         if (entry == null) {
-          entry = new IntegerLogEntry(m_log, m_path, m_properties);
+          entry = new IntegerLogEntry(m_log, m_path, m_properties, timestamp);
           m_entry = entry;
         }
 
@@ -386,7 +388,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
 
         DataLogEntry entry = m_entry;
         if (entry == null) {
-          entry = new FloatLogEntry(m_log, m_path, m_properties);
+          entry = new FloatLogEntry(m_log, m_path, m_properties, timestamp);
           m_entry = entry;
         }
 
@@ -416,7 +418,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
 
         DataLogEntry entry = m_entry;
         if (entry == null) {
-          entry = new DoubleLogEntry(m_log, m_path, m_properties);
+          entry = new DoubleLogEntry(m_log, m_path, m_properties, timestamp);
           m_entry = entry;
         }
 
@@ -447,7 +449,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
         DataLogEntry entry = m_entry;
         if (entry == null) {
           m_typeString = typeString;
-          entry = new StringLogEntry(m_log, m_path, m_properties, m_typeString);
+          entry = new StringLogEntry(m_log, m_path, m_properties, m_typeString, timestamp);
           m_entry = entry;
         }
 
@@ -477,7 +479,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
 
         DataLogEntry entry = m_entry;
         if (entry == null) {
-          entry = new BooleanArrayLogEntry(m_log, m_path, m_properties);
+          entry = new BooleanArrayLogEntry(m_log, m_path, m_properties, timestamp);
           m_entry = entry;
         }
 
@@ -517,7 +519,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
 
         DataLogEntry entry = m_entry;
         if (entry == null) {
-          entry = new IntegerArrayLogEntry(m_log, m_path, m_properties);
+          entry = new IntegerArrayLogEntry(m_log, m_path, m_properties, timestamp);
           m_entry = entry;
         }
 
@@ -563,7 +565,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
 
         DataLogEntry entry = m_entry;
         if (entry == null) {
-          entry = new FloatArrayLogEntry(m_log, m_path, m_properties);
+          entry = new FloatArrayLogEntry(m_log, m_path, m_properties, timestamp);
           m_entry = entry;
         }
 
@@ -593,7 +595,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
 
         DataLogEntry entry = m_entry;
         if (entry == null) {
-          entry = new DoubleArrayLogEntry(m_log, m_path, m_properties);
+          entry = new DoubleArrayLogEntry(m_log, m_path, m_properties, timestamp);
           m_entry = entry;
         }
 
@@ -623,7 +625,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
 
         DataLogEntry entry = m_entry;
         if (entry == null) {
-          entry = new StringArrayLogEntry(m_log, m_path, m_properties);
+          entry = new StringArrayLogEntry(m_log, m_path, m_properties, timestamp);
           m_entry = entry;
         }
 
@@ -654,7 +656,7 @@ public class DataLogTelemetryBackend implements TelemetryBackend {
         DataLogEntry entry = m_entry;
         if (entry == null) {
           m_typeString = typeString;
-          entry = new RawLogEntry(m_log, m_path, m_properties, m_typeString);
+          entry = new RawLogEntry(m_log, m_path, m_properties, m_typeString, timestamp);
           m_entry = entry;
         }
 

--- a/wpilibj/src/main/java/org/wpilib/backend/NetworkTablesTelemetryBackend.java
+++ b/wpilibj/src/main/java/org/wpilib/backend/NetworkTablesTelemetryBackend.java
@@ -299,7 +299,7 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public <T> void logStruct(T value, Struct<? super T> struct) {
+    public <T> void logStruct(T value, Struct<? super T> struct, long timestamp) {
       boolean typeMismatch = false;
       try {
         synchronized (this) {
@@ -308,7 +308,7 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
             @SuppressWarnings("unchecked")
             StructBuffer<T> buffer = (StructBuffer<T>) m_structBuffer;
             var bb = buffer.write(value);
-            pub.set(bb, 0, bb.position());
+            pub.set(bb, 0, bb.position(), timestamp);
           } else if (!m_closed) {
             typeMismatch = true;
           }
@@ -348,7 +348,7 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto) {
+    public <T> void logProtobuf(T value, Protobuf<? super T, ?> proto, long timestamp) {
       boolean typeMismatch = false;
       try {
         synchronized (this) {
@@ -357,7 +357,7 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
             @SuppressWarnings("unchecked")
             ProtobufBuffer<T, ?> buffer = (ProtobufBuffer<T, ?>) m_protoBuffer;
             var bb = buffer.write(value);
-            pub.set(bb, 0, bb.position());
+            pub.set(bb, 0, bb.position(), timestamp);
           } else if (!m_closed) {
             typeMismatch = true;
           }
@@ -372,7 +372,7 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public <T> void logStructArray(T[] value, Struct<? super T> struct) {
+    public <T> void logStructArray(T[] value, Struct<? super T> struct, long timestamp) {
       boolean typeMismatch = false;
       try {
         synchronized (this) {
@@ -381,7 +381,7 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
             @SuppressWarnings("unchecked")
             StructBuffer<T> buffer = (StructBuffer<T>) m_structBuffer;
             var bb = buffer.writeArray(value);
-            pub.set(bb, 0, bb.position());
+            pub.set(bb, 0, bb.position(), timestamp);
           } else if (!m_closed) {
             typeMismatch = true;
           }
@@ -402,7 +402,7 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
     }
 
     @Override
-    public void logBoolean(boolean value) {
+    public void logBoolean(boolean value, long timestamp) {
       Publisher pub = m_pub;
       if (pub == null) {
         synchronized (this) {
@@ -425,13 +425,13 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
       }
 
       switch (pub) {
-        case BooleanPublisher e -> e.set(value);
+        case BooleanPublisher e -> e.set(value, timestamp);
         default -> TelemetryRegistry.reportWarning(m_path, "type mismatch");
       }
     }
 
     @Override
-    public void logLong(long value) {
+    public void logLong(long value, long timestamp) {
       Publisher pub = m_pub;
       if (pub == null) {
         synchronized (this) {
@@ -454,13 +454,13 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
       }
 
       switch (pub) {
-        case IntegerPublisher e -> e.set(value);
+        case IntegerPublisher e -> e.set(value, timestamp);
         default -> TelemetryRegistry.reportWarning(m_path, "type mismatch");
       }
     }
 
     @Override
-    public void logFloat(float value) {
+    public void logFloat(float value, long timestamp) {
       Publisher pub = m_pub;
       if (pub == null) {
         synchronized (this) {
@@ -483,13 +483,13 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
       }
 
       switch (pub) {
-        case FloatPublisher e -> e.set(value);
+        case FloatPublisher e -> e.set(value, timestamp);
         default -> TelemetryRegistry.reportWarning(m_path, "type mismatch");
       }
     }
 
     @Override
-    public void logDouble(double value) {
+    public void logDouble(double value, long timestamp) {
       Publisher pub = m_pub;
       if (pub == null) {
         synchronized (this) {
@@ -512,13 +512,13 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
       }
 
       switch (pub) {
-        case DoublePublisher e -> e.set(value);
+        case DoublePublisher e -> e.set(value, timestamp);
         default -> TelemetryRegistry.reportWarning(m_path, "type mismatch");
       }
     }
 
     @Override
-    public void logString(String value, String typeString) {
+    public void logString(String value, String typeString, long timestamp) {
       Publisher pub = m_pub;
       if (pub == null) {
         synchronized (this) {
@@ -544,13 +544,13 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
       String curTypeString = m_typeString;
 
       switch (pub) {
-        case StringPublisher e when curTypeString.equals(typeString) -> e.set(value);
+        case StringPublisher e when curTypeString.equals(typeString) -> e.set(value, timestamp);
         default -> TelemetryRegistry.reportWarning(m_path, "type mismatch");
       }
     }
 
     @Override
-    public void logBooleanArray(boolean[] value) {
+    public void logBooleanArray(boolean[] value, long timestamp) {
       Publisher pub = m_pub;
       if (pub == null) {
         synchronized (this) {
@@ -573,31 +573,31 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
       }
 
       switch (pub) {
-        case BooleanArrayPublisher e -> e.set(value);
+        case BooleanArrayPublisher e -> e.set(value, timestamp);
         default -> TelemetryRegistry.reportWarning(m_path, "type mismatch");
       }
     }
 
     @Override
-    public void logShortArray(short[] value) {
+    public void logShortArray(short[] value, long timestamp) {
       long[] arr = new long[value.length];
       for (int i = 0; i < value.length; i++) {
         arr[i] = value[i];
       }
-      logLongArray(arr);
+      logLongArray(arr, timestamp);
     }
 
     @Override
-    public void logIntArray(int[] value) {
+    public void logIntArray(int[] value, long timestamp) {
       long[] arr = new long[value.length];
       for (int i = 0; i < value.length; i++) {
         arr[i] = value[i];
       }
-      logLongArray(arr);
+      logLongArray(arr, timestamp);
     }
 
     @Override
-    public void logLongArray(long[] value) {
+    public void logLongArray(long[] value, long timestamp) {
       Publisher pub = m_pub;
       if (pub == null) {
         synchronized (this) {
@@ -620,13 +620,13 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
       }
 
       switch (pub) {
-        case IntegerArrayPublisher e -> e.set(value);
+        case IntegerArrayPublisher e -> e.set(value, timestamp);
         default -> TelemetryRegistry.reportWarning(m_path, "type mismatch");
       }
     }
 
     @Override
-    public void logFloatArray(float[] value) {
+    public void logFloatArray(float[] value, long timestamp) {
       Publisher pub = m_pub;
       if (pub == null) {
         synchronized (this) {
@@ -649,13 +649,13 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
       }
 
       switch (pub) {
-        case FloatArrayPublisher e -> e.set(value);
+        case FloatArrayPublisher e -> e.set(value, timestamp);
         default -> TelemetryRegistry.reportWarning(m_path, "type mismatch");
       }
     }
 
     @Override
-    public void logDoubleArray(double[] value) {
+    public void logDoubleArray(double[] value, long timestamp) {
       Publisher pub = m_pub;
       if (pub == null) {
         synchronized (this) {
@@ -678,13 +678,13 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
       }
 
       switch (pub) {
-        case DoubleArrayPublisher e -> e.set(value);
+        case DoubleArrayPublisher e -> e.set(value, timestamp);
         default -> TelemetryRegistry.reportWarning(m_path, "type mismatch");
       }
     }
 
     @Override
-    public void logStringArray(String[] value) {
+    public void logStringArray(String[] value, long timestamp) {
       Publisher pub = m_pub;
       if (pub == null) {
         synchronized (this) {
@@ -707,13 +707,13 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
       }
 
       switch (pub) {
-        case StringArrayPublisher e -> e.set(value);
+        case StringArrayPublisher e -> e.set(value, timestamp);
         default -> TelemetryRegistry.reportWarning(m_path, "type mismatch");
       }
     }
 
     @Override
-    public void logRaw(byte[] value, String typeString) {
+    public void logRaw(byte[] value, String typeString, long timestamp) {
       Publisher pub = m_pub;
       if (pub == null) {
         synchronized (this) {
@@ -739,7 +739,7 @@ public class NetworkTablesTelemetryBackend implements TelemetryBackend {
       String curTypeString = m_typeString;
 
       switch (pub) {
-        case RawPublisher e when curTypeString.equals(typeString) -> e.set(value);
+        case RawPublisher e when curTypeString.equals(typeString) -> e.set(value, timestamp);
         default -> TelemetryRegistry.reportWarning(m_path, "type mismatch");
       }
     }

--- a/wpilibj/src/test/java/org/wpilib/backend/DataLogTelemetryBackendTest.java
+++ b/wpilibj/src/test/java/org/wpilib/backend/DataLogTelemetryBackendTest.java
@@ -91,6 +91,17 @@ class DataLogTelemetryBackendTest {
   }
 
   @Test
+  void logsExplicitTimestamp() {
+    long timestamp = 123456789L;
+
+    m_backend.getEntry("/timestamped").logDouble(2.5, timestamp);
+
+    DataLogRecord record = last(entry(readSnapshot(), "timestamped"));
+    assertEquals(timestamp, record.getTimestamp());
+    assertEquals(2.5, record.getDouble());
+  }
+
+  @Test
   void logsArrayAndRawDataTypes() {
     m_table.log("booleans", new boolean[] {true, false});
     m_table.log("shorts", new short[] {1, 2});
@@ -100,7 +111,7 @@ class DataLogTelemetryBackendTest {
     m_table.log("doubles", new double[] {9.25, 10.5});
     m_table.log("strings", new String[] {"a", "b"});
     m_table.log("raw", new byte[] {11, 12, 13});
-    m_backend.getEntry("/customRaw").logRaw(new byte[] {14, 15}, "custom");
+    m_backend.getEntry("/customRaw").logRaw(new byte[] {14, 15}, "custom", 0);
 
     LogSnapshot snapshot = readSnapshot();
 
@@ -145,7 +156,7 @@ class DataLogTelemetryBackendTest {
 
   @Test
   void logsCustomRawDataType() {
-    m_backend.getEntry("/customRaw").logRaw(new byte[] {14, 15}, "custom");
+    m_backend.getEntry("/customRaw").logRaw(new byte[] {14, 15}, "custom", 0);
 
     LogSnapshot snapshot = readSnapshot();
 
@@ -299,8 +310,8 @@ class DataLogTelemetryBackendTest {
     var staleEntry = m_backend.getEntry("/stale");
     m_backend.removeEntry("/stale");
 
-    staleEntry.logDouble(1.25);
-    m_backend.getEntry("/stale").logDouble(2.5);
+    staleEntry.logDouble(1.25, 0);
+    m_backend.getEntry("/stale").logDouble(2.5, 0);
 
     EntryData stale = entry(readSnapshot(), "stale");
     assertEquals(1, stale.records.size());

--- a/wpilibj/src/test/java/org/wpilib/backend/DataLogTelemetryBackendTest.java
+++ b/wpilibj/src/test/java/org/wpilib/backend/DataLogTelemetryBackendTest.java
@@ -92,13 +92,29 @@ class DataLogTelemetryBackendTest {
 
   @Test
   void logsExplicitTimestamp() {
-    long timestamp = 123456789L;
+    long timestamp = 123456000L;
+    Translation2d value = new Translation2d(1.25, 2.5);
 
     m_backend.getEntry("/timestamped").logDouble(2.5, timestamp);
+    m_backend.getEntry("/timestampedRaw").logRaw(new byte[] {1, 2, 3}, "custom", timestamp);
+    m_backend.getEntry("/timestampedStruct").logStruct(value, Translation2d.struct, timestamp);
+    m_backend
+        .getEntry("/timestampedStructArray")
+        .logStructArray(new Translation2d[] {value}, Translation2d.struct, timestamp);
+    m_backend.getEntry("/timestampedProto").logProtobuf(value, Translation2d.proto, timestamp);
 
-    DataLogRecord record = last(entry(readSnapshot(), "timestamped"));
-    assertEquals(timestamp, record.getTimestamp());
-    assertEquals(2.5, record.getDouble());
+    LogSnapshot snapshot = readSnapshot();
+    EntryData timestamped = entry(snapshot, "timestamped");
+    assertStartAndLastTimestamp(timestamped, timestamp);
+    assertEquals(2.5, last(timestamped).getDouble());
+
+    EntryData timestampedRaw = entry(snapshot, "timestampedRaw");
+    assertStartAndLastTimestamp(timestampedRaw, timestamp);
+    assertArrayEquals(new byte[] {1, 2, 3}, last(timestampedRaw).getRaw());
+
+    assertStartAndLastTimestamp(entry(snapshot, "timestampedStruct"), timestamp);
+    assertStartAndLastTimestamp(entry(snapshot, "timestampedStructArray"), timestamp);
+    assertStartAndLastTimestamp(entry(snapshot, "timestampedProto"), timestamp);
   }
 
   @Test
@@ -334,6 +350,7 @@ class DataLogTelemetryBackendTest {
         EntryData entry = snapshot.entries.computeIfAbsent(start.name, _ -> new EntryData());
         entry.type = start.type;
         entry.metadata = start.metadata;
+        entry.startTimestamps.add(record.getTimestamp());
       } else if (record.isSetMetadata()) {
         DataLogRecord.MetadataRecordData metadata = record.getSetMetadataData();
         String name = names.get(metadata.entry);
@@ -366,6 +383,11 @@ class DataLogTelemetryBackendTest {
     return entry.records.get(entry.records.size() - 1);
   }
 
+  private static void assertStartAndLastTimestamp(EntryData entry, long timestamp) {
+    assertEquals(List.of(timestamp), entry.startTimestamps);
+    assertEquals(timestamp, last(entry).getTimestamp());
+  }
+
   private static final class LogSnapshot {
     final Map<String, EntryData> entries = new HashMap<>();
 
@@ -382,11 +404,20 @@ class DataLogTelemetryBackendTest {
   private static final class EntryData {
     String type;
     String metadata;
+    final List<Long> startTimestamps = new ArrayList<>();
     final List<DataLogRecord> records = new ArrayList<>();
 
     @Override
     public String toString() {
-      return "{type=" + type + ", metadata=" + metadata + ", records=" + records.size() + "}";
+      return "{type="
+          + type
+          + ", metadata="
+          + metadata
+          + ", startTimestamps="
+          + startTimestamps
+          + ", records="
+          + records.size()
+          + "}";
     }
   }
 }

--- a/wpilibj/src/test/java/org/wpilib/backend/NetworkTablesTelemetryBackendTest.java
+++ b/wpilibj/src/test/java/org/wpilib/backend/NetworkTablesTelemetryBackendTest.java
@@ -66,6 +66,20 @@ class NetworkTablesTelemetryBackendTest {
   }
 
   @Test
+  void publishesExplicitTimestamp() {
+    long timestamp = 123456789L;
+    var backend = new NetworkTablesTelemetryBackend(m_inst, "/Telemetry");
+    var sub = m_inst.getDoubleTopic("/Telemetry/timestamped").subscribe(0.0);
+
+    backend.getEntry("/timestamped").logDouble(2.5, timestamp);
+
+    var value = sub.getAtomic();
+    assertEquals(timestamp, value.timestamp);
+    assertEquals(2.5, value.value);
+    backend.close();
+  }
+
+  @Test
   void publishesArrayAndRawDataTypes() {
     Telemetry.log("booleans", new boolean[] {true, false});
     Telemetry.log("shorts", new short[] {1, 2});
@@ -265,12 +279,12 @@ class NetworkTablesTelemetryBackendTest {
     var staleEntry = backend.getEntry("/stale");
     backend.removeEntry("/stale");
 
-    staleEntry.logDouble(1.25);
+    staleEntry.logDouble(1.25, 0);
 
     var topic = m_inst.getTopic("/Telemetry/stale");
     assertFalse(topic.exists());
 
-    backend.getEntry("/stale").logDouble(2.5);
+    backend.getEntry("/stale").logDouble(2.5, 0);
 
     assertTrue(topic.exists());
     assertEquals(2.5, topic.getGenericEntry().getDouble(0.0));


### PR DESCRIPTION
This allows for control of timestamps, which is especially useful with stacked backend implementations.