### PR TITLE
[commands] Lower SysId default step voltage

### DIFF
--- a/commandsv2/src/main/java/org/wpilib/command2/sysid/SysIdRoutine.java
+++ b/commandsv2/src/main/java/org/wpilib/command2/sysid/SysIdRoutine.java
@@ -75,7 +75,7 @@ public class SysIdRoutine extends SysIdRoutineLog {
      *
      * @param rampRate The voltage ramp rate used for quasistatic test routines. Defaults to 1 volt
      *     per second if left null.
-     * @param stepVoltage The step voltage output used for dynamic test routines. Defaults to 7
+     * @param stepVoltage The step voltage output used for dynamic test routines. Defaults to 4
      *     volts if left null.
      * @param timeout Safety timeout for the test routine commands. Defaults to 10 seconds if left
      *     null.
@@ -89,7 +89,7 @@ public class SysIdRoutine extends SysIdRoutineLog {
         Time timeout,
         Consumer<State> recordState) {
       this.rampRate = rampRate != null ? rampRate : Volts.of(1).per(Second);
-      this.stepVoltage = stepVoltage != null ? stepVoltage : Volts.of(7);
+      this.stepVoltage = stepVoltage != null ? stepVoltage : Volts.of(4);
       this.timeout = timeout != null ? timeout : Seconds.of(10);
       this.recordState = recordState;
     }
@@ -99,7 +99,7 @@ public class SysIdRoutine extends SysIdRoutineLog {
      *
      * @param rampRate The voltage ramp rate used for quasistatic test routines. Defaults to 1 volt
      *     per second if left null.
-     * @param stepVoltage The step voltage output used for dynamic test routines. Defaults to 7
+     * @param stepVoltage The step voltage output used for dynamic test routines. Defaults to 4
      *     volts if left null.
      * @param timeout Safety timeout for the test routine commands. Defaults to 10 seconds if left
      *     null.
@@ -113,7 +113,7 @@ public class SysIdRoutine extends SysIdRoutineLog {
      *
      * <p>rampRate: 1 volt/sec
      *
-     * <p>stepVoltage: 7 volts
+     * <p>stepVoltage: 4 volts
      *
      * <p>timeout: 10 seconds
      */

--- a/commandsv2/src/main/native/include/wpi/commands2/sysid/SysIdRoutine.hpp
+++ b/commandsv2/src/main/native/include/wpi/commands2/sysid/SysIdRoutine.hpp
@@ -26,7 +26,7 @@ class Config {
   ramp_rate_t rampRate{1_V / 1_s};
 
   /// The step voltage output used for dynamic test routines.
-  wpi::units::volt_t stepVoltage{7_V};
+  wpi::units::volt_t stepVoltage{4_V};
 
   /// Safety timeout for the test routine commands.
   wpi::units::second_t timeout{10_s};
@@ -41,7 +41,7 @@ class Config {
    * @param rampRate The voltage ramp rate used for quasistatic test routines.
    *   Defaults to 1 volt per second if left null.
    * @param stepVoltage The step voltage output used for dynamic test routines.
-   *   Defaults to 7 volts if left null.
+   *   Defaults to 4 volts if left null.
    * @param timeout Safety timeout for the test routine commands. Defaults to 10
    *   seconds if left null.
    * @param recordState Optional handle for recording test state in a

--- a/commandsv2/src/main/python/commands2/sysid/sysidroutine.py
+++ b/commandsv2/src/main/python/commands2/sysid/sysidroutine.py
@@ -39,7 +39,7 @@ class SysIdRoutine(SysIdRoutineLog):
 
         :param ramp_rate:    The voltage ramp rate used for quasistatic test routines. Defaults to 1 volt
                             per second if left null.
-        :param step_voltage: The step voltage output used for dynamic test routines. Defaults to 7
+        :param step_voltage: The step voltage output used for dynamic test routines. Defaults to 4
                             volts if left null.
         :param timeout:     Safety timeout for the test routine commands. Defaults to 10 seconds if left
                             null.
@@ -49,7 +49,7 @@ class SysIdRoutine(SysIdRoutineLog):
         """
 
         ramp_rate: volts_per_second = 1.0
-        step_voltage: volts = 7.0
+        step_voltage: volts = 4.0
         timeout: seconds = 10.0
         record_state: Optional[Callable[[State], None]] = None
 

--- a/commandsv2/src/test/java/org/wpilib/command2/sysid/SysIdRoutineTest.java
+++ b/commandsv2/src/test/java/org/wpilib/command2/sysid/SysIdRoutineTest.java
@@ -127,7 +127,7 @@ class SysIdRoutineTest {
     runCommand(m_dynamicForward);
     orderCheck = inOrder(m_mechanism);
 
-    orderCheck.verify(m_mechanism, atLeastOnce()).drive(Volts.of(7));
+    orderCheck.verify(m_mechanism, atLeastOnce()).drive(Volts.of(4));
     orderCheck.verify(m_mechanism).drive(Volts.of(0));
     orderCheck.verify(m_mechanism, never()).drive(any());
 
@@ -136,7 +136,7 @@ class SysIdRoutineTest {
     orderCheck = inOrder(m_mechanism);
 
     runCommand(m_dynamicReverse);
-    orderCheck.verify(m_mechanism, atLeastOnce()).drive(Volts.of(-7));
+    orderCheck.verify(m_mechanism, atLeastOnce()).drive(Volts.of(-4));
     orderCheck.verify(m_mechanism).drive(Volts.of(0));
     orderCheck.verify(m_mechanism, never()).drive(any());
   }

--- a/commandsv2/src/test/native/cpp/wpi/command/sysid/SysIdRoutineTest.cpp
+++ b/commandsv2/src/test/native/cpp/wpi/command/sysid/SysIdRoutineTest.cpp
@@ -166,14 +166,14 @@ TEST_CASE_METHOD(SysIdRoutineTest, "SysIdRoutineTest OutputCorrectVoltage",
   sentVoltages.clear();
 
   RunCommand(std::move(m_dynamicForward));
-  expectedVoltages = std::vector<wpi::units::volt_t>{7_V, 0_V};
+  expectedVoltages = std::vector<wpi::units::volt_t>{4_V, 0_V};
   CHECK_NEAR_UNITS(expectedVoltages[0], sentVoltages[0], 1e-6_V);
   CHECK_NEAR_UNITS(expectedVoltages[1], sentVoltages[1], 1e-6_V);
   currentStateList.clear();
   sentVoltages.clear();
 
   RunCommand(std::move(m_dynamicReverse));
-  expectedVoltages = std::vector<wpi::units::volt_t>{-7_V, 0_V};
+  expectedVoltages = std::vector<wpi::units::volt_t>{-4_V, 0_V};
   CHECK_NEAR_UNITS(expectedVoltages[0], sentVoltages[0], 1e-6_V);
   CHECK_NEAR_UNITS(expectedVoltages[1], sentVoltages[1], 1e-6_V);
   currentStateList.clear();

--- a/commandsv2/src/test/python/test_sysidroutine.py
+++ b/commandsv2/src/test/python/test_sysidroutine.py
@@ -150,7 +150,7 @@ def test_tests_output_correct_voltage(
 
     mechanism.drive.assert_has_calls(
         [
-            call(pytest.approx(7.0)),
+            call(pytest.approx(4.0)),
             call(pytest.approx(0.0)),
         ],
         any_order=False,
@@ -161,7 +161,7 @@ def test_tests_output_correct_voltage(
 
     mechanism.drive.assert_has_calls(
         [
-            call(pytest.approx(-7.0)),
+            call(pytest.approx(-4.0)),
             call(pytest.approx(0.0)),
         ],
         any_order=False,

--- a/robotpyExamples/examples/SysId/subsystems/drive.py
+++ b/robotpyExamples/examples/SysId/subsystems/drive.py
@@ -47,8 +47,9 @@ class Drive(Subsystem):
 
         # Create a new SysId routine for characterizing the drive.
         self.sys_id_routine = SysIdRoutine(
-            # Empty config defaults to 1 volt/second ramp rate and 7 volt step voltage.
-            SysIdRoutine.Config(),
+            # Use 4 volts for the dynamic test. Change this value to suit your
+            # mechanism.
+            SysIdRoutine.Config(step_voltage=4.0),
             SysIdRoutine.Mechanism(
                 # Tell SysId how to plumb the driving voltage to the motors.
                 self._drive_voltage,

--- a/robotpyExamples/examples/SysId/subsystems/shooter.py
+++ b/robotpyExamples/examples/SysId/subsystems/shooter.py
@@ -40,8 +40,9 @@ class Shooter(Subsystem):
 
         # Create a new SysId routine for characterizing the shooter.
         self.sys_id_routine = SysIdRoutine(
-            # Empty config defaults to 1 volt/second ramp rate and 7 volt step voltage.
-            SysIdRoutine.Config(),
+            # Use 4 volts for the dynamic test. Change this value to suit your
+            # mechanism.
+            SysIdRoutine.Config(step_voltage=4.0),
             SysIdRoutine.Mechanism(
                 # Tell SysId how to plumb the driving voltage to the motor(s).
                 self.shooter_motor.set_voltage,

--- a/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/include/subsystems/Drive.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/include/subsystems/Drive.hpp
@@ -39,8 +39,9 @@ class Drive : public wpi::cmd::SubsystemBase {
                             constants::drive::RIGHT_ENCODER_REVERSED};
 
   wpi::cmd::sysid::SysIdRoutine sysIdRoutine{
-      wpi::cmd::sysid::Config{std::nullopt, std::nullopt, std::nullopt,
-                              nullptr},
+      // Use 4 volts for the dynamic test. Change this value to suit your
+      // mechanism.
+      wpi::cmd::sysid::Config{std::nullopt, 4_V, std::nullopt, nullptr},
       wpi::cmd::sysid::Mechanism{
           [this](wpi::units::volt_t driveVoltage) {
             leftMotor.SetVoltage(driveVoltage);

--- a/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/include/subsystems/Shooter.hpp
+++ b/wpilibcExamples/src/main/cpp/examples/SysIdRoutine/include/subsystems/Shooter.hpp
@@ -33,8 +33,9 @@ class Shooter : public wpi::cmd::SubsystemBase {
                               constants::shooter::ENCODER_REVERSED};
 
   wpi::cmd::sysid::SysIdRoutine sysIdRoutine{
-      wpi::cmd::sysid::Config{std::nullopt, std::nullopt, std::nullopt,
-                              nullptr},
+      // Use 4 volts for the dynamic test. Change this value to suit your
+      // mechanism.
+      wpi::cmd::sysid::Config{std::nullopt, 4_V, std::nullopt, nullptr},
       wpi::cmd::sysid::Mechanism{
           [this](wpi::units::volt_t driveVoltage) {
             shooterMotor.SetVoltage(driveVoltage);

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/subsystems/Drive.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/subsystems/Drive.java
@@ -46,8 +46,8 @@ public class Drive extends SubsystemBase {
   // Create a new SysId routine for characterizing the drive.
   private final SysIdRoutine sysIdRoutine =
       new SysIdRoutine(
-          // Empty config defaults to 1 volt/second ramp rate and 7 volt step voltage.
-          new SysIdRoutine.Config(),
+          // Use 4 volts for the dynamic test. Change this value to suit your mechanism.
+          new SysIdRoutine.Config(null, Volts.of(4), null),
           new SysIdRoutine.Mechanism(
               // Tell SysId how to plumb the driving voltage to the motors.
               voltage -> {

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/subsystems/Shooter.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/sysidroutine/subsystems/Shooter.java
@@ -36,8 +36,8 @@ public class Shooter extends SubsystemBase {
   // Create a new SysId routine for characterizing the shooter.
   private final SysIdRoutine sysIdRoutine =
       new SysIdRoutine(
-          // Empty config defaults to 1 volt/second ramp rate and 7 volt step voltage.
-          new SysIdRoutine.Config(),
+          // Use 4 volts for the dynamic test. Change this value to suit your mechanism.
+          new SysIdRoutine.Config(null, Volts.of(4), null),
           new SysIdRoutine.Mechanism(
               // Tell SysId how to plumb the driving voltage to the motor(s).
               shooterMotor::setVoltage,


### PR DESCRIPTION
## Summary
- lower the default SysId dynamic step voltage from 7 V to 4 V in Java, C++, and Python
- make the Java, C++, and Python SysIdRoutine examples configure the step voltage explicitly and tell users to adjust it for their mechanism
- update the existing dynamic-voltage regression tests for the new default

## Validation
- `wpiformat 2026.71` (including C++ lint)
- Black formatting check for the changed Python files
- Python syntax compilation
- stale 7 V reference scan across the implementations, tests, and SysId examples

The focused compiled tests could not be started locally because this Windows environment has no JDK, and the repository-pinned Bazel binary download timed out. GitHub Actions will run the project build and test matrix.

Closes #7794