### PR TITLE
[wpinet] Present the vendored libuv as the libuv module

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,12 +12,12 @@ include("//shared/bazel/thirdparty/mrclib:mrclib.MODULE.bazel")
 bazel_dep(name = "apple_support", version = "2.0.0", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "rules_cc", version = "0.2.18")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
-
 bazel_dep(name = "libuv", version = "1.49.2")
 local_path_override(
     module_name = "libuv",
     path = "wpinet/src/main/native/thirdparty/libuv",
 )
+
 bazel_dep(name = "bazel_features", version = "1.43.0")
 bazel_dep(name = "bazel_lib", version = "3.5.0")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,11 +13,6 @@ bazel_dep(name = "apple_support", version = "2.0.0", repo_name = "build_bazel_ap
 bazel_dep(name = "rules_cc", version = "0.2.18")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 
-# The vendored libuv, presented as the libuv module -- the override points at
-# a MODULE.bazel/BUILD.bazel pair in the vendored tree that mirrors BCR's
-# libuv API, the same way eigen is wired up below. Everything that names
-# @libuv links this one copy, so a dependency that also uses libuv (@aos is
-# about to) does not land a second set of uv_* symbols in the binary.
 bazel_dep(name = "libuv", version = "1.49.2")
 local_path_override(
     module_name = "libuv",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,6 +12,17 @@ include("//shared/bazel/thirdparty/mrclib:mrclib.MODULE.bazel")
 bazel_dep(name = "apple_support", version = "2.0.0", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "rules_cc", version = "0.2.18")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
+
+# The vendored libuv, presented as the libuv module -- the override points at
+# a MODULE.bazel/BUILD.bazel pair in the vendored tree that mirrors BCR's
+# libuv API, the same way eigen is wired up below. Everything that names
+# @libuv links this one copy, so a dependency that also uses libuv (@aos is
+# about to) does not land a second set of uv_* symbols in the binary.
+bazel_dep(name = "libuv", version = "1.49.2")
+local_path_override(
+    module_name = "libuv",
+    path = "wpinet/src/main/native/thirdparty/libuv",
+)
 bazel_dep(name = "bazel_features", version = "1.43.0")
 bazel_dep(name = "bazel_lib", version = "3.5.0")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -232,7 +232,7 @@
     },
     "@@bzlmodrio-opencv+//:maven_cpp_deps.bzl%deps": {
       "general": {
-        "bzlTransitiveDigest": "zlNi8XygFuJzNgXwv0Yer7TqgkQ/bWpfnSebpCXfdwc=",
+        "bzlTransitiveDigest": "LEkecP6UduHL8n4nQPPSjh337LiWRwPvUIlJkaNmn/M=",
         "usagesDigest": "CnS14ymuExu7Nl5i6AZMzQdi8hsMTDI/0npjj0y1EFY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -614,7 +614,7 @@
     },
     "@@rules_apple+//apple:extensions.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "ul8vHGy74hBD66XzLuB09UmLKPv7O6yFI8pwN7jMWdc=",
+        "bzlTransitiveDigest": "UsflLeiazyu2v5pvibcvOeIdDV95S25rT96h4XU1nhY=",
         "usagesDigest": "M3VqFpeTCo4qmrNKGZw0dxBHvTYDrfV3cscGzlSAhQ4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -693,7 +693,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "03Qju4tW0vE+0RBuZGuV2A4Hx6AiSkdNahYvworx2aM=",
+        "bzlTransitiveDigest": "rL/34P1aFDq2GqVC2zCFgQ8nTuOC6ziogocpvG50Qz8=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -757,7 +757,7 @@
     },
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
-        "bzlTransitiveDigest": "yG9F6L2IZXKRbD/aIUa6sU7uITLUTBKOMWPbIvl1VdM=",
+        "bzlTransitiveDigest": "xMgnVVV6SeyGCaYQT+4rYddx63q6+JXtyCrlLeA8OLM=",
         "usagesDigest": "6MjoD3H+netDdhklgMWks3NARpHVXxy8kfsMe9XXPa8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -798,7 +798,7 @@
     },
     "@@rules_swift+//swift:extensions.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "TdyDy4TBpjOHwrF4hSiQwGdsTAvssvyD6vUJBx+7nt4=",
