### PR TITLE
[cmd3] Prevent unsafe commands from running during disabled

### DIFF
--- a/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
@@ -156,8 +156,7 @@ public final class Coroutine {
 
     // private - only the coroutine can construct these
     private ForkResult(
-        Collection<Command> forkedCommands,
-        List<ScheduleResult.Failure> failedCommands) {
+        Collection<Command> forkedCommands, List<ScheduleResult.Failure> failedCommands) {
       m_forkedCommands = List.copyOf(forkedCommands);
       m_failedCommands = List.copyOf(failedCommands);
     }

--- a/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Coroutine.java
@@ -151,13 +151,13 @@ public final class Coroutine {
    * forked and failed commands.
    */
   public final class ForkResult {
-    private final List<? extends Command> m_forkedCommands;
-    private final List<? extends ScheduleResult.Failure> m_failedCommands;
+    private final List<Command> m_forkedCommands;
+    private final List<ScheduleResult.Failure> m_failedCommands;
 
     // private - only the coroutine can construct these
     private ForkResult(
-        Collection<? extends Command> forkedCommands,
-        List<? extends ScheduleResult.Failure> failedCommands) {
+        Collection<Command> forkedCommands,
+        List<ScheduleResult.Failure> failedCommands) {
       m_forkedCommands = List.copyOf(forkedCommands);
       m_failedCommands = List.copyOf(failedCommands);
     }
@@ -215,7 +215,7 @@ public final class Coroutine {
      *
      * @return The list of failed commands.
      */
-    public List<? extends ScheduleResult.Failure> getFailedCommands() {
+    public List<ScheduleResult.Failure> getFailedCommands() {
       return m_failedCommands;
     }
 
@@ -225,7 +225,7 @@ public final class Coroutine {
      *
      * @return The list of forked commands.
      */
-    public List<? extends Command> getForkedCommands() {
+    public List<Command> getForkedCommands() {
       return m_forkedCommands;
     }
   }

--- a/commandsv3/src/main/java/org/wpilib/command3/Mechanism.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Mechanism.java
@@ -30,6 +30,20 @@ public interface Mechanism {
   }
 
   /**
+   * Marks this mechanism as being controllable when the robot is in a disabled mode. If a mechanism
+   * is not controllable, commands that require it cannot be scheduled when the robot is disabled
+   * and will be canceled when the robot enters a disabled mode.
+   *
+   * <p>By default, mechanisms are not controllable during disabled. Override this method to return
+   * {@code true} if the mechanism should be controllable during disabled modes.
+   *
+   * @return Whether this mechanism is controllable during disabled modes.
+   */
+  default boolean controllableDuringDisabled() {
+    return false;
+  }
+
+  /**
    * Gets the name of this mechanism. This will default to the name of this mechanism's class.
    *
    * @return The name of the mechanism.

--- a/commandsv3/src/main/java/org/wpilib/command3/RobotStateFetcher.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/RobotStateFetcher.java
@@ -22,6 +22,8 @@ abstract class RobotStateFetcher {
 
   abstract RobotMode getRobotMode();
 
+  abstract boolean isEnabled();
+
   /**
    * Gets the current fetcher implementation. If {@link #setFetcher(RobotStateFetcher)} has not
    * already been called to set an implementation, this will default to a {@link
@@ -66,6 +68,11 @@ abstract class RobotStateFetcher {
     @Override
     RobotMode getRobotMode() {
       return RobotState.getRobotMode();
+    }
+
+    @Override
+    boolean isEnabled() {
+      return RobotState.isEnabled();
     }
   }
 }

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -782,12 +782,16 @@ public final class Scheduler implements ProtobufSerializable {
     // required mechanisms, unless another command requiring those mechanisms is scheduled between
     // calling cancel() and calling run()
     m_runningCommands.remove(command);
-    m_queuedToRun.removeIf(state -> state.command() == command);
+    boolean queued = m_queuedToRun.removeIf(state -> state.command() == command);
 
     if (running) {
       // Only run the hook if the command was running. If it was on deck or not
       // even in the scheduler at the time, then there's nothing to do
       command.onCancel();
+    }
+
+    if (running || queued) {
+      // Emit a cancellation event only if the given command was in the scheduler
       emitCanceledEvent(command);
     }
 

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -1049,13 +1049,9 @@ public final class Scheduler implements ProtobufSerializable {
   }
 
   private void handleCoroutineIRQ(Coroutine coroutine, Command command) {
-    // The coroutine requested to be interrupted. Cancel this command and bubble up the stack
-    // to interrupt the entire composition.
-    var failure = coroutine.getForkResult().getFailedCommands().getFirst();
-
-    Command root = getRoot(command);
+    Command root = getRoot(command); // capture the root command before modifying scheduler state
     m_currentCommandAncestry.clear();
-    emitForkFailureEvent(command, failure);
+    emitForkFailureEvent(command, coroutine.getForkResult().getFailedCommands());
     cancel(root);
     Continuation.mountContinuation(null);
   }
@@ -1435,8 +1431,8 @@ public final class Scheduler implements ProtobufSerializable {
     emitEvent(event);
   }
 
-  private void emitForkFailureEvent(Command command, Scheduler.ScheduleResult.Failure failure) {
-    var event = new SchedulerEvent.ForkFailure(command, failure, RobotController.getTime());
+  private void emitForkFailureEvent(Command command, List<ScheduleResult.Failure> failures) {
+    var event = new SchedulerEvent.ForkFailure(command, failures, RobotController.getTime());
     emitEvent(event);
   }
 

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -22,8 +22,11 @@ import java.util.Stack;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.wpilib.annotation.NoDiscard;
+import org.wpilib.command3.Scheduler.ScheduleResult.AlreadyRunning;
 import org.wpilib.command3.Scheduler.ScheduleResult.LowerPriorityThanQueuedCommand;
 import org.wpilib.command3.Scheduler.ScheduleResult.LowerPriorityThanRunningCommand;
+import org.wpilib.command3.Scheduler.ScheduleResult.RequiresUnsafeMechanisms;
+import org.wpilib.command3.Scheduler.ScheduleResult.Success;
 import org.wpilib.command3.button.CommandGenericHID;
 import org.wpilib.command3.proto.SchedulerProto;
 import org.wpilib.event.EventLoop;
@@ -415,18 +418,7 @@ public final class Scheduler implements ProtobufSerializable {
      * @param alreadyRunning the running command that prevented the command from being scheduled
      */
     record LowerPriorityThanRunningCommand(Command command, Command alreadyRunning)
-        implements Failure {
-      /**
-       * A scheduling attempt that failed because the command was lower priority than a running
-       * command with shared requirements is always unsuccessful.
-       *
-       * @return false
-       */
-      @Override
-      public boolean successful() {
-        return false;
-      }
-    }
+        implements Failure {}
 
     /**
      * A scheduling attempt that failed because the command was lower priority than a queued command
@@ -436,31 +428,33 @@ public final class Scheduler implements ProtobufSerializable {
      * @param queuedCommand the queued command that prevented the command from being scheduled
      */
     record LowerPriorityThanQueuedCommand(Command command, Command queuedCommand)
-        implements Failure {
-      /**
-       * A scheduling attempt that failed because the command was lower priority than a queued
-       * command with shared requirements is always unsuccessful.
-       *
-       * @return false
-       */
-      @Override
-      public boolean successful() {
-        return false;
-      }
-    }
+        implements Failure {}
+
+    /**
+     * A scheduling attempt that failed because the robot is in a disabled state and it requires one
+     * or more mechanisms that are not {@link Mechanism#controllableDuringDisabled() controllable
+     * during disabled}.
+     *
+     * @param command the command that failed to be scheduled
+     * @param unsafeMechanisms the uncontrollable mechanisms
+     */
+    record RequiresUnsafeMechanisms(Command command, Collection<Mechanism> unsafeMechanisms)
+        implements Failure {}
   }
 
   /**
    * Checks if a command is able to be scheduled. Returns of the following states:
    *
    * <ul>
-   *   <li>{@link ScheduleResult.AlreadyRunning} if the command is already scheduled or running.
-   *   <li>{@link ScheduleResult.Success} if the command is not already scheduled or running and
-   *       does not conflict with any other scheduled or running commands.
+   *   <li>{@link AlreadyRunning} if the command is already scheduled or running.
+   *   <li>{@link Success} if the command is not already scheduled or running and does not conflict
+   *       with any other scheduled or running commands.
    *   <li>{@link LowerPriorityThanRunningCommand} if the command has a lower priority than a
    *       running command that shares requirements
    *   <li>{@link LowerPriorityThanQueuedCommand} if the command has a lower priority than a queued
    *       command that shares requirements
+   *   <li>{@link RequiresUnsafeMechanisms} if the command requires mechanisms that are not
+   *       controllable when the robot is disabled.
    * </ul>
    *
    * @param command The command to check. Cannot be null.
@@ -471,7 +465,18 @@ public final class Scheduler implements ProtobufSerializable {
     ErrorMessages.requireNonNullParam(command, "command", "isSchedulable");
 
     if (isScheduledOrRunning(command)) {
-      return new ScheduleResult.AlreadyRunning(command);
+      return new AlreadyRunning(command);
+    }
+
+    if (!RobotStateFetcher.getFetcher().isEnabled()) {
+      var uncontrollables =
+          command.requirements().stream()
+              .filter(mechanism -> !mechanism.controllableDuringDisabled())
+              .collect(Collectors.toSet());
+
+      if (!uncontrollables.isEmpty()) {
+        return new RequiresUnsafeMechanisms(command, uncontrollables);
+      }
     }
 
     Set<Command> ancestry = new HashSet<>();
@@ -488,7 +493,18 @@ public final class Scheduler implements ProtobufSerializable {
     var command = binding.command();
 
     if (isScheduledOrRunning(command)) {
-      return new ScheduleResult.AlreadyRunning(command);
+      return new AlreadyRunning(command);
+    }
+
+    if (!RobotStateFetcher.getFetcher().isEnabled()) {
+      var uncontrollables =
+          command.requirements().stream()
+              .filter(mechanism -> !mechanism.controllableDuringDisabled())
+              .collect(Collectors.toSet());
+
+      if (!uncontrollables.isEmpty()) {
+        return new RequiresUnsafeMechanisms(command, uncontrollables);
+      }
     }
 
     Set<Command> ancestry = new HashSet<>();
@@ -522,7 +538,7 @@ public final class Scheduler implements ProtobufSerializable {
       return new LowerPriorityThanQueuedCommand(command, conflict);
     }
 
-    return new ScheduleResult.Success(command);
+    return new Success(command);
   }
 
   /**
@@ -570,7 +586,7 @@ public final class Scheduler implements ProtobufSerializable {
     var command = binding.command();
 
     var result = isSchedulable(binding);
-    if (!(result instanceof ScheduleResult.Success)) {
+    if (!(result instanceof Success)) {
       // We check specifically for Success, instead of `successful()`, because only a Success
       // indicates that the command can actually go through the scheduling process. AlreadyRunning
       // means what it says on the tin, and it would be incorrect to run the command back through
@@ -810,6 +826,9 @@ public final class Scheduler implements ProtobufSerializable {
     // memory usage and avoid potential OOMs from poorly written user code.
     unbindStaleTriggers();
 
+    // If the robot is disabled, cancel any commands that require uncontrollable mechanisms
+    cancelCommandsThatCannotRunInDisabled();
+
     // Sideloads may change some state that affects triggers. Run them first.
     runPeriodicSideloads();
 
@@ -848,6 +867,54 @@ public final class Scheduler implements ProtobufSerializable {
         trigger.unbind();
         iterator.remove();
       }
+    }
+  }
+
+  private void cancelCommandsThatCannotRunInDisabled() {
+    if (RobotStateFetcher.getFetcher().isEnabled()) {
+      // Nothing to do if the robot is enabled
+      return;
+    }
+
+    List<Command> commandsToCancel = new ArrayList<>();
+
+    for (var runningState : m_runningCommands.values()) {
+      var command = runningState.command();
+      boolean canRun = true;
+      for (var mechanism : command.requirements()) {
+        if (!mechanism.controllableDuringDisabled()) {
+          canRun = false;
+          break;
+        }
+      }
+
+      if (canRun) {
+        continue;
+      }
+
+      commandsToCancel.add(getRoot(command));
+    }
+
+    for (var queuedState : m_queuedToRun) {
+      var command = queuedState.command();
+
+      boolean canRun = true;
+      for (var mechanism : command.requirements()) {
+        if (!mechanism.controllableDuringDisabled()) {
+          canRun = false;
+          break;
+        }
+      }
+
+      if (canRun) {
+        continue;
+      }
+
+      commandsToCancel.add(command);
+    }
+
+    for (var command : commandsToCancel) {
+      cancel(command);
     }
   }
 
@@ -1096,6 +1163,13 @@ public final class Scheduler implements ProtobufSerializable {
     for (int i = 0; i < bindings.size() - 1; i++) {
       Command widerScopeDefaultCommand = bindings.get(i).command();
       cancel(widerScopeDefaultCommand);
+    }
+
+    if (!RobotStateFetcher.getFetcher().isEnabled() && !mechanism.controllableDuringDisabled()) {
+      // Default commands can never be scheduled if the robot is disabled and the mechanism is not
+      // controllable during disabled, so there's no point in attempting to queue the default
+      // command
+      return;
     }
 
     // Check if the mechanism is currently in use. We can queue the default command if it's not.

--- a/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/Scheduler.java
@@ -1046,23 +1046,12 @@ public final class Scheduler implements ProtobufSerializable {
 
   private void handleCoroutineIRQ(Coroutine coroutine, Command command) {
     // The coroutine requested to be interrupted. Cancel this command and bubble up the stack
-    // to interrupt the entire composition. Because InterruptEvent only supports a single
-    // interruptor, we attribute the interrupt to the first conflicting command.
+    // to interrupt the entire composition.
     var failure = coroutine.getForkResult().getFailedCommands().getFirst();
-    Command interruptor =
-        switch (failure) {
-          case LowerPriorityThanRunningCommand(var _, Command conflict) -> conflict;
-          case LowerPriorityThanQueuedCommand(var _, Command conflict) -> conflict;
-          default -> {
-            // Shouldn't get here (this is a bug in WPILib code, not handling new cases).
-            // But we don't want to crash user programs, so just attribute to null.
-            yield null;
-          }
-        };
 
     Command root = getRoot(command);
     m_currentCommandAncestry.clear();
-    emitInterruptedEvent(command, interruptor);
+    emitForkFailureEvent(command, failure);
     cancel(root);
     Continuation.mountContinuation(null);
   }
@@ -1439,6 +1428,11 @@ public final class Scheduler implements ProtobufSerializable {
 
   private void emitInterruptedEvent(Command command, Command interrupter) {
     var event = new SchedulerEvent.Interrupted(command, interrupter, RobotController.getTime());
+    emitEvent(event);
+  }
+
+  private void emitForkFailureEvent(Command command, Scheduler.ScheduleResult.Failure failure) {
+    var event = new SchedulerEvent.ForkFailure(command, failure, RobotController.getTime());
     emitEvent(event);
   }
 

--- a/commandsv3/src/main/java/org/wpilib/command3/SchedulerEvent.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/SchedulerEvent.java
@@ -86,4 +86,14 @@ public sealed interface SchedulerEvent {
    */
   record Interrupted(Command command, Command interrupter, long timestampNanos)
       implements SchedulerEvent {}
+
+  /**
+   * An event marking when a child command could not be forked.
+   *
+   * @param command The child command that could not be forked
+   * @param failure The reason the child command could not be forked
+   * @param timestampNanos When the child command was attempted to be forked
+   */
+  record ForkFailure(Command command, Scheduler.ScheduleResult.Failure failure, long timestampNanos)
+      implements SchedulerEvent {}
 }

--- a/commandsv3/src/main/java/org/wpilib/command3/SchedulerEvent.java
+++ b/commandsv3/src/main/java/org/wpilib/command3/SchedulerEvent.java
@@ -4,7 +4,9 @@
 
 package org.wpilib.command3;
 
+import java.util.List;
 import java.util.function.Consumer;
+import org.wpilib.command3.Scheduler.ScheduleResult;
 import org.wpilib.system.RobotController;
 
 /**
@@ -90,10 +92,10 @@ public sealed interface SchedulerEvent {
   /**
    * An event marking when a child command could not be forked.
    *
-   * @param command The child command that could not be forked
-   * @param failure The reason the child command could not be forked
-   * @param timestampNanos When the child command was attempted to be forked
+   * @param command The command attempting to fork the child commands
+   * @param failures The reasons the child commands could not be forked
+   * @param timestampNanos When the child commands were attempted to be forked
    */
-  record ForkFailure(Command command, Scheduler.ScheduleResult.Failure failure, long timestampNanos)
+  record ForkFailure(Command command, List<ScheduleResult.Failure> failures, long timestampNanos)
       implements SchedulerEvent {}
 }

--- a/commandsv3/src/test/java/org/wpilib/command3/CommandTestBase.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/CommandTestBase.java
@@ -20,6 +20,7 @@ class CommandTestBase {
   protected long m_opModeId = 0;
   protected String m_opModeName = "";
   protected RobotMode m_robotMode = RobotMode.UNKNOWN;
+  protected boolean m_enabled = true;
 
   @BeforeEach
   void initScheduler() {
@@ -47,14 +48,20 @@ class CommandTestBase {
           RobotMode getRobotMode() {
             return m_robotMode;
           }
+
+          @Override
+          boolean isEnabled() {
+            return m_enabled;
+          }
         });
   }
 
   @AfterEach
-  void resetOpmodeFetcher() {
+  void resetRobotState() {
     m_opModeId = 0;
     m_opModeName = "";
     m_robotMode = RobotMode.UNKNOWN;
+    m_enabled = true;
   }
 
   /**

--- a/commandsv3/src/test/java/org/wpilib/command3/DummyMechanism.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/DummyMechanism.java
@@ -8,6 +8,7 @@ package org.wpilib.command3;
 class DummyMechanism implements Mechanism {
   private final String m_name;
   private final Scheduler m_scheduler;
+  private final boolean m_controllableDuringDisabled;
 
   /**
    * Creates a dummy mechanism.
@@ -16,8 +17,13 @@ class DummyMechanism implements Mechanism {
    * @param scheduler The registered scheduler. Cannot be null.
    */
   DummyMechanism(String name, Scheduler scheduler) {
+    this(name, scheduler, false);
+  }
+
+  DummyMechanism(String name, Scheduler scheduler, boolean controllableDuringDisabled) {
     m_name = name;
     m_scheduler = scheduler;
+    m_controllableDuringDisabled = controllableDuringDisabled;
   }
 
   @Override
@@ -28,5 +34,10 @@ class DummyMechanism implements Mechanism {
   @Override
   public Scheduler getRegisteredScheduler() {
     return m_scheduler;
+  }
+
+  @Override
+  public boolean controllableDuringDisabled() {
+    return m_controllableDuringDisabled;
   }
 }

--- a/commandsv3/src/test/java/org/wpilib/command3/MockHardwareExtension.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/MockHardwareExtension.java
@@ -29,5 +29,10 @@ public class MockHardwareExtension implements BeforeEachCallback {
     RobotMode getRobotMode() {
       return RobotMode.UNKNOWN;
     }
+
+    @Override
+    boolean isEnabled() {
+      return true;
+    }
   }
 }

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerCancellationTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerCancellationTests.java
@@ -90,6 +90,48 @@ class SchedulerCancellationTests extends CommandTestBase {
   }
 
   @Test
+  void cancelRunningEmitsEvent() {
+    var command = Command.noRequirements(Coroutine::park).named("Command");
+    m_scheduler.schedule(command);
+    m_scheduler.run();
+    m_scheduler.cancel(command);
+    assertSchedulerEvent(
+        SchedulerEvent.Canceled.class,
+        e -> e.command().equals(command),
+        "Cancellation did not emit an event");
+  }
+
+  @Test
+  void cancelQueuedEmitsEvent() {
+    var command = Command.noRequirements(Coroutine::park).named("Command");
+    m_scheduler.schedule(command);
+    m_scheduler.cancel(command);
+    assertSchedulerEvent(
+        SchedulerEvent.Canceled.class,
+        e -> e.command().equals(command),
+        "Cancellation did not emit an event");
+  }
+
+  @Test
+  void cancelUnknownDoesNotEmitEvent() {
+    // Create a command but do not schedule it.
+    // The scheduler won't know about it and should not emit an event.
+    var command = Command.noRequirements(Coroutine::park).named("Command");
+    m_scheduler.cancel(command);
+    assertEquals(
+        List.of(), m_events, "Cancellation of an unknown command should not emit an event");
+  }
+
+  @Test
+  void cancelNullDoesNothing() {
+    m_scheduler.cancel(null);
+    assertEquals(
+        List.of(),
+        m_events,
+        "Cancellation of null should not emit an event and should not throw an exception");
+  }
+
+  @Test
   void commandCancelingSelf() {
     var ranAfterCancel = new AtomicBoolean(false);
     var commandRef = new AtomicReference<Command>(null);

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerDisabledTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerDisabledTests.java
@@ -1,0 +1,144 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.wpilib.command3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.wpilib.command3.Scheduler.ScheduleResult.RequiresUnsafeMechanisms;
+import org.wpilib.command3.Scheduler.ScheduleResult.Success;
+import org.wpilib.command3.SchedulerEvent.Canceled;
+import org.wpilib.command3.SchedulerEvent.Interrupted;
+
+@SuppressWarnings("PMD.CompareObjectsWithEquals")
+class SchedulerDisabledTests extends CommandTestBase {
+  @Test
+  void cancelsCommandsWhenRobotEntersDisabled() {
+    var mech = new DummyMechanism("mech", m_scheduler);
+    var command = mech.run(Coroutine::park).named("Command");
+
+    m_scheduler.schedule(command);
+    m_scheduler.run();
+    assertEquals(List.of(command), m_scheduler.getRunningCommands());
+
+    m_enabled = false;
+    m_scheduler.run();
+    assertEquals(List.of(), m_scheduler.getRunningCommands(), "Command was not canceled");
+    assertSchedulerEvent(
+        Canceled.class, e -> e.command() == command, "Cancellation did not emit an event");
+  }
+
+  @Test
+  void cancelsCompositionWhenRobotEntersDisabled() {
+    var mech = new DummyMechanism("mech", m_scheduler);
+    var child = mech.run(Coroutine::park).named("Child");
+    var parent = Command.noRequirements(coroutine -> coroutine.await(child)).named("Parent");
+
+    m_scheduler.schedule(parent);
+    m_scheduler.run();
+    assertEquals(List.of(parent, child), m_scheduler.getRunningCommands());
+
+    m_enabled = false;
+    m_scheduler.run();
+    assertEquals(List.of(), m_scheduler.getRunningCommands(), "Composition was not canceled");
+    assertSchedulerEvent(
+        Canceled.class, e -> e.command() == parent, "Parent did not receive an event");
+    assertSchedulerEvent(
+        Canceled.class, e -> e.command() == child, "Child did not receive an event");
+  }
+
+  @Test
+  void doesNotCancelSafeCommands() {
+    var mech = new DummyMechanism("mech", m_scheduler, true);
+
+    var safeCommand = mech.run(Coroutine::park).named("Safe Command");
+
+    m_scheduler.schedule(safeCommand);
+    m_scheduler.run();
+    assertEquals(List.of(safeCommand), m_scheduler.getRunningCommands());
+
+    m_enabled = false;
+    m_scheduler.run();
+    assertEquals(
+        List.of(safeCommand),
+        m_scheduler.getRunningCommands(),
+        "Safe command should still be running");
+  }
+
+  @Test
+  void cannotScheduleUnsafeCommandInDisabled() {
+    var mech = new DummyMechanism("mech", m_scheduler);
+    var command = mech.run(Coroutine::park).named("Command");
+
+    m_enabled = false;
+    var result = m_scheduler.schedule(command);
+    assertTrue(
+        result instanceof RequiresUnsafeMechanisms(var cmd, var unsafe)
+            && cmd == command
+            && unsafe.contains(mech),
+        result.toString());
+  }
+
+  @Test
+  void cancelsCompositionWhenChildCannotBeScheduled() {
+    var mech = new DummyMechanism("mech", m_scheduler);
+
+    var child = mech.run(Coroutine::park).named("Command");
+    var parent =
+        Command.noRequirements(
+                coroutine -> {
+                  coroutine.waitUntil(() -> !m_enabled);
+
+                  coroutine.await(child);
+                })
+            .named("Parent Command");
+
+    m_scheduler.schedule(parent);
+    m_scheduler.run();
+    assertEquals(List.of(parent), m_scheduler.getRunningCommands());
+
+    m_enabled = false;
+    m_scheduler.run();
+    assertEquals(
+        List.of(),
+        m_scheduler.getRunningCommands(),
+        "Entire composition should have been canceled");
+    assertSchedulerEvent(
+        Interrupted.class,
+        e -> e.command() == parent,
+        "Parent should receive an interrupted event");
+    assertSchedulerEvent(
+        Canceled.class, e -> e.command() == parent, "Parent should receive a cancellation event");
+  }
+
+  @Test
+  void canScheduleSafeCommandInDisabled() {
+    var mech = new DummyMechanism("mech", m_scheduler, true);
+    var safeCommand = mech.run(Coroutine::park).named("Safe Command");
+
+    var result = m_scheduler.schedule(safeCommand);
+    assertTrue(result instanceof Success(var cmd) && cmd == safeCommand);
+
+    m_scheduler.run();
+    assertEquals(List.of(safeCommand), m_scheduler.getRunningCommands());
+  }
+
+  @Test
+  void unsafeDefaultCommandsCannotRunInDisabled() {
+    var mech = new DummyMechanism("mech", m_scheduler);
+    var command = mech.run(Coroutine::park).named("Command");
+
+    m_enabled = false;
+
+    mech.setDefaultCommand(command);
+    m_scheduler.run();
+    assertEquals(
+        List.of(), m_scheduler.getRunningCommands(), "The default command should not be running");
+    assertEquals(
+        command, m_scheduler.getDefaultCommandFor(mech), "The default command should be set");
+  }
+}

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerDisabledTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerDisabledTests.java
@@ -5,6 +5,7 @@
 package org.wpilib.command3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -142,5 +143,23 @@ class SchedulerDisabledTests extends CommandTestBase {
         List.of(), m_scheduler.getRunningCommands(), "The default command should not be running");
     assertEquals(
         command, m_scheduler.getDefaultCommandFor(mech), "The default command should be set");
+  }
+
+  @Test
+  void robotDisabledBetweenQueueAndRun() {
+    var mech = new DummyMechanism("mech", m_scheduler);
+    var command = mech.run(Coroutine::park).named("Command");
+
+    var result = m_scheduler.schedule(command);
+    assertInstanceOf(Success.class, result, "The command should have been scheduled");
+
+    m_enabled = false;
+    m_scheduler.run();
+    assertEquals(
+        List.of(), m_scheduler.getRunningCommands(), "The command should have been canceled");
+    assertSchedulerEvent(
+        Canceled.class,
+        e -> e.command().equals(command),
+        "The command should have received a cancellation event");
   }
 }

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerDisabledTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerDisabledTests.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.wpilib.command3.Scheduler.ScheduleResult.RequiresUnsafeMechanisms;
 import org.wpilib.command3.Scheduler.ScheduleResult.Success;
 import org.wpilib.command3.SchedulerEvent.Canceled;
-import org.wpilib.command3.SchedulerEvent.Interrupted;
+import org.wpilib.command3.SchedulerEvent.ForkFailure;
 
 @SuppressWarnings("PMD.CompareObjectsWithEquals")
 class SchedulerDisabledTests extends CommandTestBase {
@@ -108,7 +108,7 @@ class SchedulerDisabledTests extends CommandTestBase {
         m_scheduler.getRunningCommands(),
         "Entire composition should have been canceled");
     assertSchedulerEvent(
-        Interrupted.class,
+        ForkFailure.class,
         e -> e.command() == parent,
         "Parent should receive an interrupted event");
     assertSchedulerEvent(

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerDisabledTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerDisabledTests.java
@@ -120,6 +120,8 @@ class SchedulerDisabledTests extends CommandTestBase {
     var mech = new DummyMechanism("mech", m_scheduler, true);
     var safeCommand = mech.run(Coroutine::park).named("Safe Command");
 
+    m_enabled = false;
+
     var result = m_scheduler.schedule(safeCommand);
     assertTrue(result instanceof Success(var cmd) && cmd == safeCommand);
 

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerDisabledTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerDisabledTests.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.wpilib.command3.Scheduler.ScheduleResult.RequiresUnsafeMechanisms;
 import org.wpilib.command3.Scheduler.ScheduleResult.Success;
@@ -110,8 +111,13 @@ class SchedulerDisabledTests extends CommandTestBase {
         "Entire composition should have been canceled");
     assertSchedulerEvent(
         ForkFailure.class,
-        e -> e.command() == parent,
-        "Parent should receive an interrupted event");
+        e ->
+            e.command() == parent
+                && e.failures().size() == 1
+                && e.failures().getFirst() instanceof RequiresUnsafeMechanisms(var cmd, var mechs)
+                && cmd == child
+                && mechs.equals(Set.of(mech)),
+        "Parent should receive a ForkFailure event");
     assertSchedulerEvent(
         Canceled.class, e -> e.command() == parent, "Parent should receive a cancellation event");
   }

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
@@ -16,7 +16,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.wpilib.command3.Scheduler.ScheduleResult.LowerPriorityThanRunningCommand;
+import org.wpilib.command3.SchedulerEvent.Canceled;
 
+@SuppressWarnings("PMD.CompareObjectsWithEquals")
 class SchedulerPriorityLevelTests extends CommandTestBase {
   @FunctionalInterface
   private interface CoroutineForkOperation {
@@ -308,12 +310,25 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
     m_scheduler.run();
 
     assertTrue(m_scheduler.isRunning(highPriority), "Higher priority command should still run");
-    // Only the command that failed to fork should get an interrupted event.
-    // All other commands in the composition will still be canceled, but won't be interrupted.
-    assertSchedulerEvent(SchedulerEvent.ForkFailure.class, e -> e.command().equals(current), "");
+    // Only the command that failed to fork should get a fork failure event.
+    // Every command should get a cancellation event, though, including the failed command.
+    assertSchedulerEvent(
+        SchedulerEvent.ForkFailure.class,
+        e ->
+            e.command().equals(current)
+                && e.failures().size() == 1
+                && e.failures().getFirst()
+                    instanceof LowerPriorityThanRunningCommand(var cmd, var conflict)
+                && cmd.equals(unschedulable)
+                && conflict.equals(highPriority),
+        "Current command should have received a ForkFailure event");
     for (var command : List.of(grandparent, parent, current, child, grandchild)) {
       assertFalse(
           m_scheduler.isScheduledOrRunning(command), command.name() + " should have been canceled");
+      assertSchedulerEvent(
+          Canceled.class,
+          e -> e.command() == command,
+          command.name() + " should have received a cancellation event");
     }
   }
 
@@ -378,14 +393,16 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
 
     assertFalse(m_scheduler.isRunning(parent), "Parent command should have been canceled");
     assertSchedulerEvent(
-        SchedulerEvent.Canceled.class,
+        Canceled.class,
         c -> c.command().equals(parent),
         "Should have received a Canceled event for parent");
     assertSchedulerEvent(
         SchedulerEvent.ForkFailure.class,
         e ->
             e.command().equals(parent)
-                && e.failure() instanceof LowerPriorityThanRunningCommand(var failed, var running)
+                && e.failures().size() == 1
+                && e.failures().getFirst()
+                    instanceof LowerPriorityThanRunningCommand(var failed, var running)
                 && failed.equals(defaultPriority)
                 && running.equals(highPriority),
         "Parent should have failed to fork");

--- a/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/SchedulerPriorityLevelTests.java
@@ -310,7 +310,7 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
     assertTrue(m_scheduler.isRunning(highPriority), "Higher priority command should still run");
     // Only the command that failed to fork should get an interrupted event.
     // All other commands in the composition will still be canceled, but won't be interrupted.
-    assertInterruptedBy(current, highPriority);
+    assertSchedulerEvent(SchedulerEvent.ForkFailure.class, e -> e.command().equals(current), "");
     for (var command : List.of(grandparent, parent, current, child, grandchild)) {
       assertFalse(
           m_scheduler.isScheduledOrRunning(command), command.name() + " should have been canceled");
@@ -382,9 +382,13 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
         c -> c.command().equals(parent),
         "Should have received a Canceled event for parent");
     assertSchedulerEvent(
-        SchedulerEvent.Interrupted.class,
-        i -> i.command().equals(parent) && i.interrupter().equals(highPriority),
-        "Should have received an Interrupted event for parent");
+        SchedulerEvent.ForkFailure.class,
+        e ->
+            e.command().equals(parent)
+                && e.failure() instanceof LowerPriorityThanRunningCommand(var failed, var running)
+                && failed.equals(defaultPriority)
+                && running.equals(highPriority),
+        "Parent should have failed to fork");
   }
 
   private void assertUnschedulableSingleChildReturnsFailure(CoroutineForkOperation operation) {
@@ -449,16 +453,5 @@ class SchedulerPriorityLevelTests extends CommandTestBase {
     assertTrue(
         result.getFailedCommands().stream().noneMatch(Scheduler.ScheduleResult::successful),
         "All failure results should be unsuccessful");
-  }
-
-  private void assertInterruptedBy(Command command, Command interrupter) {
-    assertSchedulerEvent(
-        SchedulerEvent.Canceled.class,
-        event -> event.command().equals(command),
-        command.name() + " should have received a Canceled event");
-    assertSchedulerEvent(
-        SchedulerEvent.Interrupted.class,
-        event -> event.command().equals(command) && event.interrupter().equals(interrupter),
-        command.name() + " should have received an Interrupted event");
   }
 }


### PR DESCRIPTION
Safety is flagged at the mechanism level via `controllableDuringDisabled()`, which defaults to false (not controllable). Commands that require at least one uncontrollable mechanism cannot be scheduled while the robot is disabled. Running commands that require at least one uncontrollable mechanism will be canceled when the robot enters a disabled mode, along with their entire composition

Fixes #9336 