### PR TITLE
[cmd3] Fix awaitCompletion

### DIFF
--- a/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
@@ -202,10 +202,8 @@ public final class Coroutine {
      * <p>This method does nothing if no commands were successfully forked.
      */
     public void awaitCompletion() {
-      for (Command command : m_forkedCommands) {
-        if (m_scheduler.isRunning(command)) {
-          Coroutine.this.yield();
-        }
+      while (m_forkedCommands.stream().anyMatch(m_scheduler::isRunning)) {
+        Coroutine.this.yield();
       }
     }
 


### PR DESCRIPTION
## Problem
`awaitCompletion()` is meant to block the caller until every command it forked has finished running (per its Javadoc: "Waits for all forked commands to complete"). The previous implementation iterates each forked command exactly once and yields at most once per command, without ever re-checking whether that command finished. So for the example in Coroutine.fork()'s Javadoc:
```java
Command example() {
  return Command.noRequirements(coroutine -> {
    Command child = ...;
    ForkResult childTask = coroutine.fork(child);
    // ... do more things
    // then sync back up with the child command
    if (childTask.successful()) {
      childTask.awaitCompletion();
    }
  }).named("Example");
}
```
if child was still running at the time `awaitCompletion()` was called, the loop would yield exactly once and then return — regardless of whether child had actually completed. The parent would resume after a single scheduler tick, not when the child was actually done, silently breaking the "sync back up with the forked command" contract and potentially running concurrently with a child it believed had finished.

## Fix
Replace the single-pass for loop with a while loop that keeps yielding as long as any forked command is still running. This correctly blocks the caller across as many ticks as needed until all forked commands have finished, matching the documented behavior.