+        "bzlTransitiveDigest": "WQxCEBSXJEaQYe860JXZvAQug2B6+/VbBtRIDMF0pOc=",
         "usagesDigest": "mhACFnrdMv9Wi0Mt67bxocJqviRkDSV+Ee5Mqdj5akA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -232,7 +232,7 @@
     },
     "@@bzlmodrio-opencv+//:maven_cpp_deps.bzl%deps": {
       "general": {
-        "bzlTransitiveDigest": "LEkecP6UduHL8n4nQPPSjh337LiWRwPvUIlJkaNmn/M=",
+        "bzlTransitiveDigest": "zlNi8XygFuJzNgXwv0Yer7TqgkQ/bWpfnSebpCXfdwc=",
         "usagesDigest": "CnS14ymuExu7Nl5i6AZMzQdi8hsMTDI/0npjj0y1EFY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -614,7 +614,7 @@
     },
     "@@rules_apple+//apple:extensions.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "UsflLeiazyu2v5pvibcvOeIdDV95S25rT96h4XU1nhY=",
+        "bzlTransitiveDigest": "ul8vHGy74hBD66XzLuB09UmLKPv7O6yFI8pwN7jMWdc=",
         "usagesDigest": "M3VqFpeTCo4qmrNKGZw0dxBHvTYDrfV3cscGzlSAhQ4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -693,7 +693,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "rL/34P1aFDq2GqVC2zCFgQ8nTuOC6ziogocpvG50Qz8=",
+        "bzlTransitiveDigest": "03Qju4tW0vE+0RBuZGuV2A4Hx6AiSkdNahYvworx2aM=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -757,7 +757,7 @@
     },
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
-        "bzlTransitiveDigest": "xMgnVVV6SeyGCaYQT+4rYddx63q6+JXtyCrlLeA8OLM=",
+        "bzlTransitiveDigest": "yG9F6L2IZXKRbD/aIUa6sU7uITLUTBKOMWPbIvl1VdM=",
         "usagesDigest": "6MjoD3H+netDdhklgMWks3NARpHVXxy8kfsMe9XXPa8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -798,7 +798,7 @@
     },
     "@@rules_swift+//swift:extensions.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "WQxCEBSXJEaQYe860JXZvAQug2B6+/VbBtRIDMF0pOc=",
+        "bzlTransitiveDigest": "TdyDy4TBpjOHwrF4hSiQwGdsTAvssvyD6vUJBx+7nt4=",
         "usagesDigest": "mhACFnrdMv9Wi0Mt67bxocJqviRkDSV+Ee5Mqdj5akA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/shared/bazel/rules/robotpy/build_info_gen.bzl
+++ b/shared/bazel/rules/robotpy/build_info_gen.bzl
@@ -5,6 +5,7 @@ def generate_robotpy_native_wrapper_build_info(
         name,
         pyproject_toml,
         third_party_dirs = [],
+        module_include_targets = {},
         native_srcs_root = "src/main/native/",
         generated_include_target = None,
         generated_include_root = "src/generated/main/native/include"):
