### PR TITLE
[wpical] Fix potential deadlock

### DIFF
--- a/tools/wpical/src/main/native/cpp/WPIcal.cpp
+++ b/tools/wpical/src/main/native/cpp/WPIcal.cpp
@@ -290,11 +290,9 @@ void CalibrateCamera() {
   static bool calibrating = false;
 
   std::erase_if(videoProcessorCleanupTasks, [](auto& task) {
-    return task.wait_for(std::chrono::seconds{0}) ==
-           std::future_status::ready;
+    return task.wait_for(std::chrono::seconds{0}) == std::future_status::ready;
   });
-  const bool videoProcessorCleanupPending =
-      !videoProcessorCleanupTasks.empty();
+  const bool videoProcessorCleanupPending = !videoProcessorCleanupTasks.empty();
 
   auto cleanupVideoProcessor = [&] {
     if (!videoProcessor) {
@@ -302,8 +300,7 @@ void CalibrateCamera() {
     }
     videoProcessor->Stop();
     videoProcessorCleanupTasks.emplace_back(std::async(
-        std::launch::async,
-        [processor = std::move(videoProcessor)]() mutable {
+        std::launch::async, [processor = std::move(videoProcessor)]() mutable {
           processor.reset();
         }));
   };

--- a/tools/wpical/src/main/native/cpp/WPIcal.cpp
+++ b/tools/wpical/src/main/native/cpp/WPIcal.cpp
@@ -293,6 +293,8 @@ void CalibrateCamera() {
     return task.wait_for(std::chrono::seconds{0}) ==
            std::future_status::ready;
   });
+  const bool videoProcessorCleanupPending =
+      !videoProcessorCleanupTasks.empty();
 
   auto cleanupVideoProcessor = [&] {
     if (!videoProcessor) {
@@ -377,17 +379,25 @@ void CalibrateCamera() {
         calibrating = false;
         cleanupVideoProcessor();
       }
-    } else if (ImGui::Button("Calibrate") && !cameraVideoPath.empty()) {
-      videoProcessor = std::make_unique<wpical::CameraCalibrator>(
-          numWorkers, squareWidth, markerWidth, boardWidth, boardHeight,
-          cameraVideoPath);
-      calibrating = true;
+    } else {
+      ImGui::BeginDisabled(videoProcessorCleanupPending);
+      if (ImGui::Button("Calibrate") && !cameraVideoPath.empty()) {
+        videoProcessor = std::make_unique<wpical::CameraCalibrator>(
+            numWorkers, squareWidth, markerWidth, boardWidth, boardHeight,
+            cameraVideoPath);
+        calibrating = true;
+      }
+      ImGui::EndDisabled();
     }
     ImGui::SameLine();
     if (ImGui::Button("Close")) {
       cleanupVideoProcessor();
       calibrating = false;
       ImGui::CloseCurrentPopup();
+    }
+    if (videoProcessorCleanupPending) {
+      ImGui::TextUnformatted(
+          "Waiting for the previous calibration to finish...");
     }
     ImGui::EndPopup();
   }

--- a/tools/wpical/src/main/native/cpp/WPIcal.cpp
+++ b/tools/wpical/src/main/native/cpp/WPIcal.cpp
@@ -2,8 +2,10 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+#include <chrono>
 #include <filesystem>
 #include <format>
+#include <future>
 #include <map>
 #include <memory>
 #include <optional>
@@ -284,7 +286,25 @@ void CalibrateCamera() {
   static std::unique_ptr<pfd::open_file> cameraVideoSelector;
   static std::string cameraVideoPath;
   static std::unique_ptr<wpical::CameraCalibrator> videoProcessor;
+  static std::vector<std::future<void>> videoProcessorCleanupTasks;
   static bool calibrating = false;
+
+  std::erase_if(videoProcessorCleanupTasks, [](auto& task) {
+    return task.wait_for(std::chrono::seconds{0}) ==
+           std::future_status::ready;
+  });
+
+  auto cleanupVideoProcessor = [&] {
+    if (!videoProcessor) {
+      return;
+    }
+    videoProcessor->Stop();
+    videoProcessorCleanupTasks.emplace_back(std::async(
+        std::launch::async,
+        [processor = std::move(videoProcessor)]() mutable {
+          processor.reset();
+        }));
+  };
 
   static double squareWidth = 0.709;
   static double markerWidth = 0.551;
@@ -338,6 +358,7 @@ void CalibrateCamera() {
         }
         ImGui::CloseCurrentPopup();
         calibrating = false;
+        cleanupVideoProcessor();
       } else if (!videoProcessor->IsFinished()) {
         double processed = videoProcessor->TotalFramesProcessed();
         double total = videoProcessor->TotalFrames();
@@ -354,6 +375,7 @@ void CalibrateCamera() {
         ImGui::SetNextWindowSize(ImVec2(600, 400), ImGuiCond_Always);
         ImGui::OpenPopup("Camera Calibration Error");
         calibrating = false;
+        cleanupVideoProcessor();
       }
     } else if (ImGui::Button("Calibrate") && !cameraVideoPath.empty()) {
       videoProcessor = std::make_unique<wpical::CameraCalibrator>(
@@ -363,9 +385,7 @@ void CalibrateCamera() {
     }
     ImGui::SameLine();
     if (ImGui::Button("Close")) {
-      if (videoProcessor) {
-        videoProcessor->Stop();
-      }
+      cleanupVideoProcessor();
       calibrating = false;
       ImGui::CloseCurrentPopup();
     }

--- a/tools/wpical/src/main/native/cpp/cameracalibration.cpp
+++ b/tools/wpical/src/main/native/cpp/cameracalibration.cpp
@@ -250,8 +250,7 @@ CameraCalibrator::CameraCalibrator(size_t numWorkers, double squareWidth,
           ++framesQueued;
         }
         m_totalFrames = framesQueued;
-        while (!state->m_isFinished &&
-               TotalFramesProcessed() < framesQueued) {
+        while (!state->m_isFinished && TotalFramesProcessed() < framesQueued) {
           std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
         if (state->m_isFinished) {

--- a/tools/wpical/src/main/native/cpp/cameracalibration.cpp
+++ b/tools/wpical/src/main/native/cpp/cameracalibration.cpp
@@ -80,7 +80,7 @@ class Data {
    */
   std::optional<cv::Mat> GetFrame();
 
-  std::atomic_bool m_isFinished;
+  std::atomic_bool m_isFinished{false};
   std::optional<CameraModel> cameraModel;
   std::queue<cv::Mat> queue;
   wpi::util::mutex mutex;
@@ -232,48 +232,58 @@ CameraCalibrator::CameraCalibrator(size_t numWorkers, double squareWidth,
   }
   cv::VideoCapture cap{videoPath};
   m_totalFrames = cap.get(cv::CAP_PROP_FRAME_COUNT);
-  std::thread([this, boardHeight, boardWidth, squareWidth, state = m_state,
-               capture = std::move(cap)]() mutable {
-    cv::Size frameShape{
-        static_cast<int>(capture.get(cv::CAP_PROP_FRAME_WIDTH)),
-        static_cast<int>(capture.get(cv::CAP_PROP_FRAME_HEIGHT))};
-    while (capture.grab() && !state->m_isFinished) {
-      cv::Mat frame;
-      capture.retrieve(frame);
-      cv::Mat frameGray;
-      cv::cvtColor(frame, frameGray, cv::COLOR_BGR2GRAY);
-      state->AddFrame(std::move(frameGray));
-    }
-    while (!state->m_isFinished && TotalFramesProcessed() < TotalFrames()) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-    if (state->m_isFinished) {
-      state->cameraModel = std::nullopt;
-      return;
-    }
-    std::vector<mrcal_point3_t> allObservationBoards;
-    std::vector<mrcal_pose_t> allFramesRtToref;
-    for (auto& worker : m_workers) {
-      auto data = worker->GetData();
-      allObservationBoards.insert(allObservationBoards.end(),
-                                  data.first.begin(), data.first.end());
-      allFramesRtToref.insert(allFramesRtToref.end(), data.second.begin(),
-                              data.second.end());
-    }
-    if (allObservationBoards.empty()) {
-      state->m_isFinished = true;
-      return;
-    }
-    auto result = mrcal_main(allObservationBoards, allFramesRtToref,
-                             cv::Size(boardWidth - 1, boardHeight - 1),
-                             squareWidth * 0.0254, frameShape, 1000);
-    state->cameraModel = MrcalResultToCameraModel(*result);
-    state->m_isFinished = true;
-  }).detach();
+  m_processingThread =
+      std::thread([this, boardHeight, boardWidth, squareWidth, state = m_state,
+                   capture = std::move(cap)]() mutable {
+        cv::Size frameShape{
+            static_cast<int>(capture.get(cv::CAP_PROP_FRAME_WIDTH)),
+            static_cast<int>(capture.get(cv::CAP_PROP_FRAME_HEIGHT))};
+        int framesQueued = 0;
+        while (capture.grab() && !state->m_isFinished) {
+          cv::Mat frame;
+          if (!capture.retrieve(frame) || frame.empty()) {
+            continue;
+          }
+          cv::Mat frameGray;
+          cv::cvtColor(frame, frameGray, cv::COLOR_BGR2GRAY);
+          state->AddFrame(std::move(frameGray));
+          ++framesQueued;
+        }
+        m_totalFrames = framesQueued;
+        while (!state->m_isFinished &&
+               TotalFramesProcessed() < framesQueued) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+        if (state->m_isFinished) {
+          state->cameraModel = std::nullopt;
+          return;
+        }
+        std::vector<mrcal_point3_t> allObservationBoards;
+        std::vector<mrcal_pose_t> allFramesRtToref;
+        for (auto& worker : m_workers) {
+          auto data = worker->GetData();
+          allObservationBoards.insert(allObservationBoards.end(),
+                                      data.first.begin(), data.first.end());
+          allFramesRtToref.insert(allFramesRtToref.end(), data.second.begin(),
+                                  data.second.end());
+        }
+        if (allObservationBoards.empty()) {
+          state->m_isFinished = true;
+          return;
+        }
+        auto result = mrcal_main(allObservationBoards, allFramesRtToref,
+                                 cv::Size(boardWidth - 1, boardHeight - 1),
+                                 squareWidth * 0.0254, frameShape, 1000);
+        state->cameraModel = MrcalResultToCameraModel(*result);
+        state->m_isFinished = true;
+      });
 }
 
 CameraCalibrator::~CameraCalibrator() {
   Stop();
+  if (m_processingThread.joinable()) {
+    m_processingThread.join();
+  }
 }
 
 bool CameraCalibrator::IsFinished() {

--- a/tools/wpical/src/main/native/include/cameracalibration.hpp
+++ b/tools/wpical/src/main/native/include/cameracalibration.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <Eigen/Core>
@@ -90,6 +91,7 @@ class CameraCalibrator {
 
   std::atomic_int m_totalFrames;
   std::vector<std::shared_ptr<Worker>> m_workers;
+  std::thread m_processingThread;
 };
 
 void to_json(wpi::util::json& json, const CameraModel& cameraModel);

--- a/tools/wpical/src/main/native/thirdparty/mrcal/src/poseutils.c
+++ b/tools/wpical/src/main/native/thirdparty/mrcal/src/poseutils.c
@@ -716,7 +716,7 @@ void mrcal_compose_Rt_full( // output
     {
         // R01 = R0t R1t
         // t01 = -R0t R1t t1 - R0t t0
-        const double R0t_t0[3];
+        double R0t_t0[3];
         mul_vec3_gen33_vout_full(R0t_t0, sizeof(R0t_t0[0]),
                                  &P2(Rt_0,  3,0), Rt_0_stride1,
                                  &P2(Rt_0,0,0), Rt_0_stride0, Rt_0_stride1);

--- a/upstream_utils/mrcal_patches/0001-Fix-MSVC-build-errors.patch
+++ b/upstream_utils/mrcal_patches/0001-Fix-MSVC-build-errors.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gold856 <117957790+Gold856@users.noreply.github.com>
 Date: Mon, 11 Nov 2024 00:15:05 -0500
-Subject: [PATCH 1/6] Fix MSVC build errors
+Subject: [PATCH 1/7] Fix MSVC build errors
 
 ---
  _autodiff.hh |  4 ++--

--- a/upstream_utils/mrcal_patches/0002-Make-mrcal-C.patch
+++ b/upstream_utils/mrcal_patches/0002-Make-mrcal-C.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gold856 <117957790+Gold856@users.noreply.github.com>
 Date: Fri, 22 Nov 2024 09:55:22 -0500
-Subject: [PATCH 2/6] Make mrcal C++
+Subject: [PATCH 2/7] Make mrcal C++
 
 ---
  mrcal.c => mrcal.cpp | 0

--- a/upstream_utils/mrcal_patches/0003-Replace-VLAs-with-vectors.patch
+++ b/upstream_utils/mrcal_patches/0003-Replace-VLAs-with-vectors.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gold856 <117957790+Gold856@users.noreply.github.com>
 Date: Fri, 29 Nov 2024 22:56:02 -0500
-Subject: [PATCH 3/6] Replace VLAs with vectors
+Subject: [PATCH 3/7] Replace VLAs with vectors
 
 ---
  mrcal.cpp | 101 +++++++++++++++++++++++++++---------------------------

--- a/upstream_utils/mrcal_patches/0004-Fix-MSVC-build-errors.patch
+++ b/upstream_utils/mrcal_patches/0004-Fix-MSVC-build-errors.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gold856 <117957790+Gold856@users.noreply.github.com>
 Date: Wed, 4 Dec 2024 00:58:00 -0500
-Subject: [PATCH 4/6] Fix MSVC build errors
+Subject: [PATCH 4/7] Fix MSVC build errors
 
 ---
  minimath/minimath-extra.h |   1 +

--- a/upstream_utils/mrcal_patches/0005-Fix-UB-in-mrcal.patch
+++ b/upstream_utils/mrcal_patches/0005-Fix-UB-in-mrcal.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Matt <matthew.morley.ca@gmail.com>
 Date: Thu, 5 Dec 2024 00:10:15 -0500
-Subject: [PATCH 5/6] Fix UB in mrcal
+Subject: [PATCH 5/7] Fix UB in mrcal
 
 ---
  mrcal.cpp | 27 ++++++++++++++++-----------

--- a/upstream_utils/mrcal_patches/0006-Suppress-unused-but-set-warning.patch
+++ b/upstream_utils/mrcal_patches/0006-Suppress-unused-but-set-warning.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Thu, 16 Jul 2026 21:49:36 -0700
-Subject: [PATCH 6/6] Suppress unused-but-set warning
+Subject: [PATCH 6/7] Suppress unused-but-set warning
 
 ---
  mrcal.cpp | 2 +-

--- a/upstream_utils/mrcal_patches/0007-Fix-Clang-21-warning.patch
+++ b/upstream_utils/mrcal_patches/0007-Fix-Clang-21-warning.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Thad House <thadhouse1@gmail.com>
+Date: Sat, 29 Aug 2026 15:43:14 -0700
+Subject: [PATCH 7/7] Fix Clang 21 warning
+
+---
+ poseutils.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/poseutils.c b/poseutils.c
+index b08f3716c4bc0adf750b1167541ff6f23d3ab66b..c38bc03b32d306bde51bf3bd5cf61781082e8aa4 100644
+--- a/poseutils.c
++++ b/poseutils.c
+@@ -716,7 +716,7 @@ void mrcal_compose_Rt_full( // output
+     {
+         // R01 = R0t R1t
+         // t01 = -R0t R1t t1 - R0t t0
+-        const double R0t_t0[3];
++        double R0t_t0[3];
+         mul_vec3_gen33_vout_full(R0t_t0, sizeof(R0t_t0[0]),
+                                  &P2(Rt_0,  3,0), Rt_0_stride1,
+                                  &P2(Rt_0,0,0), Rt_0_stride0, Rt_0_stride1);


### PR DESCRIPTION
```
The seed is reproducible, but the hang is not deterministic on macOS. I ran:
wpicalTest --order rand --rng-seed 1053506793
The suite passed 50/50 consecutive runs. The seed fixes Catch2’s test ordering and RNG, but not OpenCV decoder behavior or thread scheduling.
There is, however, a credible indefinite-wait bug:
- OpenCV’s reported frame count is stored at [cameracalibration.cpp:234](/Users/thadhouse/GitHub/allwpilib/tools/wpical/src/main/native/cpp/cameracalibration.cpp).
- After decoding stops, the coordinator waits until processed frames reach that reported count at [cameracalibration.cpp:247](/Users/thadhouse/GitHub/allwpilib/tools/wpical/src/main/native/cpp/cameracalibration.cpp).
- The test waits forever for IsFinished() at [test_calibrate.cpp:51](/Users/thadhouse/GitHub/allwpilib/tools/wpical/src/test/native/cpp/test_calibrate.cpp).
If decoding ends early or CAP_PROP_FRAME_COUNT is inaccurate, the coordinator can never finish. There is already evidence of inaccurate fixture metadata: Linux altfieldvideo/long.avi reports 160 frames but ffprobe can decode only 159. That particular file does not enter this wait, but it demonstrates why trusting the reported frame count is unsafe.
The robust fix is to count frames actually queued, wait for that count to be processed, and preferably own/join the coordinator thread instead of detaching it. Checking capture.retrieve() would also avoid counting failed retrievals.
One unrelated macOS issue: Apple Clang 21 rejects the bundled mrcal const double R0t_t0[3] as an error. I temporarily removed const to build the test, then restored the source; the worktree is unchanged.
```

```
Fixed both issues.
- [cameracalibration.cpp](/Users/thadhouse/GitHub/allwpilib/tools/wpical/src/main/native/cpp/cameracalibration.cpp) now waits for successfully queued frames instead of OpenCV’s potentially inaccurate reported frame count. Failed/empty retrievals are skipped.
- The coordinator thread is now owned and joined during destruction, eliminating the detached-thread lifetime hazard.
- Shared completion state is explicitly initialized.
- [poseutils.c](/Users/thadhouse/GitHub/allwpilib/tools/wpical/src/main/native/thirdparty/mrcal/src/poseutils.c) removes the incorrect const, fixing Apple Clang 21 compilation.
Verification:
- Exact install task builds successfully.
- Seed 1053506793 passed 20/20 post-fix runs.
- git diff --check passes.
```