### PR TITLE
Add runOnce to Mechanism

### DIFF
--- a/commandsv3/src/main/java/org/wpilib/command3/Mechanism.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Mechanism.java
@@ -94,6 +94,18 @@ public interface Mechanism {
   }
 
   /**
+   * Starts building a command that requires this mechanism. The given function will be called
+   * exactly once, after which the command will complete. Useful for building commands that only
+   * need to perform a single one-shot action.
+   *
+   * @param action The action to run.
+   * @return The command builder, for further configuration.
+   */
+  default NeedsNameBuilderStage runOnce(Runnable action) {
+    return run(_ -> action.run());
+  }
+
+  /**
    * Returns a command that idles this mechanism until another command claims it. The idle command
    * has {@link Command#LOWEST_PRIORITY the lowest priority} and can be interrupted by any other
    * command.

--- a/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotcmdv3/mechanisms/HatchMechanism.java
+++ b/wpilibjExamples/src/main/java/org/wpilib/examples/hatchbotcmdv3/mechanisms/HatchMechanism.java
@@ -28,13 +28,13 @@ public class HatchMechanism implements Mechanism, TelemetryLoggable {
   /** Grabs the hatch. */
   public Command grabHatchCommand() {
     // implicitly require `this`
-    return this.run(coro -> hatchSolenoid.set(FORWARD)).named("Grab Hatch");
+    return this.runOnce(() -> hatchSolenoid.set(FORWARD)).named("Grab Hatch");
   }
 
   /** Releases the hatch. */
   public Command releaseHatchCommand() {
     // implicitly require `this`
-    return this.run(coro -> hatchSolenoid.set(REVERSE)).named("Release Hatch");
+    return this.runOnce(() -> hatchSolenoid.set(REVERSE)).named("Release Hatch");
   }
 
   @Override


### PR DESCRIPTION
Adds `runOnce(Runnable)` to the `Mechanism` interface. Meant to be the one-shot counterpart to `runRepeatedly(Runnable)`. 

Today, writing the simplest possible command  you either have to use
(`run(coro -> solenoid.set(FORWARD))`) with a unused coroutine parameter  or  (`run(_ -> ...)`). Neither is a great first thing to teach a rookie programmer. This also helps with transitioning from the `runOnce` name that teams already know from v2's `Subsystem.runOnce(Runnable)`, which should make porting a bit easier.

I also went and changed the hatchbot v3 example's to use this as an example.

Only thing to note that may cause slight confusion is I decided not to add a static `Command.runOnce` version as static factories on `Command` are all `Consumer<Coroutine>`.