### PR TITLE
[build] Disable missing-explicit-ctor lint

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -32,6 +32,8 @@ java_package_configuration(
         "-Xlint:-serial",
         # ignore unclaimed annotation warning from annotation processing
         "-Xlint:-processing",
+        # ignore warnings for classes missing explicit constructors
+        "-Xlint:-missing-explicit-ctor",
     ],
     # Apply our flags to just our repository. Otherwise, Bazel will compile its
     # tools with our flags, and not all of them are warning-free.

--- a/build.gradle
+++ b/build.gradle
@@ -197,6 +197,8 @@ subprojects {
             "-Xlint:-serial",
             // ignore unclaimed annotation warning from annotation processing
             "-Xlint:-processing",
+            // ignore warnings for classes missing explicit constructors
+            "-Xlint:-missing-explicit-ctor",
         ]
     }
     // Enables UTF-8 support in Javadoc, disables 4 MB of fonts being added to every Javadoc JAR, add our styles


### PR DESCRIPTION
Allows classes to not have explicit constructors

Closes #9349