### PR TITLE
[wpiutil,wpinet,wpigui,cscore] Fix lost wakeups

### DIFF
--- a/cscore/src/main/native/cpp/HttpCameraImpl.cpp
+++ b/cscore/src/main/native/cpp/HttpCameraImpl.cpp
@@ -29,7 +29,10 @@ HttpCameraImpl::HttpCameraImpl(std::string_view name, CS_HttpCameraKind kind,
     : SourceImpl{name, logger, notifier, telemetry}, m_kind{kind} {}
 
 HttpCameraImpl::~HttpCameraImpl() {
-  m_active = false;
+  {
+    std::scoped_lock lock(m_mutex);
+    m_active = false;
+  }
 
   // force wakeup of monitor thread
   m_monitorCond.notify_one();
@@ -545,6 +548,8 @@ void HttpCameraImpl::NumSinksChanged() {
 }
 
 void HttpCameraImpl::NumSinksEnabledChanged() {
+  // Synchronize with the enable predicate check before notifying.
+  std::scoped_lock lock(m_mutex);
   m_sinkEnabledCond.notify_one();
 }
 

--- a/cscore/src/main/native/linux/UsbCameraImpl.cpp
+++ b/cscore/src/main/native/linux/UsbCameraImpl.cpp
@@ -357,7 +357,10 @@ UsbCameraImpl::UsbCameraImpl(std::string_view name, wpi::util::Logger& logger,
 }
 
 UsbCameraImpl::~UsbCameraImpl() {
-  m_active = false;
+  {
+    std::scoped_lock lock(m_mutex);
+    m_active = false;
+  }
 
   // Just in case anyone is waiting...
   m_responseCv.notify_all();

--- a/wpigui/src/main/native/cpp/portable-file-dialogs.cpp
+++ b/wpigui/src/main/native/cpp/portable-file-dialogs.cpp
@@ -478,19 +478,24 @@ BOOL CALLBACK internal::executor::enum_windows_callback(HWND hwnd, LPARAM lParam
 void internal::executor::start_func(std::function<std::string(int *)> const &fun)
 {
     stop();
+    bool started = false;
 
-    auto trampoline = [fun, this]()
+    auto trampoline = [fun, this, &started]()
     {
-        // Save our thread id so that the caller can cancel us
-        m_tid = GetCurrentThreadId();
-        EnumWindows(&enum_windows_callback, (LPARAM)this);
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            // Save our thread id so that the caller can cancel us
+            m_tid = GetCurrentThreadId();
+            EnumWindows(&enum_windows_callback, (LPARAM)this);
+            started = true;
+        }
         m_cond.notify_all();
         return fun(&m_exit_code);
     };
 
     std::unique_lock<std::mutex> lock(m_mutex);
     m_future = std::async(std::launch::async, trampoline);
-    m_cond.wait(lock);
+    m_cond.wait(lock, [&started] { return started; });
     m_running = true;
 }
 

--- a/wpigui/src/main/native/cpp/portable-file-dialogs.cpp
+++ b/wpigui/src/main/native/cpp/portable-file-dialogs.cpp
@@ -483,7 +483,7 @@ void internal::executor::start_func(std::function<std::string(int *)> const &fun
     auto trampoline = [fun, this, &started]()
     {
         {
-            std::lock_guard<std::mutex> lock(m_mutex);
+            std::scoped_lock lock{m_mutex};
             // Save our thread id so that the caller can cancel us
             m_tid = GetCurrentThreadId();
             EnumWindows(&enum_windows_callback, (LPARAM)this);

--- a/wpinet/src/main/native/thirdparty/tcpsockets/cpp/TCPConnector_parallel.cpp
+++ b/wpinet/src/main/native/thirdparty/tcpsockets/cpp/TCPConnector_parallel.cpp
@@ -88,7 +88,10 @@ std::unique_ptr<NetworkStream> TCPConnector::connect_parallel(
           }
         }
       }
-      ++result->count;
+      {
+        std::scoped_lock lock(result->mtx);
+        ++result->count;
+      }
       result->cv.notify_all();
     }).detach();
   }

--- a/wpiutil/src/main/native/cpp/SafeThread.cpp
+++ b/wpiutil/src/main/native/cpp/SafeThread.cpp
@@ -39,6 +39,7 @@ void SetSafeThreadNotifiers(OnThreadStartFn OnStart, OnThreadEndFn OnEnd) {
 }  // namespace wpi::util::impl
 
 void SafeThread::Stop() {
+  std::scoped_lock lock(m_mutex);
   m_active = false;
   m_cond.notify_all();
 }

--- a/wpiutil/src/main/native/cpp/future.cpp
+++ b/wpiutil/src/main/native/cpp/future.cpp
@@ -10,6 +10,7 @@ namespace wpi::util {
 namespace detail {
 
 PromiseFactoryBase::~PromiseFactoryBase() {
+  std::scoped_lock lock(m_resultMutex);
   m_active = false;
   m_resultCv.notify_all();  // wake up any waiters
 }


### PR DESCRIPTION
In all these cases, atomic variables were being updated without the mutex associated with the CV being held.  This can lead to lost wakeups because the waiter can read the variable, miss the notification, and then sleep.

Supersedes #9423.