### PR TITLE
[bazel] Add linux_arm64_trixie platform

### DIFF
--- a/shared/bazel/BUILD.bazel
+++ b/shared/bazel/BUILD.bazel
@@ -68,6 +68,20 @@ platform(
 )
 
 platform(
+    name = "linux_arm64_trixie",
+    exec_properties = {
+        "Arch": "arm64",
+        "OSFamily": "Linux",
+        "container-image": "docker://wpilib/debian-base:arm64-trixie@sha256:a5addc848192deea04eb74960e0eff9acb7cd3f30e39c00d42b1b8692ba174dd",
+    },
+    flags = [
+    ] + gcc_flags,
+    parents = [
+        "@wpilib_toolchains//platforms/trixie64",
+    ],
+)
+
+platform(
     name = "osx",
     flags = [
     ],

--- a/shared/bazel/BUILD.bazel
+++ b/shared/bazel/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
+
 package(default_visibility = ["//visibility:public"])
 
 windows_flags = [
@@ -79,6 +81,11 @@ platform(
     parents = [
         "@wpilib_toolchains//platforms/trixie64",
     ],
+)
+
+alias(
+    name = "linux_host",
+    actual = ":linux_arm64_trixie" if "@platforms//cpu:aarch64" in HOST_CONSTRAINTS else ":linux_x86_64",
 )
 
 platform(

--- a/shared/bazel/compiler_flags/linux_flags.rc
+++ b/shared/bazel/compiler_flags/linux_flags.rc
@@ -36,5 +36,5 @@ build:linux --host_per_file_copt=external/.*\.cpp$,external/.*\.cc$@-Wno-missing
 build:linux --features=set_soname
 build:linux --host_features=set_soname
 
-build:linux --host_platform=//shared/bazel:linux_x86_64
-build:linux --platforms=//shared/bazel:linux_x86_64
+build:linux --host_platform=//shared/bazel:linux_host
+build:linux --platforms=//shared/bazel:linux_host

--- a/shared/bazel/rules/publishing.bzl
+++ b/shared/bazel/rules/publishing.bzl
@@ -127,6 +127,7 @@ def platform_prefix(t):
         "@wpilib_toolchains//conditions:windows_arm64": "windows/arm64/" + t,
         "@wpilib_toolchains//conditions:windows_x86_64": "windows/x86-64/" + t,
         "@wpilib_toolchains//constraints/is_systemcore:systemcore": "linux/systemcore/" + t,
+        "@wpilib_toolchains//constraints/is_trixie64:trixie64": "linux/arm64/" + t,
     })
 
 def _wpilib_maven_export_impl(

--- a/shared/bazel/rules/robotpy/robotpy_rules.bzl
+++ b/shared/bazel/rules/robotpy/robotpy_rules.bzl
@@ -62,7 +62,7 @@ def create_pybind_library(
                 "-Wno-pessimizing-move",
                 "-Wno-unused-value",
             ],
-            "@bazel_tools//src/conditions:linux_x86_64": [
+            "@bazel_tools//src/conditions:linux": [
                 "-Wno-attributes",
                 "-Wno-unused-value",
                 "-Wno-deprecated",


### PR DESCRIPTION
This fixes all the analysis failures of `//...` I could find when targeting Linux ARM from x86-64. (Cross-compiling Python bits fails since our `rules_python` setup doesn't support cross-compilation.)

Tested locally from my Linux x86-64 machine against BuildBuddy RBE. https://app.buildbuddy.io/invocation/a3615454-3b89-47fc-9518-1ac4a3e449c7

```
bazel test -c opt --config=build_buddy_rbe --platforms=//shared/bazel:linux_arm64_trixie --extra_execution_platforms=//shared/bazel:linux_arm64_trixie,//shared/bazel:linux_x86_64 -- //apriltag:apriltag-cpp-test //commandsv2:commandsv2-cpp-test //cscore:cscore-cpp-test //fields:fields-cpp-test //glass:glass-test //hal:hal-cpp-test //romiVendordep:romi-test //tools/... //wpimath:wpimath-cpp-test //wpiutil:wpiutil-cpp-test //xrpVendordep:xrp-cpp-test //wpilibj:all //:publish
```

Supercedes #9246