@@ -14,6 +15,10 @@ def generate_robotpy_native_wrapper_build_info(
     Params:
         pyproject_toml - Path to the native library wrappers definition file
         third_party_dirs - Any directories under <native_srcs_root>thirdparty that should be used by semiwrap
+        module_include_targets - Headers that live in a Bazel module rather than under
+            <native_srcs_root>thirdparty (a vendored tree with its own MODULE.bazel is its own
+            package, so globs cannot reach it). Maps a filegroup label exporting the header tree
+            to the prefix to strip from its paths, e.g. {"@libuv//:include_files": "include"}
         native_srcs_root - Package-relative prefix under which the native cpp/include/thirdparty
             directories live, relative to wherever this macro is invoked from
         generated_include_target - Optional label pointing at a public filegroup exposing that project's
@@ -35,6 +40,10 @@ def generate_robotpy_native_wrapper_build_info(
         cmd += " --third_party_dirs "
         for d in third_party_dirs:
             cmd += " " + d
+    if module_include_targets:
+        cmd += " --module_include_targets "
+        for label, strip in module_include_targets.items():
+            cmd += " " + label + "=" + strip
     native.genrule(
         name = "{}.gen_build_info".format(name),
         tools = ["//shared/bazel/rules/robotpy:generate_native_build_file"],

--- a/shared/bazel/rules/robotpy/generate_native_build_file.py
+++ b/shared/bazel/rules/robotpy/generate_native_build_file.py
@@ -91,7 +91,7 @@ def main():
     module_include_targets = []
     module_include_repos = set()
     for entry in args.module_include_targets or []:
-        label, _, strip = entry.partition("=")
+        label = entry.partition("=")[0]
         module_include_targets.append(label)
         module_include_repos.add(label.removeprefix("@").split("//")[0] + "*")
 

--- a/shared/bazel/rules/robotpy/generate_native_build_file.py
+++ b/shared/bazel/rules/robotpy/generate_native_build_file.py
@@ -20,6 +20,7 @@ def main():
     parser.add_argument("--project_cfg")
     parser.add_argument("--output_file")
     parser.add_argument("--third_party_dirs", nargs="+")
+    parser.add_argument("--module_include_targets", nargs="+")
     parser.add_argument("--native_srcs_root")
     parser.add_argument("--generated_include_target", default=None)
     parser.add_argument("--generated_include_root")
@@ -85,6 +86,15 @@ def main():
         "maven_lib_download"
     ]
 
+    # label=strip_prefix pairs for header trees that live in a Bazel module
+    # rather than under thirdparty/, e.g. @libuv//:include_files=include.
+    module_include_targets = []
+    module_include_repos = set()
+    for entry in args.module_include_targets or []:
+        label, _, strip = entry.partition("=")
+        module_include_targets.append(label)
+        module_include_repos.add(label.removeprefix("@").split("//")[0] + "*")
+
     third_party_dirs = args.third_party_dirs or []
     replace_prefix_keys = []
     if args.native_srcs_root:
@@ -103,6 +113,8 @@ def main():
 
     if args.generated_include_target:
         replace_prefix_keys.append(root_package + "/" + args.generated_include_root)
+    for entry in args.module_include_targets or []:
+        replace_prefix_keys.append(entry.partition("=")[2])
     replace_prefix_keys.sort()
 
     with open(args.output_file, "w", newline="\n") as f:
@@ -119,6 +131,8 @@ def main():
                 generated_include_target=args.generated_include_target,
                 native_srcs_root=args.native_srcs_root,
                 replace_prefix_keys=replace_prefix_keys,
+                module_include_targets=module_include_targets,
+                module_include_repos=sorted(module_include_repos),
             )
         )
 
@@ -135,8 +149,15 @@ def define_native_wrapper(name, pyproject_toml = None):
         {%- for dir in third_party_dirs %}
             "{{native_srcs_root}}thirdparty/{{dir}}/include/**",
         {%- endfor %}
-        ]){%- endif %},
+        ]){%- endif %}{% if module_include_targets %} + [
+        {%- for target in module_include_targets %}
+            "{{target}}",
+        {%- endfor %}
+        ]{%- endif %},
         out = "native/{{project_name}}/include",
+        {%- if module_include_repos %}
+        include_external_repositories = {{module_include_repos | double_quotes}},
+        {%- endif %}
         root_paths = ["src/main/native/include/"],
         replace_prefixes = {
         {%- for key in replace_prefix_keys %}

--- a/upstream_utils/libuv.py
+++ b/upstream_utils/libuv.py
@@ -47,6 +47,15 @@ def copy_upstream_src(wpilib_root: Path):
         rename_c_to_cpp=True,
     )
 
+    for f in [
+        "BUILD.bazel",
+        "MODULE.bazel",
+    ]:
+        shutil.copyfile(
+            f,
+            wpinet / "src/main/native/thirdparty/libuv" / f,
+        )
+
 
 def main():
     name = "libuv"

