### PR TITLE
[wpiutil] Fix lost-wakeup deadlock

### DIFF
--- a/wpiutil/src/main/native/cpp/SafeThread.cpp
+++ b/wpiutil/src/main/native/cpp/SafeThread.cpp
@@ -39,6 +39,7 @@ void SetSafeThreadNotifiers(OnThreadStartFn OnStart, OnThreadEndFn OnEnd) {
 }  // namespace wpi::util::impl
 
 void SafeThread::Stop() {
+  std::scoped_lock lock(m_mutex);
   m_active = false;
   m_cond.notify_all();
 }


### PR DESCRIPTION
[This](https://github.com/wpilibsuite/allwpilib/actions/runs/34723904113/job/103634584552?pr=9422) build hung, and due to the new Blacksmith agents, we were able to ssh in build machine and do some debugging.

Claude found the following, and wrote the fix:

```
Root cause: SafeThread::Stop() in wpiutil/src/main/native/cpp/SafeThread.cpp set m_active = false and called m_cond.notify_all() without holding m_mutex, while NotifierThread::Main() does its while (m_active) ... m_cond.wait(lock) check entirely under that lock. That's a lost-wakeup race: if Stop()'s notify lands in the window after Main() checks m_active (still true) but before it actually calls wait(), the notification is discarded and Main() blocks forever — which is exactly what the two backtraces showed (notifier thread stuck in pthread_cond_wait at Notifier.cpp:93, main thread stuck in join() from the static NotifierInstance destructor at process exit). Fixed by taking m_mutex in Stop() before mutating m_active and notifying.
```