### PR TITLE
[cmd3] Add `onExit` command callback to always run when a command stops running

### DIFF
--- a/commandsv3/src/main/java/org/wpilib/command3/Command.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Command.java
@@ -134,6 +134,16 @@ public interface Command {
   }
 
   /**
+   * An optional lifecycle hook that can be implemented to execute some code whenever this command
+   * exits, regardless of exit condition (natural completion, cancellation, or interruption).
+   * Commands should be careful to do a single-shot cleanup (for example, setting a motor to zero
+   * volts) and not do any complex looping logic here.
+   */
+  default void onExit() {
+    // NOP by default
+  }
+
+  /**
    * The name of the command.
    *
    * @return the name of the command

--- a/commandsv3/src/main/java/org/wpilib/command3/NeedsNameBuilderStage.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/NeedsNameBuilderStage.java
@@ -23,8 +23,20 @@ public interface NeedsNameBuilderStage {
    * @param onCancel The function to execute when the command is canceled while running. May be
    *     null.
    * @return This builder object, for chaining
+   * @see Command#onCancel()
    */
   NeedsNameBuilderStage whenCanceled(Runnable onCancel);
+
+  /**
+   * Optionally sets a callback to execute when the command exits. The callback will not run if the
+   * command was stopped after being scheduled but before starting to run, but will run whenever the
+   * command stops regardless of the cause (natural completion, cancellation, or interruption).
+   *
+   * @param onExit The function to execute when the command exits. May be null.
+   * @return This builder object, for chaining
+   * @see Command#onExit()
+   */
+  NeedsNameBuilderStage whenExited(Runnable onExit);
 
   /**
    * Sets the priority level of the command.

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -761,8 +761,11 @@ public final class Scheduler implements ProtobufSerializable {
     m_queuedToRun.removeIf(state -> state.command() == command);
 
     if (running) {
-      // Only run the hook if the command was running. If it was on deck or not
+      // Only run the hooks if the command was running. If it was on deck or not
       // even in the scheduler at the time, then there's nothing to do
+      // Always run onExit first, in case cancellation has special behavior that overrides
+      // standard exit logic.
+      command.onExit();
       command.onCancel();
       emitCanceledEvent(command);
     }
@@ -964,6 +967,7 @@ public final class Scheduler implements ProtobufSerializable {
   }
 
   private void handleCommandCompletion(Command command) {
+    command.onExit();
     emitCompletedEvent(command);
     m_runningCommands.remove(command);
     removeOrphanedChildren(command);
@@ -1202,6 +1206,9 @@ public final class Scheduler implements ProtobufSerializable {
       var entry = liveIter.next();
       liveIter.remove();
       Command canceledCommand = entry.getKey();
+      // Always run onExit first, in case cancellation has special behavior that overrides
+      // standard exit logic.
+      canceledCommand.onExit();
       canceledCommand.onCancel();
       emitCanceledEvent(canceledCommand);
     }

--- a/commandsv3/src/main/java/org/wpilib/command3/StagedCommandBuilder.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/StagedCommandBuilder.java
@@ -58,6 +58,7 @@ public final class StagedCommandBuilder {
   private final Set<Mechanism> m_requirements = new HashSet<>();
   private Consumer<Coroutine> m_impl;
   private Runnable m_onCancel = () -> {};
+  private Runnable m_onExit = () -> {};
   private String m_name;
   private int m_priority = Command.DEFAULT_PRIORITY;
   private BooleanSupplier m_endCondition;
@@ -131,6 +132,14 @@ public final class StagedCommandBuilder {
         }
 
         @Override
+        public NeedsNameBuilderStage whenExited(Runnable onExit) {
+          throwIfAlreadyBuilt();
+
+          m_onExit = onExit;
+          return this;
+        }
+
+        @Override
         public NeedsNameBuilderStage withPriority(int priority) {
           throwIfAlreadyBuilt();
 
@@ -175,6 +184,7 @@ public final class StagedCommandBuilder {
     private final Set<Mechanism> m_requirements;
     private final Consumer<Coroutine> m_impl;
     private final Runnable m_onCancel;
+    private final Runnable m_onExit;
     private final String m_name;
     private final int m_priority;
 
@@ -183,6 +193,7 @@ public final class StagedCommandBuilder {
       m_requirements = new HashSet<>(builder.m_requirements);
       m_impl = builder.m_impl;
       m_onCancel = Objects.requireNonNullElse(builder.m_onCancel, NO_OP);
+      m_onExit = Objects.requireNonNullElse(builder.m_onExit, NO_OP);
       m_name = builder.m_name;
       m_priority = builder.m_priority;
     }
@@ -195,6 +206,11 @@ public final class StagedCommandBuilder {
     @Override
     public void onCancel() {
       m_onCancel.run();
+    }
+
+    @Override
+    public void onExit() {
+      m_onExit.run();
     }
 
     @Override

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerCancellationTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerCancellationTests.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -198,6 +199,18 @@ class SchedulerCancellationTests extends CommandTestBase {
   }
 
   @Test
+  void requestCancellationCallsOnExit() {
+    AtomicBoolean callbackRan = new AtomicBoolean(false);
+    var command =
+        Command.noRequirements(Coroutine::requestCancellation)
+            .whenExited(() -> callbackRan.set(true))
+            .named("Self-Cancelling Command");
+    m_scheduler.schedule(command);
+    m_scheduler.run();
+    assertTrue(callbackRan.get(), "OnExit callback should have been called");
+  }
+
+  @Test
   void cancelAllEvictsOnDeck() {
     var command = Command.noRequirements(Coroutine::park).named("Command");
     m_scheduler.schedule(command);
@@ -245,6 +258,32 @@ class SchedulerCancellationTests extends CommandTestBase {
     // no call to run before cancelAll()
     m_scheduler.cancelAll();
     assertFalse(ranHook.get(), "onCancel hook was not called");
+  }
+
+  @Test
+  void cancelAllCallsOnExitHookForRunningCommands() {
+    AtomicBoolean ranHook = new AtomicBoolean(false);
+    var command =
+        Command.noRequirements(Coroutine::park)
+            .whenExited(() -> ranHook.set(true))
+            .named("Command");
+    m_scheduler.schedule(command);
+    m_scheduler.run();
+    m_scheduler.cancelAll();
+    assertTrue(ranHook.get(), "onExit hook was not called");
+  }
+
+  @Test
+  void cancelAllDoesNotCallOnExitHookForQueuedCommands() {
+    AtomicBoolean ranHook = new AtomicBoolean(false);
+    var command =
+        Command.noRequirements(Coroutine::park)
+            .whenExited(() -> ranHook.set(true))
+            .named("Command");
+    m_scheduler.schedule(command);
+    // no call to run before cancelAll()
+    m_scheduler.cancelAll();
+    assertFalse(ranHook.get(), "onExit hook was called when it shouldn't have been");
   }
 
   @Test
@@ -450,5 +489,229 @@ class SchedulerCancellationTests extends CommandTestBase {
     m_scheduler.cancel(group);
 
     assertTrue(ran.get(), "onCancel should have run!");
+  }
+
+  @Test
+  void doesNotRunOnExitWhenInterruptingOnDeck() {
+    var ran = new AtomicBoolean(false);
+
+    var mechanism = new DummyMechanism("The mechanism", m_scheduler);
+    var cmd = mechanism.run(Coroutine::yield).whenExited(() -> ran.set(true)).named("cmd");
+    var interrupter = mechanism.run(Coroutine::yield).named("Interrupter");
+    m_scheduler.schedule(cmd);
+    m_scheduler.schedule(interrupter);
+    m_scheduler.run();
+
+    assertFalse(ran.get(), "onExit ran when it shouldn't have!");
+  }
+
+  @Test
+  void doesNotRunOnExitWhenCancelingOnDeck() {
+    var ran = new AtomicBoolean(false);
+
+    var mechanism = new DummyMechanism("The mechanism", m_scheduler);
+    var cmd = mechanism.run(Coroutine::yield).whenExited(() -> ran.set(true)).named("cmd");
+    m_scheduler.schedule(cmd);
+    // canceling before calling .run()
+    m_scheduler.cancel(cmd);
+    m_scheduler.run();
+
+    assertFalse(ran.get(), "onExit ran when it shouldn't have!");
+  }
+
+  @Test
+  void runsOnExitWhenInterruptingCommand() {
+    var ran = new AtomicBoolean(false);
+
+    var mechanism = new DummyMechanism("The mechanism", m_scheduler);
+    var cmd = mechanism.run(Coroutine::park).whenExited(() -> ran.set(true)).named("cmd");
+    var interrupter = mechanism.run(Coroutine::park).named("Interrupter");
+    m_scheduler.schedule(cmd);
+    m_scheduler.run();
+    m_scheduler.schedule(interrupter);
+    m_scheduler.run();
+
+    assertTrue(ran.get(), "onExit should have run!");
+  }
+
+  @Test
+  void runsOnExitWhenCompleting() {
+    var exitRan = new AtomicBoolean(false);
+    var cancelRan = new AtomicBoolean(false);
+
+    var mechanism = new DummyMechanism("The mechanism", m_scheduler);
+    var cmd =
+        mechanism
+            .run(Coroutine::yield)
+            .whenExited(() -> exitRan.set(true))
+            .whenCanceled(() -> cancelRan.set(true))
+            .named("cmd");
+    m_scheduler.schedule(cmd);
+    m_scheduler.run();
+    m_scheduler.run();
+
+    assertFalse(m_scheduler.isScheduledOrRunning(cmd));
+    assertTrue(exitRan.get(), "onExit should have run on natural completion!");
+    assertFalse(cancelRan.get(), "onCancel should not have run on natural completion!");
+  }
+
+  @Test
+  void runsOnExitWhenCanceling() {
+    var ran = new AtomicBoolean(false);
+
+    var mechanism = new DummyMechanism("The mechanism", m_scheduler);
+    var cmd = mechanism.run(Coroutine::yield).whenExited(() -> ran.set(true)).named("cmd");
+    m_scheduler.schedule(cmd);
+    m_scheduler.run();
+    m_scheduler.cancel(cmd);
+
+    assertTrue(ran.get(), "onExit should have run!");
+  }
+
+  @Test
+  void runsOnExitWhenCancelingParent() {
+    var ran = new AtomicBoolean(false);
+
+    var mechanism = new DummyMechanism("The mechanism", m_scheduler);
+    var cmd = mechanism.run(Coroutine::yield).whenExited(() -> ran.set(true)).named("cmd");
+
+    var group = new SequentialGroup("Seq", Collections.singletonList(cmd));
+    m_scheduler.schedule(group);
+    m_scheduler.run();
+    m_scheduler.cancel(group);
+
+    assertTrue(ran.get(), "onExit should have run!");
+  }
+
+  @Test
+  void onExitInvokedDirectlyBeforeOnCancelWhenCanceling() {
+    List<String> invocations = new ArrayList<>();
+
+    var mechanism = new DummyMechanism("The mechanism", m_scheduler);
+    var cmd =
+        mechanism
+            .run(Coroutine::park)
+            .whenExited(() -> invocations.add("onExit"))
+            .whenCanceled(() -> invocations.add("onCancel"))
+            .named("cmd");
+
+    m_scheduler.schedule(cmd);
+    m_scheduler.run();
+    m_scheduler.cancel(cmd);
+
+    assertEquals(List.of("onExit", "onCancel"), invocations);
+  }
+
+  @Test
+  void onExitInvokedDirectlyBeforeOnCancelWhenRequestingCancellation() {
+    List<String> invocations = new ArrayList<>();
+
+    var cmd =
+        Command.noRequirements(Coroutine::requestCancellation)
+            .whenExited(() -> invocations.add("onExit"))
+            .whenCanceled(() -> invocations.add("onCancel"))
+            .named("cmd");
+
+    m_scheduler.schedule(cmd);
+    m_scheduler.run();
+
+    assertEquals(List.of("onExit", "onCancel"), invocations);
+  }
+
+  @Test
+  void onExitInvokedDirectlyBeforeOnCancelWhenInterrupted() {
+    List<String> invocations = new ArrayList<>();
+
+    var mechanism = new DummyMechanism("The mechanism", m_scheduler);
+    var cmd =
+        mechanism
+            .run(Coroutine::park)
+            .whenExited(() -> invocations.add("onExit"))
+            .whenCanceled(() -> invocations.add("onCancel"))
+            .named("cmd");
+    var interrupter = mechanism.run(Coroutine::park).named("Interrupter");
+
+    m_scheduler.schedule(cmd);
+    m_scheduler.run();
+    m_scheduler.schedule(interrupter);
+    m_scheduler.run();
+
+    assertEquals(List.of("onExit", "onCancel"), invocations);
+  }
+
+  @Test
+  void onExitInvokedDirectlyBeforeOnCancelWhenCancelAll() {
+    List<String> invocations = new ArrayList<>();
+
+    var cmd =
+        Command.noRequirements(Coroutine::park)
+            .whenExited(() -> invocations.add("onExit"))
+            .whenCanceled(() -> invocations.add("onCancel"))
+            .named("cmd");
+
+    m_scheduler.schedule(cmd);
+    m_scheduler.run();
+    m_scheduler.cancelAll();
+
+    assertEquals(List.of("onExit", "onCancel"), invocations);
+  }
+
+  @Test
+  void onExitInvokedDirectlyBeforeOnCancelWhenParentCanceled() {
+    List<String> invocations = new ArrayList<>();
+
+    var mechanism = new DummyMechanism("The mechanism", m_scheduler);
+    var cmd =
+        mechanism
+            .run(Coroutine::park)
+            .whenExited(() -> invocations.add("onExit"))
+            .whenCanceled(() -> invocations.add("onCancel"))
+            .named("cmd");
+
+    var group = new SequentialGroup("Seq", Collections.singletonList(cmd));
+    m_scheduler.schedule(group);
+    m_scheduler.run();
+    m_scheduler.cancel(group);
+
+    assertEquals(List.of("onExit", "onCancel"), invocations);
+  }
+
+  @Test
+  void customCommandOnExitInvokedBeforeOnCancel() {
+    List<String> invocations = new ArrayList<>();
+
+    Command customCmd =
+        new Command() {
+          @Override
+          public void run(Coroutine coroutine) {
+            coroutine.park();
+          }
+
+          @Override
+          public void onExit() {
+            invocations.add("onExit");
+          }
+
+          @Override
+          public void onCancel() {
+            invocations.add("onCancel");
+          }
+
+          @Override
+          public String name() {
+            return "Custom";
+          }
+
+          @Override
+          public Set<Mechanism> requirements() {
+            return Set.of();
+          }
+        };
+
+    m_scheduler.schedule(customCmd);
+    m_scheduler.run();
+    m_scheduler.cancel(customCmd);
+
+    assertEquals(List.of("onExit", "onCancel"), invocations);
   }
 }

--- a/commandsv3/src/test/java/org/wpilib/command3/StagedCommandBuilderTest.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/StagedCommandBuilderTest.java
@@ -54,6 +54,7 @@ class StagedCommandBuilderTest {
             .requiring(List.of(mech))
             .executing(Coroutine::park)
             .whenCanceled(no_op)
+            .whenExited(no_op)
             .until(() -> false)
             .withPriority(10)
             .named("Name");
@@ -138,6 +139,16 @@ class StagedCommandBuilderTest {
     var ignored = execStage.named("cmd");
 
     var err = assertThrows(IllegalStateException.class, () -> execStage.whenCanceled(() -> {}));
+    assertEquals("Command builders cannot be reused", err.getMessage());
+  }
+
+  @Test
+  void execution_whenExited_throwsAfterBuild() {
+    var builder = new StagedCommandBuilder();
+    var execStage = builder.noRequirements().executing(c -> {});
+    var ignored = execStage.named("cmd");
+
+    var err = assertThrows(IllegalStateException.class, () -> execStage.whenExited(() -> {}));
     assertEquals("Command builders cannot be reused", err.getMessage());
   }
 


### PR DESCRIPTION
Helps deduplicate code if a command should always do the same thing when it's done, rather than copying the same cleanup code at the end of `run()` and then in `whenCanceled()`/`onCancel()`