### PR TITLE
Document intrinsic Euler angle construction

### DIFF
--- a/wpimath/src/main/java/org/wpilib/math/geometry/Rotation3d.java
+++ b/wpimath/src/main/java/org/wpilib/math/geometry/Rotation3d.java
@@ -100,6 +100,9 @@ public final class Rotation3d
    * <p>Extrinsic rotations occur in that order around the axes in the fixed global frame rather
    * than the body frame.
    *
+   * <p>To construct a Rotation3d from intrinsic roll, pitch, and yaw, pass the angles in reverse
+   * order: {@code new Rotation3d(yaw, pitch, roll)}.
+   *
    * <p>Angles are measured counterclockwise with the rotation axis pointing "out of the page". If
    * you point your right thumb along the positive axis direction, your fingers curl in the
    * direction of positive rotation.
@@ -132,6 +135,9 @@ public final class Rotation3d
    *
    * <p>Extrinsic rotations occur in that order around the axes in the fixed global frame rather
    * than the body frame.
+   *
+   * <p>To construct a Rotation3d from intrinsic roll, pitch, and yaw, pass the angles in reverse
+   * order: {@code new Rotation3d(yaw, pitch, roll)}.
    *
    * <p>Angles are measured counterclockwise with the rotation axis pointing "out of the page". If
    * you point your right thumb along the positive axis direction, your fingers curl in the

--- a/wpimath/src/main/native/include/wpi/math/geometry/Rotation3d.hpp
+++ b/wpimath/src/main/native/include/wpi/math/geometry/Rotation3d.hpp
@@ -91,6 +91,9 @@ class WPILIB_DLLEXPORT Rotation3d final {
    * Extrinsic rotations occur in that order around the axes in the fixed global
    * frame rather than the body frame.
    *
+   * To construct a Rotation3d from intrinsic roll, pitch, and yaw, pass the
+   * angles in reverse order: Rotation3d{yaw, pitch, roll}.
+   *
    * Angles are measured counterclockwise with the rotation axis pointing "out
    * of the page". If you point your right thumb along the positive axis
    * direction, your fingers curl in the direction of positive rotation.


### PR DESCRIPTION
## Summary

- document how to express intrinsic roll, pitch, and yaw with the existing extrinsic-axis `Rotation3d` constructor
- add the guidance to the C++ constructor and both Java roll/pitch/yaw overloads
- include the concrete reverse-order examples requested by the issue

Closes #9399.

## Verification

- `wpiformat -j 1 -f` passed for both modified files
- `git diff --check`
- `./gradlew :wpimath:check` reached the native wpimath checks, but Java compilation could not start because the local JDK does not support this repository's Java 25 release target