--- a/upstream_utils/libuv_patches/0001-Revert-win-process-write-minidumps-when-sending-SIGQ.patch
+++ b/upstream_utils/libuv_patches/0001-Revert-win-process-write-minidumps-when-sending-SIGQ.patch
@@ -1,8 +1,8 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Fri, 14 Jul 2023 17:33:08 -0700
-Subject: [PATCH 1/9] Revert "win,process: write minidumps when sending SIGQUIT
- (#3840)"
+Subject: [PATCH 01/10] Revert "win,process: write minidumps when sending
+ SIGQUIT (#3840)"
 
 This reverts commit 748d894e82abcdfff7429cf745003e182c47f163.
 ---

--- a/upstream_utils/libuv_patches/0002-Fix-missing-casts.patch
+++ b/upstream_utils/libuv_patches/0002-Fix-missing-casts.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 26 Apr 2022 15:01:25 -0400
-Subject: [PATCH 2/9] Fix missing casts
+Subject: [PATCH 02/10] Fix missing casts
 
 ---
  src/fs-poll.c                  | 10 +++----

--- a/upstream_utils/libuv_patches/0003-Fix-warnings.patch
+++ b/upstream_utils/libuv_patches/0003-Fix-warnings.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 26 Apr 2022 15:09:43 -0400
-Subject: [PATCH 3/9] Fix warnings
+Subject: [PATCH 03/10] Fix warnings
 
 ---
  include/uv/win.h    |  5 +++++

--- a/upstream_utils/libuv_patches/0004-Preprocessor-cleanup.patch
+++ b/upstream_utils/libuv_patches/0004-Preprocessor-cleanup.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 26 Apr 2022 15:19:14 -0400
-Subject: [PATCH 4/9] Preprocessor cleanup
+Subject: [PATCH 04/10] Preprocessor cleanup
 
 ---
  include/uv.h               | 12 ------------

--- a/upstream_utils/libuv_patches/0005-Cleanup-problematic-language.patch
+++ b/upstream_utils/libuv_patches/0005-Cleanup-problematic-language.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 26 Apr 2022 15:24:47 -0400
-Subject: [PATCH 5/9] Cleanup problematic language
+Subject: [PATCH 05/10] Cleanup problematic language
 
 ---
  src/unix/tty.c | 21 +++++++++++----------

--- a/upstream_utils/libuv_patches/0006-Use-C-atomics.patch
+++ b/upstream_utils/libuv_patches/0006-Use-C-atomics.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Thu, 13 Jul 2023 22:13:47 -0700
-Subject: [PATCH 6/9] Use C++ atomics
+Subject: [PATCH 06/10] Use C++ atomics
 
 ---
  src/unix/async.c  | 25 +++++++++++++------------

--- a/upstream_utils/libuv_patches/0007-Remove-static-from-array-indices.patch
+++ b/upstream_utils/libuv_patches/0007-Remove-static-from-array-indices.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Thu, 13 Jul 2023 23:30:58 -0700
-Subject: [PATCH 7/9] Remove static from array indices
+Subject: [PATCH 07/10] Remove static from array indices
 
 ---
  src/unix/linux.c | 12 ++++++------

--- a/upstream_utils/libuv_patches/0008-Add-pragmas-for-missing-libraries-and-set-_WIN32_WIN.patch
+++ b/upstream_utils/libuv_patches/0008-Add-pragmas-for-missing-libraries-and-set-_WIN32_WIN.patch
@@ -1,8 +1,8 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Fri, 14 Jul 2023 16:40:18 -0700
-Subject: [PATCH 8/9] Add pragmas for missing libraries and set _WIN32_WINNT to
- Windows 10
+Subject: [PATCH 08/10] Add pragmas for missing libraries and set _WIN32_WINNT
+ to Windows 10
 
 This makes GetSystemTimePreciseAsFileTime() available.
 

--- a/upstream_utils/libuv_patches/0009-Remove-swearing.patch
+++ b/upstream_utils/libuv_patches/0009-Remove-swearing.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jade Turner <spacey-sooty@proton.me>
 Date: Wed, 26 Jun 2024 11:40:37 +0800
-Subject: [PATCH 9/9] Remove swearing
+Subject: [PATCH 09/10] Remove swearing
 
 ---
  src/win/fs.c  | 2 +-

--- a/upstream_utils/libuv_patches/0010-Add-bazel-module-build-files.patch
+++ b/upstream_utils/libuv_patches/0010-Add-bazel-module-build-files.patch
@@ -1,14 +1,14 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Austin Schuh <austin.linux@gmail.com>
-Date: Sat, 6 Sep 2026 12:00:00 -0700
+Date: Sun, 6 Sep 2026 12:00:00 -0700
 Subject: [PATCH 10/10] Add bazel module build files
 
 This makes our vendored copy of libuv present the same API as the
 upstream libuv module in BCR, so a local_path_override can stand in for
 the registry module.
 ---
- BUILD.bazel  | 103 ++++++++++++++++++++++++++++++++++++++++++++++++++++
- MODULE.bazel |   7 +
+ BUILD.bazel  | 103 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ MODULE.bazel |   7 ++++
  2 files changed, 110 insertions(+)
  create mode 100644 BUILD.bazel
  create mode 100644 MODULE.bazel

--- a/upstream_utils/libuv_patches/0010-Add-bazel-module-build-files.patch
+++ b/upstream_utils/libuv_patches/0010-Add-bazel-module-build-files.patch
@@ -1,0 +1,137 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Austin Schuh <austin.linux@gmail.com>
+Date: Sat, 6 Sep 2026 12:00:00 -0700
+Subject: [PATCH 10/10] Add bazel module build files
+
+This makes our vendored copy of libuv present the same API as the
+upstream libuv module in BCR, so a local_path_override can stand in for
+the registry module.
+---
+ BUILD.bazel  | 103 ++++++++++++++++++++++++++++++++++++++++++++++++++++
+ MODULE.bazel |   7 +
+ 2 files changed, 110 insertions(+)
+ create mode 100644 BUILD.bazel
+ create mode 100644 MODULE.bazel
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+new file mode 100644
+index 0000000000000000000000000000000000000000..a094bf4ec952b746ea4c71178c48ca32f2cf2e0a
+--- /dev/null
++++ b/BUILD.bazel
+@@ -0,0 +1,103 @@
++load("@rules_cc//cc:cc_library.bzl", "cc_library")
++
++# wpilib's vendored libuv, presented with the same API as BCR's libuv module: a
++# public cc_library named libuv, built from src/ and include/. The root
++# MODULE.bazel points the libuv module here with a local_path_override, so
++# everything in the tree that names @libuv -- wpinet, @aos -- links this one
++# copy, and one set of uv_* symbols lands in a binary.
++#
++# The lists differ from BCR's overlay because the vendored tree does: the
++# sources are C renamed to C++ by upstream_utils, and wpilib's patches embed
++# the Windows link pragmas and _WIN32_WINNT in the code, so the local_defines
++# and Windows linkopts BCR carries are not needed here.
++
++UNIX_UV_SRCS = [
++    "src/unix/async.cpp",
++    "src/unix/core.cpp",
++    "src/unix/dl.cpp",
++    "src/unix/fs.cpp",
++    "src/unix/getaddrinfo.cpp",
++    "src/unix/getnameinfo.cpp",
++    "src/unix/loop-watcher.cpp",
++    "src/unix/loop.cpp",
++    "src/unix/pipe.cpp",
++    "src/unix/poll.cpp",
++    "src/unix/process.cpp",
++    "src/unix/random-devurandom.cpp",
++    "src/unix/random-getentropy.cpp",
++    "src/unix/random-getrandom.cpp",
++    "src/unix/signal.cpp",
++    "src/unix/stream.cpp",
++    "src/unix/tcp.cpp",
++    "src/unix/thread.cpp",
++    "src/unix/tty.cpp",
++    "src/unix/udp.cpp",
++] + glob(["src/unix/*.h"])
++
++MAC_UV_SRCS = [
++    "src/unix/bsd-ifaddrs.cpp",
++    "src/unix/darwin.cpp",
++    "src/unix/darwin-proctitle.cpp",
++    "src/unix/fsevents.cpp",
++    "src/unix/kqueue.cpp",
++    "src/unix/proctitle.cpp",
++]
++
++LINUX_UV_SRCS = [
++    "src/unix/linux.cpp",
++    "src/unix/procfs-exepath.cpp",
++    "src/unix/proctitle.cpp",
++    "src/unix/random-sysctl-linux.cpp",
++]
++
++WIN_UV_SRCS = glob([
++    "src/win/*.cpp",
++    "src/win/*.h",
++])
++
++cc_library(
++    name = "libuv",
++    srcs = glob([
++        "src/*.cpp",
++        "src/*.h",
++    ]) + select({
++        "@platforms//os:osx": UNIX_UV_SRCS + MAC_UV_SRCS,
++        "@platforms//os:windows": WIN_UV_SRCS,
++        "//conditions:default": UNIX_UV_SRCS + LINUX_UV_SRCS,
++    }),
++    hdrs = glob(["include/**/*.h"]),
++    copts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": [
++            "-Wno-error=pedantic",
++            "-Wno-error=format",
++        ],
++    }),
++    includes = ["src"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }) + select({
++        "@platforms//os:linux": [
++            "-ldl",
++            "-lrt",
++        ],
++        "//conditions:default": [],
++    }),
++    strip_include_prefix = "include",
++    visibility = ["//visibility:public"],
++)
++
++# The raw trees, for wpinet's doxygen bundle and its published artifacts --
++# rules there cannot glob across the package boundary this BUILD file creates.
++filegroup(
++    name = "include_files",
++    srcs = glob(["include/**"]),
++    visibility = ["//visibility:public"],
++)
++
++filegroup(
++    name = "src_files",
++    srcs = glob(["src/**"]),
++    visibility = ["//visibility:public"],
++)
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000000000000000000000000000000000000..f625c7ba10dcca796c7f07e7a7e93d8544df8fb0
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "libuv",
++    version = "1.49.2",
++)
++
++bazel_dep(name = "platforms", version = "0.0.10")
++bazel_dep(name = "rules_cc", version = "0.2.18")

