### PR TITLE
[wpimath] Update the Kraken X60 DCMotor factories to use values from the CTRE Motor Testing Lab

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/system/DCMotor.java
+++ b/wpimath/src/main/java/org/wpilib/math/system/DCMotor.java
@@ -291,9 +291,9 @@ public class DCMotor implements ProtobufSerializable, StructSerializable {
    * @return a gearbox of Kraken X60 motors.
    */
   public static DCMotor getKrakenX60(int numMotors) {
-    // From https://store.ctr-electronics.com/announcing-kraken-x60/
+    // From https://motors.ctr-electronics.com/dyno/dynometer-testing/
     return new DCMotor(
-        12, 7.09, 366, 2, Units.rotationsPerMinuteToRadiansPerSecond(6000), numMotors);
+        12, 7.157, 374.4, 2, Units.rotationsPerMinuteToRadiansPerSecond(6065), numMotors);
   }
 
   /**
@@ -303,9 +303,9 @@ public class DCMotor implements ProtobufSerializable, StructSerializable {
    * @return A gearbox of Kraken X60 FOC enabled motors.
    */
   public static DCMotor getKrakenX60Foc(int numMotors) {
-    // From https://store.ctr-electronics.com/announcing-kraken-x60/
+    // From https://motors.ctr-electronics.com/dyno/dynometer-testing/
     return new DCMotor(
-        12, 9.37, 483, 2, Units.rotationsPerMinuteToRadiansPerSecond(5800), numMotors);
+        12, 9.362, 476.1, 2, Units.rotationsPerMinuteToRadiansPerSecond(5785), numMotors);
   }
 
   /**
@@ -317,7 +317,7 @@ public class DCMotor implements ProtobufSerializable, StructSerializable {
   public static DCMotor getKrakenX44(int numMotors) {
     // From https://motors.ctr-electronics.com/dyno/dynometer-testing/
     return new DCMotor(
-        12, 4.11, 279, 2, Units.rotationsPerMinuteToRadiansPerSecond(7758), numMotors);
+        12, 4.113, 279.1, 2, Units.rotationsPerMinuteToRadiansPerSecond(7758), numMotors);
   }
 
   /**
@@ -329,7 +329,7 @@ public class DCMotor implements ProtobufSerializable, StructSerializable {
   public static DCMotor getKrakenX44Foc(int numMotors) {
     // From https://motors.ctr-electronics.com/dyno/dynometer-testing/
     return new DCMotor(
-        12, 5.01, 329, 2, Units.rotationsPerMinuteToRadiansPerSecond(7368), numMotors);
+        12, 5.011, 329.2, 2, Units.rotationsPerMinuteToRadiansPerSecond(7368), numMotors);
   }
 
   /**
@@ -341,7 +341,7 @@ public class DCMotor implements ProtobufSerializable, StructSerializable {
   public static DCMotor getMinion(int numMotors) {
     // From https://motors.ctr-electronics.com/dyno/dynometer-testing/
     return new DCMotor(
-        12, 3.17, 211, 2, Units.rotationsPerMinuteToRadiansPerSecond(7704), numMotors);
+        12, 3.173, 211.6, 2, Units.rotationsPerMinuteToRadiansPerSecond(7704), numMotors);
   }
 
   /**

--- a/wpimath/src/main/native/include/wpi/math/system/DCMotor.hpp
+++ b/wpimath/src/main/native/include/wpi/math/system/DCMotor.hpp
@@ -241,8 +241,8 @@ class WPILIB_DLLEXPORT DCMotor {
    * Return a gearbox of Kraken X60 brushless motors.
    */
   static constexpr DCMotor KrakenX60(int numMotors = 1) {
-    // From https://store.ctr-electronics.com/announcing-kraken-x60/
-    return DCMotor(12_V, 7.09_Nm, 366_A, 2_A, 6000_rpm, numMotors);
+    // From https://motors.ctr-electronics.com/dyno/dynometer-testing/
+    return DCMotor(12_V, 7.157_Nm, 374.4_A, 2_A, 6065_rpm, numMotors);
   }
 
   /**
@@ -250,8 +250,8 @@ class WPILIB_DLLEXPORT DCMotor {
    * Control) enabled.
    */
   static constexpr DCMotor KrakenX60FOC(int numMotors = 1) {
-    // From https://store.ctr-electronics.com/announcing-kraken-x60/
-    return DCMotor(12_V, 9.37_Nm, 483_A, 2_A, 5800_rpm, numMotors);
+    // From https://motors.ctr-electronics.com/dyno/dynometer-testing/
+    return DCMotor(12_V, 9.362_Nm, 476.1_A, 2_A, 5785_rpm, numMotors);
   }
 
   /**
@@ -259,7 +259,7 @@ class WPILIB_DLLEXPORT DCMotor {
    */
   static constexpr DCMotor KrakenX44(int numMotors = 1) {
     // From https://motors.ctr-electronics.com/dyno/dynometer-testing/
-    return DCMotor(12_V, 4.11_Nm, 279_A, 2_A, 7758_rpm, numMotors);
+    return DCMotor(12_V, 4.113_Nm, 279.1_A, 2_A, 7758_rpm, numMotors);
   }
 
   /**
@@ -268,7 +268,7 @@ class WPILIB_DLLEXPORT DCMotor {
    */
   static constexpr DCMotor KrakenX44FOC(int numMotors = 1) {
     // From https://motors.ctr-electronics.com/dyno/dynometer-testing/
-    return DCMotor(12_V, 5.01_Nm, 329_A, 2_A, 7368_rpm, numMotors);
+    return DCMotor(12_V, 5.011_Nm, 329.2_A, 2_A, 7368_rpm, numMotors);
   }
 
   /**
@@ -276,7 +276,7 @@ class WPILIB_DLLEXPORT DCMotor {
    */
   static constexpr DCMotor Minion(int numMotors = 1) {
     // From https://motors.ctr-electronics.com/dyno/dynometer-testing/
-    return DCMotor(12_V, 3.17_Nm, 211_A, 2_A, 7704_rpm, numMotors);
+    return DCMotor(12_V, 3.173_Nm, 211.6_A, 2_A, 7704_rpm, numMotors);
   }
 
   /**


### PR DESCRIPTION
This commonizes Kraken X60 to use the dyno data in the CTRE Motor Testing Lab, which is the same source used for the Kraken X44 and Minion.