### PR TITLE
[robotpy] Fix version file generation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_java//java:java_plugin.bzl", "java_plugin")
 load("@rules_java//java/toolchains:java_package_configuration.bzl", "java_package_configuration")
 load("@rules_java//toolchains:default_java_toolchain.bzl", "default_java_toolchain")
 load("@rules_pkg//:mappings.bzl", "pkg_files")
+load("@rules_pkg//:pkg.bzl", "pkg_zip")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("//shared/bazel/rules:publishing.bzl", "publish_all")
 load("//shared/bazel/rules/robotpy:compatibility_select.bzl", "robotpy_compatibility_select")
@@ -351,5 +352,49 @@ filegroup(
         "//wpiutil:robotpy-wpiutil.generated_files",
     ],
     tags = ["manual"],
+    target_compatible_with = robotpy_compatibility_select(),
+)
+
+pkg_zip(
+    name = "robotpy_wheels_zip",
+    srcs = [
+        "//apriltag:robotpy-apriltag-wheel",
+        "//apriltag:robotpy-native-apriltag-wheel",
+        "//commandsv2:commandsv2-py-wheel",
+        "//datalog:robotpy-native-datalog-wheel",
+        "//datalog:robotpy-wpilog-wheel",
+        "//drivers:robotpy-native-wpilib-drivers-wheel",
+        "//drivers:wpilib-drivers-wheel",
+        "//fields:robotpy-fields-wheel",
+        "//fields:robotpy-native-fields-wheel",
+        "//hal:robotpy-hal-wheel",
+        "//hal:robotpy-native-wpihal-wheel",
+        "//ntcore:pyntcore-wheel",
+        "//ntcore:robotpy-native-ntcore-wheel",
+        "//romiVendordep:robotpy-native-romi-wheel",
+        "//romiVendordep:robotpy-romi-wheel",
+        "//simulation/halsim_ds_socket:robotpy-halsim-ds-socket-wheel",
+        "//simulation/halsim_gui:robotpy-halsim-gui-wheel",
+        "//simulation/halsim_gui:robotpy-native-halsim-gui-wheel",
+        "//simulation/halsim_ws_core:robotpy-halsim-ws-wheel",
+        "//telemetry:robotpy-native-telemetry-wheel",
+        "//telemetry:robotpy-telemetry-wheel",
+        "//tunables:robotpy-native-tunables-wheel",
+        "//tunables:robotpy-tunables-wheel",
+        "//wpilibc:robotpy-native-wpilib-wheel",
+        "//wpilibc:robotpy-wpilib-wheel",
+        "//wpimath:robotpy-native-wpimath-wheel",
+        "//wpimath:robotpy-wpimath-wheel",
+        "//wpinet:robotpy-native-wpinet-wheel",
+        "//wpinet:robotpy-wpinet-wheel",
+        "//wpiutil:robotpy-native-wpiutil-wheel",
+        "//wpiutil:robotpy-wpiutil-wheel",
+        "//xrpVendordep:robotpy-native-xrp-wheel",
+        "//xrpVendordep:robotpy-xrp-wheel",
+    ],
+    tags = [
+        "manual",
+        "robotpy",
+    ],
     target_compatible_with = robotpy_compatibility_select(),
 )

