### PR TITLE
[wpilibj] Fix Java exports warnings

### DIFF
--- a/wpilibj/src/main/java/org/wpilib/simulation/CallbackStore.java
+++ b/wpilibj/src/main/java/org/wpilib/simulation/CallbackStore.java
@@ -8,26 +8,26 @@ package org.wpilib.simulation;
 public class CallbackStore implements AutoCloseable {
   /** <b>Note: This interface is for simulation classes only. It should not be used by teams!</b> */
   @SuppressWarnings("PMD.ImplicitFunctionalInterface")
-  interface CancelCallbackFunc {
+  protected interface CancelCallbackFunc {
     void cancel(int index, int uid);
   }
 
   /** <b>Note: This interface is for simulation classes only. It should not be used by teams!</b> */
   @SuppressWarnings("PMD.ImplicitFunctionalInterface")
-  interface CancelCallbackChannelFunc {
+  protected interface CancelCallbackChannelFunc {
     void cancel(int index, int channel, int uid);
   }
 
   /** <b>Note: This interface is for simulation classes only. It should not be used by teams!</b> */
   @SuppressWarnings("PMD.ImplicitFunctionalInterface")
-  interface CancelCallbackNoIndexFunc {
+  protected interface CancelCallbackNoIndexFunc {
     void cancel(int uid);
   }
 
   /**
    * Constructs an empty CallbackStore. This constructor is to allow 3rd party sim providers (eg
-   * vendors) to subclass this class (without needing provide dummy constructing parameters) so that
-   * the register methods of their sim classes can return CallbackStores like the builtin sims.
+   * vendors) to subclass this class (without needing to provide dummy constructing parameters) so
+   * that the register methods of their sim classes can return CallbackStores like the builtin sims.
    * <b>Note: It should not be called by teams that are just using sims!</b>
    */
   protected CallbackStore() {
@@ -45,7 +45,7 @@ public class CallbackStore implements AutoCloseable {
    * @param uid TODO
    * @param ccf TODO
    */
-  public CallbackStore(int index, int uid, CancelCallbackFunc ccf) {
+  protected CallbackStore(int index, int uid, CancelCallbackFunc ccf) {
     this.m_cancelType = NORMAL_CANCEL;
     this.m_index = index;
     this.m_uid = uid;
@@ -60,7 +60,7 @@ public class CallbackStore implements AutoCloseable {
    * @param uid TODO
    * @param ccf TODO
    */
-  public CallbackStore(int index, int channel, int uid, CancelCallbackChannelFunc ccf) {
+  protected CallbackStore(int index, int channel, int uid, CancelCallbackChannelFunc ccf) {
     this.m_cancelType = CHANNEL_CANCEL;
     this.m_index = index;
     this.m_uid = uid;
@@ -74,7 +74,7 @@ public class CallbackStore implements AutoCloseable {
    * @param uid TODO
    * @param ccf TODO
    */
-  public CallbackStore(int uid, CancelCallbackNoIndexFunc ccf) {
+  protected CallbackStore(int uid, CancelCallbackNoIndexFunc ccf) {
     this.m_cancelType = NO_INDEX_CANCEL;
     this.m_uid = uid;
     this.m_cancelCallbackNoIndex = ccf;

--- a/wpilibj/src/main/java/org/wpilib/simulation/CallbackStore.java
+++ b/wpilibj/src/main/java/org/wpilib/simulation/CallbackStore.java
@@ -9,18 +9,36 @@ public class CallbackStore implements AutoCloseable {
   /** <b>Note: This interface is for simulation classes only. It should not be used by teams!</b> */
   @SuppressWarnings("PMD.ImplicitFunctionalInterface")
   protected interface CancelCallbackFunc {
+    /**
+     * Cancels a callback using the provided index and unique identifier.
+     *
+     * @param index The index of the resource associated with the callback.
+     * @param uid The unique identifier of the callback to cancel.
+     */
     void cancel(int index, int uid);
   }
 
   /** <b>Note: This interface is for simulation classes only. It should not be used by teams!</b> */
   @SuppressWarnings("PMD.ImplicitFunctionalInterface")
   protected interface CancelCallbackChannelFunc {
+    /**
+     * Cancels a registered callback identified by the provided parameters.
+     *
+     * @param index the index of the digital I/O channel
+     * @param channel the specific channel associated with the callback
+     * @param uid the unique identifier for the callback to cancel
+     */
     void cancel(int index, int channel, int uid);
   }
 
   /** <b>Note: This interface is for simulation classes only. It should not be used by teams!</b> */
   @SuppressWarnings("PMD.ImplicitFunctionalInterface")
   protected interface CancelCallbackNoIndexFunc {
+    /**
+     * Cancels the callback associated with the given unique identifier.
+     *
+     * @param uid the unique identifier for the callback to be canceled
+     */
     void cancel(int uid);
   }
 

--- a/wpilibj/src/main/java/org/wpilib/simulation/DifferentialDrivetrainSim.java
+++ b/wpilibj/src/main/java/org/wpilib/simulation/DifferentialDrivetrainSim.java
@@ -354,7 +354,7 @@ public class DifferentialDrivetrainSim {
   }
 
   /** Represents the different states of the drivetrain. */
-  enum State {
+  public enum State {
     X(0),
     Y(1),
     HEADING(2),

--- a/wpilibj/src/main/java/org/wpilib/simulation/DifferentialDrivetrainSim.java
+++ b/wpilibj/src/main/java/org/wpilib/simulation/DifferentialDrivetrainSim.java
@@ -355,14 +355,22 @@ public class DifferentialDrivetrainSim {
 
   /** Represents the different states of the drivetrain. */
   public enum State {
+    /** The X position state. */
     X(0),
+    /** The Y position state. */
     Y(1),
+    /** The heading state. */
     HEADING(2),
+    /** The left-side velocity state. */
     LEFT_VELOCITY(3),
+    /** The right-side velocity state. */
     RIGHT_VELOCITY(4),
+    /** The left-side position state. */
     LEFT_POSITION(5),
+    /** The right-side position state. */
     RIGHT_POSITION(6);
 
+    /** The row in the state vector the state corresponds to. */
     public final int value;
 
     State(int i) {


### PR DESCRIPTION
- Make `CallbackStore` constructors and interfaces protected instead of package-private
- Make `DifferentialDrivetraimSim.State` public

Closes #9350