### PR TITLE
[sim] Add DS alerts to sim GUI

### DIFF
--- a/glass/src/lib/native/cpp/Window.cpp
+++ b/glass/src/lib/native/cpp/Window.cpp
@@ -18,7 +18,8 @@ using namespace wpi::glass;
 
 Window::Window(Storage& storage, std::string_view id,
                Visibility defaultVisibility)
-    : m_id{id},
+    : m_storage{storage},
+      m_id{id},
       m_name{storage.GetString("name")},
       m_defaultName{id},
       m_visible{storage.GetBool("visible", defaultVisibility != HIDE)},

--- a/glass/src/lib/native/cpp/other/Alerts.cpp
+++ b/glass/src/lib/native/cpp/other/Alerts.cpp
@@ -4,29 +4,203 @@
 
 #include "wpi/glass/other/Alerts.hpp"
 
+#include <algorithm>
+#include <vector>
+
 #include <IconsFontAwesome6.h>
 #include <imgui.h>
 
+#include "wpi/glass/Context.hpp"
+#include "wpi/glass/Storage.hpp"
+
 using namespace wpi::glass;
 
-void wpi::glass::DisplayAlerts(AlertsModel* model) {
-  auto& infos = model->GetInfos();
-  auto& warnings = model->GetWarnings();
-  auto& errors = model->GetErrors();
+namespace {
 
-  const ImVec4 WARNING_COLOR{0.85f, 0.56f, 0.0f, 1.0f};
-  const ImVec4 ERROR_COLOR{0.9f, 0.25f, 0.25f, 1.0f};
+int GetLevelSortOrder(AlertData::Level level) {
+  switch (level) {
+    case AlertData::Level::HIGH:
+      return 0;
+    case AlertData::Level::MEDIUM:
+      return 1;
+    case AlertData::Level::LOW:
+      return 2;
+  }
+  return 3;
+}
 
-  // show higher severity alerts on top
-  for (auto&& error : errors) {
-    ImGui::TextColored(ERROR_COLOR, "%s %s", ICON_FA_CIRCLE_XMARK,
-                       error.c_str());
+ImVec4 GetLevelColor(AlertData::Level level) {
+  switch (level) {
+    case AlertData::Level::HIGH:
+      return {0.9f, 0.25f, 0.25f, 1.0f};
+    case AlertData::Level::MEDIUM:
+      return {0.85f, 0.56f, 0.0f, 1.0f};
+    case AlertData::Level::LOW:
+      return ImGui::GetStyleColorVec4(ImGuiCol_Text);
   }
-  for (auto&& warning : warnings) {
-    ImGui::TextColored(WARNING_COLOR, "%s %s", ICON_FA_TRIANGLE_EXCLAMATION,
-                       warning.c_str());
+  return ImGui::GetStyleColorVec4(ImGuiCol_Text);
+}
+
+void DisplayAlertTable(const std::vector<const AlertData*>& alerts,
+                       size_t begin, size_t end, bool showId,
+                       bool showActiveStartTime) {
+  int columnCount = 1;
+  if (showId) {
+    ++columnCount;
   }
-  for (auto&& info : infos) {
-    ImGui::Text("%s %s", ICON_FA_CIRCLE_INFO, info.c_str());
+  if (showActiveStartTime) {
+    ++columnCount;
   }
+
+  if (ImGui::BeginTable("Alerts", columnCount,
+                        ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+                            ImGuiTableFlags_Resizable)) {
+    ImGui::TableSetupColumn("Text", ImGuiTableColumnFlags_WidthStretch);
+    if (showId) {
+      ImGui::TableSetupColumn("ID", ImGuiTableColumnFlags_WidthStretch);
+    }
+    if (showActiveStartTime) {
+      ImGui::TableSetupColumn("Started", ImGuiTableColumnFlags_WidthFixed);
+    }
+    ImGui::TableHeadersRow();
+
+    for (size_t i = begin; i < end; ++i) {
+      const AlertData* alert = alerts[i];
+      ImGui::TableNextRow();
+      ImGui::TableNextColumn();
+      ImGui::PushStyleColor(ImGuiCol_Text, GetLevelColor(alert->level));
+      float availableWidth = ImGui::GetContentRegionAvail().x;
+      ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + availableWidth);
+      ImGui::TextUnformatted(alert->text.c_str());
+      ImGui::PopTextWrapPos();
+      ImGui::PopStyleColor();
+      if (showId) {
+        ImGui::TableNextColumn();
+        ImGui::TextUnformatted(alert->id.c_str());
+      }
+      if (showActiveStartTime) {
+        ImGui::TableNextColumn();
+        if (alert->activeStartTime != 0) {
+          ImGui::Text("%.3f", TimestampToDisplayTime(alert->activeStartTime));
+        }
+      }
+    }
+    ImGui::EndTable();
+  }
+}
+
+}  // namespace
+
+AlertsView::AlertsView(AlertsModel* model, Storage& storage)
+    : m_model{model}, m_showIds{storage.GetBool("showIds", false)} {}
+
+void wpi::glass::DisplayAlerts(AlertsModel* model, bool showIds) {
+  const auto& alerts = model->GetAlerts();
+  if (alerts.empty()) {
+    ImGui::TextUnformatted("No active alerts");
+    return;
+  }
+
+  bool showGroup = false;
+  bool hasId = false;
+  bool showActiveStartTime = false;
+  std::vector<const AlertData*> sortedAlerts;
+  sortedAlerts.reserve(alerts.size());
+  for (auto&& alert : alerts) {
+    sortedAlerts.emplace_back(&alert);
+    showGroup = showGroup || !alert.group.empty();
+    hasId = hasId || !alert.id.empty();
+    showActiveStartTime = showActiveStartTime || alert.activeStartTime != 0;
+  }
+  bool showId = showIds && hasId;
+
+  std::stable_sort(sortedAlerts.begin(), sortedAlerts.end(),
+                   [](const AlertData* lhs, const AlertData* rhs) {
+                     int lhsLevel = GetLevelSortOrder(lhs->level);
+                     int rhsLevel = GetLevelSortOrder(rhs->level);
+                     if (lhsLevel != rhsLevel) {
+                       return lhsLevel < rhsLevel;
+                     }
+                     if (lhs->group.empty() != rhs->group.empty()) {
+                       return !lhs->group.empty();
+                     }
+                     if (lhs->group != rhs->group) {
+                       return lhs->group < rhs->group;
+                     }
+                     return lhs->activeStartTime > rhs->activeStartTime;
+                   });
+
+  size_t levelBegin = 0;
+  while (levelBegin < sortedAlerts.size()) {
+    AlertData::Level level = sortedAlerts[levelBegin]->level;
+    size_t levelEnd = levelBegin + 1;
+    while (levelEnd < sortedAlerts.size() &&
+           sortedAlerts[levelEnd]->level == level) {
+      ++levelEnd;
+    }
+
+    const char* levelLabel = "Unknown";
+    switch (level) {
+      case AlertData::Level::HIGH:
+        levelLabel = ICON_FA_CIRCLE_XMARK " High";
+        break;
+      case AlertData::Level::MEDIUM:
+        levelLabel = ICON_FA_TRIANGLE_EXCLAMATION " Medium";
+        break;
+      case AlertData::Level::LOW:
+        levelLabel = ICON_FA_CIRCLE_INFO " Low";
+        break;
+    }
+
+    ImGui::PushStyleColor(ImGuiCol_Text, GetLevelColor(level));
+    bool levelOpen = TreeNodeEx(levelLabel, ImGuiTreeNodeFlags_DefaultOpen);
+    ImGui::PopStyleColor();
+    ImGui::SameLine();
+    ImGui::TextDisabled("(%zu)", levelEnd - levelBegin);
+
+    if (levelOpen) {
+      if (showGroup) {
+        size_t groupBegin = levelBegin;
+        while (groupBegin < levelEnd) {
+          const char* groupName = sortedAlerts[groupBegin]->group.empty()
+                                      ? "Ungrouped"
+                                      : sortedAlerts[groupBegin]->group.c_str();
+          size_t groupEnd = groupBegin + 1;
+          while (groupEnd < levelEnd && sortedAlerts[groupEnd]->group ==
+                                            sortedAlerts[groupBegin]->group) {
+            ++groupEnd;
+          }
+
+          bool groupOpen =
+              TreeNodeEx(groupName, ImGuiTreeNodeFlags_DefaultOpen);
+          ImGui::SameLine();
+          ImGui::TextDisabled("(%zu)", groupEnd - groupBegin);
+          if (groupOpen) {
+            DisplayAlertTable(sortedAlerts, groupBegin, groupEnd, showId,
+                              showActiveStartTime);
+            TreePop();
+          }
+          groupBegin = groupEnd;
+        }
+      } else {
+        DisplayAlertTable(sortedAlerts, levelBegin, levelEnd, showId,
+                          showActiveStartTime);
+      }
+      TreePop();
+    }
+
+    levelBegin = levelEnd;
+  }
+}
+
+void AlertsView::Display() {
+  DisplayAlerts(m_model, m_showIds);
+}
+
+void AlertsView::Settings() {
+  ImGui::Checkbox("Show IDs", &m_showIds);
+}
+
+bool AlertsView::HasSettings() {
+  return true;
 }

--- a/glass/src/lib/native/include/wpi/glass/Window.hpp
+++ b/glass/src/lib/native/include/wpi/glass/Window.hpp
@@ -30,6 +30,9 @@ class Window {
 
   std::string_view GetId() const { return m_id; }
 
+  Storage& GetStorage() { return m_storage; }
+  const Storage& GetStorage() const { return m_storage; }
+
   bool HasView() { return static_cast<bool>(m_view); }
 
   void SetView(std::unique_ptr<View> view) { m_view = std::move(view); }
@@ -119,6 +122,7 @@ class Window {
   void ScaleDefault(float scale);
 
  private:
+  Storage& m_storage;
   std::string m_id;
   std::string& m_name;
   std::string m_defaultName;

--- a/glass/src/lib/native/include/wpi/glass/other/Alerts.hpp
+++ b/glass/src/lib/native/include/wpi/glass/other/Alerts.hpp
@@ -4,20 +4,94 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "wpi/glass/Model.hpp"
+#include "wpi/glass/View.hpp"
 
 namespace wpi::glass {
 
-class AlertsModel : public Model {
- public:
-  virtual const std::vector<std::string>& GetInfos() = 0;
-  virtual const std::vector<std::string>& GetWarnings() = 0;
-  virtual const std::vector<std::string>& GetErrors() = 0;
+class Storage;
+
+/** Display information for a single active alert. */
+struct AlertData {
+  /** Alert urgency level. */
+  enum class Level { HIGH, MEDIUM, LOW };
+
+  AlertData() = default;
+
+  /**
+   * Constructs alert display data.
+   *
+   * @param group Group identifier
+   * @param id Alert identifier
+   * @param text Alert text
+   * @param activeStartTime Time the alert became active, or 0 if unavailable
+   * @param level Alert urgency level
+   */
+  AlertData(std::string_view group, std::string_view id, std::string_view text,
+            int64_t activeStartTime, Level level)
+      : group{group},
+        id{id},
+        text{text},
+        activeStartTime{activeStartTime},
+        level{level} {}
+
+  /** Group identifier. */
+  std::string group;
+
+  /** Alert identifier. */
+  std::string id;
+
+  /** Alert text. */
+  std::string text;
+
+  /** Time the alert became active, or 0 if unavailable. */
+  int64_t activeStartTime = 0;
+
+  /** Alert urgency level. */
+  Level level = Level::LOW;
 };
 
-void DisplayAlerts(AlertsModel* model);
+class AlertsModel : public Model {
+ public:
+  /**
+   * Gets active alerts.
+   *
+   * @return active alerts
+   */
+  virtual const std::vector<AlertData>& GetAlerts() = 0;
+};
+
+/**
+ * Displays active alerts grouped by level and group.
+ *
+ * @param model alerts model
+ * @param showIds true to display non-empty alert IDs
+ */
+void DisplayAlerts(AlertsModel* model, bool showIds = true);
+
+class AlertsView : public View {
+ public:
+  /**
+   * Constructs an alerts view.
+   *
+   * @param model alerts model
+   * @param storage view storage
+   */
+  AlertsView(AlertsModel* model, Storage& storage);
+
+  void Display() override;
+  void Settings() override;
+  bool HasSettings() override;
+
+ private:
+  AlertsModel* m_model;
+  bool& m_showIds;
+};
 
 }  // namespace wpi::glass

--- a/glass/src/libnt/native/cpp/NTAlerts.cpp
+++ b/glass/src/libnt/native/cpp/NTAlerts.cpp
@@ -5,9 +5,22 @@
 #include "wpi/glass/networktables/NTAlerts.hpp"
 
 #include <format>
+#include <string>
 #include <utility>
+#include <vector>
 
 using namespace wpi::glass;
+
+namespace {
+
+void AddAlerts(std::vector<AlertData>* alerts,
+               const std::vector<std::string>& texts, AlertData::Level level) {
+  for (auto&& text : texts) {
+    alerts->emplace_back("", "", text, 0, level);
+  }
+}
+
+}  // namespace
 
 NTAlertsModel::NTAlertsModel(std::string_view path)
     : NTAlertsModel{wpi::nt::NetworkTableInstance::GetDefault(), path} {}
@@ -43,8 +56,15 @@ void NTAlertsModel::Update() {
   for (auto&& v : m_errors.ReadQueue()) {
     m_errorsValue = std::move(v.value);
   }
+
+  m_alerts.clear();
+  m_alerts.reserve(m_errorsValue.size() + m_warningsValue.size() +
+                   m_infosValue.size());
+  AddAlerts(&m_alerts, m_errorsValue, AlertData::Level::HIGH);
+  AddAlerts(&m_alerts, m_warningsValue, AlertData::Level::MEDIUM);
+  AddAlerts(&m_alerts, m_infosValue, AlertData::Level::LOW);
 }
 
 bool NTAlertsModel::Exists() {
-  return m_infos.Exists();
+  return m_infos.Exists() || m_warnings.Exists() || m_errors.Exists();
 }

--- a/glass/src/libnt/native/cpp/StandardNetworkTables.cpp
+++ b/glass/src/libnt/native/cpp/StandardNetworkTables.cpp
@@ -33,8 +33,8 @@ void wpi::glass::AddStandardNetworkTablesViews(
       },
       [](Window* win, Model* model, const char*) {
         win->SetDefaultSize(300, 150);
-        return MakeFunctionView(
-            [=] { DisplayAlerts(static_cast<NTAlertsModel*>(model)); });
+        return std::make_unique<AlertsView>(static_cast<NTAlertsModel*>(model),
+                                            win->GetStorage());
       });
   provider.Register(
       NTCommandSchedulerModel::TYPE,

--- a/glass/src/libnt/native/include/wpi/glass/networktables/NTAlerts.hpp
+++ b/glass/src/libnt/native/include/wpi/glass/networktables/NTAlerts.hpp
@@ -22,13 +22,7 @@ class NTAlertsModel : public AlertsModel {
   explicit NTAlertsModel(std::string_view path);
   NTAlertsModel(wpi::nt::NetworkTableInstance inst, std::string_view path);
 
-  const std::vector<std::string>& GetInfos() override { return m_infosValue; }
-
-  const std::vector<std::string>& GetWarnings() override {
-    return m_warningsValue;
-  }
-
-  const std::vector<std::string>& GetErrors() override { return m_errorsValue; }
+  const std::vector<AlertData>& GetAlerts() override { return m_alerts; }
 
   void Update() override;
   bool Exists() override;
@@ -43,6 +37,7 @@ class NTAlertsModel : public AlertsModel {
   std::vector<std::string> m_infosValue;
   std::vector<std::string> m_warningsValue;
   std::vector<std::string> m_errorsValue;
+  std::vector<AlertData> m_alerts;
 };
 
 }  // namespace wpi::glass

--- a/simulation/halsim_gui/src/main/native/cpp/AlertSimGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/AlertSimGui.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "AlertSimGui.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include "wpi/glass/Context.hpp"
+#include "wpi/glass/Storage.hpp"
+#include "wpi/glass/Window.hpp"
+#include "wpi/glass/other/Alerts.hpp"
+#include "wpi/gui/wpigui.hpp"
+#include "wpi/util/Alert.h"
+#include "wpi/util/string.hpp"
+
+using namespace halsimgui;
+
+namespace {
+
+class AlertSimModel : public wpi::glass::AlertsModel {
+ public:
+  const std::vector<wpi::glass::AlertData>& GetAlerts() override {
+    return m_alerts;
+  }
+
+  void Update() override;
+  bool Exists() override { return true; }
+
+ private:
+  static wpi::glass::AlertData::Level GetLevel(int32_t level);
+
+  std::vector<wpi::glass::AlertData> m_alerts;
+};
+
+std::unique_ptr<AlertSimModel> gAlertModel;
+std::unique_ptr<wpi::glass::Window> gAlertWindow;
+
+}  // namespace
+
+void AlertSimModel::Update() {
+  m_alerts.clear();
+
+  int32_t allocLen = WPI_GetNumAlerts();
+  if (allocLen <= 0) {
+    return;
+  }
+
+  std::vector<WPI_AlertInfo> alerts(allocLen);
+  int32_t len = WPI_GetAlerts(alerts.data(), allocLen);
+  if (len <= 0) {
+    return;
+  }
+
+  int32_t count = std::min(len, allocLen);
+  m_alerts.reserve(count);
+  for (int32_t i = 0; i < count; ++i) {
+    const auto& alert = alerts[i];
+    if (alert.activeStartTime != 0) {
+      m_alerts.emplace_back(wpi::util::to_string_view(&alert.group),
+                            wpi::util::to_string_view(&alert.id),
+                            wpi::util::to_string_view(&alert.text),
+                            alert.activeStartTime, GetLevel(alert.level));
+    }
+  }
+
+  WPI_FreeAlerts(alerts.data(), count);
+}
+
+wpi::glass::AlertData::Level AlertSimModel::GetLevel(int32_t level) {
+  switch (level) {
+    case WPI_ALERT_HIGH:
+      return wpi::glass::AlertData::Level::HIGH;
+    case WPI_ALERT_MEDIUM:
+      return wpi::glass::AlertData::Level::MEDIUM;
+    case WPI_ALERT_LOW:
+      return wpi::glass::AlertData::Level::LOW;
+    default:
+      return wpi::glass::AlertData::Level::LOW;
+  }
+}
+
+void AlertSimGui::Initialize() {
+  gAlertModel = std::make_unique<AlertSimModel>();
+  wpi::gui::AddEarlyExecute([] { gAlertModel->Update(); });
+
+  gAlertWindow = std::make_unique<wpi::glass::Window>(
+      wpi::glass::GetStorageRoot().GetChild("Alerts"), "Alerts",
+      wpi::glass::Window::HIDE);
+  gAlertWindow->SetView(std::make_unique<wpi::glass::AlertsView>(
+      gAlertModel.get(), gAlertWindow->GetStorage()));
+  gAlertWindow->SetDefaultPos(250, 130);
+  gAlertWindow->SetDefaultSize(400, 150);
+  gAlertWindow->DisableRenamePopup();
+  wpi::gui::AddLateExecute([] { gAlertWindow->Display(); });
+
+  wpi::gui::AddWindowScaler(
+      [](float scale) { gAlertWindow->ScaleDefault(scale); });
+}
+
+void AlertSimGui::DisplayMenu() {
+  if (gAlertWindow) {
+    gAlertWindow->DisplayMenuItem();
+  }
+}

--- a/simulation/halsim_gui/src/main/native/cpp/AlertSimGui.hpp
+++ b/simulation/halsim_gui/src/main/native/cpp/AlertSimGui.hpp
@@ -1,0 +1,15 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+namespace halsimgui {
+
+class AlertSimGui {
+ public:
+  static void Initialize();
+  static void DisplayMenu();
+};
+
+}  // namespace halsimgui

--- a/simulation/halsim_gui/src/main/native/cpp/main.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/main.cpp
@@ -11,6 +11,7 @@
 #include <imgui.h>
 
 #include "AddressableLEDGui.hpp"
+#include "AlertSimGui.hpp"
 #include "AnalogInputSimGui.hpp"
 #include "DIOSimGui.hpp"
 #include "DriverStationGui.hpp"
@@ -115,6 +116,7 @@ int HALSIM_InitExtension(void) {
 
   AddressableLEDGui::Initialize();
   AnalogInputSimGui::Initialize();
+  AlertSimGui::Initialize();
   DIOSimGui::Initialize();
   NetworkTablesSimGui::Initialize();
   PCMSimGui::Initialize();
@@ -174,6 +176,7 @@ int HALSIM_InitExtension(void) {
     }
     if (ImGui::BeginMenu("DS")) {
       DriverStationGui::dsManager->DisplayMenu();
+      AlertSimGui::DisplayMenu();
       ImGui::EndMenu();
     }
     if (ImGui::BeginMenu("Plot")) {


### PR DESCRIPTION
This adds a dedicated display for alerts in a tree style view.  ID is optionally shown.

<img width="1149" height="375" alt="image" src="https://github.com/user-attachments/assets/ea8954f1-1dc9-4329-b929-0a84586c6226" />

It retains backwards compatibility with the old NT alerts format--we'll need to update this once we implement NT/datalog support for the new alerts.