### PR TITLE
[bazel] Use --force_pic

### DIFF
--- a/shared/bazel/compiler_flags/linux_flags.rc
+++ b/shared/bazel/compiler_flags/linux_flags.rc
@@ -7,10 +7,10 @@
 common:linux --repo_env=BAZEL_COPTS="-Wall:-Wextra:-Werror:-gz=zlib"
 
 # C++ only
-common:linux --repo_env=BAZEL_CXXOPTS="-std=c++23:-Wformat=2:-pedantic:-Wno-psabi:-Wno-unused-parameter:-fPIC:-pthread:-Wno-deprecated-enum-enum-conversion:-Wno-array-bounds"
+common:linux --repo_env=BAZEL_CXXOPTS="-std=c++23:-Wformat=2:-pedantic:-Wno-psabi:-Wno-unused-parameter:-pthread:-Wno-deprecated-enum-enum-conversion:-Wno-array-bounds"
 
 # C Only
-common:linux --repo_env=BAZEL_CONLYOPTS="-Wformat=2:-pedantic:-Wno-psabi:-Wno-unused-parameter:-fPIC:-pthread"
+common:linux --repo_env=BAZEL_CONLYOPTS="-Wformat=2:-pedantic:-Wno-psabi:-Wno-unused-parameter:-pthread"
 
 # Linker
 common:linux --repo_env=BAZEL_LINKOPTS="-rdynamic:-pthread:-ldl:-latomic:-Wl,-rpath,'$ORIGIN':-gz=zlib"
@@ -32,6 +32,7 @@ build:linux --host_per_file_copt=external/zlib/.*\.c@-Wno-deprecated-non-prototy
 build:linux --host_per_file_copt=external/.*@-Wno-pedantic,-Wno-implicit-fallthrough,-Wno-format-nonliteral,-Wno-sign-compare,-Wno-sign-compare,-Wno-type-limits,-Wno-maybe-uninitialized,-Wno-missing-field-initializers,-Wno-trigraphs,-Wno-attributes,-Wno-return-type,-Wno-unused-function,-Wno-format-y2k,-Wno-deprecated-declarations
 build:linux --host_per_file_copt=external/.*\.cpp$,external/.*\.cc$@-Wno-missing-requires,-Wno-volatile,-Wno-redundant-move,-Wno-class-memaccess,-Wno-ignored-qualifiers,-Wno-stringop-overflow,-Wno-extra
 
+build:linux --force_pic
 # Set soname. Needed for robotpy
 build:linux --features=set_soname
 build:linux --host_features=set_soname

--- a/shared/bazel/compiler_flags/osx_flags.rc
+++ b/shared/bazel/compiler_flags/osx_flags.rc
@@ -2,10 +2,10 @@ common:macos --repo_env=BAZEL_COPTS="-Wall:-Wextra:-Werror:-Wno-shorten-64-to-32
 common:macos --host_per_file_copt=external/.*@-Wno-deprecated-non-prototype,-Wno-unused-function,-Wno-sign-compare
 
 # C++ only
-common:macos --repo_env=BAZEL_CXXOPTS="-std=c++23:-pedantic:-fPIC:-Wno-unused-parameter:-Wno-error=deprecated-enum-enum-conversion:-Wno-missing-field-initializers:-Wno-unused-private-field:-Wno-unused-const-variable:-Wno-error=c11-extensions:-pthread:-Wno-deprecated-anon-enum-enum-conversion"
+common:macos --repo_env=BAZEL_CXXOPTS="-std=c++23:-pedantic:-Wno-unused-parameter:-Wno-error=deprecated-enum-enum-conversion:-Wno-missing-field-initializers:-Wno-unused-private-field:-Wno-unused-const-variable:-Wno-error=c11-extensions:-pthread:-Wno-deprecated-anon-enum-enum-conversion"
 
 # C only
-common:macos --repo_env=BAZEL_CONLYOPTS="-pedantic:-fPIC:-Wno-unknown-warning-option:-Wno-unused-parameter:-Wno-missing-field-initializers:-Wno-unused-private-field:-Wno-fixed-enum-extension"
+common:macos --repo_env=BAZEL_CONLYOPTS="-pedantic:-Wno-unknown-warning-option:-Wno-unused-parameter:-Wno-missing-field-initializers:-Wno-unused-private-field:-Wno-fixed-enum-extension"
 
 common:macos --repo_env=BAZEL_LINKOPTS="-Wl,-rpath,'@loader_path'"
 
@@ -14,3 +14,5 @@ common:macos --per_file_copt=external/.*@-Wno-pedantic,-Wno-deprecated-declarati
 
 common:macos --host_per_file_copt=external/.*\.c$@-Wno-c11-extensions
 common:macos --per_file_copt=external/.*\.c$@-Wno-c11-extensions
+
+common:macos --force_pic


### PR DESCRIPTION
This prevents double compilation of source files into PIC and non-PIC objects.