### PR TITLE
[commandsv3] Performance improvement for schedule()

### DIFF
--- a/benchmark/src/main/java/wpilib/robot/Main.java
+++ b/benchmark/src/main/java/wpilib/robot/Main.java
@@ -47,14 +47,14 @@ public class Main {
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public void justNewThrowable() {
-    StackTraceGatheringBenchmark.a(false);
+    StackTraceGatheringBenchmark.run(false);
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public void newThrowableGetStackTrace() {
-    StackTraceGatheringBenchmark.a(true);
+    StackTraceGatheringBenchmark.run(true);
   }
 
   @Benchmark

--- a/benchmark/src/main/java/wpilib/robot/Main.java
+++ b/benchmark/src/main/java/wpilib/robot/Main.java
@@ -45,6 +45,20 @@ public class Main {
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void justNewThrowable() {
+    StackTraceGatheringBenchmark.a(false);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void newThrowableGetStackTrace() {
+    StackTraceGatheringBenchmark.a(true);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
   public void cartPole() {
     CartPoleBenchmark.cartPole();

--- a/benchmark/src/main/java/wpilib/robot/StackTraceGatheringBenchmark.java
+++ b/benchmark/src/main/java/wpilib/robot/StackTraceGatheringBenchmark.java
@@ -1,0 +1,24 @@
+package wpilib.robot;
+
+public class StackTraceGatheringBenchmark {
+    public static void a(boolean getStackTrace) {
+        b(getStackTrace);
+    }
+
+    static void b(boolean getStackTrace) {
+        c(getStackTrace);
+    }
+
+    static void c(boolean getStackTrace) {
+        d(getStackTrace);
+    }
+
+    static void d(boolean getStackTrace) {
+        e(getStackTrace);
+    }
+
+    static void e(boolean getStackTrace) {
+        var throwable = new Throwable();
+        if (getStackTrace) throwable.getStackTrace();
+    }
+}

--- a/benchmark/src/main/java/wpilib/robot/StackTraceGatheringBenchmark.java
+++ b/benchmark/src/main/java/wpilib/robot/StackTraceGatheringBenchmark.java
@@ -1,24 +1,36 @@
 package wpilib.robot;
 
-public class StackTraceGatheringBenchmark {
-    public static void a(boolean getStackTrace) {
-        b(getStackTrace);
-    }
+/**
+ * A benchmark for measuring runtime of `new Throwable()` and `new Throwable().getStackTrace()`. The
+ * long line of nested methods is intended to replicate calling `Scheduler.getDefault().schedule()`
+ * in actual robot code (where the callsite is likely to be highly nested).
+ */
+public final class StackTraceGatheringBenchmark {
+  public static void run(boolean getStackTrace) {
+    method1(getStackTrace);
+  }
 
-    static void b(boolean getStackTrace) {
-        c(getStackTrace);
-    }
+  private static void method1(boolean getStackTrace) {
+    method2(getStackTrace);
+  }
 
-    static void c(boolean getStackTrace) {
-        d(getStackTrace);
-    }
+  private static void method2(boolean getStackTrace) {
+    method3(getStackTrace);
+  }
 
-    static void d(boolean getStackTrace) {
-        e(getStackTrace);
-    }
+  private static void method3(boolean getStackTrace) {
+    method4(getStackTrace);
+  }
 
-    static void e(boolean getStackTrace) {
-        var throwable = new Throwable();
-        if (getStackTrace) throwable.getStackTrace();
+  @SuppressWarnings("PMD.UselessPureMethodCall")
+  private static void method4(boolean getStackTrace) {
+    var throwable = new Throwable();
+    if (getStackTrace) {
+      throwable.getStackTrace();
     }
+  }
+
+  private StackTraceGatheringBenchmark() {
+    throw new UnsupportedOperationException("This is a utility class.");
+  }
 }

--- a/benchmark/src/main/java/wpilib/robot/StackTraceGatheringBenchmark.java
+++ b/benchmark/src/main/java/wpilib/robot/StackTraceGatheringBenchmark.java
@@ -1,3 +1,7 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package wpilib.robot;
 
 /**

--- a/commandsv3/src/main/java/org/wpilib/command3/Binding.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Binding.java
@@ -12,15 +12,16 @@ import org.wpilib.util.ErrorMessages;
  * @param scope The scope in which the binding is active.
  * @param type The type of binding; or, when the bound command should run
  * @param command The bound command. Cannot be null.
- * @param frames The stack frames when the binding was created. Used for telemetry and error
- *     reporting so if a command throws an exception, we can tell users where that command was bound
- *     instead of giving a fairly useless backtrace of the command framework.
+ * @param stackTraceStore A {@link Throwable} storing stack frames when the binding was created.
+ *     Used for telemetry and error reporting so if a command throws an exception, we can tell users
+ *     where that command was bound instead of giving a fairly useless backtrace of the command
+ *     framework.
  */
-record Binding(BindingScope scope, BindingType type, Command command, StackTraceElement[] frames) {
+record Binding(BindingScope scope, BindingType type, Command command, Throwable stackTraceStore) {
   public Binding {
     ErrorMessages.requireNonNullParam(scope, "scope", "Binding");
     ErrorMessages.requireNonNullParam(type, "type", "Binding");
     ErrorMessages.requireNonNullParam(command, "command", "Binding");
-    ErrorMessages.requireNonNullParam(frames, "frames", "Binding");
+    ErrorMessages.requireNonNullParam(stackTraceStore, "stackTraceStore", "Binding");
   }
 }

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -220,10 +220,7 @@ public final class Scheduler implements ProtobufSerializable {
 
     var binding =
         new Binding(
-            scope,
-            BindingType.CONTINUOUSLY_SCHEDULE_WHILE_HIGH,
-            defaultCommand,
-            new Throwable().getStackTrace());
+            scope, BindingType.CONTINUOUSLY_SCHEDULE_WHILE_HIGH, defaultCommand, new Throwable());
 
     var currentDefaultCommand = getDefaultCommandFor(mechanism);
     m_defaultCommandBindings.computeIfAbsent(mechanism, k -> new ArrayList<>()).add(binding);
@@ -559,8 +556,7 @@ public final class Scheduler implements ProtobufSerializable {
 
     // Note: we use a throwable here instead of Thread.currentThread().getStackTrace() for easier
     //       stack frame filtering and modification.
-    var binding =
-        new Binding(scope, BindingType.IMMEDIATE, command, new Throwable().getStackTrace());
+    var binding = new Binding(scope, BindingType.IMMEDIATE, command, new Throwable());
 
     return schedule(binding);
   }
@@ -1015,7 +1011,9 @@ public final class Scheduler implements ProtobufSerializable {
 
     // Intercept the exception, inject stack frames from the schedule site, and rethrow it
     var binding = state.binding();
-    e.setStackTrace(CommandTraceHelper.modifyTrace(e.getStackTrace(), binding.frames()));
+    e.setStackTrace(
+        CommandTraceHelper.modifyTrace(
+            e.getStackTrace(), binding.stackTraceStore().getStackTrace()));
     emitCompletedWithErrorEvent(command, e);
 
     // Clean up child commands after emitting the event so child Canceled events are emitted

--- a/commandsv3/src/main/java/org/wpilib/command3/Trigger.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Trigger.java
@@ -551,7 +551,7 @@ public class Trigger implements BooleanSupplier {
     //       stack frame filtering and modification.
     m_bindings
         .computeIfAbsent(bindingType, _k -> new ArrayList<>())
-        .add(new Binding(scope, bindingType, command, new Throwable().getStackTrace()));
+        .add(new Binding(scope, bindingType, command, new Throwable()));
 
     if (!m_bound) {
       // Ensure we're bound to the event loop.


### PR DESCRIPTION
Previously, `Scheduler.schedule()` would create a `Throwable` object and get its stack trace. This PR delays the `getStackTrace()` call to when an exception is actually thrown, which makes scheduling commands slightly faster.