### PR TITLE
[javacplugin] Show provenance and suppression instructions in compile-time errors

### DIFF
--- a/commandsv2/src/test/java/org/wpilib/command2/SingleCompositionTestBase.java
+++ b/commandsv2/src/test/java/org/wpilib/command2/SingleCompositionTestBase.java
@@ -30,7 +30,7 @@ public abstract class SingleCompositionTestBase<T extends Command> extends Comma
   }
 
   @Test
-  @SuppressWarnings("NoDiscard")
+  @SuppressWarnings("WPILib.NoDiscard")
   void commandInOtherCompositionTest() {
     var command = Commands.none();
     new WrapperCommand(command) {};

--- a/commandsv3/src/test/java/org/wpilib/command3/CoroutineTest.java
+++ b/commandsv3/src/test/java/org/wpilib/command3/CoroutineTest.java
@@ -220,7 +220,7 @@ class CoroutineTest extends CommandTestBase {
   }
 
   @Test
-  @SuppressWarnings("CoroutineMayNotBeInScope")
+  @SuppressWarnings("WPILib.CoroutineMayNotBeInScope")
   void usingParentCoroutineInChildThrows() {
     var parent =
         Command.noRequirements(

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/CodeAfterCoroutineParkDetector.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/CodeAfterCoroutineParkDetector.java
@@ -14,16 +14,14 @@ import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.StatementTree;
 import com.sun.source.util.JavacTask;
 import com.sun.source.util.TreeScanner;
-import com.sun.source.util.Trees;
 import javax.lang.model.element.VariableElement;
-import javax.tools.Diagnostic;
 
 /**
  * Detects any statements after a call to {@code coroutine.park()} and labels them as unreachable
  * code, similar to a {@code while (true)} statement.
  */
 public class CodeAfterCoroutineParkDetector extends CoroutineBasedDetector {
-  public static final String SUPPRESSION_KEY = "CodeAfterCoroutinePark";
+  public static final String SUPPRESSION_KEY = "WPILib.CodeAfterCoroutinePark";
 
   public CodeAfterCoroutineParkDetector(JavacTask task) {
     super(task);
@@ -34,12 +32,9 @@ public class CodeAfterCoroutineParkDetector extends CoroutineBasedDetector {
     return new Scanner(compilationUnit);
   }
 
-  private final class Scanner extends TreeScanner<Void, Void> {
-    private final CompilationUnitTree m_root;
-    private final Trees m_trees = Trees.instance(m_task);
-
+  private final class Scanner extends WPILibTreeScanner<Void, Void> {
     Scanner(CompilationUnitTree compilationUnit) {
-      m_root = compilationUnit;
+      super(compilationUnit, CodeAfterCoroutineParkDetector.this.m_task);
     }
 
     @Override
@@ -58,11 +53,10 @@ public class CodeAfterCoroutineParkDetector extends CoroutineBasedDetector {
         }
 
         if (parkInvocation != null) {
-          m_trees.printMessage(
-              Diagnostic.Kind.ERROR,
-              "Unreachable statement: `" + parkInvocation + "` will never exit",
+          printError(
+              "Unreachable statement: `" + parkInvocation + "` will never exit.",
               statement,
-              m_root);
+              SUPPRESSION_KEY);
           break;
         }
 

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/CoroutineYieldInLoopDetector.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/CoroutineYieldInLoopDetector.java
@@ -22,16 +22,10 @@ import javax.lang.model.element.VariableElement;
 /**
  * Checks for {@code while} loops inside methods or lambda functions that accept coroutine
  * arguments. If a loop does not call {@code yield()} on one of the most local coroutine objects, a
- * compiler error will be emitted for that loop element. This check cannot be silenced.
+ * compiler error will be emitted for that loop element.
  */
-// Note: cannot be silenced because annotations cannot be placed on loops.
-// This is not legal Java:
-//   @SuppressWarnings("UnsafeCoroutineUsage")
-//   while (true) { ... }
-// Placing it at a higher level (lambda or method declaration) would silence ALL unsafe usage in
-// that expression; it's impossible to do on a case-by-case basis.
 public class CoroutineYieldInLoopDetector extends CoroutineBasedDetector {
-  public static final String SUPPRESSION_KEY = "CoroutineYieldInLoop";
+  public static final String SUPPRESSION_KEY = "WPILib.CoroutineYieldInLoop";
 
   public CoroutineYieldInLoopDetector(JavacTask task) {
     super(task);
@@ -209,8 +203,7 @@ public class CoroutineYieldInLoopDetector extends CoroutineBasedDetector {
       }
 
       if (state.m_yieldCalls.isEmpty()) {
-        // Not suppressible
-        printError(buildErrorMessageForLoop(state), state.m_loop, null);
+        printError(buildErrorMessageForLoop(state), state.m_loop, SUPPRESSION_KEY);
       }
 
       // Recurse over children

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/CoroutineYieldInLoopDetector.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/CoroutineYieldInLoopDetector.java
@@ -13,13 +13,11 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.WhileLoopTree;
 import com.sun.source.util.JavacTask;
 import com.sun.source.util.TreeScanner;
-import com.sun.source.util.Trees;
 import java.util.ArrayList;
 import java.util.List;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
-import javax.tools.Diagnostic;
 
 /**
  * Checks for {@code while} loops inside methods or lambda functions that accept coroutine
@@ -91,13 +89,9 @@ public class CoroutineYieldInLoopDetector extends CoroutineBasedDetector {
     final List<LoopState> m_children = new ArrayList<>();
   }
 
-  private final class Scanner extends TreeScanner<LoopState, LoopState> {
-    private final CompilationUnitTree m_root;
-    private final Trees m_trees;
-
+  private final class Scanner extends WPILibTreeScanner<LoopState, LoopState> {
     Scanner(CompilationUnitTree compilationUnit) {
-      m_root = compilationUnit;
-      m_trees = Trees.instance(m_task);
+      super(compilationUnit, CoroutineYieldInLoopDetector.this.m_task);
     }
 
     @Override
@@ -215,8 +209,8 @@ public class CoroutineYieldInLoopDetector extends CoroutineBasedDetector {
       }
 
       if (state.m_yieldCalls.isEmpty()) {
-        m_trees.printMessage(
-            Diagnostic.Kind.ERROR, buildErrorMessageForLoop(state), state.m_loop, m_root);
+        // Not suppressible
+        printError(buildErrorMessageForLoop(state), state.m_loop, null);
       }
 
       // Recurse over children
@@ -257,7 +251,7 @@ public class CoroutineYieldInLoopDetector extends CoroutineBasedDetector {
         }
       }
 
-      messageBuilder.append(" inside loop");
+      messageBuilder.append(" inside loop.");
 
       return messageBuilder;
     }

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/IncorrectCoroutineUseDetector.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/IncorrectCoroutineUseDetector.java
@@ -12,12 +12,10 @@ import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.util.JavacTask;
 import com.sun.source.util.TreeScanner;
-import com.sun.source.util.Trees;
 import java.util.ArrayList;
 import java.util.List;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
-import javax.tools.Diagnostic;
 
 /**
  * Detects usage of an incorrect coroutine object. For example, nesting commands with multiple
@@ -40,8 +38,8 @@ import javax.tools.Diagnostic;
  * }</pre>
  */
 public class IncorrectCoroutineUseDetector extends CoroutineBasedDetector {
-  public static final String CAPTURE_SUPPRESSION_KEY = "CoroutineCapture";
-  public static final String SCOPE_SUPPRESSION_KEY = "CoroutineMayNotBeInScope";
+  public static final String CAPTURE_SUPPRESSION_KEY = "WPILib.CoroutineCapture";
+  public static final String SCOPE_SUPPRESSION_KEY = "WPILib.CoroutineMayNotBeInScope";
 
   public IncorrectCoroutineUseDetector(JavacTask task) {
     super(task);
@@ -78,13 +76,9 @@ public class IncorrectCoroutineUseDetector extends CoroutineBasedDetector {
     }
   }
 
-  private final class Scanner extends TreeScanner<State, State> {
-    private final CompilationUnitTree m_root;
-    private final Trees m_trees;
-
+  private final class Scanner extends WPILibTreeScanner<State, State> {
     Scanner(CompilationUnitTree compilationUnit) {
-      m_root = compilationUnit;
-      m_trees = Trees.instance(m_task);
+      super(compilationUnit, IncorrectCoroutineUseDetector.this.m_task);
     }
 
     @Override
@@ -144,8 +138,7 @@ public class IncorrectCoroutineUseDetector extends CoroutineBasedDetector {
         if (el instanceof VariableElement ve
             && ve.asType().equals(m_coroutineType)
             && !state.isLocalCoroutine(ve)) {
-          m_trees.printMessage(
-              Diagnostic.Kind.ERROR, nonlocalCoroutineUsageMessage(ve, state), id, m_root);
+          printError(nonlocalCoroutineUsageMessage(ve, state), id, SCOPE_SUPPRESSION_KEY);
         }
       }
 
@@ -156,11 +149,8 @@ public class IncorrectCoroutineUseDetector extends CoroutineBasedDetector {
         if (el instanceof VariableElement ve
             && ve.asType().equals(m_coroutineType)
             && !state.isLocalCoroutine(ve)) {
-          m_trees.printMessage(
-              Diagnostic.Kind.ERROR,
-              nonlocalCoroutineUsageMessage(ve, state),
-              argPath.getLeaf(),
-              m_root);
+          printError(
+              nonlocalCoroutineUsageMessage(ve, state), argPath.getLeaf(), SCOPE_SUPPRESSION_KEY);
         }
       }
 
@@ -193,7 +183,7 @@ public class IncorrectCoroutineUseDetector extends CoroutineBasedDetector {
         }
       }
 
-      return "Coroutine `%s` may not be in scope. Consider using %s"
+      return "Coroutine `%s` may not be in scope. Consider using %s."
           .formatted(ve.getSimpleName(), optionsBuilder);
     }
 
@@ -222,11 +212,8 @@ public class IncorrectCoroutineUseDetector extends CoroutineBasedDetector {
         var expressionPath = m_trees.getPath(m_root, expression);
         var expressionElement = m_trees.getElement(expressionPath);
         if (expressionElement instanceof VariableElement ve2 && state.isCapturedCoroutine(ve2)) {
-          m_trees.printMessage(
-              Diagnostic.Kind.ERROR,
-              "Captured coroutines may not be stored in fields",
-              node,
-              m_root);
+          printError(
+              "Captured coroutines may not be stored in fields.", node, CAPTURE_SUPPRESSION_KEY);
         }
       }
 

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/IntegerDivisionDetector.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/IntegerDivisionDetector.java
@@ -19,12 +19,9 @@ import com.sun.source.util.JavacTask;
 import com.sun.source.util.TaskEvent;
 import com.sun.source.util.TaskListener;
 import com.sun.source.util.TreePath;
-import com.sun.source.util.TreeScanner;
-import com.sun.source.util.Trees;
 import java.util.HashSet;
 import java.util.Set;
 import javax.lang.model.type.TypeMirror;
-import javax.tools.Diagnostic;
 
 /**
  * Detects integer division operations in Java source code and marks them as errors.
@@ -39,6 +36,8 @@ import javax.tools.Diagnostic;
 public class IntegerDivisionDetector implements TaskListener {
   private final JavacTask m_task;
   private final Set<CompilationUnitTree> m_visitedCUs = new HashSet<>();
+
+  public static final String SUPPRESSION_KEY = "WPILib.IntegerDivision";
 
   public IntegerDivisionDetector(JavacTask task) {
     m_task = task;
@@ -55,13 +54,9 @@ public class IntegerDivisionDetector implements TaskListener {
     }
   }
 
-  private final class Scanner extends TreeScanner<Void, Void> {
-    private final CompilationUnitTree m_root;
-    private final Trees m_trees;
-
+  private final class Scanner extends WPILibTreeScanner<Void, Void> {
     Scanner(CompilationUnitTree compilationUnit) {
-      m_root = compilationUnit;
-      m_trees = Trees.instance(m_task);
+      super(compilationUnit, IntegerDivisionDetector.this.m_task);
     }
 
     @Override
@@ -77,12 +72,10 @@ public class IntegerDivisionDetector implements TaskListener {
 
       // It's integer division. Now check the context.
       if (isFloatContext(m_trees.getPath(m_root, node))) {
-        if (Suppressions.hasSuppression(
-            m_trees, m_trees.getPath(m_root, node), "IntegerDivision")) {
+        if (Suppressions.hasSuppression(m_trees, m_trees.getPath(m_root, node), SUPPRESSION_KEY)) {
           return super.visitBinary(node, unused);
         }
-        m_trees.printMessage(
-            Diagnostic.Kind.ERROR, "integer division in a floating-point context", node, m_root);
+        printError("Integer division in a floating-point context.", node, SUPPRESSION_KEY);
       }
 
       return super.visitBinary(node, unused);

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/MaxLengthDetector.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/MaxLengthDetector.java
@@ -16,8 +16,6 @@ import com.sun.source.util.JavacTask;
 import com.sun.source.util.TaskEvent;
 import com.sun.source.util.TaskListener;
 import com.sun.source.util.TreePath;
-import com.sun.source.util.TreeScanner;
-import com.sun.source.util.Trees;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -25,7 +23,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
-import javax.tools.Diagnostic;
 import org.wpilib.annotation.MaxLength;
 
 public class MaxLengthDetector implements TaskListener {
@@ -47,13 +44,9 @@ public class MaxLengthDetector implements TaskListener {
     }
   }
 
-  private final class Scanner extends TreeScanner<Void, Void> {
-    private final CompilationUnitTree m_root;
-    private final Trees m_trees;
-
+  private final class Scanner extends WPILibTreeScanner<Void, Void> {
     Scanner(CompilationUnitTree compilationUnit) {
-      m_root = compilationUnit;
-      m_trees = Trees.instance(m_task);
+      super(compilationUnit, MaxLengthDetector.this.m_task);
     }
 
     @Override
@@ -96,14 +89,14 @@ public class MaxLengthDetector implements TaskListener {
           continue;
         }
 
-        m_trees.printMessage(
-            Diagnostic.Kind.ERROR,
+        printError(
             ("String literal exceeds maximum length: \"%s\""
-                    + " (%d characters) is longer than %d character%s")
+                    + " (%d characters) is longer than %d character%s.")
                 .formatted(
                     string, string.length(), maxLength.value(), maxLength.value() == 1 ? "" : "s"),
             literal,
-            m_root);
+            null // not suppressible
+            );
       }
 
       return super.visitMethodInvocation(node, unused);
@@ -141,11 +134,8 @@ public class MaxLengthDetector implements TaskListener {
 
       Integer constValue = evaluateIntConstant(valueExpr);
       if (constValue != null && constValue < 1) {
-        m_trees.printMessage(
-            Diagnostic.Kind.ERROR,
-            "@MaxLength value must be >= 1 (was " + constValue + ")",
-            valueExpr,
-            m_root);
+        // not suppressible
+        printError("@MaxLength value must be >= 1 (was " + constValue + ").", valueExpr, null);
       }
 
       return super.visitAnnotation(node, unused);

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationProcessor.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationProcessor.java
@@ -49,9 +49,9 @@ public class OpModeAnnotationProcessor extends AbstractProcessor {
           // Not an instantiable type
           messager.printMessage(
               Diagnostic.Kind.ERROR,
-              "The @"
+              "[WPILib] The @"
                   + annotationType.getSimpleName()
-                  + " OpMode annotation can only be used on non-abstract classes",
+                  + " OpMode annotation can only be used on non-abstract classes.",
               type);
         }
 
@@ -59,10 +59,10 @@ public class OpModeAnnotationProcessor extends AbstractProcessor {
           // Doesn't implement `OpMode` or extend a class that does
           messager.printMessage(
               Diagnostic.Kind.ERROR,
-              "The @"
+              "[WPILib] The @"
                   + annotationType.getSimpleName()
                   + " OpMode annotation can only be used on classes that implement the "
-                  + "org.wpilib.opmode.OpMode interface or extend a class that does",
+                  + "org.wpilib.opmode.OpMode interface or extend a class that does.",
               type);
         }
       }

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationValidator.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/OpModeAnnotationValidator.java
@@ -13,14 +13,11 @@ import com.sun.source.util.JavacTask;
 import com.sun.source.util.TaskEvent;
 import com.sun.source.util.TaskListener;
 import com.sun.source.util.TreePath;
-import com.sun.source.util.TreeScanner;
-import com.sun.source.util.Trees;
 import java.util.HashSet;
 import java.util.Set;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
-import javax.tools.Diagnostic;
 
 /**
  * Validates opmode annotations {@code @Autonomous}, {@code @Teleop}, {@code @Utility}.
@@ -61,13 +58,9 @@ public class OpModeAnnotationValidator implements TaskListener {
     }
   }
 
-  private final class Scanner extends TreeScanner<Void, Void> {
-    private final CompilationUnitTree m_root;
-    private final Trees m_trees;
-
+  private final class Scanner extends WPILibTreeScanner<Void, Void> {
     Scanner(CompilationUnitTree compilationUnit) {
-      m_root = compilationUnit;
-      m_trees = Trees.instance(m_task);
+      super(compilationUnit, OpModeAnnotationValidator.this.m_task);
     }
 
     @Override
@@ -127,12 +120,12 @@ public class OpModeAnnotationValidator implements TaskListener {
         return;
       }
 
-      m_trees.printMessage(
-          Diagnostic.Kind.ERROR,
-          "@%s opmode %s must be <= %d characters (was %d)"
+      printError(
+          "@%s opmode %s must be <= %d characters (was %d)."
               .formatted(typeName, fieldName, max, value.length()),
           valueExpr,
-          m_root);
+          null // not suppressible
+          );
     }
 
     private String evaluateStringConstant(ExpressionTree expr) {

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/PostConstructionInitializerListener.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/PostConstructionInitializerListener.java
@@ -15,7 +15,6 @@ import com.sun.source.util.JavacTask;
 import com.sun.source.util.TaskEvent;
 import com.sun.source.util.TaskListener;
 import com.sun.source.util.TreePath;
-import com.sun.source.util.TreeScanner;
 import com.sun.source.util.Trees;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,7 +30,6 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
-import javax.tools.Diagnostic;
 import org.wpilib.annotation.PostConstructionInitializer;
 
 /**
@@ -55,7 +53,8 @@ public class PostConstructionInitializerListener implements TaskListener {
     var compilationUnit = e.getCompilationUnit();
     if (e.getKind() == TaskEvent.Kind.ANALYZE && m_visitedCUs.add(compilationUnit)) {
       var state = new State();
-      compilationUnit.accept(new Scanner(compilationUnit), state);
+      var scanner = new Scanner(compilationUnit);
+      compilationUnit.accept(scanner, state);
 
       if (state.m_initializedObjects.isEmpty()) {
         // Good! No partially initialized objects were detected.
@@ -67,9 +66,8 @@ public class PostConstructionInitializerListener implements TaskListener {
       for (InitializedObject partiallyInitializedObject : state.m_initializedObjects.values()) {
         var object = partiallyInitializedObject.object();
         var uncalledInitializers = partiallyInitializedObject.initializers();
-        trees.printMessage(
-            Diagnostic.Kind.ERROR,
-            "Partially-initialized object `%s` is missing %s %s"
+        scanner.printError(
+            "Partially-initialized object `%s` is missing %s %s."
                 .formatted(
                     object.getSimpleName(),
                     uncalledInitializers.size() == 1
@@ -79,7 +77,7 @@ public class PostConstructionInitializerListener implements TaskListener {
                         .map(i -> "`" + i.initializer().getSimpleName() + "()`")
                         .collect(Collectors.joining(", "))),
             trees.getTree(object),
-            compilationUnit);
+            PostConstructionInitializer.SUPPRESSION_KEY);
       }
     }
   }
@@ -188,13 +186,9 @@ public class PostConstructionInitializerListener implements TaskListener {
     }
   }
 
-  private final class Scanner extends TreeScanner<State, State> {
-    private final CompilationUnitTree m_root;
-    private final Trees m_trees;
-
+  private final class Scanner extends WPILibTreeScanner<State, State> {
     Scanner(CompilationUnitTree compilationUnit) {
-      m_root = compilationUnit;
-      m_trees = Trees.instance(m_task);
+      super(compilationUnit, PostConstructionInitializerListener.this.m_task);
     }
 
     @Override

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/PostConstructionInitializerProcessor.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/PostConstructionInitializerProcessor.java
@@ -90,7 +90,7 @@ public class PostConstructionInitializerProcessor extends AbstractProcessor {
     String message =
         "[WPILib] Static @PostConstructionInitializer method must take a parameter of type "
             + typeName
-            + ". This error cannot be silenced.";
+            + ".";
 
     processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, errorNode);
   }
@@ -100,8 +100,7 @@ public class PostConstructionInitializerProcessor extends AbstractProcessor {
         "[WPILib] Static @PostConstructionInitializer method must take exactly one parameter "
             + "of type "
             + typeName
-            + " with a @PostConstructionInitializer.InitializedParam annotation. "
-            + "This error cannot be silenced.";
+            + " with a @PostConstructionInitializer.InitializedParam annotation.";
 
     processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, errorNode);
   }

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/PostConstructionInitializerProcessor.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/PostConstructionInitializerProcessor.java
@@ -88,14 +88,16 @@ public class PostConstructionInitializerProcessor extends AbstractProcessor {
 
   private void printErrorForNoParams(Element errorNode, Name typeName) {
     String message =
-        "Static @PostConstructionInitializer method must take a parameter of type " + typeName;
+        "[WPILib] Static @PostConstructionInitializer method must take a parameter of type "
+            + typeName;
 
     processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, errorNode);
   }
 
   private void printTaggedParameterCountError(Element errorNode, Name typeName) {
     String message =
-        "Static @PostConstructionInitializer method must take exactly one parameter of type "
+        "[WPILib] Static @PostConstructionInitializer method must take exactly one parameter "
+            + "of type "
             + typeName
             + " with a @PostConstructionInitializer.InitializedParam annotation";
 

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/PostConstructionInitializerProcessor.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/PostConstructionInitializerProcessor.java
@@ -89,7 +89,8 @@ public class PostConstructionInitializerProcessor extends AbstractProcessor {
   private void printErrorForNoParams(Element errorNode, Name typeName) {
     String message =
         "[WPILib] Static @PostConstructionInitializer method must take a parameter of type "
-            + typeName;
+            + typeName
+            + ". This error cannot be silenced.";
 
     processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, errorNode);
   }
@@ -99,7 +100,8 @@ public class PostConstructionInitializerProcessor extends AbstractProcessor {
         "[WPILib] Static @PostConstructionInitializer method must take exactly one parameter "
             + "of type "
             + typeName
-            + " with a @PostConstructionInitializer.InitializedParam annotation";
+            + " with a @PostConstructionInitializer.InitializedParam annotation. "
+            + "This error cannot be silenced.";
 
     processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, errorNode);
   }

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/ReturnValueUsedListener.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/ReturnValueUsedListener.java
@@ -11,8 +11,6 @@ import com.sun.source.tree.Tree;
 import com.sun.source.util.JavacTask;
 import com.sun.source.util.TaskEvent;
 import com.sun.source.util.TaskListener;
-import com.sun.source.util.TreeScanner;
-import com.sun.source.util.Trees;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -23,7 +21,6 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-import javax.tools.Diagnostic;
 import org.wpilib.annotation.NoDiscard;
 
 /** Checks for usages of methods that require their return values to be used. */
@@ -46,13 +43,9 @@ public class ReturnValueUsedListener implements TaskListener {
     }
   }
 
-  private final class Scanner extends TreeScanner<Void, Void> {
-    private final CompilationUnitTree m_root;
-    private final Trees m_trees;
-
+  private final class Scanner extends WPILibTreeScanner<Void, Void> {
     Scanner(CompilationUnitTree compilationUnit) {
-      m_root = compilationUnit;
-      m_trees = Trees.instance(m_task);
+      super(compilationUnit, ReturnValueUsedListener.this.m_task);
     }
 
     @Override
@@ -74,7 +67,7 @@ public class ReturnValueUsedListener implements TaskListener {
     private void checkIgnoredExpression(Tree node) {
       var path = m_trees.getPath(m_root, node);
 
-      if (Suppressions.hasSuppression(m_trees, path, "NoDiscard")) {
+      if (Suppressions.hasSuppression(m_trees, path, NoDiscard.SUPPRESSION_KEY)) {
         return;
       }
 
@@ -97,7 +90,7 @@ public class ReturnValueUsedListener implements TaskListener {
       if (invoked != null) {
         List<String> messages = getNoDiscardMessages(invoked);
         for (String msg : messages) {
-          m_trees.printMessage(Diagnostic.Kind.ERROR, msg, node, m_root);
+          printError(msg, node, NoDiscard.SUPPRESSION_KEY);
         }
       }
     }
@@ -133,7 +126,7 @@ public class ReturnValueUsedListener implements TaskListener {
       if (methodNoDiscard != null) {
         String msg = methodNoDiscard.value();
         if (msg.isEmpty()) {
-          messages.add("Result of @NoDiscard method is ignored");
+          messages.add("Result of @NoDiscard method is ignored.");
         } else {
           messages.add(msg);
         }
@@ -181,7 +174,7 @@ public class ReturnValueUsedListener implements TaskListener {
         String message = typeNoDiscard.value();
         if (message.isEmpty()) {
           out.add(
-              "Result of method returning @NoDiscard type %s is ignored"
+              "Result of method returning @NoDiscard type %s is ignored."
                   .formatted(type.getQualifiedName()));
         } else {
           out.add(message);

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/WPILibTreeScanner.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/WPILibTreeScanner.java
@@ -1,3 +1,7 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package org.wpilib.javacplugin;
 
 import com.sun.source.tree.CompilationUnitTree;

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/WPILibTreeScanner.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/WPILibTreeScanner.java
@@ -40,9 +40,7 @@ abstract class WPILibTreeScanner<R, P> extends TreeScanner<R, P> {
             .append(' ')
             .append(normalizeMessage(message));
 
-    if (suppression == null) {
-      builder.append(" This error cannot be silenced.");
-    } else {
+    if (suppression != null) {
       builder
           .append(" If this is intentional, the error may be silenced with @SuppressWarnings(\"")
           .append(suppression)

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/WPILibTreeScanner.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/WPILibTreeScanner.java
@@ -1,0 +1,51 @@
+package org.wpilib.javacplugin;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.TreeScanner;
+import com.sun.source.util.Trees;
+import javax.tools.Diagnostic;
+
+/**
+ * Base class for scanners in this plugin. Helpers are provided for error reporting
+ *
+ * @param <R> the return type of this visitor's methods. Use {@link Void} for visitors that do not
+ *     need to return results.
+ * @param <P> the type of the additional parameter to this visitor's methods. Use {@code Void} for
+ *     visitors that do not need an additional parameter.
+ */
+abstract class WPILibTreeScanner<R, P> extends TreeScanner<R, P> {
+  public static final String WPILIB_MESSAGE_PREFIX = "[WPILib]";
+
+  protected final CompilationUnitTree m_root;
+  protected final JavacTask m_task;
+  protected final Trees m_trees;
+
+  WPILibTreeScanner(CompilationUnitTree tree, JavacTask task) {
+    m_root = tree;
+    m_task = task;
+    m_trees = Trees.instance(m_task);
+  }
+
+  protected void printError(CharSequence message, Tree tree, CharSequence suppression) {
+    m_trees.printMessage(
+        Diagnostic.Kind.ERROR, buildFullMessage(message, suppression), tree, m_root);
+  }
+
+  private static String buildFullMessage(CharSequence message, CharSequence suppression) {
+    StringBuilder builder =
+        new StringBuilder(86).append(WPILIB_MESSAGE_PREFIX).append(' ').append(message);
+
+    if (suppression == null) {
+      builder.append(" This error cannot be silenced.");
+    } else {
+      builder
+          .append(" If this is intentional, the error may be silenced with @SuppressWarnings(\"")
+          .append(suppression)
+          .append("\")");
+    }
+
+    return builder.toString();
+  }
+}

--- a/javacPlugin/src/main/java/org/wpilib/javacplugin/WPILibTreeScanner.java
+++ b/javacPlugin/src/main/java/org/wpilib/javacplugin/WPILibTreeScanner.java
@@ -35,7 +35,10 @@ abstract class WPILibTreeScanner<R, P> extends TreeScanner<R, P> {
 
   private static String buildFullMessage(CharSequence message, CharSequence suppression) {
     StringBuilder builder =
-        new StringBuilder(86).append(WPILIB_MESSAGE_PREFIX).append(' ').append(message);
+        new StringBuilder(86)
+            .append(WPILIB_MESSAGE_PREFIX)
+            .append(' ')
+            .append(normalizeMessage(message));
 
     if (suppression == null) {
       builder.append(" This error cannot be silenced.");
@@ -47,5 +50,23 @@ abstract class WPILibTreeScanner<R, P> extends TreeScanner<R, P> {
     }
 
     return builder.toString();
+  }
+
+  /**
+   * Normalizes the message by appending a period if the message does not already end with a
+   * punctuation mark.
+   *
+   * @param input The message to normalize.
+   * @return The normalized message.
+   */
+  private static CharSequence normalizeMessage(CharSequence input) {
+    if (input.isEmpty()) {
+      return input;
+    }
+
+    return switch (input.charAt(input.length() - 1)) {
+      case '.', '!', '?' -> input;
+      default -> input + ".";
+    };
   }
 }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/CodeAfterCoroutineParkDetectorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/CodeAfterCoroutineParkDetectorTest.java
@@ -79,7 +79,10 @@ class CodeAfterCoroutineParkDetectorTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Unreachable statement: `coroutine.park()` will never exit", error.getMessage(null));
+        "[WPILib] Unreachable statement: `coroutine.park()` will never exit."
+            + " If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.CodeAfterCoroutinePark\")",
+        error.getMessage(null));
     assertEquals("System.out.println(\"Unreachable 1\"); ", getErrorSource(error));
   }
 
@@ -143,7 +146,10 @@ class CodeAfterCoroutineParkDetectorTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Unreachable statement: `coroutine.park()` will never exit", error.getMessage(null));
+        "[WPILib] Unreachable statement: `coroutine.park()` will never exit."
+            + " If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.CodeAfterCoroutinePark\")",
+        error.getMessage(null));
     assertEquals("for (;;) {\n    }\n", getErrorSource(error));
   }
 
@@ -176,7 +182,10 @@ class CodeAfterCoroutineParkDetectorTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Unreachable statement: `coroutine.park()` will never exit", error.getMessage(null));
+        "[WPILib] Unreachable statement: `coroutine.park()` will never exit."
+            + " If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.CodeAfterCoroutinePark\")",
+        error.getMessage(null));
     assertEquals("{\n    }\n", getErrorSource(error));
   }
 
@@ -234,7 +243,10 @@ class CodeAfterCoroutineParkDetectorTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Unreachable statement: `coroutine.park()` will never exit", error.getMessage(null));
+        "[WPILib] Unreachable statement: `coroutine.park()` will never exit."
+            + " If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.CodeAfterCoroutinePark\")",
+        error.getMessage(null));
     assertEquals("System.out.println(\"Unreachable\");\n", getErrorSource(error));
   }
 }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/CoroutineInLoopListenerTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/CoroutineInLoopListenerTest.java
@@ -129,7 +129,9 @@ class CoroutineInLoopListenerTest {
     assertThat(compilation).failed();
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals("Missing call to `coroutine.yield()` inside loop", error.getMessage(null));
+    assertEquals(
+        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
+        error.getMessage(null));
   }
 
   @Test
@@ -196,11 +198,11 @@ class CoroutineInLoopListenerTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Missing call to "
+        "[WPILib] Missing call to "
             + "`firstCoroutine.yield()`, "
             + "`c1.yield()`, "
             + "`next.yield()`, or "
-            + "`thisMightBeTheLastOne.yield()` inside loop",
+            + "`thisMightBeTheLastOne.yield()` inside loop. This error cannot be silenced.",
         error.getMessage(null));
   }
 
@@ -234,7 +236,10 @@ class CoroutineInLoopListenerTest {
     assertThat(compilation).failed();
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals("Missing call to `innerCoroutine.yield()` inside loop", error.getMessage(null));
+    assertEquals(
+        "[WPILib] Missing call to `innerCoroutine.yield()` inside loop."
+            + " This error cannot be silenced.",
+        error.getMessage(null));
   }
 
   @Test
@@ -270,7 +275,10 @@ class CoroutineInLoopListenerTest {
     // and another error for calling a method on a captured coroutine (from a different analyzer)
     assertEquals(2, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals("Missing call to `innerCoroutine.yield()` inside loop", error.getMessage(null));
+    assertEquals(
+        "[WPILib] Missing call to `innerCoroutine.yield()` inside loop."
+            + " This error cannot be silenced.",
+        error.getMessage(null));
   }
 
   @Test
@@ -305,11 +313,15 @@ class CoroutineInLoopListenerTest {
     assertEquals(2, compilation.errors().size());
 
     var error1 = compilation.errors().get(0);
-    assertEquals("Missing call to `coroutine.yield()` inside loop", error1.getMessage(null));
+    assertEquals(
+        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
+        error1.getMessage(null));
     assertEquals(8, error1.getLineNumber());
 
     var error2 = compilation.errors().get(1);
-    assertEquals("Missing call to `coroutine.yield()` inside loop", error2.getMessage(null));
+    assertEquals(
+        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
+        error2.getMessage(null));
     assertEquals(9, error2.getLineNumber());
   }
 
@@ -344,7 +356,9 @@ class CoroutineInLoopListenerTest {
     assertThat(compilation).failed();
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals("Missing call to `coroutine.yield()` inside loop", error.getMessage(null));
+    assertEquals(
+        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
+        error.getMessage(null));
     assertEquals(10, error.getLineNumber());
   }
 
@@ -379,7 +393,9 @@ class CoroutineInLoopListenerTest {
     assertThat(compilation).failed();
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals("Missing call to `coroutine.yield()` inside loop", error.getMessage(null));
+    assertEquals(
+        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
+        error.getMessage(null));
     assertEquals(8, error.getLineNumber());
   }
 
@@ -426,31 +442,45 @@ class CoroutineInLoopListenerTest {
     assertEquals(7, compilation.errors().size());
 
     var error1 = compilation.errors().get(0);
-    assertEquals("Missing call to `coroutine.yield()` inside loop", error1.getMessage(null));
+    assertEquals(
+        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
+        error1.getMessage(null));
     assertEquals(8, error1.getLineNumber());
 
     var error2 = compilation.errors().get(1);
-    assertEquals("Missing call to `coroutine.yield()` inside loop", error2.getMessage(null));
+    assertEquals(
+        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
+        error2.getMessage(null));
     assertEquals(9, error2.getLineNumber());
 
     var error3 = compilation.errors().get(2);
-    assertEquals("Missing call to `coroutine.yield()` inside loop", error3.getMessage(null));
+    assertEquals(
+        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
+        error3.getMessage(null));
     assertEquals(10, error3.getLineNumber());
 
     var error4 = compilation.errors().get(3);
-    assertEquals("Missing call to `coroutine.yield()` inside loop", error4.getMessage(null));
+    assertEquals(
+        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
+        error4.getMessage(null));
     assertEquals(11, error4.getLineNumber());
 
     var error5 = compilation.errors().get(4);
-    assertEquals("Missing call to `coroutine.yield()` inside loop", error5.getMessage(null));
+    assertEquals(
+        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
+        error5.getMessage(null));
     assertEquals(12, error5.getLineNumber());
 
     var error6 = compilation.errors().get(5);
-    assertEquals("Missing call to `coroutine.yield()` inside loop", error6.getMessage(null));
+    assertEquals(
+        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
+        error6.getMessage(null));
     assertEquals(13, error6.getLineNumber());
 
     var error7 = compilation.errors().get(6);
-    assertEquals("Missing call to `coroutine.yield()` inside loop", error7.getMessage(null));
+    assertEquals(
+        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
+        error7.getMessage(null));
     assertEquals(16, error7.getLineNumber());
   }
 }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/CoroutineInLoopListenerTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/CoroutineInLoopListenerTest.java
@@ -23,6 +23,11 @@ class CoroutineInLoopListenerTest {
       }
       """;
 
+  public static final String STANDARD_MSG =
+      "[WPILib] Missing call to `coroutine.yield()` inside loop. "
+          + "If this is intentional, the error may be silenced with "
+          + "@SuppressWarnings(\"WPILib.CoroutineYieldInLoop\")";
+
   @Test
   void noYieldInLoopWithoutCoroutines() {
     String source =
@@ -129,9 +134,7 @@ class CoroutineInLoopListenerTest {
     assertThat(compilation).failed();
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals(
-        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
-        error.getMessage(null));
+    assertEquals(STANDARD_MSG, error.getMessage(null));
   }
 
   @Test
@@ -202,7 +205,9 @@ class CoroutineInLoopListenerTest {
             + "`firstCoroutine.yield()`, "
             + "`c1.yield()`, "
             + "`next.yield()`, or "
-            + "`thisMightBeTheLastOne.yield()` inside loop. This error cannot be silenced.",
+            + "`thisMightBeTheLastOne.yield()` inside loop. "
+            + "If this is intentional, the error may be silenced with "
+            + "@SuppressWarnings(\"WPILib.CoroutineYieldInLoop\")",
         error.getMessage(null));
   }
 
@@ -238,7 +243,8 @@ class CoroutineInLoopListenerTest {
     var error = compilation.errors().get(0);
     assertEquals(
         "[WPILib] Missing call to `innerCoroutine.yield()` inside loop."
-            + " This error cannot be silenced.",
+            + " If this is intentional, the error may be silenced with "
+            + "@SuppressWarnings(\"WPILib.CoroutineYieldInLoop\")",
         error.getMessage(null));
   }
 
@@ -277,7 +283,8 @@ class CoroutineInLoopListenerTest {
     var error = compilation.errors().get(0);
     assertEquals(
         "[WPILib] Missing call to `innerCoroutine.yield()` inside loop."
-            + " This error cannot be silenced.",
+            + " If this is intentional, the error may be silenced with "
+            + "@SuppressWarnings(\"WPILib.CoroutineYieldInLoop\")",
         error.getMessage(null));
   }
 
@@ -313,15 +320,11 @@ class CoroutineInLoopListenerTest {
     assertEquals(2, compilation.errors().size());
 
     var error1 = compilation.errors().get(0);
-    assertEquals(
-        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
-        error1.getMessage(null));
+    assertEquals(STANDARD_MSG, error1.getMessage(null));
     assertEquals(8, error1.getLineNumber());
 
     var error2 = compilation.errors().get(1);
-    assertEquals(
-        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
-        error2.getMessage(null));
+    assertEquals(STANDARD_MSG, error2.getMessage(null));
     assertEquals(9, error2.getLineNumber());
   }
 
@@ -356,9 +359,7 @@ class CoroutineInLoopListenerTest {
     assertThat(compilation).failed();
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals(
-        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
-        error.getMessage(null));
+    assertEquals(STANDARD_MSG, error.getMessage(null));
     assertEquals(10, error.getLineNumber());
   }
 
@@ -393,9 +394,7 @@ class CoroutineInLoopListenerTest {
     assertThat(compilation).failed();
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals(
-        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
-        error.getMessage(null));
+    assertEquals(STANDARD_MSG, error.getMessage(null));
     assertEquals(8, error.getLineNumber());
   }
 
@@ -442,45 +441,31 @@ class CoroutineInLoopListenerTest {
     assertEquals(7, compilation.errors().size());
 
     var error1 = compilation.errors().get(0);
-    assertEquals(
-        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
-        error1.getMessage(null));
+    assertEquals(STANDARD_MSG, error1.getMessage(null));
     assertEquals(8, error1.getLineNumber());
 
     var error2 = compilation.errors().get(1);
-    assertEquals(
-        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
-        error2.getMessage(null));
+    assertEquals(STANDARD_MSG, error2.getMessage(null));
     assertEquals(9, error2.getLineNumber());
 
     var error3 = compilation.errors().get(2);
-    assertEquals(
-        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
-        error3.getMessage(null));
+    assertEquals(STANDARD_MSG, error3.getMessage(null));
     assertEquals(10, error3.getLineNumber());
 
     var error4 = compilation.errors().get(3);
-    assertEquals(
-        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
-        error4.getMessage(null));
+    assertEquals(STANDARD_MSG, error4.getMessage(null));
     assertEquals(11, error4.getLineNumber());
 
     var error5 = compilation.errors().get(4);
-    assertEquals(
-        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
-        error5.getMessage(null));
+    assertEquals(STANDARD_MSG, error5.getMessage(null));
     assertEquals(12, error5.getLineNumber());
 
     var error6 = compilation.errors().get(5);
-    assertEquals(
-        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
-        error6.getMessage(null));
+    assertEquals(STANDARD_MSG, error6.getMessage(null));
     assertEquals(13, error6.getLineNumber());
 
     var error7 = compilation.errors().get(6);
-    assertEquals(
-        "[WPILib] Missing call to `coroutine.yield()` inside loop. This error cannot be silenced.",
-        error7.getMessage(null));
+    assertEquals(STANDARD_MSG, error7.getMessage(null));
     assertEquals(16, error7.getLineNumber());
   }
 }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/IncorrectCoroutineUseDetectorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/IncorrectCoroutineUseDetectorTest.java
@@ -53,7 +53,9 @@ class IncorrectCoroutineUseDetectorTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Coroutine `outerCoroutine` may not be in scope. Consider using `innerCoroutine`",
+        "[WPILib] Coroutine `outerCoroutine` may not be in scope. Consider using `innerCoroutine`."
+            + " If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.CoroutineMayNotBeInScope\")",
         error.getMessage(null));
     assertEquals(7, error.getColumnNumber()); // leading "o" in "outerCoroutine.yield()"
   }
@@ -89,7 +91,9 @@ class IncorrectCoroutineUseDetectorTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Coroutine `outerCoroutine` may not be in scope. Consider using `innerCoroutine`",
+        "[WPILib] Coroutine `outerCoroutine` may not be in scope. Consider using `innerCoroutine`."
+            + " If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.CoroutineMayNotBeInScope\")",
         error.getMessage(null));
     // leading "o" in "outerCoroutine" passed to `method(outerCoroutine)`
     assertEquals(14, error.getColumnNumber());
@@ -127,7 +131,9 @@ class IncorrectCoroutineUseDetectorTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Coroutine `outerCoroutine` may not be in scope. Consider using `a` or `b`",
+        "[WPILib] Coroutine `outerCoroutine` may not be in scope. Consider using `a` or `b`."
+            + " If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.CoroutineMayNotBeInScope\")",
         error.getMessage(null));
     // leading "o" in "outerCoroutine" passed to `method(outerCoroutine)`
     assertEquals(14, error.getColumnNumber());
@@ -169,7 +175,9 @@ class IncorrectCoroutineUseDetectorTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Coroutine `outerCoroutine` may not be in scope. Consider using `a`, `b`, or `c`",
+        "[WPILib] Coroutine `outerCoroutine` may not be in scope. Consider using `a`, `b`, or `c`."
+            + " If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.CoroutineMayNotBeInScope\")",
         error.getMessage(null));
     // leading "o" in "outerCoroutine" passed to `method(outerCoroutine)`
     assertEquals(14, error.getColumnNumber());
@@ -203,7 +211,10 @@ class IncorrectCoroutineUseDetectorTest {
     assertThat(compilation).failed();
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals("Captured coroutines may not be stored in fields", error.getMessage(null));
+    assertEquals(
+        "[WPILib] Captured coroutines may not be stored in fields. If this is intentional,"
+            + " the error may be silenced with @SuppressWarnings(\"WPILib.CoroutineCapture\")",
+        error.getMessage(null));
   }
 
   @Test
@@ -238,12 +249,18 @@ class IncorrectCoroutineUseDetectorTest {
     assertEquals(2, compilation.errors().size());
 
     var error1 = compilation.errors().get(0);
-    assertEquals("Captured coroutines may not be stored in fields", error1.getMessage(null));
+    assertEquals(
+        "[WPILib] Captured coroutines may not be stored in fields. If this is intentional,"
+            + " the error may be silenced with @SuppressWarnings(\"WPILib.CoroutineCapture\")",
+        error1.getMessage(null));
     assertEquals(11, error1.getLineNumber());
     assertEquals("coroutineField = outerCoroutine;", getErrorSource(error1));
 
     var error2 = compilation.errors().get(1);
-    assertEquals("Captured coroutines may not be stored in fields", error2.getMessage(null));
+    assertEquals(
+        "[WPILib] Captured coroutines may not be stored in fields. If this is intentional,"
+            + " the error may be silenced with @SuppressWarnings(\"WPILib.CoroutineCapture\")",
+        error2.getMessage(null));
     assertEquals("coroutineField = innerCoroutine;", getErrorSource(error2));
     assertEquals(12, error2.getLineNumber());
   }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/IntegerDivisionDetectorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/IntegerDivisionDetectorTest.java
@@ -162,7 +162,10 @@ class IntegerDivisionDetectorTest {
                 + finalSource);
 
     for (var error : errors) {
-      assertEquals("integer division in a floating-point context", error.getMessage(null));
+      assertEquals(
+          "[WPILib] Integer division in a floating-point context. If this is intentional,"
+              + " the error may be silenced with @SuppressWarnings(\"WPILib.IntegerDivision\")",
+          error.getMessage(null));
     }
   }
 
@@ -205,7 +208,10 @@ class IntegerDivisionDetectorTest {
     var errors = compilation.errors();
     assertEquals(1, errors.size());
     var error = errors.get(0);
-    assertEquals("integer division in a floating-point context", error.getMessage(null));
+    assertEquals(
+        "[WPILib] Integer division in a floating-point context. If this is intentional,"
+            + " the error may be silenced with @SuppressWarnings(\"WPILib.IntegerDivision\")",
+        error.getMessage(null));
   }
 
   @Test
@@ -215,18 +221,18 @@ class IntegerDivisionDetectorTest {
         package wpilib.robot;
 
         class Example {
-          @SuppressWarnings("IntegerDivision")
+          @SuppressWarnings("WPILib.IntegerDivision")
           float f = 1 / 2;
 
           void method() {
-            @SuppressWarnings("IntegerDivision")
+            @SuppressWarnings("WPILib.IntegerDivision")
             double d = 3 / 4;
 
             @SuppressWarnings("all")
             float f2 = 5 / 6;
           }
 
-          @SuppressWarnings("IntegerDivision")
+          @SuppressWarnings("WPILib.IntegerDivision")
           double method2() {
             return 7 / 8;
           }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/MaxLengthDetectorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/MaxLengthDetectorTest.java
@@ -69,7 +69,7 @@ class MaxLengthDetectorTest {
     var error = errors.get(0);
     assertEquals(
         "[WPILib] String literal exceeds maximum length: \"abcdefghijklmnopqrstuvwxyz1234567890\""
-            + " (36 characters) is longer than 1 character. This error cannot be silenced.",
+            + " (36 characters) is longer than 1 character.",
         error.getMessage(null));
   }
 
@@ -102,7 +102,7 @@ class MaxLengthDetectorTest {
     var error = errors.get(0);
     assertEquals(
         "[WPILib] String literal exceeds maximum length: \"12\" (2 characters) is longer than 1"
-            + " character. This error cannot be silenced.",
+            + " character.",
         error.getMessage(null));
   }
 
@@ -157,7 +157,7 @@ class MaxLengthDetectorTest {
     assertEquals(1, errors.size());
     var error = errors.get(0);
     assertEquals(
-        "[WPILib] @MaxLength value must be >= 1 (was 0). This error cannot be silenced.",
+        "[WPILib] @MaxLength value must be >= 1 (was 0).",
         error.getMessage(null));
   }
 
@@ -185,7 +185,7 @@ class MaxLengthDetectorTest {
     assertEquals(1, errors.size());
     var error = errors.get(0);
     assertEquals(
-        "[WPILib] @MaxLength value must be >= 1 (was -123). This error cannot be silenced.",
+        "[WPILib] @MaxLength value must be >= 1 (was -123).",
         error.getMessage(null));
   }
 
@@ -215,7 +215,7 @@ class MaxLengthDetectorTest {
     assertEquals(1, errors.size());
     var error = errors.get(0);
     assertEquals(
-        "[WPILib] @MaxLength value must be >= 1 (was 0). This error cannot be silenced.",
+        "[WPILib] @MaxLength value must be >= 1 (was 0).",
         error.getMessage(null));
   }
 
@@ -245,7 +245,7 @@ class MaxLengthDetectorTest {
     assertEquals(1, errors.size());
     var error = errors.get(0);
     assertEquals(
-        "[WPILib] @MaxLength value must be >= 1 (was -3). This error cannot be silenced.",
+        "[WPILib] @MaxLength value must be >= 1 (was -3).",
         error.getMessage(null));
   }
 }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/MaxLengthDetectorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/MaxLengthDetectorTest.java
@@ -156,9 +156,7 @@ class MaxLengthDetectorTest {
     var errors = compilation.errors();
     assertEquals(1, errors.size());
     var error = errors.get(0);
-    assertEquals(
-        "[WPILib] @MaxLength value must be >= 1 (was 0).",
-        error.getMessage(null));
+    assertEquals("[WPILib] @MaxLength value must be >= 1 (was 0).", error.getMessage(null));
   }
 
   @Test
@@ -184,9 +182,7 @@ class MaxLengthDetectorTest {
     var errors = compilation.errors();
     assertEquals(1, errors.size());
     var error = errors.get(0);
-    assertEquals(
-        "[WPILib] @MaxLength value must be >= 1 (was -123).",
-        error.getMessage(null));
+    assertEquals("[WPILib] @MaxLength value must be >= 1 (was -123).", error.getMessage(null));
   }
 
   @Test
@@ -214,9 +210,7 @@ class MaxLengthDetectorTest {
     var errors = compilation.errors();
     assertEquals(1, errors.size());
     var error = errors.get(0);
-    assertEquals(
-        "[WPILib] @MaxLength value must be >= 1 (was 0).",
-        error.getMessage(null));
+    assertEquals("[WPILib] @MaxLength value must be >= 1 (was 0).", error.getMessage(null));
   }
 
   @Test
@@ -244,8 +238,6 @@ class MaxLengthDetectorTest {
     var errors = compilation.errors();
     assertEquals(1, errors.size());
     var error = errors.get(0);
-    assertEquals(
-        "[WPILib] @MaxLength value must be >= 1 (was -3).",
-        error.getMessage(null));
+    assertEquals("[WPILib] @MaxLength value must be >= 1 (was -3).", error.getMessage(null));
   }
 }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/MaxLengthDetectorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/MaxLengthDetectorTest.java
@@ -68,8 +68,8 @@ class MaxLengthDetectorTest {
     assertEquals(1, errors.size());
     var error = errors.get(0);
     assertEquals(
-        "String literal exceeds maximum length: \"abcdefghijklmnopqrstuvwxyz1234567890\""
-            + " (36 characters) is longer than 1 character",
+        "[WPILib] String literal exceeds maximum length: \"abcdefghijklmnopqrstuvwxyz1234567890\""
+            + " (36 characters) is longer than 1 character. This error cannot be silenced.",
         error.getMessage(null));
   }
 
@@ -101,7 +101,8 @@ class MaxLengthDetectorTest {
     assertEquals(1, errors.size());
     var error = errors.get(0);
     assertEquals(
-        "String literal exceeds maximum length: \"12\" (2 characters) is longer than 1 character",
+        "[WPILib] String literal exceeds maximum length: \"12\" (2 characters) is longer than 1"
+            + " character. This error cannot be silenced.",
         error.getMessage(null));
   }
 
@@ -155,7 +156,9 @@ class MaxLengthDetectorTest {
     var errors = compilation.errors();
     assertEquals(1, errors.size());
     var error = errors.get(0);
-    assertEquals("@MaxLength value must be >= 1 (was 0)", error.getMessage(null));
+    assertEquals(
+        "[WPILib] @MaxLength value must be >= 1 (was 0). This error cannot be silenced.",
+        error.getMessage(null));
   }
 
   @Test
@@ -181,7 +184,9 @@ class MaxLengthDetectorTest {
     var errors = compilation.errors();
     assertEquals(1, errors.size());
     var error = errors.get(0);
-    assertEquals("@MaxLength value must be >= 1 (was -123)", error.getMessage(null));
+    assertEquals(
+        "[WPILib] @MaxLength value must be >= 1 (was -123). This error cannot be silenced.",
+        error.getMessage(null));
   }
 
   @Test
@@ -209,7 +214,9 @@ class MaxLengthDetectorTest {
     var errors = compilation.errors();
     assertEquals(1, errors.size());
     var error = errors.get(0);
-    assertEquals("@MaxLength value must be >= 1 (was 0)", error.getMessage(null));
+    assertEquals(
+        "[WPILib] @MaxLength value must be >= 1 (was 0). This error cannot be silenced.",
+        error.getMessage(null));
   }
 
   @Test
@@ -237,6 +244,8 @@ class MaxLengthDetectorTest {
     var errors = compilation.errors();
     assertEquals(1, errors.size());
     var error = errors.get(0);
-    assertEquals("@MaxLength value must be >= 1 (was -3)", error.getMessage(null));
+    assertEquals(
+        "[WPILib] @MaxLength value must be >= 1 (was -3). This error cannot be silenced.",
+        error.getMessage(null));
   }
 }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/OpModeAnnotationProcessorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/OpModeAnnotationProcessorTest.java
@@ -45,12 +45,14 @@ class OpModeAnnotationProcessorTest {
             .compile(JavaFileObjects.forSourceString("example.Example", source));
 
     final String nonAbstractErrorMessage =
-        "The @" + annotationName + " OpMode annotation can only be used on non-abstract classes";
+        "[WPILib] The @"
+            + annotationName
+            + " OpMode annotation can only be used on non-abstract classes.";
     final String implementationErrorMessage =
-        "The @"
+        "[WPILib] The @"
             + annotationName
             + " OpMode annotation can only be used on classes that implement the "
-            + "org.wpilib.opmode.OpMode interface or extend a class that does";
+            + "org.wpilib.opmode.OpMode interface or extend a class that does.";
 
     if (!inherit) {
       assertThat(compilation).failed();

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/OpModeAnnotationProcessorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/OpModeAnnotationProcessorTest.java
@@ -7,7 +7,7 @@ package org.wpilib.javacplugin;
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.wpilib.javacplugin.CompileTestUtils.kJavaVersionOptions;
+import static org.wpilib.javacplugin.CompileTestUtils.JAVA_VERSION_OPTIONS;
 
 import com.google.common.collect.Sets;
 import com.google.testing.compile.Compilation;
@@ -40,7 +40,7 @@ class OpModeAnnotationProcessorTest {
 
     Compilation compilation =
         javac()
-            .withOptions(kJavaVersionOptions)
+            .withOptions(JAVA_VERSION_OPTIONS)
             .withProcessors(new OpModeAnnotationProcessor())
             .compile(JavaFileObjects.forSourceString("example.Example", source));
 

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/OpModeAnnotationValidatorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/OpModeAnnotationValidatorTest.java
@@ -135,35 +135,35 @@ class OpModeAnnotationValidatorTest {
 
     // Autonomous
     assertEquals(
-        "[WPILib] @Autonomous opmode name must be <= 32 characters (was 74). This error cannot be silenced.",
+        "[WPILib] @Autonomous opmode name must be <= 32 characters (was 74).",
         errors.get(0).getMessage(null));
     assertEquals(
-        "[WPILib] @Autonomous opmode group must be <= 12 characters (was 32). This error cannot be silenced.",
+        "[WPILib] @Autonomous opmode group must be <= 12 characters (was 32).",
         errors.get(1).getMessage(null));
     assertEquals(
-        "[WPILib] @Autonomous opmode description must be <= 64 characters (was 99). This error cannot be silenced.",
+        "[WPILib] @Autonomous opmode description must be <= 64 characters (was 99).",
         errors.get(2).getMessage(null));
 
     // Teleop
     assertEquals(
-        "[WPILib] @Teleop opmode name must be <= 32 characters (was 74). This error cannot be silenced.",
+        "[WPILib] @Teleop opmode name must be <= 32 characters (was 74).",
         errors.get(3).getMessage(null));
     assertEquals(
-        "[WPILib] @Teleop opmode group must be <= 12 characters (was 32). This error cannot be silenced.",
+        "[WPILib] @Teleop opmode group must be <= 12 characters (was 32).",
         errors.get(4).getMessage(null));
     assertEquals(
-        "[WPILib] @Teleop opmode description must be <= 64 characters (was 99). This error cannot be silenced.",
+        "[WPILib] @Teleop opmode description must be <= 64 characters (was 99).",
         errors.get(5).getMessage(null));
 
     // Utility
     assertEquals(
-        "[WPILib] @Utility opmode name must be <= 32 characters (was 74). This error cannot be silenced.",
+        "[WPILib] @Utility opmode name must be <= 32 characters (was 74).",
         errors.get(6).getMessage(null));
     assertEquals(
-        "[WPILib] @Utility opmode group must be <= 12 characters (was 32). This error cannot be silenced.",
+        "[WPILib] @Utility opmode group must be <= 12 characters (was 32).",
         errors.get(7).getMessage(null));
     assertEquals(
-        "[WPILib] @Utility opmode description must be <= 64 characters (was 99). This error cannot be silenced.",
+        "[WPILib] @Utility opmode description must be <= 64 characters (was 99).",
         errors.get(8).getMessage(null));
   }
 }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/OpModeAnnotationValidatorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/OpModeAnnotationValidatorTest.java
@@ -135,31 +135,35 @@ class OpModeAnnotationValidatorTest {
 
     // Autonomous
     assertEquals(
-        "@Autonomous opmode name must be <= 32 characters (was 74)",
+        "[WPILib] @Autonomous opmode name must be <= 32 characters (was 74). This error cannot be silenced.",
         errors.get(0).getMessage(null));
     assertEquals(
-        "@Autonomous opmode group must be <= 12 characters (was 32)",
+        "[WPILib] @Autonomous opmode group must be <= 12 characters (was 32). This error cannot be silenced.",
         errors.get(1).getMessage(null));
     assertEquals(
-        "@Autonomous opmode description must be <= 64 characters (was 99)",
+        "[WPILib] @Autonomous opmode description must be <= 64 characters (was 99). This error cannot be silenced.",
         errors.get(2).getMessage(null));
 
     // Teleop
     assertEquals(
-        "@Teleop opmode name must be <= 32 characters (was 74)", errors.get(3).getMessage(null));
+        "[WPILib] @Teleop opmode name must be <= 32 characters (was 74). This error cannot be silenced.",
+        errors.get(3).getMessage(null));
     assertEquals(
-        "@Teleop opmode group must be <= 12 characters (was 32)", errors.get(4).getMessage(null));
+        "[WPILib] @Teleop opmode group must be <= 12 characters (was 32). This error cannot be silenced.",
+        errors.get(4).getMessage(null));
     assertEquals(
-        "@Teleop opmode description must be <= 64 characters (was 99)",
+        "[WPILib] @Teleop opmode description must be <= 64 characters (was 99). This error cannot be silenced.",
         errors.get(5).getMessage(null));
 
-    // TestOpMode
+    // Utility
     assertEquals(
-        "@Utility opmode name must be <= 32 characters (was 74)", errors.get(6).getMessage(null));
+        "[WPILib] @Utility opmode name must be <= 32 characters (was 74). This error cannot be silenced.",
+        errors.get(6).getMessage(null));
     assertEquals(
-        "@Utility opmode group must be <= 12 characters (was 32)", errors.get(7).getMessage(null));
+        "[WPILib] @Utility opmode group must be <= 12 characters (was 32). This error cannot be silenced.",
+        errors.get(7).getMessage(null));
     assertEquals(
-        "@Utility opmode description must be <= 64 characters (was 99)",
+        "[WPILib] @Utility opmode description must be <= 64 characters (was 99). This error cannot be silenced.",
         errors.get(8).getMessage(null));
   }
 }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/PostConstructionInitializerListenerTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/PostConstructionInitializerListenerTest.java
@@ -69,7 +69,9 @@ class PostConstructionInitializerListenerTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Partially-initialized object `example` is missing a call to initializer method `init()`",
+        "[WPILib] Partially-initialized object `example` is missing a call to initializer"
+            + " method `init()`. If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.PostConstructionInitializer\")",
         error.getMessage(null));
   }
 
@@ -166,7 +168,9 @@ class PostConstructionInitializerListenerTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Partially-initialized object `example` is missing a call to initializer method `init()`",
+        "[WPILib] Partially-initialized object `example` is missing a call to initializer"
+            + " method `init()`. If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.PostConstructionInitializer\")",
         error.getMessage(null));
   }
 
@@ -225,7 +229,9 @@ class PostConstructionInitializerListenerTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Partially-initialized object `example` is missing a call to initializer method `init()`",
+        "[WPILib] Partially-initialized object `example` is missing a call to initializer"
+            + " method `init()`. If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.PostConstructionInitializer\")",
         error.getMessage(null));
   }
 
@@ -267,8 +273,9 @@ class PostConstructionInitializerListenerTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Partially-initialized object `example` is missing calls to 2 initializer methods: "
-            + "`i1Init()`, `i2Init()`",
+        "[WPILib] Partially-initialized object `example` is missing calls to 2 initializer"
+            + " methods: `i1Init()`, `i2Init()`. If this is intentional, the error may be"
+            + " silenced with @SuppressWarnings(\"WPILib.PostConstructionInitializer\")",
         error.getMessage(null));
   }
 
@@ -371,7 +378,9 @@ class PostConstructionInitializerListenerTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Partially-initialized object `example` is missing a call to initializer method `init()`",
+        "[WPILib] Partially-initialized object `example` is missing a call to initializer"
+            + " method `init()`. If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.PostConstructionInitializer\")",
         error.getMessage(null));
   }
 
@@ -416,7 +425,9 @@ class PostConstructionInitializerListenerTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Partially-initialized object `example` is missing a call to initializer method `init()`",
+        "[WPILib] Partially-initialized object `example` is missing a call to initializer"
+            + " method `init()`. If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.PostConstructionInitializer\")",
         error.getMessage(null));
   }
 
@@ -433,7 +444,7 @@ class PostConstructionInitializerListenerTest {
           void init() { }
 
           static void usage() {
-            @SuppressWarnings("PostConstructionInitializer")
+            @SuppressWarnings("WPILib.PostConstructionInitializer")
             var example = new Example();
             // example.init();
           }
@@ -460,7 +471,7 @@ class PostConstructionInitializerListenerTest {
           @PostConstructionInitializer
           void init() { }
 
-          @SuppressWarnings("PostConstructionInitializer")
+          @SuppressWarnings("WPILib.PostConstructionInitializer")
           static void usage() {
             var example = new Example();
             // example.init();
@@ -484,7 +495,7 @@ class PostConstructionInitializerListenerTest {
 
         import org.wpilib.annotation.PostConstructionInitializer;
 
-        @SuppressWarnings("PostConstructionInitializer")
+        @SuppressWarnings("WPILib.PostConstructionInitializer")
         class Example {
           @PostConstructionInitializer
           void init() { }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/PostConstructionInitializerProcessorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/PostConstructionInitializerProcessorTest.java
@@ -39,7 +39,7 @@ class PostConstructionInitializerProcessorTest {
     var error = compilation.errors().get(0);
     assertEquals(
         "[WPILib] Static @PostConstructionInitializer method must take a parameter of type "
-            + "frc.robot.Example. This error cannot be silenced.",
+            + "frc.robot.Example.",
         error.getMessage(null));
   }
 
@@ -141,14 +141,14 @@ class PostConstructionInitializerProcessorTest {
     assertEquals(
         "[WPILib] Static @PostConstructionInitializer method must take exactly one parameter "
             + "of type frc.robot.Example with a @PostConstructionInitializer.InitializedParam "
-            + "annotation. This error cannot be silenced.",
+            + "annotation.",
         error1.getMessage(null));
 
     var error2 = compilation.errors().get(1);
     assertEquals(
         "[WPILib] Static @PostConstructionInitializer method must take exactly one parameter "
             + "of type frc.robot.Example with a @PostConstructionInitializer.InitializedParam "
-            + "annotation. This error cannot be silenced.",
+            + "annotation.",
         error2.getMessage(null));
   }
 
@@ -180,7 +180,7 @@ class PostConstructionInitializerProcessorTest {
     var error = compilation.errors().get(0);
     assertEquals(
         "[WPILib] Static @PostConstructionInitializer method must take a parameter of type "
-            + "frc.robot.Example. This error cannot be silenced.",
+            + "frc.robot.Example.",
         error.getMessage(null));
   }
 }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/PostConstructionInitializerProcessorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/PostConstructionInitializerProcessorTest.java
@@ -38,7 +38,7 @@ class PostConstructionInitializerProcessorTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Static @PostConstructionInitializer method must take a parameter of type "
+        "[WPILib] Static @PostConstructionInitializer method must take a parameter of type "
             + "frc.robot.Example",
         error.getMessage(null));
   }
@@ -139,14 +139,16 @@ class PostConstructionInitializerProcessorTest {
     assertEquals(2, compilation.errors().size());
     var error1 = compilation.errors().get(0);
     assertEquals(
-        "Static @PostConstructionInitializer method must take exactly one parameter of type "
-            + "frc.robot.Example with a @PostConstructionInitializer.InitializedParam annotation",
+        "[WPILib] Static @PostConstructionInitializer method must take exactly one parameter "
+            + "of type frc.robot.Example with a @PostConstructionInitializer.InitializedParam "
+            + "annotation",
         error1.getMessage(null));
 
     var error2 = compilation.errors().get(1);
     assertEquals(
-        "Static @PostConstructionInitializer method must take exactly one parameter of type "
-            + "frc.robot.Example with a @PostConstructionInitializer.InitializedParam annotation",
+        "[WPILib] Static @PostConstructionInitializer method must take exactly one parameter "
+            + "of type frc.robot.Example with a @PostConstructionInitializer.InitializedParam "
+            + "annotation",
         error2.getMessage(null));
   }
 
@@ -177,7 +179,7 @@ class PostConstructionInitializerProcessorTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Static @PostConstructionInitializer method must take a parameter of type "
+        "[WPILib] Static @PostConstructionInitializer method must take a parameter of type "
             + "frc.robot.Example",
         error.getMessage(null));
   }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/PostConstructionInitializerProcessorTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/PostConstructionInitializerProcessorTest.java
@@ -39,7 +39,7 @@ class PostConstructionInitializerProcessorTest {
     var error = compilation.errors().get(0);
     assertEquals(
         "[WPILib] Static @PostConstructionInitializer method must take a parameter of type "
-            + "frc.robot.Example",
+            + "frc.robot.Example. This error cannot be silenced.",
         error.getMessage(null));
   }
 
@@ -141,14 +141,14 @@ class PostConstructionInitializerProcessorTest {
     assertEquals(
         "[WPILib] Static @PostConstructionInitializer method must take exactly one parameter "
             + "of type frc.robot.Example with a @PostConstructionInitializer.InitializedParam "
-            + "annotation",
+            + "annotation. This error cannot be silenced.",
         error1.getMessage(null));
 
     var error2 = compilation.errors().get(1);
     assertEquals(
         "[WPILib] Static @PostConstructionInitializer method must take exactly one parameter "
             + "of type frc.robot.Example with a @PostConstructionInitializer.InitializedParam "
-            + "annotation",
+            + "annotation. This error cannot be silenced.",
         error2.getMessage(null));
   }
 
@@ -180,7 +180,7 @@ class PostConstructionInitializerProcessorTest {
     var error = compilation.errors().get(0);
     assertEquals(
         "[WPILib] Static @PostConstructionInitializer method must take a parameter of type "
-            + "frc.robot.Example",
+            + "frc.robot.Example. This error cannot be silenced.",
         error.getMessage(null));
   }
 }

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/ReturnValueUsedListenerTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/ReturnValueUsedListenerTest.java
@@ -113,7 +113,7 @@ class ReturnValueUsedListenerTest {
 
         import org.wpilib.annotation.NoDiscard;
 
-        @NoDiscard("Custom message.")
+        @NoDiscard("Custom message")
         class Example {
           Example getExample() { return new Example(); }
 
@@ -184,7 +184,7 @@ class ReturnValueUsedListenerTest {
 
         import org.wpilib.annotation.NoDiscard;
 
-        @NoDiscard("Objects of type `Base` must be used.")
+        @NoDiscard("Objects of type `Base` must be used")
         abstract class Base { }
 
         class Example extends Base {
@@ -218,7 +218,7 @@ class ReturnValueUsedListenerTest {
 
         import org.wpilib.annotation.NoDiscard;
 
-        @NoDiscard("Objects implementing `I` must be used.")
+        @NoDiscard("Objects implementing `I` must be used")
         interface I { }
 
         class Example implements I {
@@ -252,10 +252,10 @@ class ReturnValueUsedListenerTest {
 
         import org.wpilib.annotation.NoDiscard;
 
-        @NoDiscard("Objects implementing `I` must be used.")
+        @NoDiscard("Objects implementing `I` must be used")
         interface I { }
 
-        @NoDiscard("Objects implementing `I2` must be used.")
+        @NoDiscard("Objects implementing `I2` must be used")
         interface I2 { }
 
         class Example implements I, I2 {
@@ -295,7 +295,7 @@ class ReturnValueUsedListenerTest {
         import org.wpilib.annotation.NoDiscard;
 
         class Example {
-          @NoDiscard("Custom message.")
+          @NoDiscard("Custom message")
           int getI() { return 0; }
 
           void usage() {

--- a/javacPlugin/src/test/java/org/wpilib/javacplugin/ReturnValueUsedListenerTest.java
+++ b/javacPlugin/src/test/java/org/wpilib/javacplugin/ReturnValueUsedListenerTest.java
@@ -66,7 +66,10 @@ class ReturnValueUsedListenerTest {
     assertThat(compilation).failed();
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals("Result of @NoDiscard method is ignored", error.getMessage(null));
+    assertEquals(
+        "[WPILib] Result of @NoDiscard method is ignored. If this is intentional,"
+            + " the error may be silenced with @SuppressWarnings(\"WPILib.NoDiscard\")",
+        error.getMessage(null));
   }
 
   @Test
@@ -96,7 +99,9 @@ class ReturnValueUsedListenerTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Result of method returning @NoDiscard type wpilib.robot.Example is ignored",
+        "[WPILib] Result of method returning @NoDiscard type wpilib.robot.Example is ignored."
+            + " If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.NoDiscard\")",
         error.getMessage(null));
   }
 
@@ -108,7 +113,7 @@ class ReturnValueUsedListenerTest {
 
         import org.wpilib.annotation.NoDiscard;
 
-        @NoDiscard("Custom message")
+        @NoDiscard("Custom message.")
         class Example {
           Example getExample() { return new Example(); }
 
@@ -126,7 +131,10 @@ class ReturnValueUsedListenerTest {
     assertThat(compilation).failed();
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals("Custom message", error.getMessage(null));
+    assertEquals(
+        "[WPILib] Custom message. If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.NoDiscard\")",
+        error.getMessage(null));
   }
 
   @Test
@@ -157,9 +165,14 @@ class ReturnValueUsedListenerTest {
     assertEquals(2, compilation.errors().size());
     var error1 = compilation.errors().get(0);
     var error2 = compilation.errors().get(1);
-    assertEquals("Result of @NoDiscard method is ignored", error1.getMessage(null));
     assertEquals(
-        "Result of method returning @NoDiscard type wpilib.robot.Example is ignored",
+        "[WPILib] Result of @NoDiscard method is ignored. If this is intentional,"
+            + " the error may be silenced with @SuppressWarnings(\"WPILib.NoDiscard\")",
+        error1.getMessage(null));
+    assertEquals(
+        "[WPILib] Result of method returning @NoDiscard type wpilib.robot.Example is ignored."
+            + " If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.NoDiscard\")",
         error2.getMessage(null));
   }
 
@@ -171,7 +184,7 @@ class ReturnValueUsedListenerTest {
 
         import org.wpilib.annotation.NoDiscard;
 
-        @NoDiscard("Objects of type `Base` must be used")
+        @NoDiscard("Objects of type `Base` must be used.")
         abstract class Base { }
 
         class Example extends Base {
@@ -191,7 +204,10 @@ class ReturnValueUsedListenerTest {
     assertThat(compilation).failed();
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals("Objects of type `Base` must be used", error.getMessage(null));
+    assertEquals(
+        "[WPILib] Objects of type `Base` must be used. If this is intentional, the error may"
+            + " be silenced with @SuppressWarnings(\"WPILib.NoDiscard\")",
+        error.getMessage(null));
   }
 
   @Test
@@ -202,7 +218,7 @@ class ReturnValueUsedListenerTest {
 
         import org.wpilib.annotation.NoDiscard;
 
-        @NoDiscard("Objects implementing `I` must be used")
+        @NoDiscard("Objects implementing `I` must be used.")
         interface I { }
 
         class Example implements I {
@@ -222,7 +238,10 @@ class ReturnValueUsedListenerTest {
     assertThat(compilation).failed();
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals("Objects implementing `I` must be used", error.getMessage(null));
+    assertEquals(
+        "[WPILib] Objects implementing `I` must be used. If this is intentional, the error"
+            + " may be silenced with @SuppressWarnings(\"WPILib.NoDiscard\")",
+        error.getMessage(null));
   }
 
   @Test
@@ -233,10 +252,10 @@ class ReturnValueUsedListenerTest {
 
         import org.wpilib.annotation.NoDiscard;
 
-        @NoDiscard("Objects implementing `I` must be used")
+        @NoDiscard("Objects implementing `I` must be used.")
         interface I { }
 
-        @NoDiscard("Objects implementing `I2` must be used")
+        @NoDiscard("Objects implementing `I2` must be used.")
         interface I2 { }
 
         class Example implements I, I2 {
@@ -257,8 +276,14 @@ class ReturnValueUsedListenerTest {
     assertEquals(2, compilation.errors().size());
     var error1 = compilation.errors().get(0);
     var error2 = compilation.errors().get(1);
-    assertEquals("Objects implementing `I` must be used", error1.getMessage(null));
-    assertEquals("Objects implementing `I2` must be used", error2.getMessage(null));
+    assertEquals(
+        "[WPILib] Objects implementing `I` must be used. If this is intentional, the error"
+            + " may be silenced with @SuppressWarnings(\"WPILib.NoDiscard\")",
+        error1.getMessage(null));
+    assertEquals(
+        "[WPILib] Objects implementing `I2` must be used. If this is intentional, the error"
+            + " may be silenced with @SuppressWarnings(\"WPILib.NoDiscard\")",
+        error2.getMessage(null));
   }
 
   @Test
@@ -270,7 +295,7 @@ class ReturnValueUsedListenerTest {
         import org.wpilib.annotation.NoDiscard;
 
         class Example {
-          @NoDiscard("Custom message")
+          @NoDiscard("Custom message.")
           int getI() { return 0; }
 
           void usage() {
@@ -287,7 +312,10 @@ class ReturnValueUsedListenerTest {
     assertThat(compilation).failed();
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals("Custom message", error.getMessage(null));
+    assertEquals(
+        "[WPILib] Custom message. If this is intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.NoDiscard\")",
+        error.getMessage(null));
   }
 
   @Test
@@ -316,7 +344,10 @@ class ReturnValueUsedListenerTest {
     assertThat(compilation).failed();
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
-    assertEquals("Result of @NoDiscard method is ignored", error.getMessage(null));
+    assertEquals(
+        "[WPILib] Result of @NoDiscard method is ignored. If this is intentional,"
+            + " the error may be silenced with @SuppressWarnings(\"WPILib.NoDiscard\")",
+        error.getMessage(null));
   }
 
   @Test
@@ -357,7 +388,7 @@ class ReturnValueUsedListenerTest {
           @NoDiscard
           Object get() { return null; }
 
-          @SuppressWarnings("NoDiscard")
+          @SuppressWarnings("WPILib.NoDiscard")
           void usage() {
             get();
           }
@@ -407,7 +438,7 @@ class ReturnValueUsedListenerTest {
 
         import org.wpilib.annotation.NoDiscard;
 
-        @SuppressWarnings("NoDiscard")
+        @SuppressWarnings("WPILib.NoDiscard")
         class Example {
           @NoDiscard
           Object get() { return null; }
@@ -570,7 +601,10 @@ class ReturnValueUsedListenerTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Commands must be used! Did you mean to bind it to a trigger?", error.getMessage(null));
+        "[WPILib] Commands must be used! Did you mean to bind it to a trigger? If this is"
+            + " intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.NoDiscard\")",
+        error.getMessage(null));
   }
 
   @Test
@@ -603,7 +637,10 @@ class ReturnValueUsedListenerTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Commands must be used! Did you mean to bind it to a trigger?", error.getMessage(null));
+        "[WPILib] Commands must be used! Did you mean to bind it to a trigger? If this is"
+            + " intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.NoDiscard\")",
+        error.getMessage(null));
   }
 
   @Test
@@ -633,6 +670,9 @@ class ReturnValueUsedListenerTest {
     assertEquals(1, compilation.errors().size());
     var error = compilation.errors().get(0);
     assertEquals(
-        "Commands must be used! Did you mean to bind it to a trigger?", error.getMessage(null));
+        "[WPILib] Commands must be used! Did you mean to bind it to a trigger? If this is"
+            + " intentional, the error may be silenced with"
+            + " @SuppressWarnings(\"WPILib.NoDiscard\")",
+        error.getMessage(null));
   }
 }

--- a/wpiannotations/src/main/java/org/wpilib/annotation/NoDiscard.java
+++ b/wpiannotations/src/main/java/org/wpilib/annotation/NoDiscard.java
@@ -19,7 +19,14 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.CLASS) // needs to be stored in the class for use by libraries
 public @interface NoDiscard {
   /**
-   * An error message to display if the return value is not used.
+   * The string key to use in {@link SuppressWarnings} annotations to suppress compiler error
+   * messages related to this annotation.
+   */
+  String SUPPRESSION_KEY = "WPILib.NoDiscard";
+
+  /**
+   * An error message to display if the return value is not used. Messages should end with
+   * punctuation (a period, question mark, or exclamation point) for readability.
    *
    * @return The error message.
    */

--- a/wpiannotations/src/main/java/org/wpilib/annotation/NoDiscard.java
+++ b/wpiannotations/src/main/java/org/wpilib/annotation/NoDiscard.java
@@ -25,8 +25,7 @@ public @interface NoDiscard {
   String SUPPRESSION_KEY = "WPILib.NoDiscard";
 
   /**
-   * An error message to display if the return value is not used. Messages should end with
-   * punctuation (a period, question mark, or exclamation point) for readability.
+   * An error message to display if the return value is not used.
    *
    * @return The error message.
    */

--- a/wpiannotations/src/main/java/org/wpilib/annotation/PostConstructionInitializer.java
+++ b/wpiannotations/src/main/java/org/wpilib/annotation/PostConstructionInitializer.java
@@ -48,7 +48,7 @@ public @interface PostConstructionInitializer {
    * The string key to use in {@link SuppressWarnings} annotations to suppress compiler error
    * messages related to this annotation.
    */
-  String SUPPRESSION_KEY = "PostConstructionInitializer";
+  String SUPPRESSION_KEY = "WPILib.PostConstructionInitializer";
 
   /**
    * Marks a specific parameter in a static initializer method as being the initialized object. This

--- a/wpiannotations/src/main/java/org/wpilib/annotation/PostConstructionInitializer.java
+++ b/wpiannotations/src/main/java/org/wpilib/annotation/PostConstructionInitializer.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  * </ul>
  *
  * <p>Errors reported by the compiler plugin may be suppressed by annotating the offending method
- * with {@code SuppressWarnings("PostConstructionInitializer")} or {@code
+ * with {@code SuppressWarnings("WPILib.PostConstructionInitializer")} or {@code
  * SuppressWarnings(PostConstructionInitializer.SUPPRESSION_KEY)}. This is intended to be used in
  * tests to allow runtime error handling code to be tested, but may also be used to suppress
  * spurious warnings in production code.


### PR DESCRIPTION
All error messages now start with `[WPILib]` to make it clear they're coming from the WPILib compiler plugin, not the java compiler or other annotation processors

Messages also include suppression instructions, when possible, or explicitly say the error cannot be silenced.

Examples:

- `` [WPILib] Unreachable statement: `coroutine.park()` will never exit. If this is intentional, the error may be silenced with @SuppressWarnings("WPILib.CodeAfterCoroutinePark") ``
- `` [WPILib] Commands must be used! Did you mean to bind it to a trigger? If this is intentional, the error may be silenced with @SuppressWarnings("WPILib.NoDiscard") ``
- `` [WPILib] @Autonomous opmode description must be <= 64 characters (was 99). This error cannot be silenced. ``