### PR TITLE
[wpilibc] Add Unbind to EventLoop

### DIFF
--- a/wpilibc/src/main/native/cpp/event/EventLoop.cpp
+++ b/wpilibc/src/main/native/cpp/event/EventLoop.cpp
@@ -20,25 +20,28 @@ struct RunningSetter {
 };
 }  // namespace
 
+size_t EventLoop::nextId = 1; // Skip id 0 in case it is needed for null later
+
 EventLoop::EventLoop() {}
 
-wpi::util::unique_function<void()>& EventLoop::Bind(
+size_t EventLoop::Bind(
     wpi::util::unique_function<void()>&& action) {
   if (m_running) {
     throw WPILIB_MakeError(err::Error,
                            "Cannot bind EventLoop while it is running");
   }
-  return m_bindings.emplace_back(std::move(action));
+  return m_bindings.emplace_back(nextId++, std::move(action)).id;
 }
 
-void EventLoop::Unbind(wpi::util::unique_function<void()>& action) {
+void EventLoop::Unbind(size_t actionId) {
   if (m_running) {
     throw WPILIB_MakeError(err::Error,
                            "Cannot unbind EventLoop while it is running");
   }
   for (auto iter = m_bindings.begin(); iter != m_bindings.end(); iter++) {
-    if (&*iter == &action) {
-      m_bindings.erase(iter);
+    if (iter->id == actionId) {
+      std::swap(*iter, m_bindings.back());
+      m_bindings.pop_back();
       break;
     }
   }
@@ -46,8 +49,8 @@ void EventLoop::Unbind(wpi::util::unique_function<void()>& action) {
 
 void EventLoop::Poll() {
   RunningSetter runSetter{m_running};
-  for (wpi::util::unique_function<void()>& action : m_bindings) {
-    action();
+  for (Binding& action : m_bindings) {
+    action.handler();
   }
 }
 

--- a/wpilibc/src/main/native/cpp/event/EventLoop.cpp
+++ b/wpilibc/src/main/native/cpp/event/EventLoop.cpp
@@ -20,8 +20,6 @@ struct RunningSetter {
 };
 }  // namespace
 
-size_t EventLoop::nextId = 1; // Skip id 0 in case it is needed for null later
-
 EventLoop::EventLoop() {}
 
 size_t EventLoop::Bind(

--- a/wpilibc/src/main/native/cpp/event/EventLoop.cpp
+++ b/wpilibc/src/main/native/cpp/event/EventLoop.cpp
@@ -22,12 +22,26 @@ struct RunningSetter {
 
 EventLoop::EventLoop() {}
 
-void EventLoop::Bind(wpi::util::unique_function<void()> action) {
+wpi::util::unique_function<void()>& EventLoop::Bind(
+    wpi::util::unique_function<void()>&& action) {
   if (m_running) {
     throw WPILIB_MakeError(err::Error,
                            "Cannot bind EventLoop while it is running");
   }
-  m_bindings.emplace_back(std::move(action));
+  return m_bindings.emplace_back(std::move(action));
+}
+
+void EventLoop::Unbind(wpi::util::unique_function<void()>& action) {
+  if (m_running) {
+    throw WPILIB_MakeError(err::Error,
+                           "Cannot unbind EventLoop while it is running");
+  }
+  for (auto iter = m_bindings.begin(); iter != m_bindings.end(); iter++) {
+    if (&*iter == &action) {
+      m_bindings.erase(iter);
+      break;
+    }
+  }
 }
 
 void EventLoop::Poll() {

--- a/wpilibc/src/main/native/cpp/event/EventLoop.cpp
+++ b/wpilibc/src/main/native/cpp/event/EventLoop.cpp
@@ -22,8 +22,7 @@ struct RunningSetter {
 
 EventLoop::EventLoop() {}
 
-size_t EventLoop::Bind(
-    wpi::util::unique_function<void()>&& action) {
+size_t EventLoop::Bind(wpi::util::unique_function<void()>&& action) {
   if (m_running) {
     throw WPILIB_MakeError(err::Error,
                            "Cannot bind EventLoop while it is running");

--- a/wpilibc/src/main/native/include/wpi/event/EventLoop.hpp
+++ b/wpilibc/src/main/native/include/wpi/event/EventLoop.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <functional>
-#include <vector>
+#include <list>
 
 #include "wpi/util/FunctionExtras.hpp"
 
@@ -23,8 +23,19 @@ class EventLoop {
    * Bind a new action to run when the loop is polled.
    *
    * @param action the action to run.
+   * @returns A reference to the bound action, so that it may be later unbound.
    */
-  void Bind(wpi::util::unique_function<void()> action);
+  wpi::util::unique_function<void()>& Bind(
+      wpi::util::unique_function<void()>&& action);
+
+  /**
+   * Unbinds an action so that is no longer ran when the loop is polled.
+   * This must be provided the same reference that was returned from `Bind`.
+   * The reference will no longer be valid after this is called.
+   *
+   * @param action the action to unbind.
+   */
+  void Unbind(wpi::util::unique_function<void()>& action);
 
   /**
    * Poll all bindings.
@@ -37,7 +48,7 @@ class EventLoop {
   void Clear();
 
  private:
-  std::vector<wpi::util::unique_function<void()>> m_bindings;
+  std::list<wpi::util::unique_function<void()>> m_bindings;
   bool m_running{false};
 };
 }  // namespace wpi

--- a/wpilibc/src/main/native/include/wpi/event/EventLoop.hpp
+++ b/wpilibc/src/main/native/include/wpi/event/EventLoop.hpp
@@ -23,16 +23,16 @@ class EventLoop {
    * Bind a new action to run when the loop is polled.
    *
    * @param action the action to run.
-   * @returns An id for the bound action, so that it may be later unbound.
+   * @returns An id for the bound action, so that it may be later unbound. Only
+   * valid within this event loop.
    */
   size_t Bind(wpi::util::unique_function<void()>&& action);
 
   /**
    * Unbinds an action so that is no longer ran when the loop is polled.
-   * This must be provided the same reference that was returned from `Bind`.
-   * The reference will no longer be valid after this is called.
+   * This must be provided the same id that was returned from `Bind`.
    *
-   * @param action the action to unbind.
+   * @param actionId the id of the action to unbind.
    */
   void Unbind(size_t actionId);
 

--- a/wpilibc/src/main/native/include/wpi/event/EventLoop.hpp
+++ b/wpilibc/src/main/native/include/wpi/event/EventLoop.hpp
@@ -30,7 +30,7 @@ class EventLoop {
 
   /**
    * Unbinds an action so that is no longer ran when the loop is polled.
-   * This must be provided the same id that was returned from `Bind`.
+   * This may change the call order of the remaining events.
    *
    * @param actionId the id of the action to unbind.
    */

--- a/wpilibc/src/main/native/include/wpi/event/EventLoop.hpp
+++ b/wpilibc/src/main/native/include/wpi/event/EventLoop.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <functional>
-#include <list>
+#include <vector>
 
 #include "wpi/util/FunctionExtras.hpp"
 
@@ -23,9 +23,9 @@ class EventLoop {
    * Bind a new action to run when the loop is polled.
    *
    * @param action the action to run.
-   * @returns A reference to the bound action, so that it may be later unbound.
+   * @returns An id for the bound action, so that it may be later unbound.
    */
-  wpi::util::unique_function<void()>& Bind(
+  size_t Bind(
       wpi::util::unique_function<void()>&& action);
 
   /**
@@ -35,7 +35,7 @@ class EventLoop {
    *
    * @param action the action to unbind.
    */
-  void Unbind(wpi::util::unique_function<void()>& action);
+  void Unbind(size_t actionId);
 
   /**
    * Poll all bindings.
@@ -48,7 +48,13 @@ class EventLoop {
   void Clear();
 
  private:
-  std::list<wpi::util::unique_function<void()>> m_bindings;
+  static size_t nextId;
+  struct Binding {
+    size_t id;
+    wpi::util::unique_function<void()> handler;
+  };
+
+  std::vector<Binding> m_bindings;
   bool m_running{false};
 };
 }  // namespace wpi

--- a/wpilibc/src/main/native/include/wpi/event/EventLoop.hpp
+++ b/wpilibc/src/main/native/include/wpi/event/EventLoop.hpp
@@ -25,8 +25,7 @@ class EventLoop {
    * @param action the action to run.
    * @returns An id for the bound action, so that it may be later unbound.
    */
-  size_t Bind(
-      wpi::util::unique_function<void()>&& action);
+  size_t Bind(wpi::util::unique_function<void()>&& action);
 
   /**
    * Unbinds an action so that is no longer ran when the loop is polled.
@@ -48,7 +47,7 @@ class EventLoop {
   void Clear();
 
  private:
-  static size_t nextId;
+  size_t nextId = 1;  // Skip id 0 in case it is needed for null later
   struct Binding {
     size_t id;
     wpi::util::unique_function<void()> handler;

--- a/wpilibc/src/main/python/semiwrap/EventLoop.yml
+++ b/wpilibc/src/main/python/semiwrap/EventLoop.yml
@@ -7,9 +7,8 @@ classes:
       Bind:
         cpp_code: |
           [](EventLoop *self, std::function<void()> action) {
-            self->Bind(std::move(action));
+            return self->Bind(std::move(action));
           }
       Unbind:
-        ignore: true # Handling references from Python still needs to be figured out
       Poll:
       Clear:

--- a/wpilibc/src/main/python/semiwrap/EventLoop.yml
+++ b/wpilibc/src/main/python/semiwrap/EventLoop.yml
@@ -9,5 +9,7 @@ classes:
           [](EventLoop *self, std::function<void()> action) {
             self->Bind(std::move(action));
           }
+      Unbind:
+        ignore: true # Handling references from Python still needs to be figured out
       Poll:
       Clear:

--- a/wpilibc/src/test/native/cpp/event/EventLoopTest.cpp
+++ b/wpilibc/src/test/native/cpp/event/EventLoopTest.cpp
@@ -11,11 +11,40 @@
 
 using namespace wpi;
 
+TEST_CASE("EventLoopTest BindUnbind", "[wpilibc][event]") {
+  EventLoop loop;
+  int pollCount = 0;
+
+  auto& task = loop.Bind([&pollCount] { pollCount++; });
+
+  loop.Poll();
+
+  REQUIRE(pollCount == 1);
+
+  loop.Poll();
+
+  REQUIRE(pollCount == 2);
+
+  loop.Unbind(task);
+
+  loop.Poll();
+
+  REQUIRE(pollCount == 2);
+}
+
 TEST_CASE("EventLoopTest ConcurrentModification", "[wpilibc][event]") {
   EventLoop loop;
 
   loop.Bind(
       [&loop] { REQUIRE_THROWS_AS(loop.Bind([] {}), wpi::RuntimeError); });
+
+  loop.Poll();
+
+  loop.Clear();
+
+  util::unique_function<void()>* task = &loop.Bind([&loop, &task] {
+    REQUIRE_THROWS_AS(loop.Unbind(*task), wpi::RuntimeError);
+  });
 
   loop.Poll();
 

--- a/wpilibc/src/test/native/cpp/event/EventLoopTest.cpp
+++ b/wpilibc/src/test/native/cpp/event/EventLoopTest.cpp
@@ -16,10 +16,7 @@ TEST_CASE("EventLoopTest BindUnbind", "[wpilibc][event]") {
   int pollCount = 0;
 
   auto& task = loop.Bind([&pollCount] { pollCount++; });
-
-  loop.Poll();
-
-  REQUIRE(pollCount == 1);
+  auto& task2 = loop.Bind([&pollCount] { pollCount++; });
 
   loop.Poll();
 
@@ -29,7 +26,13 @@ TEST_CASE("EventLoopTest BindUnbind", "[wpilibc][event]") {
 
   loop.Poll();
 
-  REQUIRE(pollCount == 2);
+  REQUIRE(pollCount == 3);
+
+  loop.Unbind(task2);
+
+  loop.Poll();
+
+  REQUIRE(pollCount == 3);
 }
 
 TEST_CASE("EventLoopTest ConcurrentModification", "[wpilibc][event]") {

--- a/wpilibc/src/test/native/cpp/event/EventLoopTest.cpp
+++ b/wpilibc/src/test/native/cpp/event/EventLoopTest.cpp
@@ -15,8 +15,8 @@ TEST_CASE("EventLoopTest BindUnbind", "[wpilibc][event]") {
   EventLoop loop;
   int pollCount = 0;
 
-  auto& task = loop.Bind([&pollCount] { pollCount++; });
-  auto& task2 = loop.Bind([&pollCount] { pollCount++; });
+  size_t task = loop.Bind([&pollCount] { pollCount++; });
+  size_t task2 = loop.Bind([&pollCount] { pollCount++; });
 
   loop.Poll();
 
@@ -45,8 +45,8 @@ TEST_CASE("EventLoopTest ConcurrentModification", "[wpilibc][event]") {
 
   loop.Clear();
 
-  util::unique_function<void()>* task = &loop.Bind([&loop, &task] {
-    REQUIRE_THROWS_AS(loop.Unbind(*task), wpi::RuntimeError);
+  size_t task = loop.Bind([&loop, &task] {
+    REQUIRE_THROWS_AS(loop.Unbind(task), wpi::RuntimeError);
   });
 
   loop.Poll();

--- a/wpilibc/src/test/python/event/test_event_loop.py
+++ b/wpilibc/src/test/python/event/test_event_loop.py
@@ -3,6 +3,31 @@ import pytest
 from wpilib import EventLoop
 
 
+def test_bind_unbind():
+    loop = EventLoop()
+
+    pollCount = 0
+    def count_poll():
+        nonlocal pollCount
+        pollCount += 1
+
+    task1 = loop.bind(count_poll)
+    task2 = loop.bind(count_poll)
+    loop.poll()
+
+    assert pollCount == 2
+
+    loop.unbind(task1)
+    loop.poll()
+
+    assert pollCount == 3
+
+    loop.unbind(task2)
+
+    loop.poll()
+
+    assert pollCount == 3
+
 def test_concurrent_modification():
     loop = EventLoop()
 
@@ -11,6 +36,17 @@ def test_concurrent_modification():
             loop.bind(lambda: None)
 
     loop.bind(bind_during_poll)
+    loop.poll()
+
+    loop.clear()
+
+    taskId = None
+
+    def unbind_during_poll():
+        with pytest.raises(RuntimeError):
+            loop.unbind(taskId)
+
+    taskId = loop.bind(unbind_during_poll)
     loop.poll()
 
     loop.clear()

--- a/wpilibc/src/test/python/event/test_event_loop.py
+++ b/wpilibc/src/test/python/event/test_event_loop.py
@@ -7,6 +7,7 @@ def test_bind_unbind():
     loop = EventLoop()
 
     pollCount = 0
+
     def count_poll():
         nonlocal pollCount
         pollCount += 1
@@ -27,6 +28,7 @@ def test_bind_unbind():
     loop.poll()
 
     assert pollCount == 3
+
 
 def test_concurrent_modification():
     loop = EventLoop()


### PR DESCRIPTION
This adds the capability to remove bindings from wpilibc's `EventLoop` to mirror the Java changes in #8366 in preparation for C++ cmdv3. Bindings are given an id unique within each `EventLoop` that can be used to later remove the binding. Removal does not preserve the order of bindings to minimize data copying.