### PR TITLE
[example] Remove unescessary code in C++ Getting Started example

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
@@ -15,8 +15,6 @@ class Robot : public wpi::TimedRobot {
     // result in both sides moving forward. Depending on how your robot's
     // gearbox is constructed, you might have to invert the left side instead.
     right.SetInverted(true);
-    robotDrive.SetExpiration(100_ms);
-    timer.Start();
   }
 
   void AutonomousInit() override { timer.Restart(); }


### PR DESCRIPTION
Matches Java and Python
Removes timer start in Robot Constructor (timer is restarted in Autounomous Init) and setting motor safety timeout to default