--- a/wpinet/BUILD.bazel
+++ b/wpinet/BUILD.bazel
@@ -133,10 +133,6 @@ wpilib_cc_library(
         ":ada",
         ":private_includes",
         "//wpiutil",
-        # The real libuv, shared with @aos -- linking wpinet's vendored copy
-        # next to AOS's @libuv would put two sets of uv_* symbols in every
-        # robot binary. The vendored tree still exists for the CMake build;
-        # Bazel does not compile it.
         "@libuv",
     ],
 )

--- a/wpinet/BUILD.bazel
+++ b/wpinet/BUILD.bazel
@@ -15,9 +15,8 @@ filegroup(
     name = "doxygen-files",
     srcs = glob([
         "src/main/native/include/**/*",
-        "src/main/native/thirdparty/libuv/include/**/*",
         "src/main/native/thirdparty/tcpsockets/include/**/*",
-    ]),
+    ]) + ["@libuv//:include_files"],
     visibility = ["//visibility:public"],
 )
 
@@ -53,83 +52,16 @@ pkg_files(
     strip_prefix = "src/main/native/thirdparty/ada/src",
 )
 
-WIN_UV_SRCS = glob([
-    "src/main/native/thirdparty/libuv/src/win/*.cpp",
-    "src/main/native/thirdparty/libuv/src/win/*.h",
-])
-
-UNIX_UV_SRCS = [
-    "src/main/native/thirdparty/libuv/src/unix/async.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/core.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/dl.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/fs.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/getaddrinfo.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/getnameinfo.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/loop-watcher.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/loop.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/pipe.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/poll.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/process.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/random-devurandom.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/random-getentropy.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/random-getrandom.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/signal.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/stream.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/tcp.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/thread.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/tty.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/udp.cpp",
-] + glob(["src/main/native/thirdparty/libuv/src/unix/*.h"])
-
-MAC_UV_SRCS = [
-    "src/main/native/thirdparty/libuv/src/unix/bsd-ifaddrs.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/darwin.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/darwin-proctitle.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/fsevents.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/kqueue.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/proctitle.cpp",
-]
-
-LINUX_UV_SRCS = [
-    "src/main/native/thirdparty/libuv/src/unix/linux.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/procfs-exepath.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/proctitle.cpp",
-    "src/main/native/thirdparty/libuv/src/unix/random-sysctl-linux.cpp",
-]
-
-cc_library(
-    name = "libuv-headers",
-    hdrs = glob([
-        "src/main/native/thirdparty/libuv/include/**/*.h",
-    ]),
-    includes = ["src/main/native/thirdparty/libuv/src"],
-    strip_include_prefix = "src/main/native/thirdparty/libuv/include",
-)
-
-filegroup(
-    name = "libuv-srcs",
-    srcs = select({
-               "@wpilib_toolchains//constraints/combined:is_unix": UNIX_UV_SRCS,
-               "//conditions:default": [],
-           }) +
-           select({
-               "@platforms//os:osx": MAC_UV_SRCS,
-               "@platforms//os:windows": WIN_UV_SRCS,
-               "@wpilib_toolchains//constraints/combined:is_linux": LINUX_UV_SRCS,
-           }) + glob(["src/main/native/thirdparty/libuv/src/*"]),
-    visibility = ["//wpinet:__subpackages__"],
-)
-
 pkg_files(
     name = "thirdparty-libuv-hdr-pkg",
-    srcs = glob(["src/main/native/thirdparty/libuv/include/**"]),
-    strip_prefix = "src/main/native/thirdparty/libuv/include",
+    srcs = ["@libuv//:include_files"],
+    strip_prefix = "include",
 )
 
 pkg_files(
     name = "thirdparty-libuv-src-pkg",
-    srcs = glob(["src/main/native/thirdparty/libuv/src/**"]),
-    strip_prefix = "src/main/native/thirdparty/libuv/src",
+    srcs = ["@libuv//:src_files"],
+    strip_prefix = "src",
 )
 
 third_party_cc_lib_helper(
@@ -166,9 +98,7 @@ wpilib_cc_library(
     srcs = glob(
         ["src/main/native/cpp/**"],
         exclude = ["src/main/native/cpp/jni/**"],
-    ) + [
-        ":libuv-srcs",
-    ] + ["native-srcs"],
+    ) + ["native-srcs"],
     hdrs = glob(["src/main/native/include/**/*"]),
     copts = select({
         "@platforms//os:windows": [],
@@ -201,9 +131,13 @@ wpilib_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":ada",
-        ":libuv-headers",
         ":private_includes",
         "//wpiutil",
+        # The real libuv, shared with @aos -- linking wpinet's vendored copy
+        # next to AOS's @libuv would put two sets of uv_* symbols in every
+        # robot binary. The vendored tree still exists for the CMake build;
+        # Bazel does not compile it.
+        "@libuv",
     ],
 )
 
@@ -356,7 +290,6 @@ generate_robotpy_native_wrapper_build_info(
     pyproject_toml = "src/main/python/native-pyproject.toml",
     third_party_dirs = [
         "ada",
-        "libuv",
         "llhttp",
         "tcpsockets",
     ],

--- a/wpinet/BUILD.bazel
+++ b/wpinet/BUILD.bazel
@@ -283,6 +283,9 @@ cc_binary(
 
 generate_robotpy_native_wrapper_build_info(
     name = "robotpy-native-wpinet-generator",
+    module_include_targets = {
+        "@libuv//:include_files": "include",
+    },
     pyproject_toml = "src/main/python/native-pyproject.toml",
     third_party_dirs = [
         "ada",

--- a/wpinet/robotpy_native_build_info.bzl
+++ b/wpinet/robotpy_native_build_info.bzl
@@ -10,10 +10,14 @@ def define_native_wrapper(name, pyproject_toml = None):
             "src/main/native/thirdparty/ada/include/**",
             "src/main/native/thirdparty/llhttp/include/**",
             "src/main/native/thirdparty/tcpsockets/include/**",
-        ]),
+        ]) + [
+            "@libuv//:include_files",
+        ],
         out = "native/wpinet/include",
+        include_external_repositories = ["libuv*"],
         root_paths = ["src/main/native/include/"],
         replace_prefixes = {
+            "include": "",
             "wpinet/src/main/native/include": "",
             "wpinet/src/main/native/thirdparty/ada/include": "",
             "wpinet/src/main/native/thirdparty/llhttp/include": "",

--- a/wpinet/robotpy_native_build_info.bzl
+++ b/wpinet/robotpy_native_build_info.bzl
@@ -8,7 +8,6 @@ def define_native_wrapper(name, pyproject_toml = None):
         name = "{}.copy_headers".format(name),
         srcs = native.glob(["src/main/native/include/**"]) + native.glob([
             "src/main/native/thirdparty/ada/include/**",
-            "src/main/native/thirdparty/libuv/include/**",
             "src/main/native/thirdparty/llhttp/include/**",
             "src/main/native/thirdparty/tcpsockets/include/**",
         ]),
@@ -17,7 +16,6 @@ def define_native_wrapper(name, pyproject_toml = None):
         replace_prefixes = {
             "wpinet/src/main/native/include": "",
             "wpinet/src/main/native/thirdparty/ada/include": "",
-            "wpinet/src/main/native/thirdparty/libuv/include": "",
             "wpinet/src/main/native/thirdparty/llhttp/include": "",
             "wpinet/src/main/native/thirdparty/tcpsockets/include": "",
         },

--- a/wpinet/src/main/native/thirdparty/libuv/BUILD.bazel
+++ b/wpinet/src/main/native/thirdparty/libuv/BUILD.bazel
@@ -1,0 +1,103 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# wpilib's vendored libuv, presented with the same API as BCR's libuv module: a
+# public cc_library named libuv, built from src/ and include/. The root
+# MODULE.bazel points the libuv module here with a local_path_override, so
+# everything in the tree that names @libuv -- wpinet, @aos -- links this one
+# copy, and one set of uv_* symbols lands in a binary.
+#
+# The lists differ from BCR's overlay because the vendored tree does: the
+# sources are C renamed to C++ by upstream_utils, and wpilib's patches embed
+# the Windows link pragmas and _WIN32_WINNT in the code, so the local_defines
+# and Windows linkopts BCR carries are not needed here.
+
+UNIX_UV_SRCS = [
+    "src/unix/async.cpp",
+    "src/unix/core.cpp",
+    "src/unix/dl.cpp",
+    "src/unix/fs.cpp",
+    "src/unix/getaddrinfo.cpp",
+    "src/unix/getnameinfo.cpp",
+    "src/unix/loop-watcher.cpp",
+    "src/unix/loop.cpp",
+    "src/unix/pipe.cpp",
+    "src/unix/poll.cpp",
+    "src/unix/process.cpp",
+    "src/unix/random-devurandom.cpp",
+    "src/unix/random-getentropy.cpp",
+    "src/unix/random-getrandom.cpp",
+    "src/unix/signal.cpp",
+    "src/unix/stream.cpp",
+    "src/unix/tcp.cpp",
+    "src/unix/thread.cpp",
+    "src/unix/tty.cpp",
+    "src/unix/udp.cpp",
+] + glob(["src/unix/*.h"])
+
+MAC_UV_SRCS = [
+    "src/unix/bsd-ifaddrs.cpp",
+    "src/unix/darwin.cpp",
+    "src/unix/darwin-proctitle.cpp",
+    "src/unix/fsevents.cpp",
+    "src/unix/kqueue.cpp",
+    "src/unix/proctitle.cpp",
+]
+
+LINUX_UV_SRCS = [
+    "src/unix/linux.cpp",
+    "src/unix/procfs-exepath.cpp",
+    "src/unix/proctitle.cpp",
+    "src/unix/random-sysctl-linux.cpp",
+]
+
+WIN_UV_SRCS = glob([
+    "src/win/*.cpp",
+    "src/win/*.h",
+])
+
+cc_library(
+    name = "libuv",
+    srcs = glob([
+        "src/*.cpp",
+        "src/*.h",
+    ]) + select({
+        "@platforms//os:osx": UNIX_UV_SRCS + MAC_UV_SRCS,
+        "@platforms//os:windows": WIN_UV_SRCS,
+        "//conditions:default": UNIX_UV_SRCS + LINUX_UV_SRCS,
+    }),
+    hdrs = glob(["include/**/*.h"]),
+    copts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "-Wno-error=pedantic",
+            "-Wno-error=format",
+        ],
+    }),
+    includes = ["src"],
+    linkopts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-pthread"],
+    }) + select({
+        "@platforms//os:linux": [
+            "-ldl",
+            "-lrt",
+        ],
+        "//conditions:default": [],
+    }),
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)
+
+# The raw trees, for wpinet's doxygen bundle and its published artifacts --
+# rules there cannot glob across the package boundary this BUILD file creates.
+filegroup(
+    name = "include_files",
+    srcs = glob(["include/**"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "src_files",
+    srcs = glob(["src/**"]),
+    visibility = ["//visibility:public"],
+)

--- a/wpinet/src/main/native/thirdparty/libuv/MODULE.bazel
+++ b/wpinet/src/main/native/thirdparty/libuv/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "libuv",
+    version = "1.49.2",
+)
+
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.2.18")


### PR DESCRIPTION
The vendored tree gains a MODULE.bazel/BUILD.bazel pair mirroring BCR's libuv API -- a public cc_library named libuv -- and a local_path_override points the libuv module at it, the same way eigen is wired up. wpinet builds against @libuv instead of globbing the sources itself, and any dependency that names @libuv (@aos is about to become one) links this same copy, so one set of uv_* symbols lands in a binary. The vendored code stays the source of truth; nothing resolves from the registry.

The build files ride in upstream_utils as a patch and a copy step, again following eigen, so a libuv upgrade regenerates them. The robotpy header bundle drops the vendored libuv globs the way wpimath's drops eigen -- the module boundary is a package boundary, and globs stop at it; the doxygen bundle and the published header zip switch to filegroups the module exports, and their contents are unchanged.