### PR TITLE
[cmd3] Do not track command-scoped bindings for cleanup

### DIFF
--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -578,10 +578,18 @@ public final class Scheduler implements ProtobufSerializable {
       return result;
     }
 
-    // Track this binding so we can disable it when it's out of scope.
-    // Note that, even though triggers can clean themselves up, commands that are manually scheduled
-    // cannot do the same, so we have to track them in the scheduler.
-    m_activeBindings.add(binding);
+    if (!(binding.scope() instanceof BindingScope.ForCommand)) {
+      // Track this binding so we can disable it when it's out of scope.
+      // Note that, even though triggers can clean themselves up, commands that are manually
+      // scheduled cannot do the same, so we have to track them in the scheduler.
+
+      // We don't bother tracking command-scoped bindings; the bound command will already be
+      // cleaned up in the same cycle that the parent command exits, so this would attempt to
+      // double-cancel a child command across two cycles (once when the parent exits, and then in
+      // the next cycle in cancelStaleBindings). That would cause problems if the command object
+      // is immediately rescheduled as cancelStaleBindings would immediately cancel the new run
+      m_activeBindings.add(binding);
+    }
 
     // Evict conflicting on-deck commands
     // We check above if the input command is lower priority than any of these,

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerCancellationTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerCancellationTests.java
@@ -368,6 +368,75 @@ class SchedulerCancellationTests extends CommandTestBase {
   }
 
   @Test
+  void compositionsWithSharedCommandsDoNotSelfCancel() {
+    var mech = new DummyMechanism("Mech", m_scheduler);
+
+    var count = new AtomicInteger(0);
+    var cancellationCount = new AtomicInteger(0);
+    var innerCommand =
+        mech.run(
+                coroutine -> {
+                  count.set(0);
+
+                  while (true) {
+                    count.incrementAndGet();
+                    coroutine.yield();
+                  }
+                })
+            .whenCanceled(cancellationCount::incrementAndGet)
+            .named("Inner Command");
+
+    // two compositions with conflicting requirements (mech) running the same command object
+    final var parent1 =
+        Command.requiring(mech).executing(c -> c.await(innerCommand)).named("Parent 1");
+    final var parent2 =
+        Command.requiring(mech).executing(c -> c.await(innerCommand)).named("Parent 2");
+
+    m_scheduler.schedule(parent1);
+    m_scheduler.run();
+    assertEquals(List.of(parent1, innerCommand), m_scheduler.getRunningCommands());
+    assertEquals(1, count.get());
+    m_scheduler.run();
+    assertEquals(2, count.get());
+
+    m_scheduler.schedule(parent2);
+    m_scheduler.run();
+    assertEquals(
+        List.of(parent2, innerCommand),
+        m_scheduler.getRunningCommands(),
+        "parent2 should have started");
+    assertEquals(1, cancellationCount.get(), "Inner command should have been canceled");
+    assertEquals(1, count.get(), "Inner command should have restarted");
+
+    m_scheduler.run();
+    assertEquals(
+        List.of(parent2, innerCommand),
+        m_scheduler.getRunningCommands(),
+        "parent2 and inner command should still be running");
+    assertEquals(1, cancellationCount.get(), "Inner command should not have been canceled again");
+    assertEquals(2, count.get(), "Inner command should have continued running");
+  }
+
+  @Test
+  void compositionsAwaitingSameCommandDoNotInterrupt() {
+    var mech = new DummyMechanism("Mech", m_scheduler);
+    var sharedCommand = mech.run(Coroutine::park).named("Shared Command");
+
+    // Both compositions await the same command instance, so parent2's `await` call just waits
+    // for the already-running process to exit instead of restarting it and interrupting parent1
+    final var parent1 = Command.noRequirements(c -> c.await(sharedCommand)).named("Parent 1");
+    final var parent2 = Command.noRequirements(c -> c.await(sharedCommand)).named("Parent 2");
+
+    m_scheduler.schedule(parent1);
+    m_scheduler.run();
+    assertEquals(List.of(parent1, sharedCommand), m_scheduler.getRunningCommands());
+
+    m_scheduler.schedule(parent2);
+    m_scheduler.run();
+    assertEquals(List.of(parent1, sharedCommand, parent2), m_scheduler.getRunningCommands());
+  }
+
+  @Test
   void doesNotRunOnCancelWhenInterruptingOnDeck() {
     var ran = new AtomicBoolean(false);
 


### PR DESCRIPTION
Because inner commands are always canceled when their parents exit, command-scoped bindings would continue to track those inner commands until the next scheduler cycle, which caused problems if the same inner command object is reused in that cycle

Fixes #9400