--- a/apriltag/robotpy_pybind_build_info.bzl
+++ b/apriltag/robotpy_pybind_build_info.bzl
@@ -232,6 +232,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/robotpy_apriltag/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(

--- a/datalog/robotpy_pybind_build_info.bzl
+++ b/datalog/robotpy_pybind_build_info.bzl
@@ -253,6 +253,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/wpilog/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(

--- a/drivers/robotpy_pybind_build_info.bzl
+++ b/drivers/robotpy_pybind_build_info.bzl
@@ -289,6 +289,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/wpilib_drivers/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(

--- a/fields/robotpy_pybind_build_info.bzl
+++ b/fields/robotpy_pybind_build_info.bzl
@@ -225,6 +225,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/robotpy_fields/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(

--- a/hal/robotpy_pybind_build_info.bzl
+++ b/hal/robotpy_pybind_build_info.bzl
@@ -526,6 +526,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/hal/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(

--- a/ntcore/robotpy_pybind_build_info.bzl
+++ b/ntcore/robotpy_pybind_build_info.bzl
@@ -508,6 +508,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/ntcore/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(

--- a/romiVendordep/robotpy_pybind_build_info.bzl
+++ b/romiVendordep/robotpy_pybind_build_info.bzl
@@ -232,6 +232,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/romi/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(

--- a/shared/bazel/rules/gen/gen-version-file.bzl
+++ b/shared/bazel/rules/gen/gen-version-file.bzl
@@ -1,6 +1,6 @@
 def _generate_version_file_impl(ctx):
     out = ctx.actions.declare_file(ctx.attr.output_file)
-    wpilib_version = ctx.var.get("WPILIB_VERSION")
+    wpilib_version = ctx.var.get(ctx.attr.version_variable)
     ctx.actions.expand_template(
         output = out,
         template = ctx.file.template,
@@ -16,5 +16,6 @@ generate_version_file = rule(
             allow_single_file = True,
             mandatory = True,
         ),
+        "version_variable": attr.string(default = "WPILIB_VERSION"),
     },
 )

--- a/shared/bazel/rules/robotpy/pybind_build_file_template.jinja2
+++ b/shared/bazel/rules/robotpy/pybind_build_file_template.jinja2
@@ -196,6 +196,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "{{stripped_include_prefix}}/{{version_file}}",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 {% endif %}
     robotpy_library(

--- a/shared/bazel/rules/robotpy/robotpy_rules.bzl
+++ b/shared/bazel/rules/robotpy/robotpy_rules.bzl
@@ -127,6 +127,7 @@ def robotpy_library(
         python_requires = python_requires,
         license = "BSD-3-Clause",
         tags = ["robotpy"],
+        visibility = ["//visibility:public"],
     )
 
     pycross_wheel_library(

--- a/simulation/halsim_ds_socket/BUILD.bazel
+++ b/simulation/halsim_ds_socket/BUILD.bazel
@@ -107,6 +107,7 @@ generate_version_file(
     name = "generate_python_version",
     output_file = "src/main/python/halsim_ds_socket/version.py",
     template = "//shared/bazel/rules/robotpy:version_template.in",
+    version_variable = "ROBOTPY_VERSION",
 )
 
 robotpy_library(

--- a/simulation/halsim_gui/robotpy_pybind_build_info.bzl
+++ b/simulation/halsim_gui/robotpy_pybind_build_info.bzl
@@ -133,6 +133,7 @@ def define_pybind_library(name, pkgcfgs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/halsim_gui/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(

--- a/simulation/halsim_ws_core/BUILD.bazel
+++ b/simulation/halsim_ws_core/BUILD.bazel
@@ -74,6 +74,7 @@ generate_version_file(
     name = "generate_python_version",
     output_file = "src/main/python/halsim_ws/version.py",
     template = "//shared/bazel/rules/robotpy:version_template.in",
+    version_variable = "ROBOTPY_VERSION",
 )
 
 robotpy_library(

--- a/telemetry/robotpy_pybind_build_info.bzl
+++ b/telemetry/robotpy_pybind_build_info.bzl
@@ -211,6 +211,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/telemetry/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(

--- a/tunables/robotpy_pybind_build_info.bzl
+++ b/tunables/robotpy_pybind_build_info.bzl
@@ -202,6 +202,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/tunables/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(

--- a/wpilibc/robotpy_pybind_build_info.bzl
+++ b/wpilibc/robotpy_pybind_build_info.bzl
@@ -1986,6 +1986,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/wpilib/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(

--- a/wpimath/robotpy_pybind_build_info.bzl
+++ b/wpimath/robotpy_pybind_build_info.bzl
@@ -1486,6 +1486,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/wpimath/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(

--- a/wpinet/robotpy_pybind_build_info.bzl
+++ b/wpinet/robotpy_pybind_build_info.bzl
@@ -201,6 +201,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/wpinet/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(

--- a/wpiutil/robotpy_pybind_build_info.bzl
+++ b/wpiutil/robotpy_pybind_build_info.bzl
@@ -294,6 +294,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/wpiutil/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(

--- a/xrpVendordep/robotpy_pybind_build_info.bzl
+++ b/xrpVendordep/robotpy_pybind_build_info.bzl
@@ -252,6 +252,7 @@ def define_pybind_library(name, pkgcfgs = [], extra_pybind_hdrs = []):
         name = "{}.generate_version".format(name),
         output_file = "src/main/python/xrp/version.py",
         template = "//shared/bazel/rules/robotpy:version_template.in",
+        version_variable = "ROBOTPY_VERSION",
     )
 
     robotpy_library(


### PR DESCRIPTION
This generalizes the `generate_version_file` macro to take in the name of the build variable to use to differentiate wpilib version and robotpy version which can be different. This is already handled for the naming of the wheels, but the generated `__version__.py` file was using the wpilib value.

I also added a target to zip up all the wheels.